### PR TITLE
feat(configuration): add Asn field to PrefixSourceConfig for AS-number scoping

### DIFF
--- a/BGPLite.Configuration/PrefixSourceConfig.cs
+++ b/BGPLite.Configuration/PrefixSourceConfig.cs
@@ -25,6 +25,10 @@ public sealed class PrefixSourceConfig
     /// <summary>Raw URL of a CIDR list (kind = <c>"http"</c>).</summary>
     [YamlMember(Alias = "Url")]
     public string? Url { get; init; }
+    
+    /// <summary>AS number(s) this prefix source is valid for (kind = <c>"asn"</c>).</summary>
+    [YamlMember(Alias = "Asn")]
+    public uint? Asn { get; init; }
 
     /// <summary>Local file path, relative to <c>AppContext.BaseDirectory</c> (kind = <c>"file"</c>).</summary>
     [YamlMember(Alias = "Path")]


### PR DESCRIPTION
## Summary
Add an optional `Asn` (`uint?`) property to `PrefixSourceConfig`, exposed as YAML alias `Asn`, so a prefix source can be scoped to a specific AS number — alongside the existing `Url`/`Path` source selectors.

## Changes
- `BGPLite.Configuration/PrefixSourceConfig.cs`: add `Asn` (`uint?`) with `[YamlMember(Alias = "Asn")]` and XML doc.

## Type of change
- [x] feat — new optional config field; additive and backward-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)