### PR TITLE
chore: add CI/CodeQL/format workflows + Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+
+# Conservative: no auto-merge (Dependabot only opens PRs); CI build+test must pass.
+# Minor + patch are grouped into one PR; major bumps open separate PRs for review
+# (xUnit 2->3 and YamlDotNet major are known-breaking — review carefully).
+# Security/vulnerability updates run independently of this config.
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      patch-and-minor:
+        update-types:
+          - "patch"
+          - "minor"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      # Restore only from public nuget.org so CI does not depend on private feeds.
+      - name: Restore
+        run: dotnet restore BGPLite.sln --source https://api.nuget.org/v3/index.json
+
+      - name: Build
+        run: dotnet build BGPLite.sln -c Release --no-restore
+
+      - name: Test
+        run: dotnet test BGPLite.Tests/BGPLite.Tests.csproj -c Release --no-build --logger "console;verbosity=normal"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '37 5 * * 2'
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: csharp
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,24 @@
+name: format
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  format-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      # Fails the check if `dotnet format` would change anything.
+      # Run `dotnet format BGPLite.sln` locally if this check fails.
+      - name: Verify formatting
+        run: dotnet format BGPLite.sln --verify-no-changes --severity warn --no-restore

--- a/BGPLite.Configuration/PrefixSourceConfig.cs
+++ b/BGPLite.Configuration/PrefixSourceConfig.cs
@@ -25,7 +25,7 @@ public sealed class PrefixSourceConfig
     /// <summary>Raw URL of a CIDR list (kind = <c>"http"</c>).</summary>
     [YamlMember(Alias = "Url")]
     public string? Url { get; init; }
-    
+
     /// <summary>AS number(s) this prefix source is valid for (kind = <c>"asn"</c>).</summary>
     [YamlMember(Alias = "Asn")]
     public uint? Asn { get; init; }

--- a/BGPLite/BGPLite.csproj
+++ b/BGPLite/BGPLite.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\appsettings.yml" Link="appsettings.yml" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\appsettings.yml" Link="appsettings.yml" CopyToOutputDirectory="PreserveNewest" Condition="Exists('..\appsettings.yml')" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
First CI for the repo (currently only CodeRabbit runs). Adds build+test, CodeQL security, dotnet-format checks, and conservative Dependabot.

## Workflows
- **ci.yml** — `dotnet build` + `dotnet test` on push/PR (.NET 10, restore from public `nuget.org` only — no dependency on private machine feeds).
- **codeql.yml** — C# security analysis (on PR + weekly).
- **format.yml** — `dotnet format --verify-no-changes` on PR.
- **dependabot.yml** — conservative: minor+patch grouped, major separate, **no auto-merge**; CI catches breaking changes; security updates run independently.

## Notes
- Private NuGet feed (`proget.radek-lab.ru`) is **not** in the repo or history — it lives in the maintainer's machine `nuget.config`. CI restores from `nuget.org` only.
- Also fixes one trailing-whitespace line in `PrefixSourceConfig.cs` so the format check is green from the start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated dependency update pull requests with weekly cadence and conservative behavior.
  * Introduced CI builds and test runs for pushes and pull requests.
  * Added CodeQL security analysis and automated dotnet formatting verification.
* **Bug Fixes**
  * Prevented content inclusion issues by only including and copying `appsettings.yml` when it exists.
* **Style**
  * Minor whitespace formatting cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->