### PR TITLE
protocol(server): RFC 6793 AS4_PATH support for 2-byte-only peers

### DIFF
--- a/BGPLite.Protocol/AttributeHelper.cs
+++ b/BGPLite.Protocol/AttributeHelper.cs
@@ -30,7 +30,7 @@ public static class AttributeHelper
         {
             Flags = BgpConstants.Attribute.FlagTransitive,
             TypeCode = BgpConstants.Attribute.AsPath,
-            Data = WritePathData(ases, fourByteAsn ? 4 : 2)
+            Data = WritePathData(ases, fourByteAsn ? 4 : 2, "AS_PATH")
         };
     }
 
@@ -44,7 +44,7 @@ public static class AttributeHelper
         {
             Flags = BgpConstants.Attribute.FlagOptional | BgpConstants.Attribute.FlagTransitive,
             TypeCode = BgpConstants.Attribute.As4Path,
-            Data = WritePathData(ases, 4)
+            Data = WritePathData(ases, 4, "AS4_PATH")
         };
     }
 
@@ -90,10 +90,10 @@ public static class AttributeHelper
         return ases.ToArray();
     }
 
-    private static byte[] WritePathData(uint[] ases, int asSize)
+    private static byte[] WritePathData(uint[] ases, int asSize, string attributeName)
     {
         if (ases.Length > byte.MaxValue)
-            throw new ArgumentOutOfRangeException(nameof(ases), "AS path segment length cannot exceed 255 ASNs.");
+            throw new ArgumentOutOfRangeException(nameof(ases), $"{attributeName} segment length cannot exceed 255 ASNs.");
 
         var data = new byte[2 + ases.Length * asSize];
         data[0] = BgpConstants.AsPath.AsSequence;

--- a/BGPLite.Protocol/AttributeHelper.cs
+++ b/BGPLite.Protocol/AttributeHelper.cs
@@ -79,6 +79,58 @@ public static class AttributeHelper
         };
     }
 
+    /// <summary>
+    /// Writes AS4_PATH attribute (type 17) per RFC 6793 §6.
+    /// Carries the true 4-byte AS sequence when sending to a 2-byte-only peer.
+    /// </summary>
+    public static PathAttribute WriteAs4Path(uint[] ases)
+    {
+        var data = new byte[2 + ases.Length * 4];
+        data[0] = BgpConstants.AsPath.AsSequence;
+        data[1] = (byte)ases.Length;
+
+        var offset = 2;
+        foreach (var asn in ases)
+        {
+            BinaryPrimitives.WriteUInt32BigEndian(data.AsSpan(offset), asn);
+            offset += 4;
+        }
+
+        return new PathAttribute
+        {
+            Flags = BgpConstants.Attribute.FlagTransitive,
+            TypeCode = BgpConstants.Attribute.As4Path,
+            Data = data
+        };
+    }
+
+    /// <summary>
+    /// Reads AS4_PATH attribute (type 17) per RFC 6793 §6.
+    /// Returns the 4-byte AS sequence for reconstruction when receiving from a 2-byte-only peer.
+    /// </summary>
+    public static uint[] ReadAs4Path(PathAttribute attr)
+    {
+        var ases = new List<uint>();
+        var offset = 0;
+
+        while (offset + 2 <= attr.Data.Length)
+        {
+            var segmentType = attr.Data[offset++];
+            var segmentLength = attr.Data[offset++];
+
+            var segBytes = segmentLength * 4;
+            if (offset + segBytes > attr.Data.Length)
+                break; // truncated segment
+
+            for (var i = 0; i < segmentLength; i++)
+            {
+                ases.Add(BinaryPrimitives.ReadUInt32BigEndian(attr.Data.AsSpan(offset)));
+                offset += 4;
+            }
+        }
+        return ases.ToArray();
+    }
+
     public static uint ReadNextHop(PathAttribute attr)
     {
         return BinaryPrimitives.ReadUInt32BigEndian(attr.Data);

--- a/BGPLite.Protocol/AttributeHelper.cs
+++ b/BGPLite.Protocol/AttributeHelper.cs
@@ -31,9 +31,13 @@ public static class AttributeHelper
             var segmentType = attr.Data[offset++];
             var segmentLength = attr.Data[offset++];
 
+            if (segmentType != BgpConstants.AsPath.AsSequence &&
+                segmentType != BgpConstants.AsPath.AsSet)
+                throw new BgpParseException($"Invalid AS_PATH segment type: {segmentType}");
+
             var segBytes = segmentLength * asSize;
             if (offset + segBytes > attr.Data.Length)
-                break; // truncated segment — stop rather than read out of bounds
+                throw new BgpParseException("Truncated AS_PATH segment");
 
             for (var i = 0; i < segmentLength; i++)
             {
@@ -44,13 +48,18 @@ public static class AttributeHelper
                 offset += asSize;
             }
         }
-        // NOTE: AS4_PATH (attr 17) is not parsed/merged here; AS_PATH is not re-advertised
-        // by this server, so AS_TRANS(23456) reconstruction (RFC 6793 §6) is unnecessary.
+
+        if (offset != attr.Data.Length)
+            throw new BgpParseException("Malformed AS_PATH attribute");
+
         return ases.ToArray();
     }
 
     public static PathAttribute WriteAsPath(uint[] ases, bool fourByteAsn)
     {
+        if (ases.Length > byte.MaxValue)
+            throw new ArgumentOutOfRangeException(nameof(ases), "AS_PATH segment length cannot exceed 255 ASNs.");
+
         var asSize = fourByteAsn ? 4 : 2;
         var data = new byte[2 + ases.Length * asSize];
         data[0] = BgpConstants.AsPath.AsSequence;
@@ -85,6 +94,9 @@ public static class AttributeHelper
     /// </summary>
     public static PathAttribute WriteAs4Path(uint[] ases)
     {
+        if (ases.Length > byte.MaxValue)
+            throw new ArgumentOutOfRangeException(nameof(ases), "AS4_PATH segment length cannot exceed 255 ASNs.");
+
         var data = new byte[2 + ases.Length * 4];
         data[0] = BgpConstants.AsPath.AsSequence;
         data[1] = (byte)ases.Length;
@@ -119,9 +131,13 @@ public static class AttributeHelper
             var segmentType = attr.Data[offset++];
             var segmentLength = attr.Data[offset++];
 
+            if (segmentType != BgpConstants.AsPath.AsSequence &&
+                segmentType != BgpConstants.AsPath.AsSet)
+                throw new BgpParseException($"Invalid AS4_PATH segment type: {segmentType}");
+
             var segBytes = segmentLength * 4;
             if (offset + segBytes > attr.Data.Length)
-                break; // truncated segment
+                throw new BgpParseException("Truncated AS4_PATH segment");
 
             for (var i = 0; i < segmentLength; i++)
             {
@@ -129,6 +145,9 @@ public static class AttributeHelper
                 offset += 4;
             }
         }
+        if (offset != attr.Data.Length)
+            throw new BgpParseException("Malformed AS4_PATH attribute");
+
         return ases.ToArray();
     }
 

--- a/BGPLite.Protocol/AttributeHelper.cs
+++ b/BGPLite.Protocol/AttributeHelper.cs
@@ -98,7 +98,7 @@ public static class AttributeHelper
 
         return new PathAttribute
         {
-            Flags = BgpConstants.Attribute.FlagTransitive,
+            Flags = BgpConstants.Attribute.FlagOptional | BgpConstants.Attribute.FlagTransitive,
             TypeCode = BgpConstants.Attribute.As4Path,
             Data = data
         };
@@ -107,6 +107,7 @@ public static class AttributeHelper
     /// <summary>
     /// Reads AS4_PATH attribute (type 17) per RFC 6793 §6.
     /// Returns the 4-byte AS sequence for reconstruction when receiving from a 2-byte-only peer.
