### PR TITLE
chore: publish Docker image to GHCR on release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+**/bin/
+**/obj/
+.git/
+.github/
+.handoff/
+tests/
+*.md
+article-*.md
+appsettings.yml
+.gitignore

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -57,3 +57,32 @@ jobs:
           gh release upload "${{ github.event.release.tag_name }}" \
             bgplite-${{ github.event.release.tag_name }}-${{ matrix.rid }}.${{ matrix.archive }} \
             --repo "$GITHUB_REPOSITORY" --clobber
+
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          # repository_owner is lowercase (ruhex); image name lowercased explicitly.
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/bgplite:latest
+            ghcr.io/${{ github.repository_owner }}/bgplite:${{ github.event.release.tag_name }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+# Example deployment for the BGPLite route-server.
+#
+# Config is NOT baked into the image — mount your real appsettings.yml from the host
+# (keeps secrets out of the image). See appsettings.Example.yml for the schema.
+#
+# BGP peers must reach the server's real TCP/179, so on Linux this uses host networking
+# (simplest for peering). If you prefer bridge networking, drop `network_mode: host`,
+# map `ports: ["179:179","5000:5000"]`, and add `cap_add: [NET_BIND_SERVICE]`
+# (port 179 < 1024) or run a reverse-proxy/port-remapper.
+services:
+  bgplite:
+    image: ghcr.io/ruhex/bgplite:latest
+    build: .
+    container_name: bgplite
+    network_mode: host
+    volumes:
+      - ./appsettings.yml:/app/appsettings.yml:ro
+      - ./data:/app/data
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
Adds Docker image publishing on top of the release flow (#48), so the route-server ships to GHCR as well as the self-contained binaries.

## Changes
- **`release-assets.yml`** — new `docker` job: on \`release: published\`, builds the **existing multi-stage Dockerfile** and pushes to GHCR as \`ghcr.io/<owner>/bgplite:latest\` + \`:<tag>\` (GHA build cache).
- **`docker-compose.yml`** — example deployment: host networking for BGP :179, \`appsettings.yml\` **mounted from host** (secrets stay out of the image), data volume.
- **`.dockerignore`** — lean build context.

The existing \`Dockerfile\` is reused unchanged. **Configs are not baked in** — answer to the earlier question: mount \`appsettings.yml\` from the host (compose does this); \`appsettings.Example.yml\` in the repo is the template.

## Verified locally
\`docker build .\` succeeds; \`appsettings.yml\` excluded from the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)