### PR TITLE
ci(release-assets): checkout in resolve so workflow_run finds the tag

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -25,6 +25,9 @@ jobs:
       tag: ${{ steps.t.outputs.tag }}
       do: ${{ steps.t.outputs.do }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - id: t
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
@@ -35,10 +38,7 @@ jobs:
               echo "do=false" >> "$GITHUB_OUTPUT"; exit 0
             fi
             SHA="${{ github.event.workflow_run.head_sha }}"
-            TAG=$(git ls-remote --tags origin | awk -F/ '{print $3}' | sed 's/\^{}$//' | while read t; do
-                    s=$(git ls-remote origin "refs/tags/$t" | awk '{print $1}')
-                    [ "$s" = "$SHA" ] && echo "$t" && break
-                  done)
+            TAG=$(git tag --points-at "$SHA" | grep -E '^v' | head -n1)
             if [ -z "$TAG" ]; then
               echo "do=false" >> "$GITHUB_OUTPUT"   # Release run without a new tag
             else


### PR DESCRIPTION
v1.0.1 published with no binaries/image: the `resolve` job used `git ls-remote` without `actions/checkout`, so under `workflow_run` no tag was found and build/docker were skipped. Add checkout (fetch-depth 0) and resolve via `git tag --points-at <sha>`.