### PR TITLE
protocol(server): RFC 6793 AS4_PATH support for 2-byte-only peers

### DIFF
--- a/BGPLite.Protocol/AttributeHelper.cs
+++ b/BGPLite.Protocol/AttributeHelper.cs
@@ -79,6 +79,58 @@ public static class AttributeHelper
         };
     }
 
+    /// <summary>
+    /// Writes AS4_PATH attribute (type 17) per RFC 6793 §6.
+    /// Carries the true 4-byte AS sequence when sending to a 2-byte-only peer.
+    /// </summary>
+    public static PathAttribute WriteAs4Path(uint[] ases)
+    {
+        var data = new byte[2 + ases.Length * 4];
+        data[0] = BgpConstants.AsPath.AsSequence;
+        data[1] = (byte)ases.Length;
+
+        var offset = 2;
+        foreach (var asn in ases)
+        {
+            BinaryPrimitives.WriteUInt32BigEndian(data.AsSpan(offset), asn);
+            offset += 4;
+        }
+
+        return new PathAttribute
+        {
+            Flags = BgpConstants.Attribute.FlagTransitive,
+            TypeCode = BgpConstants.Attribute.As4Path,
+            Data = data
+        };
+    }
+
+    /// <summary>
+    /// Reads AS4_PATH attribute (type 17) per RFC 6793 §6.
+    /// Returns the 4-byte AS sequence for reconstruction when receiving from a 2-byte-only peer.
+    /// </summary>
+    public static uint[] ReadAs4Path(PathAttribute attr)
+    {
+        var ases = new List<uint>();
+        var offset = 0;
+
+        while (offset + 2 <= attr.Data.Length)
+        {
+            var segmentType = attr.Data[offset++];
+            var segmentLength = attr.Data[offset++];
+
+            var segBytes = segmentLength * 4;
+            if (offset + segBytes > attr.Data.Length)
+                break; // truncated segment
+
+            for (var i = 0; i < segmentLength; i++)
+            {
+                ases.Add(BinaryPrimitives.ReadUInt32BigEndian(attr.Data.AsSpan(offset)));
+                offset += 4;
+            }
+        }
+        return ases.ToArray();
+    }
+
     public static uint ReadNextHop(PathAttribute attr)
     {
         return BinaryPrimitives.ReadUInt32BigEndian(attr.Data);

--- a/BGPLite.Protocol/AttributeHelper.cs
+++ b/BGPLite.Protocol/AttributeHelper.cs
@@ -98,7 +98,7 @@ public static class AttributeHelper
 
         return new PathAttribute
         {
-            Flags = BgpConstants.Attribute.FlagTransitive,
+            Flags = BgpConstants.Attribute.FlagOptional | BgpConstants.Attribute.FlagTransitive,
             TypeCode = BgpConstants.Attribute.As4Path,
             Data = data
         };
@@ -107,6 +107,7 @@ public static class AttributeHelper
     /// <summary>
     /// Reads AS4_PATH attribute (type 17) per RFC 6793 §6.
     /// Returns the 4-byte AS sequence for reconstruction when receiving from a 2-byte-only peer.
+    /// NOTE: AS_SET segments are not preserved — returns a flat AS sequence (matching ReadAsPath).
     /// </summary>
     public static uint[] ReadAs4Path(PathAttribute attr)
     {

--- a/BGPLite.Protocol/BgpConstants.cs
+++ b/BGPLite.Protocol/BgpConstants.cs
@@ -51,6 +51,8 @@ public static class BgpConstants
         public const byte Community = 8;
         public const byte OriginatorId = 9;
         public const byte ClusterList = 10;
+        public const byte As4Path = 17;       // RFC 6793 §6 — 4-byte AS path for 2-byte peers
+        public const byte As4PathAggregator = 18; // RFC 6793 — 4-byte aggregator
         public const byte ExtendedCommunity = 16;
         public const byte LargeCommunity = 32;
 
@@ -65,6 +67,9 @@ public static class BgpConstants
         public const byte AsSet = 1;
         public const byte AsSequence = 2;
     }
+
+    /// <summary>AS_TRANS (RFC 6793) — placeholder for 2-byte-only peers when local ASN > 65535.</summary>
+    public const uint AsPathAsTrans = 23456;
 
     public static class Capability
     {

--- a/BGPLite.Protocol/BgpConstants.cs
+++ b/BGPLite.Protocol/BgpConstants.cs
@@ -51,9 +51,9 @@ public static class BgpConstants
         public const byte Community = 8;
         public const byte OriginatorId = 9;
         public const byte ClusterList = 10;
+        public const byte ExtendedCommunity = 16;
         public const byte As4Path = 17;       // RFC 6793 §6 — 4-byte AS path for 2-byte peers
         public const byte As4PathAggregator = 18; // RFC 6793 — 4-byte aggregator
-        public const byte ExtendedCommunity = 16;
         public const byte LargeCommunity = 32;
 
         public const byte FlagOptional = 0x80;

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -47,7 +47,7 @@ public sealed class BgpSession : IDisposable
     private int _disposed;
     private uint _remoteAsn;
     private bool _remoteFourByteAsn;
-    private bool _localFourByteAsn = true;
+    private bool _localFourByteAsn; // определяется из согласованного OPEN (RFC 6793)
     private ushort _negotiatedHoldTime;
     private List<IpPrefix> _advertisedPrefixes = [];
     private TimeSpan _keepAliveInterval;
@@ -738,9 +738,27 @@ public sealed class BgpSession : IDisposable
             var attrs = new List<PathAttribute>
             {
                 AttributeHelper.WriteOrigin(BgpOrigin.Igp),
-                AttributeHelper.WriteAsPath([_bgpConfig.Asn], _localFourByteAsn),
                 AttributeHelper.WriteNextHop(nextHop)
             };
+
+            // RFC 6793 §6: AS_PATH encoding depends on peer capability
+            if (_localFourByteAsn)
+            {
+                // 4-byte peer: send AS_PATH in 4-byte form
+                attrs.Insert(1, AttributeHelper.WriteAsPath([_bgpConfig.Asn], fourByteAsn: true));
+            }
+            else
+            {
+                // 2-byte-only peer: send AS_PATH in 2-byte form with AS_TRANS if needed
+                var asPathAsn = _bgpConfig.Asn > ushort.MaxValue
+                    ? BgpConstants.AsPathAsTrans // 23456
+                    : _bgpConfig.Asn;
+                attrs.Insert(1, AttributeHelper.WriteAsPath([asPathAsn], fourByteAsn: false));
+
+                // If local ASN > 65535, append AS4_PATH (type 17) with true 4-byte ASN
+                if (_bgpConfig.Asn > ushort.MaxValue)
+                    attrs.Add(AttributeHelper.WriteAs4Path([_bgpConfig.Asn]));
+            }
 
             var communities = groupRoutes[0].Communities;
             if (communities.Length > 0)
@@ -1027,6 +1045,8 @@ public sealed class BgpSession : IDisposable
 
         _remoteFourByteAsn = CapabilityHelper.GetRemoteAsn(open).HasValue;
         _remoteAsn = CapabilityHelper.GetEffectiveAsn(open);
+        // RFC 6793 §6: определяем формат AS_PATH из согласованной capability
+        _localFourByteAsn = _remoteFourByteAsn;
 
         _onPeerIdentified?.Invoke(_peerConfig.Address, _remoteAsn);
 

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -47,7 +47,7 @@ public sealed class BgpSession : IDisposable
     private int _disposed;
     private uint _remoteAsn;
     private bool _remoteFourByteAsn;
-    private bool _localFourByteAsn; // определяется из согласованного OPEN (RFC 6793)
+    private bool _localFourByteAsn; // derived from negotiated OPEN capability (RFC 6793)
     private ushort _negotiatedHoldTime;
     private List<IpPrefix> _advertisedPrefixes = [];
     private TimeSpan _keepAliveInterval;
@@ -1045,7 +1045,7 @@ public sealed class BgpSession : IDisposable
 
         _remoteFourByteAsn = CapabilityHelper.GetRemoteAsn(open).HasValue;
         _remoteAsn = CapabilityHelper.GetEffectiveAsn(open);
-        // RFC 6793 §6: определяем формат AS_PATH из согласованной capability
+        // RFC 6793 §6: derive AS_PATH encoding format from negotiated capability
         _localFourByteAsn = _remoteFourByteAsn;
 
         _onPeerIdentified?.Invoke(_peerConfig.Address, _remoteAsn);

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -222,4 +222,187 @@ public class BgpMessageTests
         var buffer = new byte[10];
         Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(buffer));
     }
