### PR TITLE
fix(deps): bump EF Core Sqlite to 10.0.9 in Tests (NU1605 with #54)

### DIFF
--- a/BGPLite.Tests/BGPLite.Tests.csproj
+++ b/BGPLite.Tests/BGPLite.Tests.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />


### PR DESCRIPTION
Fixes main's red CI after #54: Dependabot bumped EF Core Sqlite only in `BGPLite.Api`, but `BGPLite.Tests` references it directly at 9.0.0 -> NU1605 downgrade (TreatWarningsAsError) -> restore fails. Sync Tests to 10.0.9.

Verified locally: 0 errors, 166 tests pass.