### PR TITLE
chore: add .coderabbit.yaml with BGP/RFC review context

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# CodeRabbit configuration for BGPLite.
+language: "en-US"
+early_access: false
+
+reviews:
+  # Keep the lighter profile; project-specific strictness comes from path_instructions below.
+  profile: "chill"
+  high_level_summary: true
+  poem: false              # no AI poem in the review
+  collapse_walkthrough: true   # keep the walkthrough collapsed by default
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+  path_instructions:
+    - path: "**/*.cs"
+      instructions: |
+        BGPLite is a hand-rolled BGP route server implementing RFC 4271 on raw TCP sockets
+        (.NET 10, no BIRD/FRR/GoBGP). Prioritize, in this order:
+        - Protocol correctness vs RFC 4271: message framing/lengths, FSM transitions, path
+          attribute ordering and flag bits (reserved bit 0x08 MUST be 0), OPEN/UPDATE/NOTIFICATION
+          validation, Hold Time rules (0 or >= 3), AS numbering (4-byte ASN, AS_TRANS 23456).
+        - Memory/bounds safety in BGPLite.Protocol codecs (PrefixCodec, BgpMessageReader/Writer):
+          reject prefix length > 32, capability/optional-params length must not overflow a byte,
+          no silent truncation of IPv6 or over-long values.
+        - Concurrency in BGPLite.Server (ConcurrentDictionary TryAdd/TryUpdate CAS, Interlocked,
+          volatile state, send locks, hold-timer expiry).
+        - Backward-compatibility of config DTOs (YAML aliases in BGPLite.Configuration).
+        Don't bikeshed naming/style; the codebase follows its existing conventions.
+    - path: "**/*.md"
+      instructions: |
+        Documentation (README, FIXPLAN, AGENTS, articles). Review only for factual accuracy,
+        broken links/references, and clarity. Treat as LOW effort — do not nitpick prose or style.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,7 +13,7 @@ reviews:
     enabled: true
     drafts: false
     base_branches:
-      - main
+      - "^main$"
   path_instructions:
     - path: "**/*.cs"
       instructions: |


### PR DESCRIPTION
## What
Adds `.coderabbit.yaml` to tune the CodeRabbit auto-reviewer (installed on the repo) for BGPLite.

## Settings
- **`**/*.cs`** → path-specific guidance: BGP route server implementing **RFC 4271** on raw TCP sockets (.NET 10). Reviewer focuses on, in order: protocol correctness (message framing, FSM, path-attribute ordering/flag bits, OPEN/UPDATE/NOTIFICATION validation, Hold Time rules, 4-byte ASN), **codec bounds/memory safety** in `BGPLite.Protocol`, **concurrency** in `BGPLite.Server` (CAS / Interlocked / volatile / locks / hold-timer), and **config back-compat**. Asked not to bikeshed style.
- **`**/*.md`** → **LOW effort**: factual accuracy, broken links, clarity only — so docs-only PRs (like #17, #26) don't generate noise.
- `poem: false`, `collapse_walkthrough: true`, `profile: chill`, `auto_review` on for PRs into `main`.
- `language: en-US` (matches the repo). **No auto-approve** (not in schema / stays off) — merges stay human.

## Notes
- `walkthrough` has no on/off field; `collapse_walkthrough: true` keeps it collapsed. `poem` and `collapse_walkthrough` are already the defaults here — set explicitly for self-documentation.
- Validated field names/types against the official `schema.v2.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a project-wide review configuration to standardize automated code reviews.
  * Enabled high-level summaries and automatic reviews on the main branch.
  * Configured targeted review priorities for protocol correctness, safety, concurrency behavior, and YAML DTO backward compatibility, plus focused accuracy checks for Markdown documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->