+    /// NOTE: AS_SET segments are not preserved — returns a flat AS sequence (matching ReadAsPath).
     /// </summary>
     public static uint[] ReadAs4Path(PathAttribute attr)
     {

--- a/BGPLite.Protocol/AttributeHelper.cs
+++ b/BGPLite.Protocol/AttributeHelper.cs
@@ -21,70 +21,16 @@ public static class AttributeHelper
 
     public static uint[] ReadAsPath(PathAttribute attr, bool fourByteAsn)
     {
-        var ases = new List<uint>();
-        var offset = 0;
-        var asSize = fourByteAsn ? 4 : 2;
-
-        while (offset + 2 <= attr.Data.Length)
-        {
-            // segment header: [type][length]
-            var segmentType = attr.Data[offset++];
-            var segmentLength = attr.Data[offset++];
-
-            if (segmentType != BgpConstants.AsPath.AsSequence &&
-                segmentType != BgpConstants.AsPath.AsSet)
-                throw new BgpParseException($"Invalid AS_PATH segment type: {segmentType}");
-
-            var segBytes = segmentLength * asSize;
-            if (offset + segBytes > attr.Data.Length)
-                throw new BgpParseException("Truncated AS_PATH segment");
-
-            for (var i = 0; i < segmentLength; i++)
-            {
-                if (fourByteAsn)
-                    ases.Add(BinaryPrimitives.ReadUInt32BigEndian(attr.Data.AsSpan(offset)));
-                else
-                    ases.Add(BinaryPrimitives.ReadUInt16BigEndian(attr.Data.AsSpan(offset)));
-                offset += asSize;
-            }
-        }
-
-        if (offset != attr.Data.Length)
-            throw new BgpParseException("Malformed AS_PATH attribute");
-
-        return ases.ToArray();
+        return ReadPathData(attr.Data, fourByteAsn ? 4 : 2, "AS_PATH");
     }
 
     public static PathAttribute WriteAsPath(uint[] ases, bool fourByteAsn)
     {
-        if (ases.Length > byte.MaxValue)
-            throw new ArgumentOutOfRangeException(nameof(ases), "AS_PATH segment length cannot exceed 255 ASNs.");
-
-        var asSize = fourByteAsn ? 4 : 2;
-        var data = new byte[2 + ases.Length * asSize];
-        data[0] = BgpConstants.AsPath.AsSequence;
-        data[1] = (byte)ases.Length;
-
-        var offset = 2;
-        foreach (var asn in ases)
-        {
-            if (fourByteAsn)
-            {
-                BinaryPrimitives.WriteUInt32BigEndian(data.AsSpan(offset), asn);
-                offset += 4;
-            }
-            else
-            {
-                BinaryPrimitives.WriteUInt16BigEndian(data.AsSpan(offset), (ushort)asn);
-                offset += 2;
-            }
-        }
-
         return new PathAttribute
         {
             Flags = BgpConstants.Attribute.FlagTransitive,
             TypeCode = BgpConstants.Attribute.AsPath,
-            Data = data
+            Data = WritePathData(ases, fourByteAsn ? 4 : 2)
         };
     }
 
@@ -94,25 +40,11 @@ public static class AttributeHelper
     /// </summary>
     public static PathAttribute WriteAs4Path(uint[] ases)
     {
-        if (ases.Length > byte.MaxValue)
-            throw new ArgumentOutOfRangeException(nameof(ases), "AS4_PATH segment length cannot exceed 255 ASNs.");
-
-        var data = new byte[2 + ases.Length * 4];
-        data[0] = BgpConstants.AsPath.AsSequence;
-        data[1] = (byte)ases.Length;
-
-        var offset = 2;
-        foreach (var asn in ases)
-        {
-            BinaryPrimitives.WriteUInt32BigEndian(data.AsSpan(offset), asn);
-            offset += 4;
-        }
-
         return new PathAttribute
         {
             Flags = BgpConstants.Attribute.FlagOptional | BgpConstants.Attribute.FlagTransitive,
             TypeCode = BgpConstants.Attribute.As4Path,
-            Data = data
+            Data = WritePathData(ases, 4)
         };
     }
 
@@ -123,32 +55,80 @@ public static class AttributeHelper
     /// </summary>
     public static uint[] ReadAs4Path(PathAttribute attr)
     {
+        return ReadPathData(attr.Data, 4, "AS4_PATH");
+    }
+
+    private static uint[] ReadPathData(ReadOnlySpan<byte> data, int asSize, string attributeName)
+    {
         var ases = new List<uint>();
         var offset = 0;
 
-        while (offset + 2 <= attr.Data.Length)
+        while (offset + 2 <= data.Length)
         {
-            var segmentType = attr.Data[offset++];
-            var segmentLength = attr.Data[offset++];
+            // segment header: [type][length]
+            var segmentType = data[offset++];
+            var segmentLength = data[offset++];
 
             if (segmentType != BgpConstants.AsPath.AsSequence &&
                 segmentType != BgpConstants.AsPath.AsSet)
-                throw new BgpParseException($"Invalid AS4_PATH segment type: {segmentType}");
+                throw new BgpParseException($"Invalid {attributeName} segment type: {segmentType}");
 
-            var segBytes = segmentLength * 4;
-            if (offset + segBytes > attr.Data.Length)
-                throw new BgpParseException("Truncated AS4_PATH segment");
+            var segBytes = segmentLength * asSize;
+            if (offset + segBytes > data.Length)
+                throw new BgpParseException($"Truncated {attributeName} segment");
 
             for (var i = 0; i < segmentLength; i++)
             {
-                ases.Add(BinaryPrimitives.ReadUInt32BigEndian(attr.Data.AsSpan(offset)));
-                offset += 4;
+                ases.Add(ReadAsn(data.Slice(offset, asSize), asSize));
+                offset += asSize;
             }
         }
-        if (offset != attr.Data.Length)
-            throw new BgpParseException("Malformed AS4_PATH attribute");
+
+        if (offset != data.Length)
+            throw new BgpParseException($"Malformed {attributeName} attribute");
 
         return ases.ToArray();
+    }
+
+    private static byte[] WritePathData(uint[] ases, int asSize)
+    {
+        if (ases.Length > byte.MaxValue)
+            throw new ArgumentOutOfRangeException(nameof(ases), "AS path segment length cannot exceed 255 ASNs.");
+
+        var data = new byte[2 + ases.Length * asSize];
+        data[0] = BgpConstants.AsPath.AsSequence;
+        data[1] = (byte)ases.Length;
+
+        var offset = 2;
+        foreach (var asn in ases)
+        {
+            WriteAsn(data.AsSpan(offset, asSize), asn, asSize);
+            offset += asSize;
+        }
+
+        return data;
+    }
+
+    private static uint ReadAsn(ReadOnlySpan<byte> data, int asSize) => asSize switch
+    {
+        2 => BinaryPrimitives.ReadUInt16BigEndian(data),
+        4 => BinaryPrimitives.ReadUInt32BigEndian(data),
+        _ => throw new ArgumentOutOfRangeException(nameof(asSize))
+    };
+
+    private static void WriteAsn(Span<byte> data, uint asn, int asSize)
+    {
+        switch (asSize)
+        {
+            case 2:
+                BinaryPrimitives.WriteUInt16BigEndian(data, (ushort)asn);
+                break;
+            case 4:
+                BinaryPrimitives.WriteUInt32BigEndian(data, asn);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(asSize));
+        }
     }
 
     public static uint ReadNextHop(PathAttribute attr)

--- a/BGPLite.Protocol/BgpConstants.cs
+++ b/BGPLite.Protocol/BgpConstants.cs
@@ -51,6 +51,8 @@ public static class BgpConstants
         public const byte Community = 8;
         public const byte OriginatorId = 9;
         public const byte ClusterList = 10;
+        public const byte As4Path = 17;       // RFC 6793 §6 — 4-byte AS path for 2-byte peers
+        public const byte As4PathAggregator = 18; // RFC 6793 — 4-byte aggregator
         public const byte ExtendedCommunity = 16;
         public const byte LargeCommunity = 32;
 
@@ -65,6 +67,9 @@ public static class BgpConstants
         public const byte AsSet = 1;
         public const byte AsSequence = 2;
     }
+
+    /// <summary>AS_TRANS (RFC 6793) — placeholder for 2-byte-only peers when local ASN > 65535.</summary>
+    public const uint AsPathAsTrans = 23456;
 
     public static class Capability
     {

--- a/BGPLite.Protocol/BgpConstants.cs
+++ b/BGPLite.Protocol/BgpConstants.cs
@@ -66,10 +66,10 @@ public static class BgpConstants
     {
         public const byte AsSet = 1;
         public const byte AsSequence = 2;
-    }
 
-    /// <summary>AS_TRANS (RFC 6793) — placeholder for 2-byte-only peers when local ASN > 65535.</summary>
-    public const uint AsPathAsTrans = 23456;
+        /// <summary>AS_TRANS (RFC 6793) — placeholder for 2-byte-only peers when local ASN > 65535.</summary>
+        public const uint AsTrans = 23456;
+    }
 
     public static class Capability
     {

--- a/BGPLite.Protocol/BgpConstants.cs
+++ b/BGPLite.Protocol/BgpConstants.cs
@@ -51,9 +51,9 @@ public static class BgpConstants
         public const byte Community = 8;
         public const byte OriginatorId = 9;
         public const byte ClusterList = 10;
+        public const byte ExtendedCommunity = 16;
         public const byte As4Path = 17;       // RFC 6793 §6 — 4-byte AS path for 2-byte peers
         public const byte As4PathAggregator = 18; // RFC 6793 — 4-byte aggregator
-        public const byte ExtendedCommunity = 16;
         public const byte LargeCommunity = 32;
 
         public const byte FlagOptional = 0x80;

--- a/BGPLite.Protocol/BgpConstants.cs
+++ b/BGPLite.Protocol/BgpConstants.cs
@@ -35,6 +35,7 @@ public static class BgpConstants
         public const byte Unspecific = 0;
         public const byte UnsupportedVersion = 1;
         public const byte BadPeerAs = 2;
+        public const byte MissingWellKnownAttribute = 3;
         public const byte BadBgpIdentifier = 3;
         public const byte UnacceptableHoldTime = 6;
     }

--- a/BGPLite.Protocol/BgpMessageWriter.cs
+++ b/BGPLite.Protocol/BgpMessageWriter.cs
@@ -70,7 +70,16 @@ public static class BgpMessageWriter
 
         var capDataLen = 0;
         foreach (var cap in capabilities)
