### PR TITLE
chore: automate releases — release-please + self-contained assets

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -1,0 +1,59 @@
+name: Release Assets
+
+# When release-please publishes a Release (creates the vX.Y.Z tag), build
+# self-contained single-file binaries and attach them to that Release.
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rid: linux-x64
+            archive: tar.gz
+          - rid: linux-arm64
+            archive: tar.gz
+          - rid: win-x64
+            archive: zip
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Publish self-contained (${{ matrix.rid }})
+        run: |
+          dotnet publish BGPLite/BGPLite.csproj \
+            -c Release \
+            -r ${{ matrix.rid }} \
+            --self-contained true \
+            -p:PublishSingleFile=true \
+            -p:IncludeNativeLibrariesForSelfExtract=true \
+            -o publish/${{ matrix.rid }} \
+            --source https://api.nuget.org/v3/index.json
+
+      - name: Package (${{ matrix.rid }})
+        run: |
+          cd publish/${{ matrix.rid }}
+          if [ "${{ matrix.archive }}" = "zip" ]; then
+            zip -r ../../bgplite-${{ github.event.release.tag_name }}-${{ matrix.rid }}.zip .
+          else
+            tar -czf ../../bgplite-${{ github.event.release.tag_name }}-${{ matrix.rid }}.tar.gz .
+          fi
+
+      - name: Upload asset to Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            bgplite-${{ github.event.release.tag_name }}-${{ matrix.rid }}.${{ matrix.archive }} \
+            --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release
+
+# release-please: manages version + tag + GitHub Release from Conventional Commits.
+#   feat:     -> minor (e.g. 1.2.3 -> 1.3.0)
+#   fix:      -> patch (e.g. 1.2.3 -> 1.3.0... wait: 1.2.4)
+#   feat!/fix! or "BREAKING CHANGE:" footer -> major
+#   chore:/docs:/ci: -> no release
+# It opens a "release PR" that accumulates the changelog; merging that PR tags
+# vX.Y.Z and publishes the Release (which triggers release-assets.yml).
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          release-type: simple
+          include-v-in-tag: true


### PR DESCRIPTION
## Summary
Adds release automation on top of the CI from #47.

## Workflows
- **`release.yml`** — \`release-please\` (on push to main). Conventional Commits drive versioning: \`feat\`→minor, \`fix\`→patch, \`feat!\`/BREAKING→major; \`chore\`/\`docs\`/\`ci\`→no release. It keeps a **release PR** with the accumulating changelog; merging it creates the \`vX.Y.Z\` tag + GitHub Release.
- **`release-assets.yml`** — on \`release: published\`, builds **self-contained single-file** binaries for \`linux-x64\`, \`linux-arm64\`, \`win-x64\` (cross-publish on the ubuntu runner) and uploads \`.tar.gz\`/\`.zip\` to the Release.

## Verified locally
\`dotnet publish -r linux-x64 --self-contained -p:PublishSingleFile\` → working 77M single-file binary.

## How you release
Just keep writing conventional commits (\`feat:\`, \`fix:\`). release-please opens a release PR when there's something to release — merge it and the tag + Release + binaries are produced automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)