### PR TITLE
fix(api): key peer records by (Ip, Asn) so NAT'd peers don't share one row

### DIFF
--- a/BGPLite.Api/BgpDbContext.cs
+++ b/BGPLite.Api/BgpDbContext.cs
@@ -17,6 +17,16 @@ public class BgpDbContext : DbContext
             "PeerId TEXT NOT NULL, Asn INTEGER NOT NULL, " +
             "PRIMARY KEY (PeerId, Asn), " +
             "FOREIGN KEY (PeerId) REFERENCES Peers(Id) ON DELETE CASCADE)");
+
+        // Peer identity is (Ip, Asn), not Ip alone, so several peers behind one source IP (distinct
+        // AS) can coexist as separate rows (issue #19). EnsureCreated does not evolve an existing
+        // schema, so migrate the index idempotently: drop the legacy Ip-only unique index and create
+        // the composite one if it is missing. Existing data is already unique by Ip (the old index
+        // enforced it), so (Ip, Asn) is unique on it as well — the CREATE cannot fail.
+        db.Database.ExecuteSqlRaw("DROP INDEX IF EXISTS IX_Peers_Ip;");
+        db.Database.ExecuteSqlRaw(
+            "CREATE UNIQUE INDEX IF NOT EXISTS UX_Peers_Ip_Asn ON Peers (Ip, Asn);");
+
         db.Peers.Where(p => p.Status == "active").ExecuteUpdate(
             s => s.SetProperty(p => p.Status, "inactive"));
     }
@@ -26,7 +36,10 @@ public class BgpDbContext : DbContext
         model.Entity<Peer>(e =>
         {
             e.HasKey(p => p.Id);
-            e.HasIndex(p => p.Ip).IsUnique();
+            // Composite identity (Ip, Asn): distinct peers behind one source IP with different AS
+            // must be separate rows (issue #19). Named so the idempotent migration in Initialize
+            // can recreate it deterministically across fresh and existing databases.
+            e.HasIndex(p => new { p.Ip, p.Asn }).IsUnique().HasDatabaseName("UX_Peers_Ip_Asn");
             e.Property(p => p.Status).HasDefaultValue("inactive");
         });
 