-            capDataLen += 2 + cap.Data.Length;
+        {
+            var capLen = 2 + cap.Data.Length;
+            if (capLen > byte.MaxValue)
+                throw new ArgumentOutOfRangeException(nameof(capabilities), "Capability data length must fit in one byte.");
+
+            if (capDataLen > byte.MaxValue - 2 - capLen)
+                throw new ArgumentOutOfRangeException(nameof(capabilities), "OPEN optional parameters length must fit in one byte.");
+
+            capDataLen += capLen;
+        }
 
         return 2 + capDataLen;
     }

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -817,11 +817,11 @@ public sealed class BgpSession : IDisposable
     internal static void ValidateMandatoryAttributes(bool originSeen, bool asPathSeen, bool nextHopSeen)
     {
         if (!originSeen)
-            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, "Missing mandatory ORIGIN attribute");
+            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MissingWellKnownAttribute, "Missing mandatory ORIGIN attribute");
         if (!asPathSeen)
-            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, "Missing mandatory AS_PATH attribute");
+            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MissingWellKnownAttribute, "Missing mandatory AS_PATH attribute");
         if (!nextHopSeen)
-            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, "Missing mandatory NEXT_HOP attribute");
+            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MissingWellKnownAttribute, "Missing mandatory NEXT_HOP attribute");
     }
 
     /// <summary>

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -47,7 +47,7 @@ public sealed class BgpSession : IDisposable
     private int _disposed;
     private uint _remoteAsn;
     private bool _remoteFourByteAsn;
-    private bool _localFourByteAsn = true;
+    private bool _localFourByteAsn; // определяется из согласованного OPEN (RFC 6793)
     private ushort _negotiatedHoldTime;
     private List<IpPrefix> _advertisedPrefixes = [];
     private TimeSpan _keepAliveInterval;
@@ -738,9 +738,27 @@ public sealed class BgpSession : IDisposable
             var attrs = new List<PathAttribute>
             {
                 AttributeHelper.WriteOrigin(BgpOrigin.Igp),
-                AttributeHelper.WriteAsPath([_bgpConfig.Asn], _localFourByteAsn),
                 AttributeHelper.WriteNextHop(nextHop)
             };
+
+            // RFC 6793 §6: AS_PATH encoding depends on peer capability
+            if (_localFourByteAsn)
+            {
+                // 4-byte peer: send AS_PATH in 4-byte form
+                attrs.Insert(1, AttributeHelper.WriteAsPath([_bgpConfig.Asn], fourByteAsn: true));
+            }
+            else
+            {
+                // 2-byte-only peer: send AS_PATH in 2-byte form with AS_TRANS if needed
+                var asPathAsn = _bgpConfig.Asn > ushort.MaxValue
+                    ? BgpConstants.AsPathAsTrans // 23456
+                    : _bgpConfig.Asn;
+                attrs.Insert(1, AttributeHelper.WriteAsPath([asPathAsn], fourByteAsn: false));
+
+                // If local ASN > 65535, append AS4_PATH (type 17) with true 4-byte ASN
+                if (_bgpConfig.Asn > ushort.MaxValue)
+                    attrs.Add(AttributeHelper.WriteAs4Path([_bgpConfig.Asn]));
+            }
 
             var communities = groupRoutes[0].Communities;
             if (communities.Length > 0)
@@ -1027,6 +1045,8 @@ public sealed class BgpSession : IDisposable
 
         _remoteFourByteAsn = CapabilityHelper.GetRemoteAsn(open).HasValue;
         _remoteAsn = CapabilityHelper.GetEffectiveAsn(open);
+        // RFC 6793 §6: определяем формат AS_PATH из согласованной capability
+        _localFourByteAsn = _remoteFourByteAsn;
 
         _onPeerIdentified?.Invoke(_peerConfig.Address, _remoteAsn);
 

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -391,50 +391,63 @@ public sealed class BgpSession : IDisposable
         // Process announcements
         if (update.Nlri.Count > 0)
         {
-            var origin = BgpOrigin.Incomplete;
-            uint nextHop = 0;
-            uint[] asPath = [];
-            uint[] communities = [];
-
-            foreach (var attr in update.PathAttributes)
+            try
             {
-                switch (attr.TypeCode)
+                var origin = BgpOrigin.Incomplete;
+                uint nextHop = 0;
+                uint[] asPath = [];
+                uint[] communities = [];
+                uint[] as4Path = [];
+
+                foreach (var attr in update.PathAttributes)
                 {
-                    case BgpConstants.Attribute.Origin:
-                        if (attr.Data.Length < 1)
-                            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, "Malformed ORIGIN attribute");
-                        origin = AttributeHelper.ReadOrigin(attr);
-                        break;
-                    case BgpConstants.Attribute.AsPath:
-                        asPath = AttributeHelper.ReadAsPath(attr, _remoteFourByteAsn);
-                        break;
-                    case BgpConstants.Attribute.NextHop:
-                        if (attr.Data.Length < 4)
-                            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, "Malformed NEXT_HOP attribute");
-                        nextHop = AttributeHelper.ReadNextHop(attr);
-                        break;
-                    case BgpConstants.Attribute.Community:
-                        communities = AttributeHelper.ReadCommunities(attr);
-                        break;
+                    switch (attr.TypeCode)
+                    {
+                        case BgpConstants.Attribute.Origin:
+                            if (attr.Data.Length < 1)
+                                throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, "Malformed ORIGIN attribute");
+                            origin = AttributeHelper.ReadOrigin(attr);
+                            break;
+                        case BgpConstants.Attribute.AsPath:
+                            asPath = AttributeHelper.ReadAsPath(attr, _remoteFourByteAsn);
+                            break;
+                        case BgpConstants.Attribute.As4Path when !_remoteFourByteAsn:
+                            as4Path = AttributeHelper.ReadAs4Path(attr);
+                            break;
+                        case BgpConstants.Attribute.NextHop:
+                            if (attr.Data.Length < 4)
+                                throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, "Malformed NEXT_HOP attribute");
+                            nextHop = AttributeHelper.ReadNextHop(attr);
+                            break;
+                        case BgpConstants.Attribute.Community:
+                            communities = AttributeHelper.ReadCommunities(attr);
+                            break;
+                    }
+                }
+
+                asPath = MergeAsPathWithAs4Path(asPath, as4Path);
+
+                foreach (var nlri in update.Nlri)
+                {
+                    var route = new Route
+                    {
+                        Prefix = nlri.Address,
+                        PrefixLength = nlri.Length,
+                        NextHop = nextHop,
+                        AsPath = asPath,
+                        Communities = communities
+                    };
+
+                    if (_routeFilter.AcceptIncoming(route, _peerConfig))
+                    {
+                        _routeTable.AddOrUpdate(route);
+                        _logger.LogDebug("Route added: {Prefix} via {NextHop}", nlri, BgpConstants.UintToIPAddress(nextHop));
+                    }
                 }
             }
-
-            foreach (var nlri in update.Nlri)
+            catch (BgpParseException ex)
             {
-                var route = new Route
-                {
-                    Prefix = nlri.Address,
-                    PrefixLength = nlri.Length,
-                    NextHop = nextHop,
-                    AsPath = asPath,
-                    Communities = communities
-                };
-
-                if (_routeFilter.AcceptIncoming(route, _peerConfig))
-                {
-                    _routeTable.AddOrUpdate(route);
-                    _logger.LogDebug("Route added: {Prefix} via {NextHop}", nlri, BgpConstants.UintToIPAddress(nextHop));
-                }
+                throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, ex.Message);
             }
         }
 
@@ -735,16 +748,7 @@ public sealed class BgpSession : IDisposable
         // one group would be tagged with another group's communities on the wire.
         foreach (var groupRoutes in GroupByCommunitySet(routes))
         {
-            var attrs = new List<PathAttribute>
-            {
-                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
-            };
-            attrs.AddRange(BuildAsPathAttributes(_bgpConfig.Asn, _localFourByteAsn));
-            attrs.Add(AttributeHelper.WriteNextHop(nextHop));
-
-            var communities = groupRoutes[0].Communities;
-            if (communities.Length > 0)
-                attrs.Add(AttributeHelper.WriteCommunities(communities));
+            var attrs = BuildUpdateAttributes(_bgpConfig.Asn, _localFourByteAsn, nextHop, groupRoutes[0].Communities);
 
             var nlri = groupRoutes.Select(r => new IpPrefix(r.Prefix, r.PrefixLength)).ToList();
             await SendUpdateBatchAsync(attrs, nlri);
@@ -774,6 +778,64 @@ public sealed class BgpSession : IDisposable
                 attrs.Add(AttributeHelper.WriteAs4Path([localAsn]));
         }
         return attrs;
