### PR TITLE
protocol: implement ROUTE_REFRESH message type 5 (RFC 2918) — closes #29

### DIFF
--- a/BGPLite.Protocol/BgpMessageReader.cs
+++ b/BGPLite.Protocol/BgpMessageReader.cs
@@ -27,6 +27,7 @@ public static class BgpMessageReader
             BgpMessageType.Keepalive => BgpKeepaliveMessage.Instance,
             BgpMessageType.Update => ParseUpdate(payload),
             BgpMessageType.Notification => ParseNotification(payload),
+            BgpMessageType.RouteRefresh => ParseRouteRefresh(payload),
             _ => throw new BgpParseException($"Unknown message type: {type}")
         };
     }
@@ -219,6 +220,23 @@ public static class BgpMessageReader
             ErrorCode = errorCode,
             SubErrorCode = subErrorCode,
             Data = data
+        };
+    }
+
+    private static BgpRouteRefreshMessage ParseRouteRefresh(ReadOnlySpan<byte> payload)
+    {
+        if (payload.Length != 4)
+            throw new BgpParseException($"ROUTE_REFRESH payload must be exactly 4 bytes, got {payload.Length}");
+
+        var afi = BinaryPrimitives.ReadUInt16BigEndian(payload);
+        var reserved = payload[2];
+        var safi = payload[3];
+
+        return new BgpRouteRefreshMessage
+        {
+            Afi = afi,
+            Reserved = reserved,
+            Safi = safi
         };
     }
 

--- a/BGPLite.Protocol/BgpMessageType.cs
+++ b/BGPLite.Protocol/BgpMessageType.cs
@@ -5,5 +5,6 @@ public enum BgpMessageType : byte
     Open = 1,
     Update = 2,
     Notification = 3,
-    Keepalive = 4
+    Keepalive = 4,
+    RouteRefresh = 5
 }

--- a/BGPLite.Protocol/BgpMessageWriter.cs
+++ b/BGPLite.Protocol/BgpMessageWriter.cs
@@ -12,6 +12,7 @@ public static class BgpMessageWriter
             BgpKeepaliveMessage => WriteKeepalive(buffer),
             BgpUpdateMessage update => WriteUpdate(update, buffer),
             BgpNotificationMessage notification => WriteNotification(notification, buffer),
+            BgpRouteRefreshMessage refresh => WriteRouteRefresh(refresh, buffer),
             _ => throw new ArgumentException($"Unknown message type: {message.Type}")
         };
     }
@@ -24,6 +25,7 @@ public static class BgpMessageWriter
             BgpKeepaliveMessage => BgpConstants.MessageHeaderSize,
             BgpUpdateMessage update => BgpConstants.MessageHeaderSize + GetUpdatePayloadSize(update),
             BgpNotificationMessage n => BgpConstants.MessageHeaderSize + 2 + (n.Data?.Length ?? 0),
+            BgpRouteRefreshMessage => BgpConstants.MessageHeaderSize + 4,
             _ => throw new ArgumentException($"Unknown message type: {message.Type}")
         };
     }
@@ -205,6 +207,16 @@ public static class BgpMessageWriter
             msg.Data.AsSpan().CopyTo(buffer[p..]);
         }
 
+        return totalLength;
+    }
+
+    private static int WriteRouteRefresh(BgpRouteRefreshMessage msg, Span<byte> buffer)
+    {
+        var totalLength = BgpConstants.MessageHeaderSize + 4;
+        WriteHeader(BgpMessageType.RouteRefresh, totalLength, buffer);
+        BinaryPrimitives.WriteUInt16BigEndian(buffer[BgpConstants.MessageHeaderSize..], msg.Afi);
+        buffer[BgpConstants.MessageHeaderSize + 2] = msg.Reserved;
+        buffer[BgpConstants.MessageHeaderSize + 3] = msg.Safi;
         return totalLength;
     }
 

--- a/BGPLite.Protocol/BgpRouteRefreshMessage.cs
+++ b/BGPLite.Protocol/BgpRouteRefreshMessage.cs
@@ -1,0 +1,10 @@
+namespace BGPLite.Protocol;
+
+public sealed class BgpRouteRefreshMessage : BgpMessage
+{
+    public ushort Afi { get; init; }
+    public byte Reserved { get; init; }
+    public byte Safi { get; init; }
+
+    public override BgpMessageType Type => BgpMessageType.RouteRefresh;
+}

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -47,6 +47,7 @@ public sealed class BgpSession : IDisposable
     private int _disposed;
     private uint _remoteAsn;
     private bool _remoteFourByteAsn;
+    private bool _remoteRouteRefresh;
     private bool _localFourByteAsn = true;
     private ushort _negotiatedHoldTime;
     private List<IpPrefix> _advertisedPrefixes = [];
@@ -344,6 +345,18 @@ public sealed class BgpSession : IDisposable
                     // does not reply with a Cease.
                     Interlocked.CompareExchange(ref _teardownReason, (int)TeardownReason.RemoteNotification, (int)TeardownReason.None);
                     return;
