### PR TITLE
chore: ignore .handoff/ (local agent handoff notes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ logs/
 
 ## GrayMatter (local agent memory)
 .graymatter/
+
+## Claude Code local handoff notes
+.handoff/


### PR DESCRIPTION
Adds  to  so the local Claude Code handoff scratch dir isn't swept into commits (it slipped in via `git add -A` earlier this session and had to be history-rewritten out).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignore rules to exclude local handoff notes from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->