+    }
+
+    /// <summary>
+    /// Builds outbound UPDATE path attributes in RFC order: ORIGIN, AS_PATH, NEXT_HOP,
+    /// COMMUNITY, AS4_PATH. Internal for test coverage.
+    /// </summary>
+    internal static List<PathAttribute> BuildUpdateAttributes(uint localAsn, bool localFourByteAsn, uint nextHop, uint[] communities)
+    {
+        var attrs = new List<PathAttribute>(5)
+        {
+            AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+        };
+
+        var asPathAttrs = BuildAsPathAttributes(localAsn, localFourByteAsn);
+        attrs.Add(asPathAttrs[0]);
+        attrs.Add(AttributeHelper.WriteNextHop(nextHop));
+
+        if (communities.Length > 0)
+            attrs.Add(AttributeHelper.WriteCommunities(communities));
+
+        if (asPathAttrs.Count > 1)
+            attrs.Add(asPathAttrs[1]);
+
+        return attrs;
+    }
+
+    /// <summary>
+    /// Reconstructs the true AS path for a 2-byte peer by replacing AS_TRANS placeholders
+    /// with the corresponding AS4_PATH values. Internal for test coverage.
+    /// </summary>
+    internal static uint[] MergeAsPathWithAs4Path(uint[] asPath, uint[] as4Path)
+    {
+        if (as4Path.Length == 0)
+            return asPath;
+
+        var merged = new uint[asPath.Length];
+        var as4Index = 0;
+
+        for (var i = 0; i < asPath.Length; i++)
+        {
+            var asn = asPath[i];
+            if (asn == BgpConstants.AsPath.AsTrans)
+            {
+                if (as4Index >= as4Path.Length)
+                    throw new BgpParseException("Malformed AS4_PATH attribute");
+
+                merged[i] = as4Path[as4Index++];
+            }
+            else
+            {
+                merged[i] = asn;
+            }
+        }
+
+        if (as4Index != as4Path.Length)
+            throw new BgpParseException("Malformed AS4_PATH attribute");
+
+        return merged;
     }
 
     /// <summary>

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -738,27 +738,9 @@ public sealed class BgpSession : IDisposable
             var attrs = new List<PathAttribute>
             {
                 AttributeHelper.WriteOrigin(BgpOrigin.Igp),
-                AttributeHelper.WriteNextHop(nextHop)
             };
-
-            // RFC 6793 §6: AS_PATH encoding depends on peer capability
-            if (_localFourByteAsn)
-            {
-                // 4-byte peer: send AS_PATH in 4-byte form
-                attrs.Insert(1, AttributeHelper.WriteAsPath([_bgpConfig.Asn], fourByteAsn: true));
-            }
-            else
-            {
-                // 2-byte-only peer: send AS_PATH in 2-byte form with AS_TRANS if needed
-                var asPathAsn = _bgpConfig.Asn > ushort.MaxValue
-                    ? BgpConstants.AsPathAsTrans // 23456
-                    : _bgpConfig.Asn;
-                attrs.Insert(1, AttributeHelper.WriteAsPath([asPathAsn], fourByteAsn: false));
-
-                // If local ASN > 65535, append AS4_PATH (type 17) with true 4-byte ASN
-                if (_bgpConfig.Asn > ushort.MaxValue)
-                    attrs.Add(AttributeHelper.WriteAs4Path([_bgpConfig.Asn]));
-            }
+            attrs.AddRange(BuildAsPathAttributes(_bgpConfig.Asn, _localFourByteAsn));
+            attrs.Add(AttributeHelper.WriteNextHop(nextHop));
 
             var communities = groupRoutes[0].Communities;
             if (communities.Length > 0)
@@ -767,6 +749,31 @@ public sealed class BgpSession : IDisposable
             var nlri = groupRoutes.Select(r => new IpPrefix(r.Prefix, r.PrefixLength)).ToList();
             await SendUpdateBatchAsync(attrs, nlri);
         }
+    }
+
+    /// <summary>
+    /// Builds AS_PATH and optionally AS4_PATH attributes per RFC 6793 §6.
+    /// - <paramref name="localFourByteAsn"/>=true: single 4-byte AS_PATH.
+    /// - <paramref name="localFourByteAsn"/>=false: 2-byte AS_PATH (AS_TRANS(23456) if
+    ///   <paramref name="localAsn"/> &gt; 65535) plus AS4_PATH carrying the true 4-byte ASN.
+    /// Internal for test coverage.
+    /// </summary>
+    internal static List<PathAttribute> BuildAsPathAttributes(uint localAsn, bool localFourByteAsn)
+    {
+        var attrs = new List<PathAttribute>(2);
+        if (localFourByteAsn)
+        {
+            attrs.Add(AttributeHelper.WriteAsPath([localAsn], fourByteAsn: true));
+        }
+        else
+        {
+            var asPathAsn = localAsn > ushort.MaxValue ? BgpConstants.AsPath.AsTrans : localAsn;
+            attrs.Add(AttributeHelper.WriteAsPath([asPathAsn], fourByteAsn: false));
+
+            if (localAsn > ushort.MaxValue)
+                attrs.Add(AttributeHelper.WriteAs4Path([localAsn]));
+        }
+        return attrs;
     }
 
     /// <summary>
@@ -944,7 +951,7 @@ public sealed class BgpSession : IDisposable
                 restartState: true, restartTime, forwardingState: _bgpConfig.GracefulRestartForwardingState));
         }
 
-        var asn16 = _bgpConfig.Asn > ushort.MaxValue ? (ushort)23456 : (ushort)_bgpConfig.Asn;
+        var asn16 = _bgpConfig.Asn > ushort.MaxValue ? (ushort)BgpConstants.AsPath.AsTrans : (ushort)_bgpConfig.Asn;
         var routerId = BgpConstants.IPAddressToUint(_bgpConfig.GetRouterIdAddress());
 
         _logger.LogInformation(

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -47,7 +47,7 @@ public sealed class BgpSession : IDisposable
     private int _disposed;
     private uint _remoteAsn;
     private bool _remoteFourByteAsn;
-    private bool _localFourByteAsn; // определяется из согласованного OPEN (RFC 6793)
+    private bool _localFourByteAsn; // derived from negotiated OPEN capability (RFC 6793)
     private ushort _negotiatedHoldTime;
     private List<IpPrefix> _advertisedPrefixes = [];
     private TimeSpan _keepAliveInterval;
@@ -1045,7 +1045,7 @@ public sealed class BgpSession : IDisposable
 
         _remoteFourByteAsn = CapabilityHelper.GetRemoteAsn(open).HasValue;
         _remoteAsn = CapabilityHelper.GetEffectiveAsn(open);
-        // RFC 6793 §6: определяем формат AS_PATH из согласованной capability
+        // RFC 6793 §6: derive AS_PATH encoding format from negotiated capability
         _localFourByteAsn = _remoteFourByteAsn;
 
         _onPeerIdentified?.Invoke(_peerConfig.Address, _remoteAsn);

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -393,7 +393,9 @@ public sealed class BgpSession : IDisposable
         {
             try
             {
-                var origin = BgpOrigin.Incomplete;
+                var originSeen = false;
+                var asPathSeen = false;
+                var nextHopSeen = false;
                 uint nextHop = 0;
                 uint[] asPath = [];
                 uint[] communities = [];
@@ -406,10 +408,12 @@ public sealed class BgpSession : IDisposable
                         case BgpConstants.Attribute.Origin:
                             if (attr.Data.Length < 1)
                                 throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, "Malformed ORIGIN attribute");
-                            origin = AttributeHelper.ReadOrigin(attr);
+                            AttributeHelper.ReadOrigin(attr);
+                            originSeen = true;
                             break;
                         case BgpConstants.Attribute.AsPath:
                             asPath = AttributeHelper.ReadAsPath(attr, _remoteFourByteAsn);
+                            asPathSeen = true;
                             break;
                         case BgpConstants.Attribute.As4Path when !_remoteFourByteAsn:
                             as4Path = AttributeHelper.ReadAs4Path(attr);
@@ -418,6 +422,7 @@ public sealed class BgpSession : IDisposable
                             if (attr.Data.Length < 4)
                                 throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, "Malformed NEXT_HOP attribute");
                             nextHop = AttributeHelper.ReadNextHop(attr);
+                            nextHopSeen = true;
                             break;
                         case BgpConstants.Attribute.Community:
                             communities = AttributeHelper.ReadCommunities(attr);
@@ -425,6 +430,7 @@ public sealed class BgpSession : IDisposable
                     }
                 }
 
+                ValidateMandatoryAttributes(originSeen, asPathSeen, nextHopSeen);
                 asPath = MergeAsPathWithAs4Path(asPath, as4Path);
 
                 foreach (var nlri in update.Nlri)
@@ -805,35 +811,41 @@ public sealed class BgpSession : IDisposable
     }
 
     /// <summary>
-    /// Reconstructs the true AS path for a 2-byte peer by replacing AS_TRANS placeholders
-    /// with the corresponding AS4_PATH values. Internal for test coverage.
+    /// Validates that a route announcement carried the mandatory well-known attributes.
+    /// Internal for test coverage.
+    /// </summary>
+    internal static void ValidateMandatoryAttributes(bool originSeen, bool asPathSeen, bool nextHopSeen)
+    {
+        if (!originSeen)
+            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, "Missing mandatory ORIGIN attribute");
+        if (!asPathSeen)
+            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, "Missing mandatory AS_PATH attribute");
+        if (!nextHopSeen)
+            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, "Missing mandatory NEXT_HOP attribute");
+    }
+
+    /// <summary>
+    /// Reconstructs the true AS path for a 2-byte peer using RFC 6793 trailing-sequence
+    /// reconstruction. The last N ASNs in AS_PATH are replaced with the AS4_PATH values,
+    /// where N = min(AS_PATH length, AS4_PATH length). Internal for test coverage.
     /// </summary>
     internal static uint[] MergeAsPathWithAs4Path(uint[] asPath, uint[] as4Path)
     {
         if (as4Path.Length == 0)
             return asPath;
 
-        var merged = new uint[asPath.Length];
-        var as4Index = 0;
-
-        for (var i = 0; i < asPath.Length; i++)
+        if (as4Path.Length >= asPath.Length)
         {
-            var asn = asPath[i];
-            if (asn == BgpConstants.AsPath.AsTrans)
-            {
-                if (as4Index >= as4Path.Length)
-                    throw new BgpParseException("Malformed AS4_PATH attribute");
+            if (as4Path.Length > asPath.Length)
+                return asPath;
 
-                merged[i] = as4Path[as4Index++];
-            }
-            else
-            {
-                merged[i] = asn;
-            }
+            return as4Path;
         }
 
-        if (as4Index != as4Path.Length)
-            throw new BgpParseException("Malformed AS4_PATH attribute");
+        var merged = new uint[asPath.Length];
+        var leadingCount = asPath.Length - as4Path.Length;
+        Array.Copy(asPath, 0, merged, 0, leadingCount);
+        Array.Copy(as4Path, 0, merged, leadingCount, as4Path.Length);
 
         return merged;
     }

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -222,4 +222,187 @@ public class BgpMessageTests
         var buffer = new byte[10];
         Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(buffer));
     }