+                case BgpRouteRefreshMessage refresh:
+                    _logger.LogInformation("RouteRefresh received from {Peer} for AFI={Afi} SAFI={Safi}", _peerConfig.Address, refresh.Afi, refresh.Safi);
+                    if (!_remoteRouteRefresh)
+                    {
+                        _logger.LogWarning("RouteRefresh received from {Peer} without negotiated capability, ignoring", _peerConfig.Address);
+                        break;
+                    }
+                    if (refresh.Afi == BgpConstants.Afi.IPv4 && refresh.Safi == BgpConstants.Safi.Unicast)
+                        await RefreshRoutesAsync();
+                    else
+                        _logger.LogDebug("RouteRefresh ignored: unsupported AFI/SAFI from {Peer}", _peerConfig.Address);
+                    break;
             }
         }
     }
@@ -1027,6 +1040,7 @@ public sealed class BgpSession : IDisposable
 
         _remoteFourByteAsn = CapabilityHelper.GetRemoteAsn(open).HasValue;
         _remoteAsn = CapabilityHelper.GetEffectiveAsn(open);
+        _remoteRouteRefresh = open.Capabilities.Any(c => c.Code == BgpConstants.Capability.RouteRefresh);
 
         _onPeerIdentified?.Invoke(_peerConfig.Address, _remoteAsn);
 

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -346,16 +346,16 @@ public sealed class BgpSession : IDisposable
                     Interlocked.CompareExchange(ref _teardownReason, (int)TeardownReason.RemoteNotification, (int)TeardownReason.None);
                     return;
                 case BgpRouteRefreshMessage refresh:
-                    _logger.LogInformation("RouteRefresh received from {Peer} for AFI={Afi} SAFI={Safi}", _peerConfig.Address, refresh.Afi, refresh.Safi);
+                    _logger.LogInformation("RouteRefresh received from {Peer} for AFI={Afi} SAFI={Safi}", _peer, refresh.Afi, refresh.Safi);
                     if (!_remoteRouteRefresh)
                     {
-                        _logger.LogWarning("RouteRefresh received from {Peer} without negotiated capability, ignoring", _peerConfig.Address);
+                        _logger.LogWarning("RouteRefresh received from {Peer} without negotiated capability, ignoring", _peer);
                         break;
                     }
                     if (refresh.Afi == BgpConstants.Afi.IPv4 && refresh.Safi == BgpConstants.Safi.Unicast)
                         await RefreshRoutesAsync();
                     else
-                        _logger.LogDebug("RouteRefresh ignored: unsupported AFI/SAFI from {Peer}", _peerConfig.Address);
+                        _logger.LogDebug("RouteRefresh ignored: unsupported AFI/SAFI from {Peer}", _peer);
                     break;
             }
         }

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -374,7 +374,7 @@ public sealed class BgpSession : IDisposable
                     if (prevTicks != 0 && new TimeSpan(nowTicks - prevTicks) < MinRouteRefreshInterval)
                     {
                         _logger.LogDebug("RouteRefresh rate-limited from {Peer} (last refresh {Ago} ago)",
-                            _peer, DateTime.UtcNow - new DateTime(prevTicks, DateTimeKind.Utc));
+                            _peer, new TimeSpan(nowTicks - prevTicks));
                         break;
                     }
                     if (Interlocked.CompareExchange(ref _lastRouteRefreshTicks, nowTicks, prevTicks) != prevTicks)

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -53,6 +53,14 @@ public sealed class BgpSession : IDisposable
     private List<IpPrefix> _advertisedPrefixes = [];
     private TimeSpan _keepAliveInterval;
     private long _lastReceivedTicks; // UTC ticks of last received message; drives the HoldTimer (Interlocked)
+    // Debounce ROUTE_REFRESH (RFC 2918): rate-limit per-session route re-announcements to avoid
+    // DoS where a peer spams type-5 and forces a full re-advertise. Initial 0 = never refreshed.
+    // Read/written via Interlocked so RefreshRoutesAsync and ReadLoopAsync can't race.
+    private long _lastRouteRefreshTicks;
+    // Minimum gap between peer-triggered route refreshes. 1s is a reasonable default:
+    // long enough to make flood-DoS impractical, short enough that a legitimate peer retry
+    // after a lost UPDATE still gets a fresh advertisement promptly.
+    private static readonly TimeSpan MinRouteRefreshInterval = TimeSpan.FromSeconds(1);
 
     public BgpFsmState State => _state;
     public PeerConfig Peer => _peerConfig;
@@ -352,10 +360,29 @@ public sealed class BgpSession : IDisposable
                         _logger.LogWarning("RouteRefresh received from {Peer} without negotiated capability, ignoring", _peer);
                         break;
                     }
