### PR TITLE
docs: overhaul README (badges/TOC/RFC/Docker) + MIT LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mikhail Movchan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,52 +1,150 @@
-# BGPLite
+<p align="center">
+  <h1 align="center">🛰️ BGPLite</h1>
+  <p align="center"><em>A lightweight, hand-rolled BGP-4 route server for dynamic prefix provisioning.</em></p>
+  <p align="center">Peers register via HTTP, subscribe to AS-lists / country lists / custom prefixes, and receive them over eBGP — powered by RIPEstat and pluggable prefix sources.</em></p>
+</p>
 
-Lightweight BGP route server with dynamic prefix provisioning via RIPE Stat and HTTP management API.
+<p align="center">
+  <a href="https://github.com/ruhex/BGPLite/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/ruhex/BGPLite/actions/workflows/ci.yml/badge.svg"></a>
+  <a href="https://github.com/ruhex/BGPLite/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/ruhex/BGPLite/actions/workflows/codeql.yml/badge.svg"></a>
+  <a href="https://github.com/ruhex/BGPLite/releases"><img alt="Release" src="https://img.shields.io/github/v/release/ruhex/BGPLite?logo=github"></a>
+  <a href="https://github.com/ruhex/BGPLite/pkgs/container/bgplite"><img alt="Docker" src="https://img.shields.io/badge/ghcr.io-bgplite-2496ed?logo=docker"></a>
+  <a href="https://dotnet.microsoft.com/"><img alt=".NET" src="https://img.shields.io/badge/.NET-10-512bd4?logo=dotnet"></a>
+  <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/github/license/ruhex/BGPLite?color=blue"></a>
+</p>
 
-Built with .NET 10. Peers register through the API with subscriptions to AS-lists (Cloudflare, Google, Apple, Meta, etc.) or custom prefixes. On BGP connection, prefixes are fetched from RIPE Stat with caching and advertised to the peer.
+<p align="center">
+  <a href="https://github.com/ruhex/BGPLite/stargazers"><img alt="stars" src="https://img.shields.io/github/stars/ruhex/BGPLite?style=flat"></a>
+  <a href="#"><img alt="commits: conventional" src="https://img.shields.io/badge/commits-conventional-fe7d37?logo=semantic-release"></a>
+  <a href="#"><img alt="CodeRabbit" src="https://img.shields.io/badge/review-CodeRabbit-6c43f5?logo=githubactions"></a>
+  <a href="https://github.com/ruhex/BGPLite/issues"><img alt="issues" src="https://img.shields.io/github/issues/ruhex/BGPLite"></a>
+</p>
 
-## Features
+---
 
-- BGP session management (OPEN, UPDATE, KEEPALIVE, NOTIFICATION)
-- 4-byte ASN support
-- Dynamic prefix provisioning via RIPE Stat API with in-memory caching
-- Per-peer AS-list subscriptions and custom prefix support
-- Configurable prefix sources (local file / HTTP / ...) via a provider factory, with in-memory caching
-- Auto-registration of unknown peers with default RU prefix set
-- HTTP management API for peer and route management
-- SQLite peer store via EF Core
-- Docker support
+## 📑 Table of Contents
 
