### PR TITLE
fix: configure RIPEstat timeout and add retry for heavy ris-prefixes …

### DIFF
--- a/BGPLite.Configuration/RipeStatConfig.cs
+++ b/BGPLite.Configuration/RipeStatConfig.cs
@@ -4,8 +4,31 @@ namespace BGPLite.Configuration;
 
 public sealed class RipeStatConfig
 {
+    /// <summary>Default request timeout for RIPEstat queries. Generous on purpose: the
+    /// <c>ris-prefixes</c> endpoint can take minutes to generate a response for large origin
+    /// ASes (e.g. AS3356 / Lumen — a Tier-1 transit backbone — routinely ~2 minutes).</summary>
+    public const int DefaultTimeoutSeconds = 180;
+
     [YamlMember(Alias = "AsnLists")]
     public List<AsnList> AsnLists { get; init; } = [];
+
+    /// <summary>Per-request HTTP timeout in seconds for RIPEstat queries. Defaults to
+    /// <see cref="DefaultTimeoutSeconds"/>. Raise it for very large origin ASes whose
+    /// <c>ris-prefixes</c> response takes minutes to generate; lower it for small ASes
+    /// to fail fast.</summary>
+    [YamlMember(Alias = "TimeoutSeconds")]
+    public int TimeoutSeconds { get; init; } = DefaultTimeoutSeconds;
+
+    /// <summary>Number of retries after a transient failure (client timeout, HTTP 429 / 5xx).
+    /// 0 disables retries. Each retry uses exponential backoff (see <see cref="RetryDelaySeconds"/>).
+    /// Defaults to 2.</summary>
+    [YamlMember(Alias = "RetryAttempts")]
+    public int RetryAttempts { get; init; } = 2;
+
+    /// <summary>Base delay in seconds between retries; doubled on each attempt (exponential
+    /// backoff). Defaults to 2. Set to 0 for immediate retries (e.g. in tests).</summary>
+    [YamlMember(Alias = "RetryDelaySeconds")]
+    public int RetryDelaySeconds { get; init; } = 2;
 }
 
 public sealed class AsnList

--- a/BGPLite.Providers/RipeStatProvider.cs
+++ b/BGPLite.Providers/RipeStatProvider.cs
@@ -1,20 +1,58 @@
 using System.Net;
 using System.Text.Json;
+using BGPLite.Configuration;
 using BGPLite.Protocol;
 using Microsoft.Extensions.Http;
 using Microsoft.Extensions.Logging;
 
 namespace BGPLite.Providers;
 