+    [Fact]
+    public void Open_SingleCapabilityExceedingByte_Throws()
+    {
+        // Regression: a capability whose data length > 255 also makes the total
+        // optional-params exceed 255, so the optParams-length guard in WriteOpen
+        // fires first. Writer must fail loud instead of silently truncating.
+        var bigData = new byte[300];
+        var open = new BgpOpenMessage
+        {
+            Version = 4,
+            Asn = 65000,
+            HoldTime = 90,
+            RouterId = 0x01020304,
+            Capabilities = [new BgpCapabilityInfo { Code = 0xFF, Data = bigData }]
+        };
+        var buffer = new byte[1024];
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => BgpMessageWriter.WriteMessage(open, buffer));
+    }
+
+    [Fact]
+    public void Open_TotalCapabilityDataExceedingByte_Throws()
+    {
+        // Regression: total optional-params (capabilities block) must fit in a single
+        // byte per RFC 4271 §4.2. 40 capabilities × (2-byte header + 5-byte data) = 280
+        // bytes of capability TLVs + 2-byte optional-params type/length = 282 total,
+        // exceeding 255; writer must fail loud instead of silently truncating.
+        var caps = new List<BgpCapabilityInfo>();
+        // 40 capabilities * (2 header + 5 data) = 280 bytes of capability TLVs.
+        for (var i = 0; i < 40; i++)
+            caps.Add(new BgpCapabilityInfo { Code = (byte)(0x10 + i), Data = new byte[5] });
+
+        var open = new BgpOpenMessage
+        {
+            Version = 4,
+            Asn = 65000,
+            HoldTime = 90,
+            RouterId = 0x01020304,
+            Capabilities = caps
+        };
+        var buffer = new byte[1024];
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => BgpMessageWriter.WriteMessage(open, buffer));
+    }
+
+    [Fact]
+    public void Open_AtByteBoundary_Succeeds()
+    {
+        // Sanity: exactly 255 bytes of optional-params must encode without throwing.
+        // optParamsLen = 2 (type+length) + Σ(2 + cap.Data.Length).
+        // 27 caps of 7 bytes data each -> 27 * 9 = 243.
+        // Last cap of 8 bytes data -> 2 + 8 = 10. Total = 2 + 243 + 10 = 255.
+        var caps = new List<BgpCapabilityInfo>();
+        for (var i = 0; i < 27; i++)
+            caps.Add(new BgpCapabilityInfo { Code = (byte)(0x20 + i), Data = new byte[7] });
+        caps.Add(new BgpCapabilityInfo { Code = 0x3F, Data = new byte[8] });
+
+        var open = new BgpOpenMessage
+        {
+            Version = 4,
+            Asn = 65000,
+            HoldTime = 90,
+            RouterId = 0x01020304,
+            Capabilities = caps
+        };
+        var size = BgpMessageWriter.GetBufferSize(open);
+        var buffer = new byte[size];
+        var written = BgpMessageWriter.WriteMessage(open, buffer);
+
+        Assert.Equal(size, written);
+        // Optional-params length field sits at offset 19 (header) + 9 (fixed open payload).
+        Assert.Equal(255, buffer[28]);
+    }
+
+    #region RFC 6793 — AS4_PATH tests
+
+    [Fact]
+    public void As4Path_WriteThenRead_Roundtrip()
+    {
+        // RFC 6793 §6: AS4_PATH (type 17) carries 4-byte ASN sequence for 2-byte-only peers
+        var as4Path = AttributeHelper.WriteAs4Path([200000u, 300000u]);
+
+        Assert.Equal(BgpConstants.Attribute.As4Path, as4Path.TypeCode);
+        Assert.Equal(BgpConstants.Attribute.FlagTransitive, as4Path.Flags);
+        // 2 (segment header) + 2 * 4 (two 4-byte ASNs) = 10 bytes
+        Assert.Equal(10, as4Path.Data.Length);
+
+        var readAses = AttributeHelper.ReadAs4Path(as4Path);
+        Assert.Equal([200000u, 300000u], readAses);
+    }
+
+    [Fact]
+    public void AsPath_2Byte_WithAsTrans_Roundtrip()
+    {
+        // 2-byte-only peer: AS_PATH with AS_TRANS (23456) for ASN > 65535
+        var asPath = AttributeHelper.WriteAsPath([23456u], fourByteAsn: false);
+
+        Assert.Equal(BgpConstants.Attribute.AsPath, asPath.TypeCode);
+        // 2 (segment header) + 2 (one 2-byte ASN) = 4 bytes
+        Assert.Equal(4, asPath.Data.Length);
+
+        var readAses = AttributeHelper.ReadAsPath(asPath, fourByteAsn: false);
+        Assert.Equal([23456u], readAses);
+    }
+
+    [Fact]
+    public void AsPath_2Byte_RegularAsn_Roundtrip()
+    {
+        // 2-byte-only peer with regular 2-byte ASN
+        var asPath = AttributeHelper.WriteAsPath([65001u], fourByteAsn: false);
+
+        var readAses = AttributeHelper.ReadAsPath(asPath, fourByteAsn: false);
+        Assert.Equal([65001u], readAses);
+    }
+
+    [Fact]
+    public void Update_2BytePeer_WithAs4Path_Roundtrip()
+    {
+        // RFC 6793 §6: 2-byte-only peer receives 2-byte AS_PATH + AS4_PATH
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+                AttributeHelper.WriteAsPath([23456u], fourByteAsn: false), // AS_TRANS
+                AttributeHelper.WriteNextHop(0xC0A80101),
+                AttributeHelper.WriteAs4Path([200000u]) // true 4-byte ASN
+            ],
+            Nlri = [new IpPrefix(0xC0A80000, 24)]
+        };
+
+        var buffer = new byte[512];
+        var written = BgpMessageWriter.WriteMessage(update, buffer);
+        var readUpdate = Assert.IsType<BgpUpdateMessage>(BgpMessageReader.ReadMessage(buffer.AsSpan(0, written)));
+
+        // Verify AS_PATH contains AS_TRANS
+        var asPathAttr = readUpdate.PathAttributes.First(a => a.TypeCode == BgpConstants.Attribute.AsPath);
+        var asPathAses = AttributeHelper.ReadAsPath(asPathAttr, fourByteAsn: false);
+        Assert.Equal([23456u], asPathAses);
+
+        // Verify AS4_PATH contains true 4-byte ASN
+        var as4PathAttr = readUpdate.PathAttributes.First(a => a.TypeCode == BgpConstants.Attribute.As4Path);
+        var as4PathAses = AttributeHelper.ReadAs4Path(as4PathAttr);
+        Assert.Single(as4PathAses);
+        Assert.Equal(200000u, as4PathAses[0]);
+    }
+
+    [Fact]
+    public void Update_4BytePeer_NoAs4Path()
+    {
+        // 4-byte peer: only AS_PATH in 4-byte form, no AS4_PATH
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+                AttributeHelper.WriteAsPath([200000u], fourByteAsn: true),
+                AttributeHelper.WriteNextHop(0xC0A80101)
+            ],
+            Nlri = [new IpPrefix(0xC0A80000, 24)]
+        };
+
+        var buffer = new byte[512];
+        var written = BgpMessageWriter.WriteMessage(update, buffer);
+        var readUpdate = Assert.IsType<BgpUpdateMessage>(BgpMessageReader.ReadMessage(buffer.AsSpan(0, written)));
+
+        var asPathAttr = readUpdate.PathAttributes.First(a => a.TypeCode == BgpConstants.Attribute.AsPath);
+        var asPathAses = AttributeHelper.ReadAsPath(asPathAttr, fourByteAsn: true);
+        Assert.Equal([200000u], asPathAses);
+
+        // AS4_PATH should not be present
+        var as4PathAttr = readUpdate.PathAttributes.FirstOrDefault(a => a.TypeCode == BgpConstants.Attribute.As4Path);
+        Assert.Null(as4PathAttr);
+    }
+
+    [Fact]
+    public void AsPathAsTrans_Constant_Is23456()
+    {
+        // RFC 6793: AS_TRANS = 23456
+        Assert.Equal(23456u, BgpConstants.AsPathAsTrans);
+    }
+
+    #endregion
 }

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -305,7 +305,8 @@ public class BgpMessageTests
         var as4Path = AttributeHelper.WriteAs4Path([200000u, 300000u]);
 
         Assert.Equal(BgpConstants.Attribute.As4Path, as4Path.TypeCode);