--- a/BGPLite.Api/PeerStore.cs
+++ b/BGPLite.Api/PeerStore.cs
@@ -13,10 +13,9 @@ public sealed class PeerStore : IPeerStore
     public string CreatePeer(string ip, uint asn, string? description)
     {
         using var db = _dbFactory.CreateDbContext();
-        var existing = db.Peers.FirstOrDefault(p => p.Ip == ip);
+        var existing = db.Peers.FirstOrDefault(p => p.Ip == ip && p.Asn == asn);
         if (existing is not null)
         {
-            existing.Asn = asn;
             existing.Description = description;
             db.SaveChanges();
             return existing.Id;
@@ -31,24 +30,23 @@ public sealed class PeerStore : IPeerStore
     public void UpsertPeer(string ip, uint asn)
     {
         using var db = _dbFactory.CreateDbContext();
-        var peer = db.Peers.FirstOrDefault(p => p.Ip == ip);
+        var peer = db.Peers.FirstOrDefault(p => p.Ip == ip && p.Asn == asn);
         if (peer is null)
         {
             db.Peers.Add(new Peer { Ip = ip, Asn = asn, Status = "active", LastSessionAt = DateTime.UtcNow });
         }
         else
         {
-            peer.Asn = asn;
             peer.Status = "active";
             peer.LastSessionAt = DateTime.UtcNow;
         }
         db.SaveChanges();
     }
 
-    public void UpdateSessionStatus(string ip, bool active)
+    public void UpdateSessionStatus(string ip, uint asn, bool active)
     {
         using var db = _dbFactory.CreateDbContext();
-        var peer = db.Peers.FirstOrDefault(p => p.Ip == ip);
+        var peer = db.Peers.FirstOrDefault(p => p.Ip == ip && p.Asn == asn);
         if (peer is null) return;
 
         peer.Status = active ? "active" : "inactive";
@@ -85,6 +83,18 @@ public sealed class PeerStore : IPeerStore
     {
         using var db = _dbFactory.CreateDbContext();
         var peer = db.Peers.Include(p => p.Communities).FirstOrDefault(p => p.Ip == ip);
+        return peer is null ? null : MapToInfo(peer);
+    }
+
+    /// <summary>
+    /// Resolves a peer by its durable identity <c>(Ip, Asn)</c> — the form a BGP session knows once
+    /// it has parsed the peer's OPEN (issue #19). Several peers may share a source IP with distinct
+    /// AS; this returns the specific one, unlike the Ip-only <see cref="GetPeerByIp"/>.
+    /// </summary>
+    public PeerInfo? GetPeer(string ip, uint asn)
+    {
+        using var db = _dbFactory.CreateDbContext();
+        var peer = db.Peers.Include(p => p.Communities).FirstOrDefault(p => p.Ip == ip && p.Asn == asn);
         return peer is null ? null : MapToInfo(peer);
     }
 

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -271,7 +271,7 @@ public sealed class BgpSession : IDisposable
             if (wasEstablished)
             {
                 _metrics.SessionClosed();
-                _peerStore?.UpdateSessionStatus(_peerConfig.Address, false);
+                _peerStore?.UpdateSessionStatus(_peerConfig.Address, _remoteAsn, false);
             }
             _metrics.PeerDisconnected();
             _logger.LogInformation("SessionClosed with {Peer}", _peerConfig.Address);
@@ -443,10 +443,10 @@ public sealed class BgpSession : IDisposable
 
         if (_peerStore is not null && _prefixService is not null && _appConfig is not null)
         {
-            var peer = _peerStore.GetPeerByIp(_peerConfig.Address);
+            var peer = _peerStore.GetPeer(_peerConfig.Address, _remoteAsn);
             if (peer is not null)
             {
-                _peerStore.UpdateSessionStatus(_peerConfig.Address, true);
+                _peerStore.UpdateSessionStatus(_peerConfig.Address, _remoteAsn, true);
 
                 var subscriptionIds = _peerStore.GetSubscriptions(peer.Id);
                 var customPrefixes = _peerStore.GetCustomPrefixes(peer.Id);

--- a/BGPLite.Server/IPeerStore.cs
+++ b/BGPLite.Server/IPeerStore.cs
@@ -4,9 +4,10 @@ public interface IPeerStore
 {
     string CreatePeer(string ip, uint asn, string? description);
     void UpsertPeer(string ip, uint asn);
-    void UpdateSessionStatus(string ip, bool active);
+    void UpdateSessionStatus(string ip, uint asn, bool active);
     void DeletePeer(string id);
     PeerInfo? GetPeerByIp(string ip);
+    PeerInfo? GetPeer(string ip, uint asn);
     PeerInfo? GetPeerById(string id);
     List<string> GetSubscriptions(string peerId);
     List<string> GetCustomPrefixes(string peerId);

--- a/BGPLite.Tests/BGPLite.Tests.csproj
+++ b/BGPLite.Tests/BGPLite.Tests.csproj
@@ -14,10 +14,12 @@
     <ProjectReference Include="..\BGPLite.Server\BGPLite.Server.csproj" />
     <ProjectReference Include="..\BGPLite.Routing\BGPLite.Routing.csproj" />
     <ProjectReference Include="..\BGPLite.Configuration\BGPLite.Configuration.csproj" />
+    <ProjectReference Include="..\BGPLite.Api\BGPLite.Api.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/BGPLite.Tests/PeerStoreKeyingTests.cs
+++ b/BGPLite.Tests/PeerStoreKeyingTests.cs
@@ -1,0 +1,166 @@
+using BGPLite.Api;
+using BGPLite.Api.Entities;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// Regression coverage for issue #19: the peer table is keyed by (Ip, Asn), so several distinct
+/// peers arriving from the same source IP (different AS) are separate rows with independent
+/// subscriptions / prefixes / status. Per RFC 4271 §4.2 the OPEN "My Autonomous System" identifies
+/// the sender; a configured neighbor is conventionally (address, ASN). Uses a real in-memory
+/// SQLite database so the composite UNIQUE constraint is actually exercised (the EF Core InMemory
+/// provider does not enforce unique indexes).
+/// </summary>
+public class PeerStoreKeyingTests
+{
+    private const string SharedIp = "203.0.113.10";
+
+    /// <summary>Opens a private in-memory SQLite DB (kept alive by the returned connection, which
+    /// the caller must keep open/dispose) and returns a PeerStore over it.</summary>
+    private static (PeerStore store, SqliteConnection connection) NewStore()
+    {
+        var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        var options = new DbContextOptionsBuilder<BgpDbContext>()
+            .UseSqlite(connection)
+            .Options;
+        using (var boot = new BgpDbContext(options))
+            BgpDbContext.Initialize(boot); // EnsureCreated + composite-index migration
+
+        return (new PeerStore(new StaticOptionsFactory(options)), connection);
+    }
+
+    private sealed class StaticOptionsFactory : IDbContextFactory<BgpDbContext>
+    {
+        private readonly DbContextOptions<BgpDbContext> _options;
+        public StaticOptionsFactory(DbContextOptions<BgpDbContext> options) => _options = options;
+        public BgpDbContext CreateDbContext() => new(_options);
+    }
+
+    [Fact]
+    public void Distinct_Asns_From_Same_Ip_Create_Separate_Peer_Records()
+    {
+        var (store, connection) = NewStore();
+        using var conn = connection;
+
+        var idA = store.CreatePeer(SharedIp, 64512, "A");
+        var idB = store.CreatePeer(SharedIp, 64513, "B"); // same source IP, different AS
+
+        Assert.NotEqual(idA, idB);
+
+        var a = store.GetPeer(SharedIp, 64512);
+        var b = store.GetPeer(SharedIp, 64513);
+        Assert.NotNull(a);
+        Assert.NotNull(b);
+        Assert.Equal((uint?)64512, a!.Asn);
+        Assert.Equal((uint?)64513, b!.Asn);
+        Assert.NotEqual(a.Id, b.Id);
+
+        // Resolving by an AS that never connected must NOT return another peer's record.
+        Assert.Null(store.GetPeer(SharedIp, 64599));
+    }
+
+    [Fact]
+    public void Composite_Unique_Index_Rejects_Duplicate_IpAsn()
+    {
+        var (_, connection) = NewStore();
+        using var conn = connection;
+        var options = new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(connection).Options;
+
+        using var db = new BgpDbContext(options);
+        db.Peers.Add(new Peer { Ip = SharedIp, Asn = 64512 });
+        db.SaveChanges();
+
+        // The failed SaveChanges below leaves this entity in the Added state, so detach it before
+        // the next insert or it would be retried and trip the unique constraint again.
+        var dup = new Peer { Ip = SharedIp, Asn = 64512 }; // exact duplicate (Ip, Asn)
+        db.Peers.Add(dup);
+        Assert.Throws<DbUpdateException>(() => db.SaveChanges());
+        db.Entry(dup).State = EntityState.Detached;
+
+        // A different AS on the same IP is still allowed.
+        db.Peers.Add(new Peer { Ip = SharedIp, Asn = 64513 });
+        db.SaveChanges();
+    }
+
+    [Fact]
+    public void UpdateSessionStatus_Is_Scoped_To_IpAsn()
+    {
+        var (store, connection) = NewStore();
+        using var conn = connection;
+
+        var idA = store.CreatePeer(SharedIp, 64512, "A");
+        var idB = store.CreatePeer(SharedIp, 64513, "B");
+        store.UpdateSessionStatus(SharedIp, 64512, active: true);
+
+        Assert.Equal("active", store.GetDbPeerById(idA)!.Status);
+        Assert.Equal("inactive", store.GetDbPeerById(idB)!.Status); // untouched — different AS
+
+        store.UpdateSessionStatus(SharedIp, 64513, active: true);
+        Assert.Equal("active", store.GetDbPeerById(idB)!.Status);
+    }
+
+    [Fact]
+    public void CreatePeer_Is_Idempotent_On_IpAsn()
+    {
+        var (store, connection) = NewStore();
+        using var conn = connection;
+
+        var id1 = store.CreatePeer(SharedIp, 64512, "first");
+        var id2 = store.CreatePeer(SharedIp, 64512, "second"); // same (Ip, Asn) → update, not a new row
+
+        Assert.Equal(id1, id2);
+        Assert.Equal("second", store.GetDbPeerById(id1)!.Description);
+    }
+
+    /// <summary>
+    /// Hard requirement: existing peer data on the server must survive the index change. Simulates a
+    /// database created by a previous (Ip-only-unique) version holding a real peer row, runs the
+    /// idempotent migration in <see cref="BgpDbContext.Initialize"/>, and asserts the row is intact
+    /// and the legacy Ip-only unique index has been replaced by the composite (so a second peer with
+    /// a different AS can now coexist).
+    /// </summary>
+    [Fact]
+    public void Initialize_Migrates_Legacy_Unique_Index_And_Preserves_Data()
+    {
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        var options = new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(connection).Options;
+
+        // A database created by a previous (Ip-only-unique) version, holding real data.
+        using (var setup = new BgpDbContext(options))
+        {
+            setup.Database.ExecuteSqlRaw(
+                "CREATE TABLE Peers (" +
+                "Id TEXT NOT NULL PRIMARY KEY, Ip TEXT NOT NULL, Asn INTEGER NULL, " +
+                "Description TEXT NULL, Status TEXT NOT NULL DEFAULT 'inactive', " +
+                "CreatedAt TEXT NOT NULL, LastSessionAt TEXT NULL);");
+            setup.Database.ExecuteSqlRaw("CREATE UNIQUE INDEX IX_Peers_Ip ON Peers (Ip);");
+            setup.Database.ExecuteSqlRaw(
+                "INSERT INTO Peers (Id, Ip, Asn, Description, Status, CreatedAt) " +
+                "VALUES ('peer-1', '203.0.113.10', 64512, 'existing peer', 'inactive', '2024-01-01T00:00:00Z');");
+        }
+
+        // Upgrade: Initialize drops IX_Peers_Ip and creates the composite UX_Peers_Ip_Asn (data
+        // untouched — only index DDL, never row DML).
+        using (var boot = new BgpDbContext(options))
+            BgpDbContext.Initialize(boot);
+
+        using var check = new BgpDbContext(options);
+        var existing = check.Peers.AsNoTracking().Single();
+        Assert.Equal("peer-1", existing.Id);                 // data preserved
+        Assert.Equal("203.0.113.10", existing.Ip);
+        Assert.Equal((uint?)64512, existing.Asn);
+        Assert.Equal("existing peer", existing.Description);
+
+        // The legacy Ip-only unique index is gone: a second peer with a DIFFERENT AS now coexists.
+        var store = new PeerStore(new StaticOptionsFactory(options));
+        var idB = store.CreatePeer("203.0.113.10", 64513, "new peer behind same NAT");
+        Assert.NotEqual("peer-1", idB);
+
+        using var check2 = new BgpDbContext(options);
+        Assert.Equal(2, check2.Peers.AsNoTracking().Count());
+    }
+}


### PR DESCRIPTION
## Summary

The peer table had a **UNIQUE index on `Ip` alone** and every `PeerStore` lookup (`CreatePeer`/`UpsertPeer`/`UpdateSessionStatus`/`GetPeerByIp`) matched by IP, so distinct peers arriving from the same source IP (different AS) collapsed into a single record: the second overwrote the first's AS and both shared one set of subscriptions / custom prefixes / status. This is the persistence-layer half of the same root cause as #18.

## Why

Per **RFC 4271 §4.2** the OPEN *"My Autonomous System"* identifies the sender, and **§6.2** leaves acceptable AS to local policy; a configured neighbor is conventionally `(address, ASN)` (FRR/BIRD/OpenBGPD). The BGP Identifier (§4.2) is deliberately left as future work.

## Changes

- Replace the Ip-unique index with a composite `(Ip, Asn)` → `UX_Peers_Ip_Asn`; migrate existing databases idempotently in `BgpDbContext.Initialize` (the app uses `EnsureCreated`, which does not evolve schema).
- Key `CreatePeer`/`UpsertPeer`/`UpdateSessionStatus` on `(Ip, Asn)`; add `GetPeer(ip, asn)`.
- `IPeerStore.UpdateSessionStatus(ip, asn, active)`; `BgpSession` passes `_remoteAsn` (known after OPEN) to the peer lookup and status update.
- `GetPeerByIp` stays Ip-scoped for `/api/me` backward compatibility.

### Data preservation (hard requirement)

Existing production data is **untouched**: the migration is index DDL only (`DROP INDEX IF EXISTS IX_Peers_Ip; CREATE UNIQUE INDEX IF NOT EXISTS UX_Peers_Ip_Asn`), zero row DML. Existing peers already carry their AS (written from OPEN), so each maps cleanly to the new `(Ip, Asn)` identity; the legacy Ip-unique index guarantees the composite is already unique on existing rows, so the `CREATE INDEX` cannot fail. Covered by `Initialize_Migrates_Legacy_Unique_Index_And_Preserves_Data`.

## Validation

- `dotnet build` clean; `dotnet test` — **118 passed** (adds `PeerStoreKeyingTests` on in-memory SQLite: separate rows for same-IP/different-AS, composite unique constraint, scoped status, idempotent `CreatePeer`, legacy-schema migration preserving data).
- `dotnet format` applied.

## Risk / regressions

Low. `IPeerStore` signature change (`UpdateSessionStatus` + new `GetPeer`) — only `PeerStore` implements it and only `BgpSession` calls the changed methods; updated together. Known follow-ups (left Ip-scoped, tracked in #19): `/api/me` and `GetCommunitiesByIp`/`PeerCommunityFilter` cannot disambiguate same-IP peers without the AS.

Companion PR for the session map: #18 (`SessionKey` = IP + port). **Both are needed for the full fix.**

Closes #19.