-public sealed class RipeStatProvider(IHttpClientFactory httpFactory, ILogger<RipeStatProvider> logger)
+public sealed class RipeStatProvider
 {
     /// <summary>Named-client key registered with <c>IHttpClientFactory</c>.</summary>
     public const string ClientName = "ripestat";
 
+    private readonly IHttpClientFactory _httpFactory;
+    private readonly ILogger<RipeStatProvider> _logger;
+    private readonly RipeStatConfig _config;
+
+    public RipeStatProvider(IHttpClientFactory httpFactory, ILogger<RipeStatProvider> logger, RipeStatConfig? config = null)
+    {
+        _httpFactory = httpFactory;
+        _logger = logger;
+        _config = config ?? new RipeStatConfig();
+    }
+
     public async Task<IReadOnlyList<(uint Prefix, byte PrefixLength)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
     {
         var url = $"https://stat.ripe.net/data/ris-prefixes/data.json?resource=AS{asn}&list_prefixes=true";
-        var http = httpFactory.CreateClient(ClientName);
+
+        // The ris-prefixes endpoint is slow for large origin ASes (minutes) and can fail
+        // transiently under load, so we retry transient failures a few times before giving up.
+        var retries = Math.Max(0, _config.RetryAttempts);
+
+        for (var attempt = 0; ; attempt++)
+        {
+            ct.ThrowIfCancellationRequested();
+            try
+            {
+                return await FetchOnceAsync(url, asn, ct);
+            }
+            // Retry only transient failures — and never retry when the caller cancelled us.
+            catch (Exception ex) when (!ct.IsCancellationRequested && attempt < retries && IsTransient(ex))
+            {
+                var backoff = TimeSpan.FromSeconds(_config.RetryDelaySeconds * Math.Pow(2, attempt));
+                _logger.LogWarning(
+                    "AS{Asn}: RIPEstat attempt {Attempt}/{Total} failed ({Reason}); retrying in {Delay:F0}s",
+                    asn, attempt + 1, retries + 1, ex.GetType().Name, backoff.TotalSeconds);
+                await Task.Delay(backoff, ct);
+            }
+        }
+    }
+
+    private async Task<IReadOnlyList<(uint Prefix, byte PrefixLength)>> FetchOnceAsync(string url, uint asn, CancellationToken ct)
+    {
+        var http = _httpFactory.CreateClient(ClientName);
         using var response = await http.GetAsync(url, ct);
         response.EnsureSuccessStatusCode();
 
@@ -39,7 +77,22 @@ public sealed class RipeStatProvider(IHttpClientFactory httpFactory, ILogger<Rip
             result.Add((prefix, length));
         }
 
-        logger.LogInformation("AS{Asn}: fetched {Count} prefixes", asn, result.Count);
+        _logger.LogInformation("AS{Asn}: fetched {Count} prefixes", asn, result.Count);
         return result;
     }
+
+    private static bool IsTransient(Exception ex) => ex switch
+    {
+        // Client timeout: HttpClient fires a TaskCanceledException when its own Timeout elapses.
+        // (A caller-initiated cancellation is filtered out by the `!ct.IsCancellationRequested`
+        // guard above before we ever get here.)
+        OperationCanceledException => true,
+        // Transient HTTP failures: rate limiting and server errors. Network-level failures
+        // (DNS, connection refused, TLS) surface as HttpRequestException with a null StatusCode.
+        HttpRequestException hre => hre.StatusCode is null || IsTransientStatus(hre.StatusCode.Value),
+        _ => false,
+    };
+
+    private static bool IsTransientStatus(HttpStatusCode code) =>
+        (int)code == 429 || (int)code >= 500;
 }

--- a/BGPLite.Tests/ConfigurationTests.cs
+++ b/BGPLite.Tests/ConfigurationTests.cs
@@ -171,4 +171,50 @@ public class ConfigurationTests
         Assert.Empty(config.PrefixSources);
         Assert.Null(config.DefaultPrefixSource);
     }
+
+    [Fact]
+    public void LoadFromText_RipeStatDefaults_WhenSectionAbsent()
+    {
+        var yaml = """
+            Bgp:
+              Asn: 65444
+              RouterId: 10.0.0.1
+            """;
+
+        var config = ConfigLoader.LoadFromText(yaml);
+
+        Assert.Null(config.RipeStat);
+        // The provider falls back to these defaults when the section is absent.
+        Assert.Equal(180, RipeStatConfig.DefaultTimeoutSeconds);
+        Assert.Equal(180, new RipeStatConfig().TimeoutSeconds);
+        Assert.Equal(2, new RipeStatConfig().RetryAttempts);
+    }
+
+    [Fact]
+    public void LoadFromText_ParsesRipeStatOptions()
+    {
+        var yaml = """
+            Bgp:
+              Asn: 65444
+              RouterId: 10.0.0.1
+            RipeStat:
+              TimeoutSeconds: 300
+              RetryAttempts: 4
+              RetryDelaySeconds: 5
+              AsnLists:
+                - Name: tier1
+                  Description: "Tier-1 transit"
+                  Asns: [3356, 1299]
+            """;
+
+        var config = ConfigLoader.LoadFromText(yaml);
+
+        Assert.NotNull(config.RipeStat);
+        Assert.Equal(300, config.RipeStat!.TimeoutSeconds);
+        Assert.Equal(4, config.RipeStat.RetryAttempts);
+        Assert.Equal(5, config.RipeStat.RetryDelaySeconds);
+        var list = Assert.Single(config.RipeStat.AsnLists);
+        Assert.Equal("tier1", list.Name);
+        Assert.Equal(new uint[] { 3356, 1299 }, list.Asns);
+    }
 }