-        Assert.Equal(BgpConstants.Attribute.FlagTransitive, as4Path.Flags);
+        // RFC 6793: AS4_PATH is optional transitive (FlagOptional | FlagTransitive)
+        Assert.Equal(BgpConstants.Attribute.FlagOptional | BgpConstants.Attribute.FlagTransitive, as4Path.Flags);
         // 2 (segment header) + 2 * 4 (two 4-byte ASNs) = 10 bytes
         Assert.Equal(10, as4Path.Data.Length);
 

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -399,10 +399,10 @@ public class BgpMessageTests
     }
 
     [Fact]
-    public void AsPathAsTrans_Constant_Is23456()
+    public void AsPath_AsTrans_Constant_Is23456()
     {
         // RFC 6793: AS_TRANS = 23456
-        Assert.Equal(23456u, BgpConstants.AsPathAsTrans);
+        Assert.Equal(23456u, BgpConstants.AsPath.AsTrans);
     }
 
     #endregion

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -315,6 +315,61 @@ public class BgpMessageTests
     }
 
     [Fact]
+    public void As4Path_OverlongSegment_Throws()
+    {
+        var asns = Enumerable.Range(0, 256).Select(i => (uint)i).ToArray();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => AttributeHelper.WriteAs4Path(asns));
+    }
+
+    [Fact]
+    public void AsPath_OverlongSegment_Throws()
+    {
+        var asns = Enumerable.Range(0, 256).Select(i => (uint)i).ToArray();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => AttributeHelper.WriteAsPath(asns, fourByteAsn: false));
+    }
+
+    [Fact]
+    public void AsPath_TruncatedSegment_Throws()
+    {
+        var attr = new PathAttribute
+        {
+            Flags = BgpConstants.Attribute.FlagTransitive,
+            TypeCode = BgpConstants.Attribute.AsPath,
+            Data = new byte[] { BgpConstants.AsPath.AsSequence, 2, 0x00, 0x01 }
+        };
+
+        Assert.Throws<BgpParseException>(() => AttributeHelper.ReadAsPath(attr, fourByteAsn: false));
+    }
+
+    [Fact]
+    public void AsPath_InvalidSegmentType_Throws()
+    {
+        var attr = new PathAttribute
+        {
+            Flags = BgpConstants.Attribute.FlagTransitive,
+            TypeCode = BgpConstants.Attribute.AsPath,
+            Data = new byte[] { 0x7F, 1, 0x00, 0x01 }
+        };
+
+        Assert.Throws<BgpParseException>(() => AttributeHelper.ReadAsPath(attr, fourByteAsn: false));
+    }
+
+    [Fact]
+    public void As4Path_TruncatedSegment_Throws()
+    {
+        var attr = new PathAttribute
+        {
+            Flags = BgpConstants.Attribute.FlagOptional | BgpConstants.Attribute.FlagTransitive,
+            TypeCode = BgpConstants.Attribute.As4Path,
+            Data = new byte[] { BgpConstants.AsPath.AsSequence, 2, 0x00, 0x00, 0x00, 0x01 }
+        };
+
+        Assert.Throws<BgpParseException>(() => AttributeHelper.ReadAs4Path(attr));
+    }
+
+    [Fact]
     public void AsPath_2Byte_WithAsTrans_Roundtrip()
     {
         // 2-byte-only peer: AS_PATH with AS_TRANS (23456) for ASN > 65535

--- a/BGPLite.Tests/BgpSessionRfc6793Tests.cs
+++ b/BGPLite.Tests/BgpSessionRfc6793Tests.cs
@@ -95,15 +95,36 @@ public class BgpSessionRfc6793Tests
     public void MergeAsPathWithAs4Path_ReconstructsTrueSequence()
     {
         var merged = BgpSession.MergeAsPathWithAs4Path(
-            [BgpConstants.AsPath.AsTrans, 65001u],
-            [200000u]);
+            [65010u, BgpConstants.AsPath.AsTrans, 65001u],
+            [200000u, 65001u]);
 
-        Assert.Equal([200000u, 65001u], merged);
+        Assert.Equal([65010u, 200000u, 65001u], merged);
     }
 
     [Fact]
-    public void MergeAsPathWithAs4Path_MismatchedLengths_Throws()
+    public void MergeAsPathWithAs4Path_As4PathLongerThanAsPath_IgnoresAs4Path()
     {
-        Assert.Throws<BgpParseException>(() => BgpSession.MergeAsPathWithAs4Path([65001u], [200000u]));
+        var merged = BgpSession.MergeAsPathWithAs4Path([65001u], [200000u, 65002u]);
+
+        Assert.Equal([65001u], merged);
+    }
+
+    [Theory]
+    [InlineData(false, true, true)]
+    [InlineData(true, false, true)]
+    [InlineData(true, true, false)]
+    public void ValidateMandatoryAttributes_MissingRequiredAttribute_Throws(bool originSeen, bool asPathSeen, bool nextHopSeen)
+    {
+        var ex = Assert.Throws<BgpNotificationException>(() =>
+            BgpSession.ValidateMandatoryAttributes(originSeen, asPathSeen, nextHopSeen));
+
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.Unspecific, ex.SubErrorCode);
+    }
+
+    [Fact]
+    public void ValidateMandatoryAttributes_AllPresent_Succeeds()
+    {
+        BgpSession.ValidateMandatoryAttributes(true, true, true);
     }
 }

--- a/BGPLite.Tests/BgpSessionRfc6793Tests.cs
+++ b/BGPLite.Tests/BgpSessionRfc6793Tests.cs
@@ -67,4 +67,43 @@ public class BgpSessionRfc6793Tests
         var ases = AttributeHelper.ReadAsPath(asPathAttr, fourByteAsn: false);
         Assert.Equal([65001u], ases);
     }
+
+    [Fact]
+    public void BuildUpdateAttributes_2BytePeer_LargeAsn_PlacesCommunityBeforeAs4Path()
+    {
+        var attrs = BgpSession.BuildUpdateAttributes(
+            localAsn: 200000u,
+            localFourByteAsn: false,
+            nextHop: 0xC0A80101,
+            communities: [0x0000FF01]);
+
+        Assert.Equal(
+            [
+                BgpConstants.Attribute.Origin,
+                BgpConstants.Attribute.AsPath,
+                BgpConstants.Attribute.NextHop,
+                BgpConstants.Attribute.Community,
+                BgpConstants.Attribute.As4Path
+            ],
+            attrs.Select(a => a.TypeCode).ToArray());
+
+        Assert.Equal([BgpConstants.AsPath.AsTrans], AttributeHelper.ReadAsPath(attrs[1], fourByteAsn: false));
+        Assert.Equal([200000u], AttributeHelper.ReadAs4Path(attrs[4]));
+    }
+
+    [Fact]
+    public void MergeAsPathWithAs4Path_ReconstructsTrueSequence()
+    {
+        var merged = BgpSession.MergeAsPathWithAs4Path(
+            [BgpConstants.AsPath.AsTrans, 65001u],
+            [200000u]);
+
+        Assert.Equal([200000u, 65001u], merged);
+    }
+
+    [Fact]
+    public void MergeAsPathWithAs4Path_MismatchedLengths_Throws()
+    {
+        Assert.Throws<BgpParseException>(() => BgpSession.MergeAsPathWithAs4Path([65001u], [200000u]));
+    }
 }

--- a/BGPLite.Tests/BgpSessionRfc6793Tests.cs
+++ b/BGPLite.Tests/BgpSessionRfc6793Tests.cs
@@ -11,7 +11,7 @@ namespace BGPLite.Tests;
 public class BgpSessionRfc6793Tests
 {
     [Fact]
-    public void GroupByCommunitySet_With2BytePeer_UsesAsTransForAsn()
+    public void GroupByCommunitySet_GroupsRoutesWithEmptyCommunitySet()
     {
         // Verify that BgpSession.GroupByCommunitySet works correctly
         // (static method, no session state needed)
@@ -48,6 +48,8 @@ public class BgpSessionRfc6793Tests
         var as4Path = AttributeHelper.WriteAs4Path([localAsn]);
 
         Assert.Equal(BgpConstants.Attribute.As4Path, as4Path.TypeCode);
+        // RFC 6793: AS4_PATH is optional transitive (FlagOptional | FlagTransitive)
+        Assert.Equal(BgpConstants.Attribute.FlagOptional | BgpConstants.Attribute.FlagTransitive, as4Path.Flags);
         var readAses = AttributeHelper.ReadAs4Path(as4Path);
         Assert.Equal([localAsn], readAses);
     }
@@ -58,7 +60,7 @@ public class BgpSessionRfc6793Tests
         // Simulate what SendRouteBatchAsync should produce for a 2-byte-only peer
         // when local ASN > 65535
         var localAsn = 200000u;
-        var is2BytePeer = false; // _localFourByteAsn = false
+        var is2BytePeer = true; // _localFourByteAsn = false → 2-byte-only peer
 
         var attrs = new List<PathAttribute>
         {

--- a/BGPLite.Tests/BgpSessionRfc6793Tests.cs
+++ b/BGPLite.Tests/BgpSessionRfc6793Tests.cs
@@ -109,6 +109,24 @@ public class BgpSessionRfc6793Tests
         Assert.Equal([65001u], merged);
     }
 
+    [Fact]
+    public void MergeAsPathWithAs4Path_EqualLengths_ReturnsAs4Path()
+    {
+        var merged = BgpSession.MergeAsPathWithAs4Path(
+            [BgpConstants.AsPath.AsTrans, 65001u],
+            [200000u, 65001u]);
+
+        Assert.Equal([200000u, 65001u], merged);
+    }
+
+    [Fact]
+    public void MergeAsPathWithAs4Path_EmptyAs4Path_ReturnsAsPathUnchanged()
+    {
+        var merged = BgpSession.MergeAsPathWithAs4Path([65010u, 65001u], []);
+
+        Assert.Equal([65010u, 65001u], merged);
+    }
+
     [Theory]
     [InlineData(false, true, true)]
     [InlineData(true, false, true)]
@@ -119,7 +137,7 @@ public class BgpSessionRfc6793Tests
             BgpSession.ValidateMandatoryAttributes(originSeen, asPathSeen, nextHopSeen));
 
         Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