-                    if (refresh.Afi == BgpConstants.Afi.IPv4 && refresh.Safi == BgpConstants.Safi.Unicast)
-                        await RefreshRoutesAsync();
-                    else
+                    if (refresh.Afi != BgpConstants.Afi.IPv4 || refresh.Safi != BgpConstants.Safi.Unicast)
+                    {
                         _logger.LogDebug("RouteRefresh ignored: unsupported AFI/SAFI from {Peer}", _peer);
+                        break;
+                    }
+                    // Debounce: ignore ROUTE_REFRESH floods. Atomic check-and-set so a burst of N
+                    // concurrent route refreshes from the peer can't all slip through and trigger
+                    // N full re-announcements. First caller wins; the rest see a non-zero
+                    // previous-timestamp and bail out cheaply with a debug log.
+                    var nowTicks = DateTime.UtcNow.Ticks;
+                    var prevTicks = Interlocked.Read(ref _lastRouteRefreshTicks);
+                    if (prevTicks != 0 && new TimeSpan(nowTicks - prevTicks) < MinRouteRefreshInterval)
+                    {
+                        _logger.LogDebug("RouteRefresh rate-limited from {Peer} (last refresh {Ago} ago)",
+                            _peer, DateTime.UtcNow - new DateTime(prevTicks, DateTimeKind.Utc));
+                        break;
+                    }
+                    if (Interlocked.CompareExchange(ref _lastRouteRefreshTicks, nowTicks, prevTicks) != prevTicks)
+                    {
+                        // Another refresh raced ahead of us; the winning call will do the work.
+                        break;
+                    }
+                    await RefreshRoutesAsync();
                     break;
             }
         }

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -222,4 +222,38 @@ public class BgpMessageTests
         var buffer = new byte[10];
         Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(buffer));
     }
+
+    [Fact]
+    public void RouteRefresh_RoundTrip()
+    {
+        var msg = new BgpRouteRefreshMessage
+        {
+            Afi = BgpConstants.Afi.IPv4,
+            Reserved = 0,
+            Safi = BgpConstants.Safi.Unicast
+        };
+
+        var buffer = new byte[64];
+        var written = BgpMessageWriter.WriteMessage(msg, buffer);
+        var read = BgpMessageReader.ReadMessage(buffer.AsSpan(0, written));
+
+        var rr = Assert.IsType<BgpRouteRefreshMessage>(read);
+        Assert.Equal(BgpConstants.Afi.IPv4, rr.Afi);
+        Assert.Equal((byte)0, rr.Reserved);
+        Assert.Equal(BgpConstants.Safi.Unicast, rr.Safi);
+    }
+
+    [Fact]
+    public void RouteRefresh_InvalidLength_Throws()
+    {
+        var buffer = new byte[64];
+        BgpConstants.Marker.CopyTo(buffer);
+        BinaryPrimitives.WriteUInt16BigEndian(buffer[16..], (ushort)(BgpConstants.MessageHeaderSize + 3));
+        buffer[18] = (byte)BgpMessageType.RouteRefresh;
+        buffer[19] = 0;
+        buffer[20] = 1;
+        buffer[21] = 1;
+
+        Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(buffer.AsSpan(0, 22)));
+    }
 }


### PR DESCRIPTION
## Summary
Implements the `ROUTE_REFRESH` message (type 5) end-to-end per RFC 2918 §3, resolving the self-inflicted session-teardown hazard where BGPLite advertised the Route Refresh capability but could not handle the message.

This is a **rebase of #40** (by @bashrusakh, contributed from a fork) onto current `main`, with the one merge conflict resolved. All credit for the implementation to @bashrusakh; I only resolved the conflict so it can merge.

## What (from #40)
- `BgpMessageType.RouteRefresh = 5`
- `BgpRouteRefreshMessage` (AFI, Reserved, SAFI)
- `BgpMessageReader.ParseRouteRefresh` (validates payload == 4 bytes) + `BgpMessageWriter.WriteRouteRefresh`
- `BgpSession.ReadLoopAsync`: capability-gated (`_remoteRouteRefresh`), IPv4/Unicast only, then `RefreshRoutesAsync()`
- **DoS debounce** (CodeRabbit Major from #40, addressed in `7d99072`): `_lastRouteRefreshTicks` + `MinRouteRefreshInterval` (1s) with `Interlocked.CompareExchange` check-and-set so a flood of ROUTE_REFRESH cannot trigger N full RIB re-announcements
- Unit tests: round-trip + invalid-length guard

## Conflict resolution
`BGPLite.Tests/BgpMessageTests.cs` conflicted with #38 (both appended tests at end of class). Resolved by keeping both test sets (RouteRefresh + OPEN/overflow). The other touched file, `BgpMessageWriter.cs`, auto-merged.

## Verification
- `dotnet build`: 0 errors (21 pre-existing warnings)
- `dotnet test`: **142 passed / 0 failed**
- RFC 2918 §2/§3 compliance verified (4-byte AFI/Reserved/SAFI body; capability-gated).

Closes #29. Supersedes #40 (fork PR that couldn't be auto-merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for BGP Route Refresh messages, including creating, sending, and reading them.
  * Sessions can now react to Route Refresh requests when the capability is negotiated, helping update routes more efficiently.

* **Bug Fixes**
  * Invalid Route Refresh message lengths are now rejected.
  * Unsupported or unexpected Route Refresh requests are safely ignored, and repeated requests are rate-limited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->