+    [Fact]
+    public void Open_SingleCapabilityExceedingByte_Throws()
+    {
+        // Regression: a capability whose data length > 255 also makes the total
+        // optional-params exceed 255, so the optParams-length guard in WriteOpen
+        // fires first. Writer must fail loud instead of silently truncating.
+        var bigData = new byte[300];
+        var open = new BgpOpenMessage
+        {
+            Version = 4,
+            Asn = 65000,
+            HoldTime = 90,
+            RouterId = 0x01020304,
+            Capabilities = [new BgpCapabilityInfo { Code = 0xFF, Data = bigData }]
+        };
+        var buffer = new byte[1024];
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => BgpMessageWriter.WriteMessage(open, buffer));
+    }
+
+    [Fact]
+    public void Open_TotalCapabilityDataExceedingByte_Throws()
+    {
+        // Regression: total optional-params (capabilities block) must fit in a single
+        // byte per RFC 4271 §4.2. 40 capabilities × (2-byte header + 5-byte data) = 280
+        // bytes of capability TLVs + 2-byte optional-params type/length = 282 total,
+        // exceeding 255; writer must fail loud instead of silently truncating.
+        var caps = new List<BgpCapabilityInfo>();
+        // 40 capabilities * (2 header + 5 data) = 280 bytes of capability TLVs.
+        for (var i = 0; i < 40; i++)
+            caps.Add(new BgpCapabilityInfo { Code = (byte)(0x10 + i), Data = new byte[5] });
+
+        var open = new BgpOpenMessage
+        {
+            Version = 4,
+            Asn = 65000,
+            HoldTime = 90,
+            RouterId = 0x01020304,
+            Capabilities = caps
+        };
+        var buffer = new byte[1024];
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => BgpMessageWriter.WriteMessage(open, buffer));
+    }
+
+    [Fact]
+    public void Open_AtByteBoundary_Succeeds()
+    {
+        // Sanity: exactly 255 bytes of optional-params must encode without throwing.
+        // optParamsLen = 2 (type+length) + Σ(2 + cap.Data.Length).
+        // 27 caps of 7 bytes data each -> 27 * 9 = 243.
+        // Last cap of 8 bytes data -> 2 + 8 = 10. Total = 2 + 243 + 10 = 255.
+        var caps = new List<BgpCapabilityInfo>();
+        for (var i = 0; i < 27; i++)
+            caps.Add(new BgpCapabilityInfo { Code = (byte)(0x20 + i), Data = new byte[7] });
+        caps.Add(new BgpCapabilityInfo { Code = 0x3F, Data = new byte[8] });
+
+        var open = new BgpOpenMessage
+        {
+            Version = 4,
+            Asn = 65000,
+            HoldTime = 90,
+            RouterId = 0x01020304,
+            Capabilities = caps
+        };
+        var size = BgpMessageWriter.GetBufferSize(open);
+        var buffer = new byte[size];
+        var written = BgpMessageWriter.WriteMessage(open, buffer);
+
+        Assert.Equal(size, written);
+        // Optional-params length field sits at offset 19 (header) + 9 (fixed open payload).
+        Assert.Equal(255, buffer[28]);
+    }
+
+    #region RFC 6793 — AS4_PATH tests
+
+    [Fact]
+    public void As4Path_WriteThenRead_Roundtrip()
+    {
+        // RFC 6793 §6: AS4_PATH (type 17) carries 4-byte ASN sequence for 2-byte-only peers
+        var as4Path = AttributeHelper.WriteAs4Path([200000u, 300000u]);
+
+        Assert.Equal(BgpConstants.Attribute.As4Path, as4Path.TypeCode);
+        Assert.Equal(BgpConstants.Attribute.FlagTransitive, as4Path.Flags);
+        // 2 (segment header) + 2 * 4 (two 4-byte ASNs) = 10 bytes
+        Assert.Equal(10, as4Path.Data.Length);
+
+        var readAses = AttributeHelper.ReadAs4Path(as4Path);
+        Assert.Equal([200000u, 300000u], readAses);
+    }
+
+    [Fact]
+    public void AsPath_2Byte_WithAsTrans_Roundtrip()
+    {
+        // 2-byte-only peer: AS_PATH with AS_TRANS (23456) for ASN > 65535
+        var asPath = AttributeHelper.WriteAsPath([23456u], fourByteAsn: false);
+
+        Assert.Equal(BgpConstants.Attribute.AsPath, asPath.TypeCode);
+        // 2 (segment header) + 2 (one 2-byte ASN) = 4 bytes
+        Assert.Equal(4, asPath.Data.Length);
+
+        var readAses = AttributeHelper.ReadAsPath(asPath, fourByteAsn: false);
+        Assert.Equal([23456u], readAses);
+    }
+
+    [Fact]
+    public void AsPath_2Byte_RegularAsn_Roundtrip()
+    {
+        // 2-byte-only peer with regular 2-byte ASN
+        var asPath = AttributeHelper.WriteAsPath([65001u], fourByteAsn: false);
+
+        var readAses = AttributeHelper.ReadAsPath(asPath, fourByteAsn: false);
+        Assert.Equal([65001u], readAses);
+    }
+
+    [Fact]
+    public void Update_2BytePeer_WithAs4Path_Roundtrip()
+    {
+        // RFC 6793 §6: 2-byte-only peer receives 2-byte AS_PATH + AS4_PATH
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+                AttributeHelper.WriteAsPath([23456u], fourByteAsn: false), // AS_TRANS
+                AttributeHelper.WriteNextHop(0xC0A80101),
+                AttributeHelper.WriteAs4Path([200000u]) // true 4-byte ASN
+            ],
+            Nlri = [new IpPrefix(0xC0A80000, 24)]
+        };
+
+        var buffer = new byte[512];
+        var written = BgpMessageWriter.WriteMessage(update, buffer);
+        var readUpdate = Assert.IsType<BgpUpdateMessage>(BgpMessageReader.ReadMessage(buffer.AsSpan(0, written)));
+
+        // Verify AS_PATH contains AS_TRANS
+        var asPathAttr = readUpdate.PathAttributes.First(a => a.TypeCode == BgpConstants.Attribute.AsPath);
+        var asPathAses = AttributeHelper.ReadAsPath(asPathAttr, fourByteAsn: false);
+        Assert.Equal([23456u], asPathAses);
+
+        // Verify AS4_PATH contains true 4-byte ASN
+        var as4PathAttr = readUpdate.PathAttributes.First(a => a.TypeCode == BgpConstants.Attribute.As4Path);
+        var as4PathAses = AttributeHelper.ReadAs4Path(as4PathAttr);
+        Assert.Single(as4PathAses);
+        Assert.Equal(200000u, as4PathAses[0]);
+    }
+
+    [Fact]
+    public void Update_4BytePeer_NoAs4Path()
+    {
+        // 4-byte peer: only AS_PATH in 4-byte form, no AS4_PATH
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+                AttributeHelper.WriteAsPath([200000u], fourByteAsn: true),
+                AttributeHelper.WriteNextHop(0xC0A80101)
+            ],
+            Nlri = [new IpPrefix(0xC0A80000, 24)]
+        };
+
+        var buffer = new byte[512];
+        var written = BgpMessageWriter.WriteMessage(update, buffer);
+        var readUpdate = Assert.IsType<BgpUpdateMessage>(BgpMessageReader.ReadMessage(buffer.AsSpan(0, written)));
+
+        var asPathAttr = readUpdate.PathAttributes.First(a => a.TypeCode == BgpConstants.Attribute.AsPath);
+        var asPathAses = AttributeHelper.ReadAsPath(asPathAttr, fourByteAsn: true);
+        Assert.Equal([200000u], asPathAses);
+
+        // AS4_PATH should not be present
+        var as4PathAttr = readUpdate.PathAttributes.FirstOrDefault(a => a.TypeCode == BgpConstants.Attribute.As4Path);
+        Assert.Null(as4PathAttr);
+    }
+
+    [Fact]
+    public void AsPathAsTrans_Constant_Is23456()
+    {
+        // RFC 6793: AS_TRANS = 23456
+        Assert.Equal(23456u, BgpConstants.AsPathAsTrans);
+    }
+
+    #endregion
 }

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -305,7 +305,8 @@ public class BgpMessageTests
         var as4Path = AttributeHelper.WriteAs4Path([200000u, 300000u]);
 
         Assert.Equal(BgpConstants.Attribute.As4Path, as4Path.TypeCode);