-        Assert.Equal(BgpConstants.SubError.Unspecific, ex.SubErrorCode);
+        Assert.Equal(BgpConstants.SubError.MissingWellKnownAttribute, ex.SubErrorCode);
     }
 
     [Fact]

--- a/BGPLite.Tests/BgpSessionRfc6793Tests.cs
+++ b/BGPLite.Tests/BgpSessionRfc6793Tests.cs
@@ -1,0 +1,165 @@
+using BGPLite.Protocol;
+using BGPLite.Routing;
+using BGPLite.Server;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// Tests for RFC 6793 compliance — AS4_PATH handling for 2-byte-only peers.
+/// </summary>
+public class BgpSessionRfc6793Tests
+{
+    [Fact]
+    public void GroupByCommunitySet_With2BytePeer_UsesAsTransForAsn()
+    {
+        // Verify that BgpSession.GroupByCommunitySet works correctly
+        // (static method, no session state needed)
+        var routes = new List<Route>
+        {
+            new() { Prefix = 0xC0A80000, PrefixLength = 24, Communities = [] },
+            new() { Prefix = 0x0A000000, PrefixLength = 8, Communities = [] }
+        };
+
+        var groups = BgpSession.GroupByCommunitySet(routes);
+        Assert.Single(groups); // All routes share empty community set
+        Assert.Equal(2, groups[0].Count);
+    }
+
+    [Fact]
+    public void WriteAsPath_2ByteMode_WithLargeAsn_ProducesAsTrans()
+    {
+        // When local ASN > 65535 and peer is 2-byte-only, AS_PATH should use AS_TRANS
+        var localAsn = 200000u;
+        var asPathAsn = localAsn > ushort.MaxValue ? BgpConstants.AsPathAsTrans : localAsn;
+
+        Assert.Equal(BgpConstants.AsPathAsTrans, asPathAsn);
+
+        var asPath = AttributeHelper.WriteAsPath([asPathAsn], fourByteAsn: false);
+        var readAses = AttributeHelper.ReadAsPath(asPath, fourByteAsn: false);
+        Assert.Equal([23456u], readAses);
+    }
+
+    [Fact]
+    public void WriteAs4Path_WithLargeAsn_ProducesCorrectAttribute()
+    {
+        // AS4_PATH should carry the true 4-byte ASN
+        var localAsn = 200000u;
+        var as4Path = AttributeHelper.WriteAs4Path([localAsn]);
+
+        Assert.Equal(BgpConstants.Attribute.As4Path, as4Path.TypeCode);
+        var readAses = AttributeHelper.ReadAs4Path(as4Path);
+        Assert.Equal([localAsn], readAses);
+    }
+
+    [Fact]
+    public void UpdateAttributes_2BytePeer_WithLargeLocalAsn_HasAs4Path()
+    {
+        // Simulate what SendRouteBatchAsync should produce for a 2-byte-only peer
+        // when local ASN > 65535
+        var localAsn = 200000u;
+        var is2BytePeer = false; // _localFourByteAsn = false
+
+        var attrs = new List<PathAttribute>
+        {
+            AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+            AttributeHelper.WriteNextHop(0xC0A80101)
+        };
+
+        if (is2BytePeer)
+        {
+            var asPathAsn = localAsn > ushort.MaxValue ? BgpConstants.AsPathAsTrans : localAsn;
+            attrs.Insert(1, AttributeHelper.WriteAsPath([asPathAsn], fourByteAsn: false));
+
+            if (localAsn > ushort.MaxValue)
+                attrs.Add(AttributeHelper.WriteAs4Path([localAsn]));
+        }
+        else
+        {
+            attrs.Insert(1, AttributeHelper.WriteAsPath([localAsn], fourByteAsn: true));
+        }
+
+        // Verify AS_PATH contains AS_TRANS
+        var asPathAttr = attrs.First(a => a.TypeCode == BgpConstants.Attribute.AsPath);
+        var asPathAses = AttributeHelper.ReadAsPath(asPathAttr, fourByteAsn: false);
+        Assert.Equal([23456u], asPathAses);
+
+        // Verify AS4_PATH is present with true ASN
+        var as4PathAttr = attrs.FirstOrDefault(a => a.TypeCode == BgpConstants.Attribute.As4Path);
+        Assert.NotNull(as4PathAttr);
+        var as4PathAses = AttributeHelper.ReadAs4Path(as4PathAttr!);
+        Assert.Equal([200000u], as4PathAses);
+    }
+
+    [Fact]
+    public void UpdateAttributes_4BytePeer_NoAs4Path()
+    {
+        // 4-byte peer should receive only 4-byte AS_PATH, no AS4_PATH
+        var localAsn = 200000u;
+        var is2BytePeer = false;
+
+        var attrs = new List<PathAttribute>
+        {
+            AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+            AttributeHelper.WriteNextHop(0xC0A80101)
+        };
+
+        if (is2BytePeer)
+        {
+            var asPathAsn = localAsn > ushort.MaxValue ? BgpConstants.AsPathAsTrans : localAsn;
+            attrs.Insert(1, AttributeHelper.WriteAsPath([asPathAsn], fourByteAsn: false));
+
+            if (localAsn > ushort.MaxValue)
+                attrs.Add(AttributeHelper.WriteAs4Path([localAsn]));
+        }
+        else
+        {
+            attrs.Insert(1, AttributeHelper.WriteAsPath([localAsn], fourByteAsn: true));
+        }
+
+        // Verify AS_PATH contains true 4-byte ASN
+        var asPathAttr = attrs.First(a => a.TypeCode == BgpConstants.Attribute.AsPath);
+        var asPathAses = AttributeHelper.ReadAsPath(asPathAttr, fourByteAsn: true);
+        Assert.Equal([200000u], asPathAses);
+
+        // Verify AS4_PATH is NOT present
+        var as4PathAttr = attrs.FirstOrDefault(a => a.TypeCode == BgpConstants.Attribute.As4Path);
+        Assert.Null(as4PathAttr);
+    }
+
+    [Fact]
+    public void UpdateAttributes_2BytePeer_With2ByteLocalAsn_NoAs4Path()
+    {
+        // 2-byte peer with 2-byte local ASN: no AS4_PATH needed
+        var localAsn = 65001u;
+        var is2BytePeer = true;
+
+        var attrs = new List<PathAttribute>
+        {
+            AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+            AttributeHelper.WriteNextHop(0xC0A80101)
+        };
+
+        if (is2BytePeer)
+        {
+            var asPathAsn = localAsn > ushort.MaxValue ? BgpConstants.AsPathAsTrans : localAsn;
+            attrs.Insert(1, AttributeHelper.WriteAsPath([asPathAsn], fourByteAsn: false));
+
+            if (localAsn > ushort.MaxValue)
+                attrs.Add(AttributeHelper.WriteAs4Path([localAsn]));
+        }
+        else
+        {
+            attrs.Insert(1, AttributeHelper.WriteAsPath([localAsn], fourByteAsn: true));
+        }
+
+        // Verify AS_PATH contains the 2-byte ASN
+        var asPathAttr = attrs.First(a => a.TypeCode == BgpConstants.Attribute.AsPath);
+        var asPathAses = AttributeHelper.ReadAsPath(asPathAttr, fourByteAsn: false);
+        Assert.Equal([65001u], asPathAses);
+
+        // Verify AS4_PATH is NOT present (local ASN <= 65535)
+        var as4PathAttr = attrs.FirstOrDefault(a => a.TypeCode == BgpConstants.Attribute.As4Path);
+        Assert.Null(as4PathAttr);
+    }
+}

--- a/BGPLite.Tests/BgpSessionRfc6793Tests.cs
+++ b/BGPLite.Tests/BgpSessionRfc6793Tests.cs
@@ -1,7 +1,6 @@
 using BGPLite.Protocol;
 using BGPLite.Routing;
 using BGPLite.Server;
-using Microsoft.Extensions.Logging.Abstractions;
 
 namespace BGPLite.Tests;
 
@@ -27,141 +26,45 @@ public class BgpSessionRfc6793Tests
     }
 
     [Fact]