--- a/BGPLite.Tests/RipeStatProviderTests.cs
+++ b/BGPLite.Tests/RipeStatProviderTests.cs
@@ -1,0 +1,152 @@
+using System.Net;
+using BGPLite.Configuration;
+using BGPLite.Providers;
+using Microsoft.Extensions.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BGPLite.Tests;
+
+public class RipeStatProviderTests
+{
+    private const string TwoPrefixBody =
+        """
+        {"status":"ok","data":{"resource":"65001","prefixes":{"v4":{"originating":["10.0.0.0/24","192.168.0.0/16"]},"v6":{"originating":[]}}}}
+        """;
+
+    /// <summary>Returns a scripted sequence of responses: each step is either an
+    /// <see cref="HttpStatusCode"/> (as a 200/5xx body) or an <see cref="Exception"/> to throw.
+    /// The last step repeats if there are more calls than steps.</summary>
+    private sealed class ScriptedHandler : HttpMessageHandler
+    {
+        private readonly object[] _steps;
+        private int _index;
+        public int Calls { get; private set; }
+
+        public ScriptedHandler(params object[] steps) => _steps = steps;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Calls++;
+            var i = Math.Min(_index, _steps.Length - 1);
+            _index++;
+            var step = _steps[i];
+            return step switch
+            {
+                HttpStatusCode code => Task.FromResult(new HttpResponseMessage(code)
+                {
+                    Content = new StringContent(TwoPrefixBody)
+                }),
+                Exception ex => Task.FromException<HttpResponseMessage>(ex),
+                _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(TwoPrefixBody)
+                })
+            };
+        }
+    }
+
+    private sealed class StubFactory : IHttpClientFactory
+    {
+        private readonly HttpMessageHandler _handler;
+        public StubFactory(HttpMessageHandler handler) => _handler = handler;
+        public HttpClient CreateClient(string name) => new(_handler, disposeHandler: false);
+    }
+
+    private static RipeStatProvider Provider(ScriptedHandler handler, int retries = 2) =>
+        new(new StubFactory(handler),
+            NullLogger<RipeStatProvider>.Instance,
+            new RipeStatConfig { RetryAttempts = retries, RetryDelaySeconds = 0 });
+
+    [Fact]
+    public async Task ParsesPrefixes()
+    {
+        var handler = new ScriptedHandler(HttpStatusCode.OK);
+        var result = await Provider(handler).GetPrefixesAsync(65001);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(1, handler.Calls);
+    }
+
+    [Fact]
+    public async Task RetriesOnTransient5xx_ThenSucceeds()
+    {
+        var handler = new ScriptedHandler(
+            HttpStatusCode.InternalServerError, HttpStatusCode.BadGateway, HttpStatusCode.OK);
+
+        var result = await Provider(handler, retries: 2).GetPrefixesAsync(65001);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(3, handler.Calls); // 1 initial + 2 retries
+    }
+
+    [Fact]
+    public async Task RetriesOn429_ThenSucceeds()
+    {
+        var handler = new ScriptedHandler((HttpStatusCode)429, HttpStatusCode.OK);
+
+        var result = await Provider(handler, retries: 2).GetPrefixesAsync(65001);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(2, handler.Calls);
+    }
+
+    [Fact]
+    public async Task RetriesOnTimeout_ThenSucceeds()
+    {
+        // A client timeout surfaces as TaskCanceledException (a subclass of
+        // OperationCanceledException). It must be retried when the caller didn't cancel.
+        var handler = new ScriptedHandler(new TaskCanceledException(), HttpStatusCode.OK);
+
+        var result = await Provider(handler, retries: 1).GetPrefixesAsync(65001);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(2, handler.Calls);
+    }
+
+    [Fact]
+    public async Task ThrowsAfterExhaustingRetries()
+    {
+        var handler = new ScriptedHandler(HttpStatusCode.ServiceUnavailable); // repeats
+
+        await Assert.ThrowsAsync<HttpRequestException>(
+            () => Provider(handler, retries: 2).GetPrefixesAsync(65001));
+
+        Assert.Equal(3, handler.Calls); // 1 initial + 2 retries, then gives up
+    }
+
+    [Fact]
+    public async Task DoesNotRetry_WhenRetryAttemptsZero()
+    {
+        var handler = new ScriptedHandler(HttpStatusCode.InternalServerError, HttpStatusCode.OK);
+
+        await Assert.ThrowsAsync<HttpRequestException>(
+            () => Provider(handler, retries: 0).GetPrefixesAsync(65001));
+
+        Assert.Equal(1, handler.Calls);
+    }
+
+    [Fact]
+    public async Task DoesNotRetry_NonTransientStatus()
+    {
+        // 404 is a client error — not transient, so it must not be retried.
+        var handler = new ScriptedHandler(HttpStatusCode.NotFound, HttpStatusCode.OK);
+
+        await Assert.ThrowsAsync<HttpRequestException>(
+            () => Provider(handler, retries: 2).GetPrefixesAsync(65001));
+
+        Assert.Equal(1, handler.Calls);
+    }
+
+    [Fact]
+    public async Task PropagatesCallerCancellation_WithoutCalling()
+    {
+        var handler = new ScriptedHandler(HttpStatusCode.OK);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => Provider(handler).GetPrefixesAsync(65001, cts.Token));
+
+        Assert.Equal(0, handler.Calls); // bails before the first HTTP call
+    }
+}