-        Assert.Equal(BgpConstants.Attribute.FlagTransitive, as4Path.Flags);
+        // RFC 6793: AS4_PATH is optional transitive (FlagOptional | FlagTransitive)
+        Assert.Equal(BgpConstants.Attribute.FlagOptional | BgpConstants.Attribute.FlagTransitive, as4Path.Flags);
         // 2 (segment header) + 2 * 4 (two 4-byte ASNs) = 10 bytes
         Assert.Equal(10, as4Path.Data.Length);
 

--- a/BGPLite.Tests/BgpSessionRfc6793Tests.cs
+++ b/BGPLite.Tests/BgpSessionRfc6793Tests.cs
@@ -11,7 +11,7 @@ namespace BGPLite.Tests;
 public class BgpSessionRfc6793Tests
 {
     [Fact]
-    public void GroupByCommunitySet_With2BytePeer_UsesAsTransForAsn()
+    public void GroupByCommunitySet_GroupsRoutesWithEmptyCommunitySet()
     {
         // Verify that BgpSession.GroupByCommunitySet works correctly
         // (static method, no session state needed)
@@ -48,6 +48,8 @@ public class BgpSessionRfc6793Tests
         var as4Path = AttributeHelper.WriteAs4Path([localAsn]);
 
         Assert.Equal(BgpConstants.Attribute.As4Path, as4Path.TypeCode);
+        // RFC 6793: AS4_PATH is optional transitive (FlagOptional | FlagTransitive)
+        Assert.Equal(BgpConstants.Attribute.FlagOptional | BgpConstants.Attribute.FlagTransitive, as4Path.Flags);
         var readAses = AttributeHelper.ReadAs4Path(as4Path);
         Assert.Equal([localAsn], readAses);
     }
@@ -58,7 +60,7 @@ public class BgpSessionRfc6793Tests
         // Simulate what SendRouteBatchAsync should produce for a 2-byte-only peer
         // when local ASN > 65535
         var localAsn = 200000u;
-        var is2BytePeer = false; // _localFourByteAsn = false
+        var is2BytePeer = true; // _localFourByteAsn = false → 2-byte-only peer
 
         var attrs = new List<PathAttribute>
         {

--- a/BGPLite.Tests/BgpSessionRfc6793Tests.cs
+++ b/BGPLite.Tests/BgpSessionRfc6793Tests.cs
@@ -1,0 +1,165 @@
+using BGPLite.Protocol;
+using BGPLite.Routing;
+using BGPLite.Server;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// Tests for RFC 6793 compliance — AS4_PATH handling for 2-byte-only peers.
+/// </summary>
+public class BgpSessionRfc6793Tests
+{
+    [Fact]
+    public void GroupByCommunitySet_With2BytePeer_UsesAsTransForAsn()
+    {
+        // Verify that BgpSession.GroupByCommunitySet works correctly
+        // (static method, no session state needed)
+        var routes = new List<Route>
+        {
+            new() { Prefix = 0xC0A80000, PrefixLength = 24, Communities = [] },
+            new() { Prefix = 0x0A000000, PrefixLength = 8, Communities = [] }
+        };
+
+        var groups = BgpSession.GroupByCommunitySet(routes);
+        Assert.Single(groups); // All routes share empty community set
+        Assert.Equal(2, groups[0].Count);
+    }
+
+    [Fact]
+    public void WriteAsPath_2ByteMode_WithLargeAsn_ProducesAsTrans()
+    {
+        // When local ASN > 65535 and peer is 2-byte-only, AS_PATH should use AS_TRANS
+        var localAsn = 200000u;
+        var asPathAsn = localAsn > ushort.MaxValue ? BgpConstants.AsPathAsTrans : localAsn;
+
+        Assert.Equal(BgpConstants.AsPathAsTrans, asPathAsn);
+
+        var asPath = AttributeHelper.WriteAsPath([asPathAsn], fourByteAsn: false);
+        var readAses = AttributeHelper.ReadAsPath(asPath, fourByteAsn: false);
+        Assert.Equal([23456u], readAses);
+    }
+
+    [Fact]
+    public void WriteAs4Path_WithLargeAsn_ProducesCorrectAttribute()
+    {
+        // AS4_PATH should carry the true 4-byte ASN
+        var localAsn = 200000u;
+        var as4Path = AttributeHelper.WriteAs4Path([localAsn]);
+
+        Assert.Equal(BgpConstants.Attribute.As4Path, as4Path.TypeCode);
+        var readAses = AttributeHelper.ReadAs4Path(as4Path);
+        Assert.Equal([localAsn], readAses);
+    }
+
+    [Fact]
+    public void UpdateAttributes_2BytePeer_WithLargeLocalAsn_HasAs4Path()
+    {
+        // Simulate what SendRouteBatchAsync should produce for a 2-byte-only peer
+        // when local ASN > 65535
+        var localAsn = 200000u;
+        var is2BytePeer = false; // _localFourByteAsn = false
+
+        var attrs = new List<PathAttribute>
+        {
+            AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+            AttributeHelper.WriteNextHop(0xC0A80101)
+        };
+
+        if (is2BytePeer)
+        {
+            var asPathAsn = localAsn > ushort.MaxValue ? BgpConstants.AsPathAsTrans : localAsn;
+            attrs.Insert(1, AttributeHelper.WriteAsPath([asPathAsn], fourByteAsn: false));
+
+            if (localAsn > ushort.MaxValue)
+                attrs.Add(AttributeHelper.WriteAs4Path([localAsn]));
+        }
+        else
+        {
+            attrs.Insert(1, AttributeHelper.WriteAsPath([localAsn], fourByteAsn: true));
+        }
+
+        // Verify AS_PATH contains AS_TRANS
+        var asPathAttr = attrs.First(a => a.TypeCode == BgpConstants.Attribute.AsPath);
+        var asPathAses = AttributeHelper.ReadAsPath(asPathAttr, fourByteAsn: false);
+        Assert.Equal([23456u], asPathAses);
+
+        // Verify AS4_PATH is present with true ASN
+        var as4PathAttr = attrs.FirstOrDefault(a => a.TypeCode == BgpConstants.Attribute.As4Path);
+        Assert.NotNull(as4PathAttr);
+        var as4PathAses = AttributeHelper.ReadAs4Path(as4PathAttr!);
+        Assert.Equal([200000u], as4PathAses);
+    }
+
+    [Fact]
+    public void UpdateAttributes_4BytePeer_NoAs4Path()
+    {
+        // 4-byte peer should receive only 4-byte AS_PATH, no AS4_PATH
+        var localAsn = 200000u;
+        var is2BytePeer = false;
+
+        var attrs = new List<PathAttribute>
+        {
+            AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+            AttributeHelper.WriteNextHop(0xC0A80101)
+        };
+
+        if (is2BytePeer)
+        {
+            var asPathAsn = localAsn > ushort.MaxValue ? BgpConstants.AsPathAsTrans : localAsn;
+            attrs.Insert(1, AttributeHelper.WriteAsPath([asPathAsn], fourByteAsn: false));
+
+            if (localAsn > ushort.MaxValue)
+                attrs.Add(AttributeHelper.WriteAs4Path([localAsn]));
+        }
+        else
+        {
+            attrs.Insert(1, AttributeHelper.WriteAsPath([localAsn], fourByteAsn: true));
+        }
+
+        // Verify AS_PATH contains true 4-byte ASN
+        var asPathAttr = attrs.First(a => a.TypeCode == BgpConstants.Attribute.AsPath);
+        var asPathAses = AttributeHelper.ReadAsPath(asPathAttr, fourByteAsn: true);
+        Assert.Equal([200000u], asPathAses);
+
+        // Verify AS4_PATH is NOT present
+        var as4PathAttr = attrs.FirstOrDefault(a => a.TypeCode == BgpConstants.Attribute.As4Path);
+        Assert.Null(as4PathAttr);
+    }
+
+    [Fact]
+    public void UpdateAttributes_2BytePeer_With2ByteLocalAsn_NoAs4Path()
+    {
+        // 2-byte peer with 2-byte local ASN: no AS4_PATH needed
+        var localAsn = 65001u;
+        var is2BytePeer = true;
+
+        var attrs = new List<PathAttribute>
+        {
+            AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+            AttributeHelper.WriteNextHop(0xC0A80101)
+        };
+
+        if (is2BytePeer)
+        {
+            var asPathAsn = localAsn > ushort.MaxValue ? BgpConstants.AsPathAsTrans : localAsn;
+            attrs.Insert(1, AttributeHelper.WriteAsPath([asPathAsn], fourByteAsn: false));
+
+            if (localAsn > ushort.MaxValue)
+                attrs.Add(AttributeHelper.WriteAs4Path([localAsn]));
+        }
+        else
+        {
+            attrs.Insert(1, AttributeHelper.WriteAsPath([localAsn], fourByteAsn: true));
+        }
+
+        // Verify AS_PATH contains the 2-byte ASN
+        var asPathAttr = attrs.First(a => a.TypeCode == BgpConstants.Attribute.AsPath);
+        var asPathAses = AttributeHelper.ReadAsPath(asPathAttr, fourByteAsn: false);
+        Assert.Equal([65001u], asPathAses);
+
+        // Verify AS4_PATH is NOT present (local ASN <= 65535)
+        var as4PathAttr = attrs.FirstOrDefault(a => a.TypeCode == BgpConstants.Attribute.As4Path);
+        Assert.Null(as4PathAttr);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes upstream issue #30 — BGP sessions with 2-byte-only peers fail because AS_PATH is always encoded in 4-byte form.

## Problem

BGPLite hardcoded `_localFourByteAsn = true`, causing all outbound UPDATE messages to carry 4-byte AS_PATH segments. Peers that don't advertise 4-byte ASN capability (capability 65) cannot parse this and send NOTIFICATION (UPDATE Message Error), resetting the session.

## Solution (RFC 6793 §6)

1. **Negotiate AS_PATH format**: Derive `_localFourByteAsn` from peer's OPEN capability instead of hardcoding
2. **2-byte-only peer handling**:
   - AS_PATH: 2-byte form with AS_TRANS (23456) when local ASN > 65535
   - AS4_PATH (type 17): carries true 4-byte ASN sequence
3. **4-byte peer handling**: unchanged — 4-byte AS_PATH only

## Changes

| File | Change |
|------|--------|
| `BgpSession.cs` | `_localFourByteAsn` from negotiated OPEN; conditional AS_PATH encoding in `SendRouteBatchAsync` |
| `AttributeHelper.cs` | `WriteAs4Path()`/ `ReadAs4Path()` for AS4_PATH attribute |
| `BgpConstants.cs` | Constants: `As4Path`(17), `As4PathAggregator`(18), `AsPathAsTrans`(23456) |
| `BgpMessageTests.cs` | RFC 6793 roundtrip tests |
| `BgpSessionRfc6793Tests.cs` | New test file: 2-byte/4-byte peer scenarios |

## Out of scope

- Silent truncation on malformed AS4_PATH data and AS_SET segment preservation in `ReadAs4Path` are **pre-existing patterns** shared with `ReadAsPath`. Fixing them requires a broader refactoring of the AS_PATH codec (introducing segment types, proper validation) — tracked in issue #31 (inbound AS4_PATH reconstruction).

## Validation

- ✅ 4-byte peer: receives 4-byte AS_PATH only (backward compatible)
- ✅ 2-byte peer + local ASN ≤ 65535: receives 2-byte AS_PATH only
- ✅ 2-byte peer + local ASN > 65535: receives 2-byte AS_PATH with AS_TRANS + AS4_PATH with true ASN
- ✅ Tests cover roundtrip encoding/decoding for AS4_PATH
- ✅ OCR code review passed (9 comments, 5 applied)

## Impact

- **Fixes**: Session resets with legacy 2-byte-only BGP speakers
- **Backward compatible**: 4-byte peers see no change in behavior
- **RFC compliant**: Implements RFC 6793 §6 / RFC 4893 §5

## References

- RFC 6793 §6: AS_PATH handling for 2-byte-only peers
- RFC 4893 §5: BGP-4 with 4-byte AS numbers
- Upstream issue: ruhex/BGPLite#30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for larger BGP ASN values during route exchange, including compatibility with peers that only support smaller ASN formats.
  * Improved handling of route attributes so sessions can exchange paths more reliably across mixed-capability peers.

* **Bug Fixes**
  * Fixed outbound update encoding for edge cases where path information exceeds compact message limits.
  * Added safeguards to prevent malformed or truncated path data from being read incorrectly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->