-    public void WriteAsPath_2ByteMode_WithLargeAsn_ProducesAsTrans()
+    public void BuildAsPathAttributes_4BytePeer_ProducesOnlyAsPath()
     {
-        // When local ASN > 65535 and peer is 2-byte-only, AS_PATH should use AS_TRANS
-        var localAsn = 200000u;
-        var asPathAsn = localAsn > ushort.MaxValue ? BgpConstants.AsPathAsTrans : localAsn;
+        // 4-byte peer: only 4-byte AS_PATH, no AS4_PATH
+        var attrs = BgpSession.BuildAsPathAttributes(localAsn: 200000u, localFourByteAsn: true);
 
-        Assert.Equal(BgpConstants.AsPathAsTrans, asPathAsn);
-
-        var asPath = AttributeHelper.WriteAsPath([asPathAsn], fourByteAsn: false);
-        var readAses = AttributeHelper.ReadAsPath(asPath, fourByteAsn: false);
-        Assert.Equal([23456u], readAses);
+        var asPathAttr = Assert.Single(attrs);
+        Assert.Equal(BgpConstants.Attribute.AsPath, asPathAttr.TypeCode);
+        var ases = AttributeHelper.ReadAsPath(asPathAttr, fourByteAsn: true);
+        Assert.Equal([200000u], ases);
     }
 
     [Fact]
-    public void WriteAs4Path_WithLargeAsn_ProducesCorrectAttribute()
+    public void BuildAsPathAttributes_2BytePeer_LargeAsn_AsTransPlusAs4Path()
     {
-        // AS4_PATH should carry the true 4-byte ASN
-        var localAsn = 200000u;
-        var as4Path = AttributeHelper.WriteAs4Path([localAsn]);
+        // 2-byte-only peer + local ASN > 65535: 2-byte AS_PATH with AS_TRANS + AS4_PATH
+        var attrs = BgpSession.BuildAsPathAttributes(localAsn: 200000u, localFourByteAsn: false);
 
-        Assert.Equal(BgpConstants.Attribute.As4Path, as4Path.TypeCode);
-        // RFC 6793: AS4_PATH is optional transitive (FlagOptional | FlagTransitive)
-        Assert.Equal(BgpConstants.Attribute.FlagOptional | BgpConstants.Attribute.FlagTransitive, as4Path.Flags);
-        var readAses = AttributeHelper.ReadAs4Path(as4Path);
-        Assert.Equal([localAsn], readAses);
-    }
+        Assert.Equal(2, attrs.Count);
 
-    [Fact]
-    public void UpdateAttributes_2BytePeer_WithLargeLocalAsn_HasAs4Path()
-    {
-        // Simulate what SendRouteBatchAsync should produce for a 2-byte-only peer
-        // when local ASN > 65535
-        var localAsn = 200000u;
-        var is2BytePeer = true; // _localFourByteAsn = false → 2-byte-only peer
-
-        var attrs = new List<PathAttribute>
-        {
-            AttributeHelper.WriteOrigin(BgpOrigin.Igp),
-            AttributeHelper.WriteNextHop(0xC0A80101)
-        };
-
-        if (is2BytePeer)
-        {
-            var asPathAsn = localAsn > ushort.MaxValue ? BgpConstants.AsPathAsTrans : localAsn;
-            attrs.Insert(1, AttributeHelper.WriteAsPath([asPathAsn], fourByteAsn: false));
-
-            if (localAsn > ushort.MaxValue)
-                attrs.Add(AttributeHelper.WriteAs4Path([localAsn]));
-        }
-        else
-        {
-            attrs.Insert(1, AttributeHelper.WriteAsPath([localAsn], fourByteAsn: true));
-        }
-
-        // Verify AS_PATH contains AS_TRANS
-        var asPathAttr = attrs.First(a => a.TypeCode == BgpConstants.Attribute.AsPath);
+        var asPathAttr = attrs[0];
+        Assert.Equal(BgpConstants.Attribute.AsPath, asPathAttr.TypeCode);
         var asPathAses = AttributeHelper.ReadAsPath(asPathAttr, fourByteAsn: false);
-        Assert.Equal([23456u], asPathAses);
+        Assert.Equal([BgpConstants.AsPath.AsTrans], asPathAses);
 
-        // Verify AS4_PATH is present with true ASN
-        var as4PathAttr = attrs.FirstOrDefault(a => a.TypeCode == BgpConstants.Attribute.As4Path);
-        Assert.NotNull(as4PathAttr);
-        var as4PathAses = AttributeHelper.ReadAs4Path(as4PathAttr!);
+        var as4PathAttr = attrs[1];
+        Assert.Equal(BgpConstants.Attribute.As4Path, as4PathAttr.TypeCode);
+        var as4PathAses = AttributeHelper.ReadAs4Path(as4PathAttr);
         Assert.Equal([200000u], as4PathAses);
     }
 
     [Fact]
-    public void UpdateAttributes_4BytePeer_NoAs4Path()
+    public void BuildAsPathAttributes_2BytePeer_2ByteAsn_AsPathOnly()
     {
-        // 4-byte peer should receive only 4-byte AS_PATH, no AS4_PATH
-        var localAsn = 200000u;
-        var is2BytePeer = false;
+        // 2-byte-only peer + local ASN <= 65535: 2-byte AS_PATH only, no AS4_PATH
+        var attrs = BgpSession.BuildAsPathAttributes(localAsn: 65001u, localFourByteAsn: false);
 
-        var attrs = new List<PathAttribute>
-        {
-            AttributeHelper.WriteOrigin(BgpOrigin.Igp),
-            AttributeHelper.WriteNextHop(0xC0A80101)
-        };
-
-        if (is2BytePeer)
-        {
-            var asPathAsn = localAsn > ushort.MaxValue ? BgpConstants.AsPathAsTrans : localAsn;
-            attrs.Insert(1, AttributeHelper.WriteAsPath([asPathAsn], fourByteAsn: false));
-
-            if (localAsn > ushort.MaxValue)
-                attrs.Add(AttributeHelper.WriteAs4Path([localAsn]));
-        }
-        else
-        {
-            attrs.Insert(1, AttributeHelper.WriteAsPath([localAsn], fourByteAsn: true));
-        }
-
-        // Verify AS_PATH contains true 4-byte ASN
-        var asPathAttr = attrs.First(a => a.TypeCode == BgpConstants.Attribute.AsPath);
-        var asPathAses = AttributeHelper.ReadAsPath(asPathAttr, fourByteAsn: true);
-        Assert.Equal([200000u], asPathAses);
-
-        // Verify AS4_PATH is NOT present
-        var as4PathAttr = attrs.FirstOrDefault(a => a.TypeCode == BgpConstants.Attribute.As4Path);
-        Assert.Null(as4PathAttr);
-    }
-
-    [Fact]
-    public void UpdateAttributes_2BytePeer_With2ByteLocalAsn_NoAs4Path()
-    {
-        // 2-byte peer with 2-byte local ASN: no AS4_PATH needed
-        var localAsn = 65001u;
-        var is2BytePeer = true;
-
-        var attrs = new List<PathAttribute>
-        {
-            AttributeHelper.WriteOrigin(BgpOrigin.Igp),
-            AttributeHelper.WriteNextHop(0xC0A80101)
-        };
-
-        if (is2BytePeer)
-        {
-            var asPathAsn = localAsn > ushort.MaxValue ? BgpConstants.AsPathAsTrans : localAsn;
-            attrs.Insert(1, AttributeHelper.WriteAsPath([asPathAsn], fourByteAsn: false));
-
-            if (localAsn > ushort.MaxValue)
-                attrs.Add(AttributeHelper.WriteAs4Path([localAsn]));
-        }
-        else
-        {
-            attrs.Insert(1, AttributeHelper.WriteAsPath([localAsn], fourByteAsn: true));
-        }
-
-        // Verify AS_PATH contains the 2-byte ASN
-        var asPathAttr = attrs.First(a => a.TypeCode == BgpConstants.Attribute.AsPath);
-        var asPathAses = AttributeHelper.ReadAsPath(asPathAttr, fourByteAsn: false);
-        Assert.Equal([65001u], asPathAses);
-
-        // Verify AS4_PATH is NOT present (local ASN <= 65535)
-        var as4PathAttr = attrs.FirstOrDefault(a => a.TypeCode == BgpConstants.Attribute.As4Path);
-        Assert.Null(as4PathAttr);
+        var asPathAttr = Assert.Single(attrs);
+        Assert.Equal(BgpConstants.Attribute.AsPath, asPathAttr.TypeCode);
+        var ases = AttributeHelper.ReadAsPath(asPathAttr, fourByteAsn: false);
+        Assert.Equal([65001u], ases);
     }
 }


### PR DESCRIPTION
## Summary

Fixes upstream issue #30: BGPLite now negotiates 4-byte ASN support correctly and handles RFC 6793 path attributes for 2-byte-only peers.

## What changed

- Derives `_localFourByteAsn` from OPEN capability negotiation instead of hardcoding it.
- Emits 2-byte AS_PATH + AS4_PATH when our ASN is > 65535 and the peer is 2-byte-only.
- Validates OPEN capability and optional-parameter lengths before encoding.
- Rejects UPDATE announcements that omit mandatory ORIGIN / AS_PATH / NEXT_HOP.
- Deduplicates the shared AS_PATH/AS4_PATH codec helpers and keeps write-path errors attribute-specific.

## Related work

- Partially addresses issue #31 (inbound AS4_PATH reconstruction / codec cleanup) by merging AS_PATH + AS4_PATH on receive and consolidating the codec helpers.
- The full typed-segment / AS_SET preservation refactor still remains tracked in #31.

## Validation

- OCR review passed on the latest commits.
- `git diff --check` is clean.
- `dotnet test` could not be run in this environment (`dotnet` not installed).

## Risk

- Path reconstruction is stricter now: malformed UPDATEs are rejected instead of being silently accepted.