-## Requirements
+- [What is BGPLite?](#-what-is-bgplite)
+- [Features](#-features)
+- [Architecture](#-architecture)
+- [Quick Start](#-quick-start)
+- [Configuration](#-configuration)
+- [How it works](#-how-it-works)
+- [Management API](#-management-api)
+- [RFC compliance](#-rfc-compliance)
+- [Roadmap](#-roadmap)
+- [Contributing](#-contributing)
+- [License](#-license)
 
-- .NET 10.0 SDK
-- Linux (BGP port 179 requires root or `CAP_NET_BIND_SERVICE`)
+## 🧭 What is BGPLite?
 
-## Quick Start
+**BGPLite** is a BGP-4 **route server**: it accepts eBGP sessions from clients and **dynamically advertises curated prefix sets** to them — by ASN (Cloudflare, Google, Apple, Meta…), by country, or fully custom. It is **not** a full router: it originates/announces curated prefixes, it does not forward transit traffic or run a full RIB/FIB.
 
-Copy the example config and edit with your settings:
+Clients register a subscription through the HTTP management API; on the next BGP connection the server resolves the prefixes (RIPEstat + file/http sources, cached) and announces them. Unknown peers are auto-registered with a default set (e.g. RU).
+
+- **Production-deployed** at `bgp.vhex.dev` (real BGP peers).
+- **Pure .NET 10**, raw TCP/179 sockets (no BIRD/FRR/GoBGP) — the BGP stack is written from scratch per RFC 4271.
+
+## ✨ Features
+
+- **Full BGP-4 message support** — OPEN / UPDATE / KEEPALIVE / NOTIFICATION.
+- **4-byte ASN** (RFC 4893/6793) — `AS_TRANS` 23456, capability 65, AS4_PATH for 2-byte-only peers.
+- **Capability negotiation** (RFC 5492) — tuned for BIRD / FRR / Mikrotik / Cisco / Juniper.
+- **Graceful Restart** (RFC 4724).
+- **Route Refresh** (RFC 2918) — capability-gated, DoS-debounced.
+- **BGP Communities** (RFC 1997) — per-peer filtering and tagging (`ASN:VALUE`).
+- **UPDATE batching** (≤100 NLRI) and **exact-union CIDR aggregation**.
+- **Prefix provisioning** via a pluggable provider factory:
+  - `http` (any raw-file URL), `file`, and **RIPEstat** (`stat.ripe.net`) with in-memory TTL caching.
+  - Per-source HTTP timeout, custom headers, and community tagging.
+  - Extend with your own `IPrefixSourceProvider`.
+- **HTTP management API** for peer/route/session management.
+- **SQLite peer store** via EF Core (`EnsureCreated`, raw-SQL migrations — see [FIXPLAN](FIXPLAN.md) P4).
+- **First-class ops**: Docker image in GHCR, self-contained binaries (linux-x64/arm64, win-x64), Conventional-Commits releases.
+
+## 🏗 Architecture
+
+```
+            ┌──────────────── HTTP :5000 (management API + SQLite peer store) ──────────────┐
+            │                                                                                │
+  client ───┤   POST /api/peers (subscribe: asnLists / customPrefixes / communities)        │
+            │                                                                                │
+            └────────────────────────────────────────────────────────────────────────────────┘
+                                            │  on connect
+  BGP peer ──TCP/179──► BGPLite.Server (session FSM, timers, hold-timer, Cease)
+                                │ resolves subscription
+                                ▼
+                     BGPLite.Providers (RIPEstat / file / http  →  TTL cache)
+                                │ BGPLite.Routing (RouteTable, aggregation, community filter)
+                                ▼
+                          advertise prefixes via UPDATE
+```
+
+Solution layout (8 projects, ~6k LOC):
+
+| Project | Responsibility |
+|---------|----------------|
+| `BGPLite` | Entry point, host setup, DI |
+| `BGPLite.Protocol` | BGP wire codec (messages, FSM, capabilities, path attributes) |
+| `BGPLite.Server` | TCP listener, session FSM, timers, Cease/teardown |
+| `BGPLite.Routing` | Route table, community filters, CIDR aggregation |
+| `BGPLite.Providers` | PrefixService, RIPEstat, prefix-source providers + factory |
+| `BGPLite.Api` | Management HTTP API + SQLite peer store (EF Core) |
+| `BGPLite.Configuration` | YAML config loading, `AppConfig` models |
+| `BGPLite.Tests` | xUnit unit tests |
+
+## 🚀 Quick Start
+
+> **Port 179 < 1024**: bind needs `root` or `CAP_NET_BIND_SERVICE` (Linux). The Docker compose example uses host networking to make peering straightforward.
+
+### Option A — Docker (recommended)
+
+```bash
+# Pull the official image from GHCR
+docker pull ghcr.io/ruhex/bgplite:latest
+
+# Configure (secrets stay OUT of the image — mount from host)
+cp appsettings.Example.yml appsettings.yml
+$EDITOR appsettings.yml
+
+# Run (host networking for BGP; or map ports + add NET_BIND_SERVICE)
+docker run -d --name bgplite \
+  --network host \
+  -v "$PWD/appsettings.yml:/app/appsettings.yml:ro" \
+  -v "$PWD/data:/app/data" \
+  ghcr.io/ruhex/bgplite:latest
+```
+
+…or with the bundled `docker-compose.yml`:
 
 ```bash
 cp appsettings.Example.yml appsettings.yml
+docker compose up -d
 ```
 
-Run:
+### Option B — Prebuilt binary (release)
+
+Grab a self-contained single-file binary from [Releases](https://github.com/ruhex/BGPLite/releases):
 
 ```bash
-sudo dotnet run --project BGPLite
+tar xzf bgplite-v1.0.0-linux-x64.tar.gz
+cp appsettings.Example.yml appsettings.yml   # template included in the archive
+sudo ./BGPLite                                # port 179 needs root
 ```
 
-Or with Docker:
+### Option C — Build from source
 
 ```bash
-docker build -t bgplite .
-docker run -d \
-  -p 179:179 \
-  -p 5000:5000 \
-  -v $(pwd)/appsettings.yml:/app/appsettings.yml \
-  bgplite
+git clone https://github.com/ruhex/BGPLite && cd BGPLite
+cp appsettings.Example.yml appsettings.yml   # then edit
+sudo dotnet run --project BGPLite -c Release
 ```
 
-## Configuration
+Requires the **.NET 10 SDK** (`global.json` pins it).
+
+## ⚙️ Configuration
+
+BGPLite reads `appsettings.yml` (YAML). See [`appsettings.Example.yml`](appsettings.Example.yml) for the full schema. Highlights:
 
 ```yaml
 Bgp:
@@ -60,169 +158,95 @@ Peers:
     RemoteAsn: 65001
     Description: "example-peer"
 
-RipeStat:
-  AsnLists:
-    - Name: cloudflare
-      Description: "AS13335 Cloudflare Inc."
-      Asns: [13335]
+RipeStat:                      # resolves ASN → prefixes via stat.ripe.net (cached, retried)
+  TimeoutSeconds: 180
+  RetryAttempts: 2
 
-    - Name: google
-      Description: "AS15169 Google LLC"
-      Asns: [15169]
-
-    - Name: apple
-      Description: "AS714 Apple Inc."
-      Asns: [714]
-
-    - Name: meta
-      Description: "AS32934 Facebook, Inc."
-      Asns: [32934]
-
-    - Name: ru
-      Description: "Russia"
-      Country: RU
-```
-
-### Prefix Sources
-
-Prefix lists are loaded at startup from configurable sources, selected by `Kind` through a provider factory (`file`, `http`, ...) and kept in an in-memory TTL cache. Each source may attach a BGP community in `ASN:VALUE` form and, for `http`, override the fetch `Timeout` (seconds) and add custom request `Headers` (e.g. `Authorization`, `X-API-Key`). Add a new loading method by implementing `IPrefixSourceProvider` and registering it.
-
-```yaml
-PrefixSources:
+PrefixSources:                 # provider factory (Kind: file | http), in-memory TTL cache
   - Kind: http
     Name: ru
-    Description: "Russia prefixes from a remote list"
-    Url: "https://raw.githubusercontent.com/<org>/<repo>/main/ru.txt"   # any direct raw-file URL
-    Timeout: 30                                                          # optional, seconds
-    Headers:                                                             # optional request headers
-      Authorization: "Bearer <token>"
+    Url: "https://raw.githubusercontent.com/<org>/<repo>/main/ru.txt"
+    Timeout: 30
   - Kind: file
     Name: local
-    Path: "extra.txt"
+    Path: extra.txt
     Community: "65444:100"
 
-DefaultPrefixSource: ru   # source served as the RU/default set to unconfigured peers
+DefaultPrefixSource: ru        # served to unconfigured/auto-registered peers
 ```
 
-List files are CIDR-per-line (e.g. `2.16.20.0/23`); blank lines and `#` comments are ignored.
+- Prefix list files: one CIDR per line (`2.16.20.0/23`); blank lines and `#` comments ignored.
+- Peer data lives in SQLite at `$BGPLITE_DATA/bgplite.db` (defaults to `./data`).
 
-### Data Directory
+## 🔁 How it works
 
-Peer data is stored in SQLite at `$BGPLITE_DATA/bgplite.db` (defaults to `./data`).
+1. **Register a peer** via `POST /api/peers` (IP, ASN, AS-list subscriptions and/or custom prefixes).
+2. **Peer connects** over BGP to port 179.
+3. **Session establishes** — the server looks the peer up:
+   - **known** → fetches prefixes for its subscriptions (RIPEstat, cached) + custom prefixes, advertises all;
+   - **unknown** → auto-registers and advertises the **default** prefix source.
+4. **Stats updated** — peer status `active`, session time recorded.
 
-## How It Works
+## 🌐 Management API
 
-1. **Register a peer** via `POST /api/peers` with IP, ASN, AS-list subscriptions, and/or custom prefixes
-2. **Peer connects** via BGP to port 179
-3. **Session establishes** — the server looks up the peer in the database:
-   - If found → fetches prefixes for subscribed AS-lists from RIPE Stat (cached), adds custom prefixes, advertises all to the peer
-   - If not found → auto-registers the peer and advertises the default prefix source (RU)
-4. **Statistics updated** — peer status set to `active`, session time recorded
-
-## Management API
-
-Available on port 5000.
+Available on port **5000**.
 
 ### Peers
-
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `GET` | `/api/my-ip` | Returns client's IP address |
-| `POST` | `/api/peers` | Register a new peer |
-| `GET` | `/api/peers` | List all peers |
-
-#### Register a Peer
+| `GET`  | `/api/my-ip` | Returns the caller's IP |
+| `POST` | `/api/peers` | Register a peer |
+| `GET`  | `/api/peers` | List all peers |
 
 ```bash
-curl -X POST http://localhost:5000/api/peers \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "ip": "10.0.0.2",
-    "asn": 65001,
-    "description": "customer-1",
-    "asnLists": ["cloudflare", "google"],
-    "customPrefixes": ["203.0.113.0/24"]
-  }'
+curl -X POST http://localhost:5000/api/peers -H 'Content-Type: application/json' -d '{
+  "ip": "10.0.0.2", "asn": 65001, "description": "customer-1",
+  "asnLists": ["cloudflare", "google"], "customPrefixes": ["203.0.113.0/24"]
+}'
 ```
 
-Response:
-
-```json
-{
-  "data": {
-    "id": "a1b2c3d4-...",
-    "ip": "10.0.0.2",
-    "asn": 65001,
-    "description": "customer-1",
-    "status": "inactive",
-    "createdAt": "2026-06-09T12:00:00Z",
-    "asnLists": ["cloudflare", "google"],
-    "customPrefixes": ["203.0.113.0/24"]
-  }
-}
-```
-
-#### List Peers
-
-```bash
-curl http://localhost:5000/api/peers
-```
-
-Returns peers with `id`, `ip`, `asn`, `description`, `status`, `createdAt`, `lastSessionAt`, `communities`.
-
-### AS Lists
-
+### AS-lists / routes / sessions
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `GET` | `/api/asn-lists` | List available AS-lists with prefix counts |
-| `GET` | `/api/as/{asn}/prefixes/count` | Get prefix count for a specific ASN |
+| `GET`  | `/api/asn-lists` | Available AS-lists with prefix counts |
+| `GET`  | `/api/as/{asn}/prefixes/count` | Prefix count for an ASN |
+| `GET`  | `/api/sessions` | Active BGP session count |
+| `GET`  | `/api/routes/count` | Route counts by community |
 
-```bash
-curl http://localhost:5000/api/asn-lists
-curl http://localhost:5000/api/as/13335/prefixes/count
-```
-
-### Sessions & Routes
-
+### Per-peer community filter & metadata
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `GET` | `/api/sessions` | Active BGP session count |
-| `GET` | `/api/routes/count` | Route counts by community |
-
-### Peer Management (Legacy)
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| `GET` | `/api/peer/{ip}/communities` | Get peer community filter |
-| `PUT` | `/api/peer/{ip}/communities` | Set peer community filter |
-| `DELETE` | `/api/peer/{ip}/communities` | Clear community filter |
+| `GET` / `PUT` / `DELETE` | `/api/peer/{ip}/communities` | Get / set / clear community filter |
 | `PUT` | `/api/peer/{ip}/description` | Set peer description |
 
-```bash
-# Set community filter
-curl -X PUT http://localhost:5000/api/peer/10.0.0.2/communities \
-  -H 'Content-Type: application/json' \
-  -d '{"communities": ["65444:100"]}'
+## 📜 RFC compliance
 
-# Route statistics
-curl http://localhost:5000/api/routes/count
-```
+A §-by-§ audit lives in [`RFC_COMPLIANCE.md`](RFC_COMPLIANCE.md). Summary:
 
-## Project Structure
+| RFC | Topic | Status |
+|-----|-------|--------|
+| [4271](https://www.rfc-editor.org/rfc/rfc4271) | BGP-4 (base) | ✅ core |
+| [4893](https://www.rfc-editor.org/rfc/rfc4893) / [6793](https://www.rfc-editor.org/rfc/rfc6793) | 4-byte ASN, AS4_PATH | ✅ |
+| [5492](https://www.rfc-editor.org/rfc/rfc5492) | Capabilities | ✅ |
+| [1997](https://www.rfc-editor.org/rfc/rfc1997) | Communities | ✅ |
+| [4724](https://www.rfc-editor.org/rfc/rfc4724) | Graceful Restart | ✅ |
+| [2918](https://www.rfc-editor.org/rfc/rfc2918) | Route Refresh | ✅ |
+| [2385](https://www.rfc-editor.org/rfc/rfc2385) | TCP-MD5 auth | 🟡 open (#36) |
+| [4760](https://www.rfc-editor.org/rfc/rfc4760) / [2545](https://www.rfc-editor.org/rfc/rfc2545) | MP-BGP / IPv6 | 🔜 roadmap (#14/#15) |
 
-```
-BGPLite/
-├── BGPLite/               # Entry point, host setup, DI
-├── BGPLite.Api/           # Management HTTP API, peer store (EF Core)
-│   └── Entities/          # EF Core entity models
-├── BGPLite.Configuration/ # YAML config loading, AppConfig models
-├── BGPLite.Protocol/      # BGP message encoding/decoding
-├── BGPLite.Providers/     # PrefixService, RipeStatProvider, prefix source providers + factory
-├── BGPLite.Routing/       # Route table, community filters
-├── BGPLite.Server/        # TCP listener, BGP session FSM
-└── BGPLite.Tests/         # Unit tests
-```
+## 🗺 Roadmap
 
-## License
+Prioritized work is tracked in [`FIXPLAN.md`](FIXPLAN.md) (P1–P7) and via [issues](https://github.com/ruhex/BGPLite/issues). Currently open focus areas: routing correctness (P3), configuration validation (P4), test coverage (P5), and the remaining RFC compliance gaps (P7). IPv6 / MP-BGP is the largest upcoming feature (#14/#15).
 
-MIT
+## 🤝 Contributing
+
+Contributions are welcome. To keep history clean and releases automatic:
+
+- Use **Conventional Commits** (`feat:`, `fix:`, `docs:`, `chore:`…) — [release-please](https://github.com/googleapis/release-please) derives versions & changelogs from them.
+- Open a **feature branch → PR**; CI runs build + tests + `dotnet format` + CodeQL on every PR.
+- [CodeRabbit](https://coderabbit.ai) posts an automated review on each PR (`.coderabbit.yaml` configures BGP/RFC-aware focus).
+- Squash-merge into `main`; releases tag & publish themselves.
+
+## 📄 License
+
+[MIT](LICENSE) © Mikhail Movchan


### PR DESCRIPTION
## Summary
A long-overdue README refresh + the missing LICENSE file.

## README
- **Badges** (CI, CodeQL, Release, Docker/GHCR, .NET, license, stars, conventional-commits, CodeRabbit, issues) — silero-vad-style header.
- Centered title + tagline, **Table of Contents**.
- Refreshed **Features** (RFC compliance, Graceful Restart, Route Refresh, aggregation, provider factory).
- **Architecture** diagram + project table.
- **Quick Start**: Docker from GHCR (recommended) + release binary + source — replaces the stale `docker build` snippet.
- Compact **Configuration**, **How it works**, **Management API** tables (preserved endpoints).
- **RFC compliance** summary table (links to RFC_COMPLIANCE.md), **Roadmap** (FIXPLAN), **Contributing** (conventional commits + CI + CodeRabbit).

## LICENSE
Adds MIT (was referenced as MIT in the old README footer, but the file was missing).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)