--- a/BGPLite/Program.cs
+++ b/BGPLite/Program.cs
@@ -60,8 +60,20 @@ builder.Services.AddSingleton<IPrefixSourceService>(sp => sp.GetRequiredService<
 
 // RIPE Stat provider — registered unconditionally so arbitrary ASNs (peer custom ASNs,
 // API lookups) can be resolved on demand, regardless of preconfigured RipeStat.AsnLists.
-builder.Services.AddHttpClient(RipeStatProvider.ClientName, c => c.Timeout = TimeSpan.FromSeconds(30));
-builder.Services.AddSingleton<RipeStatProvider>();
+// The ris-prefixes endpoint can take minutes to respond for large origin ASes (e.g. AS3356 /
+// Lumen), so the timeout is configurable and defaults to a generous value. Fall back to the
+// built-in defaults when the RipeStat section is absent — the provider still serves ad-hoc
+// lookups, and its retry handles transient failures (timeouts, 429/5xx).
+var ripeStatConfig = config.RipeStat ?? new RipeStatConfig();
+builder.Services.AddHttpClient(RipeStatProvider.ClientName, c =>
+{
+    c.Timeout = TimeSpan.FromSeconds(ripeStatConfig.TimeoutSeconds);
+    c.DefaultRequestHeaders.UserAgent.ParseAdd("BGPLite/1.0");
+});
+builder.Services.AddSingleton(sp => new RipeStatProvider(
+    sp.GetRequiredService<IHttpClientFactory>(),
+    sp.GetRequiredService<ILogger<RipeStatProvider>>(),
+    ripeStatConfig));
 
 builder.Services.AddSingleton<IPrefixService>(sp =>
 {

--- a/appsettings.Example.yml
+++ b/appsettings.Example.yml
@@ -9,6 +9,19 @@ Peers:
     RemoteAsn: 65001
     Description: "example-peer"
 
+# RIPEstat (stat.ripe.net) used to resolve ASNs → prefixes via the ris-prefixes endpoint.
+# That endpoint is slow for large origin ASes (AS3356/Lumen takes ~2 minutes), so the HTTP
+# timeout defaults to 180s and is tunable here. Transient failures (timeout, HTTP 429/5xx)
+# are retried with exponential backoff.
+RipeStat:
+  TimeoutSeconds: 180        # per-request HTTP timeout (default 180)
+  RetryAttempts: 2           # retries after a transient failure (default 2, 0 disables)
+  RetryDelaySeconds: 2       # base delay between retries, doubled each attempt (default 2)
+  # AsnLists:               # pre-warmed ASN groups at startup
+  #   - Name: tier1
+  #     Description: "Tier-1 transit ASes"
+  #     Asns: [3356, 1299]
+
 # Prefix sources loaded at startup via the provider factory (Kind: file | http).
 # "http" fetches any direct raw-file URL (raw.githubusercontent.com, a gist, self-hosted, ...).
 # Each source may override the HTTP timeout (Timeout, seconds) and tag a Community in "ASN:VALUE".


### PR DESCRIPTION
…queries

The ris-prefixes endpoint takes ~2 minutes for large origin ASes (e.g. AS3356/Lumen, a Tier-1 backbone), but the RIPEstat HttpClient was hard-coded to a 30s timeout, so lookups for big ASes timed out and were silently skipped during warmup / threw on direct lookups.

- Make the HTTP timeout configurable via RipeStat.TimeoutSeconds (default 180s, up from 30s); falls back to defaults when the section is absent.
- Add retry with exponential backoff for transient failures (client timeout, HTTP 429/5xx); caller cancellation is never retried.
- Set a User-Agent on the RIPEstat client.
- Cover with RipeStatProviderTests and config tests.