### PR TITLE
feat(routing): per-list BGP communities via ICommunityResolver (Phase 1 of #63)

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -516,6 +516,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
                 l.Name,
                 l.Description,
                 l.Country,
+                Community = l.Community,
                 prefixCount,
                 type = l.Country is not null ? "country" : "asn"
             });
@@ -535,6 +536,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
                     Name = source.Name,
                     Description = source.Description,
                     Country = (string?)null,
+                    Community = source.Community,
                     prefixCount = prefixes.Count,
                     type = "list"
                 });

--- a/BGPLite.Configuration/RipeStatConfig.cs
+++ b/BGPLite.Configuration/RipeStatConfig.cs
@@ -44,4 +44,8 @@ public sealed class AsnList
 
     [YamlMember(Alias = "Country")]
     public string? Country { get; init; }
+
+    /// <summary>Optional community in <c>"ASN:VALUE"</c> form stamped on every prefix advertised from this list (e.g. <c>"65444:100"</c>).</summary>
+    [YamlMember(Alias = "Community")]
+    public string? Community { get; init; }
 }

--- a/BGPLite.Routing/ICommunityResolver.cs
+++ b/BGPLite.Routing/ICommunityResolver.cs
@@ -1,0 +1,43 @@
+namespace BGPLite.Routing;
+
+/// <summary>Kind of prefix source a route originated from, used to resolve its BGP community/communities.</summary>
+public enum CommunitySourceKind
+{
+    /// <summary>A configured <c>AsnList</c> (RIPEstat ASN subscription).</summary>
+    AsnList,
+    /// <summary>A configured prefix source (<c>PrefixSources</c>, file/http).</summary>
+    PrefixSource,
+    /// <summary>A country-based <c>AsnList</c> (resolved like an AsnList by name).</summary>
+    Country,
+    /// <summary>Per-peer custom prefixes / custom ASNs (no list identity in Phase 1).</summary>
+    Custom,
+    /// <summary>Fallback / default source when nothing else applies.</summary>
+    Default
+}
+
+/// <summary>
+/// Identifies where a prefix came from so a community can be resolved for it.
+/// <c>ListName</c> carries the list/source name for <see cref="CommunitySourceKind.AsnList"/>,
+/// <see cref="CommunitySourceKind.Country"/>, <see cref="CommunitySourceKind.PrefixSource"/>
+/// (and the default-source name for <see cref="CommunitySourceKind.Default"/>).
+/// </summary>
+public sealed record CommunitySource(CommunitySourceKind Kind, string? ListName = null);
+
+/// <summary>
+/// Resolves the BGP community/communities to attach to prefixes that came from a given source.
+/// Returns an empty array when the source has no community (callers must treat empty as "untagged").
+/// Implementations: <see cref="ConfigCommunityResolver"/> (static config); a future DB-backed
+/// resolver for named user lists (Phase 2).
+/// </summary>
+public interface ICommunityResolver
+{
+    /// <summary>Returns the community value(s) for the given source, or an empty array if none.</summary>
+    uint[] Resolve(CommunitySource source);
+}
+
+/// <summary>Resolves to no communities. Default when no resolver is wired up.</summary>
+public sealed class NullCommunityResolver : ICommunityResolver
+{
+    public static NullCommunityResolver Instance { get; } = new();
+    public uint[] Resolve(CommunitySource source) => [];
+}

--- a/BGPLite.Server/BgpServer.cs
+++ b/BGPLite.Server/BgpServer.cs
@@ -21,6 +21,7 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
     private readonly IPeerStore? _peerStore;
     private readonly IPrefixService? _prefixService;
     private readonly IPrefixAggregator _prefixAggregator;
+    private readonly ICommunityResolver _communityResolver;
     // Keyed by the accepted TCP connection (remote IP + remote source port), NOT by remote IP
     // alone: per RFC 4271 §8.2.1 there is one session per TCP connection, so several distinct peers
     // arriving from the same source IP (different ephemeral source ports) must coexist as separate
@@ -46,7 +47,8 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
         Action<string, uint>? onPeerIdentified = null,
         IPeerStore? peerStore = null,
         IPrefixService? prefixService = null,
-        IPrefixAggregator? prefixAggregator = null)
+        IPrefixAggregator? prefixAggregator = null,
+        ICommunityResolver? communityResolver = null)
     {
         _config = config;
         _routeTable = routeTable;
@@ -58,6 +60,7 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
         _peerStore = peerStore;
         _prefixService = prefixService;
         _prefixAggregator = prefixAggregator ?? new ExactUnionPrefixAggregator();
+        _communityResolver = communityResolver ?? NullCommunityResolver.Instance;
     }
 
     public Task StartAsync(CancellationToken cancellationToken)
@@ -159,7 +162,7 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
                     socket, peerConfig, _config.Bgp, _routeTable,
                     _routeFilter, _metrics, _sessionLogger,
                     _onPeerIdentified,
-                    _peerStore, _prefixService, _config, _prefixAggregator);
+                    _peerStore, _prefixService, _config, _prefixAggregator, _communityResolver);
 
                 if (Volatile.Read(ref _acceptingConnections) == 0)
                 {

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -28,6 +28,7 @@ public sealed class BgpSession : IDisposable
     private readonly IPrefixService? _prefixService;
     private readonly AppConfig? _appConfig;
     private readonly IPrefixAggregator _prefixAggregator;
+    private readonly ICommunityResolver _communityResolver;
 
     // volatile: read by external threads (BgpServer.RefreshPeerAsync/StopAsync). Guarantees
     // acquire/release so IsEstablished reflects the most recent TransitionTo without JIT caching.
@@ -127,7 +128,8 @@ public sealed class BgpSession : IDisposable
         IPeerStore? peerStore = null,
         IPrefixService? prefixService = null,
         AppConfig? appConfig = null,
-        IPrefixAggregator? prefixAggregator = null)
+        IPrefixAggregator? prefixAggregator = null,
+        ICommunityResolver? communityResolver = null)
     {
         _socket = socket;
         _stream = new NetworkStream(socket, ownsSocket: true);
@@ -143,6 +145,7 @@ public sealed class BgpSession : IDisposable
         _prefixService = prefixService;
         _appConfig = appConfig;
         _prefixAggregator = prefixAggregator ?? new ExactUnionPrefixAggregator();
+        _communityResolver = communityResolver ?? NullCommunityResolver.Instance;
     }
 
     public async Task RunAsync(CancellationToken cancellationToken = default)
@@ -504,6 +507,9 @@ public sealed class BgpSession : IDisposable
     {
         var nextHop = BgpConstants.IPAddressToUint(_bgpConfig.GetRouterIdAddress());
         var routes = new List<Route>();
+        // Community for the default (RU) prefix source, if any — stamped on RU-default routes.
+        var defaultComms = _communityResolver.Resolve(
+            new CommunitySource(CommunitySourceKind.PrefixSource, _appConfig?.DefaultPrefixSource));
 
         if (_peerStore is not null && _prefixService is not null && _appConfig is not null)
         {
@@ -525,12 +531,7 @@ public sealed class BgpSession : IDisposable
                         var ruPrefixes = await _prefixService.GetRuPrefixesAsync();
                         foreach (var (prefix, length, _) in ruPrefixes)
                         {
-                            routes.Add(new Route
-                            {
-                                Prefix = prefix,
-                                PrefixLength = length,
-                                NextHop = nextHop
-                            });
+                            routes.Add(MakeRoute(prefix, length, nextHop, null, defaultComms));
                         }
                         _logger.LogInformation("Sent {Count} RU prefixes to unconfigured peer {Peer}",
                             ruPrefixes.Count, _peer);
@@ -550,53 +551,50 @@ public sealed class BgpSession : IDisposable
                     .Where(l => subscriptionIds.Contains(l.Name))
                     .ToList() ?? [];
 
-                // ASN-based lists
-                var asns = subscribedLists
-                    .Where(l => l.Asns.Count > 0)
-                    .SelectMany(l => l.Asns)
-                    .ToList();
+                // ASN-based lists — resolve per list so each list's community is stamped on its prefixes
+                // (PrefixService caches per ASN, so per-list calls don't multiply RIPEstat traffic).
+                // Each list is fetched in its own try/catch: one failing list does not drop the others'
+                // prefixes (intentional resilience vs the old single-batch all-or-nothing path).
+                var asnLists = subscribedLists.Where(l => l.Asns.Count > 0).ToList();
 
-                _logger.LogInformation("Peer {Peer} resolved {Count} ASNs from subscriptions", _peer, asns.Count);
+                _logger.LogInformation("Peer {Peer} resolved {Count} ASNs from subscriptions",
+                    _peer, asnLists.SelectMany(l => l.Asns).Count());
 
-                if (asns.Count > 0)
+                if (asnLists.Count > 0)
                 {
-                    try
+                    var before = routes.Count;
+                    foreach (var list in asnLists)
                     {
-                        var prefixes = await _prefixService.GetPrefixesForAsns(asns);
-                        foreach (var (prefix, length, asn) in prefixes)
+                        try
                         {
-                            routes.Add(new Route
-                            {
-                                Prefix = prefix,
-                                PrefixLength = length,
-                                NextHop = nextHop,
-                                AsPath = [asn]
-                            });
+                            var comms = _communityResolver.Resolve(
+                                new CommunitySource(CommunitySourceKind.AsnList, list.Name));
+                            var prefixes = await _prefixService.GetPrefixesForAsns(list.Asns);
+                            foreach (var (prefix, length, asn) in prefixes)
+                                routes.Add(MakeRoute(prefix, length, nextHop, [asn], comms));
                         }
-                        _logger.LogInformation("Fetched {Count} prefixes for {Peer} from ASN subscriptions",
-                            routes.Count, _peer);
+                        catch (Exception ex)
+                        {
+                            _logger.LogError(ex, "Failed to fetch prefixes for {Peer} (list '{List}')", _peer, list.Name);
+                        }
                     }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "Failed to fetch prefixes for {Peer}", _peer);
-                    }
+                    _logger.LogInformation("Fetched {Count} prefixes for {Peer} from ASN subscriptions",
+                        routes.Count - before, _peer);
                 }
 
-                // Country-based lists (e.g. RU with no ASNs → use local nets.txt)
-                if (subscribedLists.Any(l => l.Asns.Count == 0 && l.Country is not null))
+                // Country-based lists (e.g. RU with no ASNs → use local nets.txt). All country lists
+                // currently resolve to the RU default prefix set; stamp the configured community
+                // (if any) of the first country list on those prefixes.
+                var countryLists = subscribedLists.Where(l => l.Asns.Count == 0 && l.Country is not null).ToList();
+                if (countryLists.Count > 0)
                 {
                     try
                     {
+                        var comms = _communityResolver.Resolve(
+                            new CommunitySource(CommunitySourceKind.Country, countryLists[0].Name));
                         var ruPrefixes = await _prefixService.GetRuPrefixesAsync();
                         foreach (var (prefix, length, _) in ruPrefixes)
-                        {
-                            routes.Add(new Route
-                            {
-                                Prefix = prefix,
-                                PrefixLength = length,
-                                NextHop = nextHop
-                            });
-                        }
+                            routes.Add(MakeRoute(prefix, length, nextHop, null, comms));
                         _logger.LogInformation("Fetched {Count} RU prefixes for {Peer}", ruPrefixes.Count, _peer);
                     }
                     catch (Exception ex)
@@ -616,16 +614,10 @@ public sealed class BgpSession : IDisposable
                 {
                     try
                     {
+                        var comms = _communityResolver.Resolve(new CommunitySource(CommunitySourceKind.PrefixSource, name));
                         var srcPrefixes = await _prefixService.GetSourcePrefixesAsync(name);
                         foreach (var (prefix, length) in srcPrefixes)
-                        {
-                            routes.Add(new Route
-                            {
-                                Prefix = prefix,
-                                PrefixLength = length,
-                                NextHop = nextHop
-                            });
-                        }
+                            routes.Add(MakeRoute(prefix, length, nextHop, null, comms));
                         _logger.LogInformation("Fetched {Count} prefixes from source '{Source}' for {Peer}",
                             srcPrefixes.Count, name, _peer);
                     }
@@ -639,18 +631,14 @@ public sealed class BgpSession : IDisposable
                 _logger.LogInformation("Peer {Peer} has {SubRoutes} subscription routes + {CustomCount} custom prefixes",
                     _peer, routes.Count, customPrefixes.Count);
 
+                var customComms = _communityResolver.Resolve(new CommunitySource(CommunitySourceKind.Custom));
                 foreach (var cidr in customPrefixes)
                 {
                     var slash = cidr.IndexOf('/');
                     var ip = IPAddress.Parse(cidr[..slash]);
                     var length = byte.Parse(cidr[(slash + 1)..]);
                     var prefix = BgpConstants.IPAddressToUint(ip);
-                    routes.Add(new Route
-                    {
-                        Prefix = prefix,
-                        PrefixLength = length,
-                        NextHop = nextHop
-                    });
+                    routes.Add(MakeRoute(prefix, length, nextHop, null, customComms));
                 }
 
                 // Add custom AS prefixes (already loaded above)
@@ -660,15 +648,7 @@ public sealed class BgpSession : IDisposable
                     {
                         var asnPrefixes = await _prefixService.GetPrefixesForAsns(customAsns);
                         foreach (var (prefix, length, asn) in asnPrefixes)
-                        {
-                            routes.Add(new Route
-                            {
-                                Prefix = prefix,
-                                PrefixLength = length,
-                                NextHop = nextHop,
-                                AsPath = [asn]
-                            });
-                        }
+                            routes.Add(MakeRoute(prefix, length, nextHop, [asn], customComms));
                         _logger.LogInformation("Peer {Peer} custom AS: {Asns} -> {Count} prefixes",
                             _peer, string.Join(",", customAsns), asnPrefixes.Count);
                     }
@@ -688,14 +668,7 @@ public sealed class BgpSession : IDisposable
                     {
                         var ruPrefixes = await _prefixService.GetRuPrefixesAsync();
                         foreach (var (prefix, length, _) in ruPrefixes)
-                        {
-                            routes.Add(new Route
-                            {
-                                Prefix = prefix,
-                                PrefixLength = length,
-                                NextHop = nextHop
-                            });
-                        }
+                            routes.Add(MakeRoute(prefix, length, nextHop, null, defaultComms));
                     }
                     catch (Exception ex)
                     {
@@ -703,6 +676,8 @@ public sealed class BgpSession : IDisposable
                     }
                 }
 
+                // Apply the per-peer outgoing community filter (same rule as the shared-table path).
+                routes = routes.Where(r => _routeFilter.AcceptOutgoing(r, _peerConfig)).ToList();
                 await SendRoutesAsync(nextHop, routes);
                 return;
             }
@@ -717,14 +692,7 @@ public sealed class BgpSession : IDisposable
                 {
                     var ruPrefixes = await _prefixService.GetRuPrefixesAsync();
                     foreach (var (prefix, length, _) in ruPrefixes)
-                    {
-                        routes.Add(new Route
-                        {
-                            Prefix = prefix,
-                            PrefixLength = length,
-                            NextHop = nextHop
-                        });
-                    }
+                        routes.Add(MakeRoute(prefix, length, nextHop, null, defaultComms));
                     _logger.LogInformation("Fetched {Count} RU prefixes for unknown peer {Peer}",
                         ruPrefixes.Count, _peer);
                 }
@@ -898,6 +866,19 @@ public sealed class BgpSession : IDisposable
         routes.GroupBy(r => r.Communities, CommunitySetComparer.Instance)
               .Select(g => g.ToList())
               .ToList();
+
+    /// <summary>
+    /// Builds a <see cref="Route"/> carrying the given community set. Internal so the per-list
+    /// community stamping logic is unit-testable without a live session (Route is init-only).
+    /// </summary>
+    internal static Route MakeRoute(uint prefix, byte length, uint nextHop, uint[]? asPath, uint[] communities) => new()
+    {
+        Prefix = prefix,
+        PrefixLength = length,
+        NextHop = nextHop,
+        AsPath = asPath ?? [],
+        Communities = communities
+    };
 
     /// <summary>Sequence equality over a route's community array (set-equivalence within a batch).</summary>
     private sealed class CommunitySetComparer : IEqualityComparer<uint[]>

--- a/BGPLite.Server/ConfigCommunityResolver.cs
+++ b/BGPLite.Server/ConfigCommunityResolver.cs
@@ -1,0 +1,65 @@
+using BGPLite.Configuration;
+using BGPLite.Protocol;
+using BGPLite.Routing;
+using Microsoft.Extensions.Logging;
+
+namespace BGPLite.Server;
+
+/// <summary>
+/// Resolves communities from static config: <see cref="AsnList.Community"/> (for AsnList/Country)
+/// and <see cref="PrefixSourceConfig.Community"/> (for PrefixSource, incl. the default source).
+/// Parsed values are cached; malformed communities are logged and treated as none (never throw
+/// during a peer send). <see cref="CommunitySourceKind.Custom"/>/<see cref="CommunitySourceKind.Default"/>
+/// without a list name resolve to none in Phase 1.
+/// </summary>
+public sealed class ConfigCommunityResolver : ICommunityResolver
+{
+    private readonly AppConfig _config;
+    private readonly ILogger<ConfigCommunityResolver>? _logger;
+    private readonly Dictionary<string, uint[]> _parsed = new();
+    private static readonly uint[] Empty = [];
+
+    public ConfigCommunityResolver(AppConfig config, BgpConfig bgpConfig, ILogger<ConfigCommunityResolver>? logger = null)
+    {
+        _config = config;
+        _logger = logger;
+    }
+
+    public uint[] Resolve(CommunitySource source)
+    {
+        var raw = source.Kind switch
+        {
+            CommunitySourceKind.AsnList => FindAsnListCommunity(source.ListName),
+            CommunitySourceKind.Country => FindAsnListCommunity(source.ListName),
+            CommunitySourceKind.PrefixSource => FindPrefixSourceCommunity(source.ListName ?? _config.DefaultPrefixSource),
+            // Custom / Default carry no list identity in Phase 1 → untagged.
+            _ => null,
+        };
+        return string.IsNullOrWhiteSpace(raw) ? Empty : ParseCached(raw!);
+    }
+
+    private string? FindAsnListCommunity(string? name) =>
+        name is null ? null : _config.RipeStat?.AsnLists.FirstOrDefault(l => l.Name == name)?.Community;
+
+    private string? FindPrefixSourceCommunity(string? name) =>
+        name is null ? null : _config.PrefixSources.FirstOrDefault(s => s.Name == name)?.Community;
+
+    private uint[] ParseCached(string community)
+    {
+        if (_parsed.TryGetValue(community, out var cached)) return cached;
+        uint[] result;
+        try
+        {
+            result = [CommunityCodec.Parse(community)];
+        }
+        catch (FormatException ex)
+        {
+            _logger?.LogWarning(ex,
+                "Invalid community '{Community}' in config; prefixes from this list will be advertised untagged.",
+                community);
+            result = Empty;
+        }
+        _parsed[community] = result;
+        return result;
+    }
+}

--- a/BGPLite.Tests/CommunityResolverTests.cs
+++ b/BGPLite.Tests/CommunityResolverTests.cs
@@ -1,0 +1,115 @@
+using BGPLite.Configuration;
+using BGPLite.Protocol;
+using BGPLite.Routing;
+using BGPLite.Server;
+using Xunit;
+
+namespace BGPLite.Tests;
+
+public class CommunityResolverTests
+{
+    private static ConfigCommunityResolver Resolver(AppConfig config) =>
+        new(config, new BgpConfig(), logger: null);
+
+    private static AppConfig ConfigWith(
+        IEnumerable<AsnList>? asnLists = null,
+        IEnumerable<PrefixSourceConfig>? sources = null,
+        string? defaultSource = null) => new()
+        {
+            RipeStat = asnLists is null ? null : new RipeStatConfig { AsnLists = asnLists.ToList() },
+            PrefixSources = (sources ?? []).ToList(),
+            DefaultPrefixSource = defaultSource
+        };
+
+    [Fact]
+    public void Resolve_AsnList_ReturnsParsedCommunity()
+    {
+        var cfg = ConfigWith(asnLists: [new AsnList { Name = "cloudflare", Community = "65000:100" }]);
+        var comms = Resolver(cfg).Resolve(new CommunitySource(CommunitySourceKind.AsnList, "cloudflare"));
+        Assert.Equal([CommunityCodec.Parse("65000:100")], comms);
+    }
+
+    [Fact]
+    public void Resolve_AsnList_MissingCommunity_ReturnsEmpty()
+    {
+        var cfg = ConfigWith(asnLists: [new AsnList { Name = "cloudflare" }]);
+        Assert.Empty(Resolver(cfg).Resolve(new CommunitySource(CommunitySourceKind.AsnList, "cloudflare")));
+    }
+
+    [Fact]
+    public void Resolve_AsnList_UnknownName_ReturnsEmpty()
+    {
+        var cfg = ConfigWith(asnLists: [new AsnList { Name = "cloudflare", Community = "65000:100" }]);
+        Assert.Empty(Resolver(cfg).Resolve(new CommunitySource(CommunitySourceKind.AsnList, "nope")));
+    }
+
+    [Fact]
+    public void Resolve_PrefixSource_ReturnsParsedCommunity()
+    {
+        var cfg = ConfigWith(sources: [new PrefixSourceConfig { Name = "aws", Community = "65000:200" }]);
+        var comms = Resolver(cfg).Resolve(new CommunitySource(CommunitySourceKind.PrefixSource, "aws"));
+        Assert.Equal([CommunityCodec.Parse("65000:200")], comms);
+    }
+
+    [Fact]
+    public void Resolve_Country_UsesAsnListCommunity()
+    {
+        var cfg = ConfigWith(asnLists: [new AsnList { Name = "ru", Country = "RU", Community = "65000:300" }]);
+        var comms = Resolver(cfg).Resolve(new CommunitySource(CommunitySourceKind.Country, "ru"));
+        Assert.Equal([CommunityCodec.Parse("65000:300")], comms);
+    }
+
+    [Fact]
+    public void Resolve_PrefixSource_FallsBackToDefaultSource_WhenListNameNull()
+    {
+        var cfg = ConfigWith(
+            sources: [new PrefixSourceConfig { Name = "ru", Community = "65000:1" }],
+            defaultSource: "ru");
+        var comms = Resolver(cfg).Resolve(new CommunitySource(CommunitySourceKind.PrefixSource, null));
+        Assert.Equal([CommunityCodec.Parse("65000:1")], comms);
+    }
+
+    [Fact]
+    public void Resolve_Custom_And_Default_ReturnEmpty()
+    {
+        var r = Resolver(ConfigWith());
+        Assert.Empty(r.Resolve(new CommunitySource(CommunitySourceKind.Custom)));
+        Assert.Empty(r.Resolve(new CommunitySource(CommunitySourceKind.Default)));
+    }
+
+    [Fact]
+    public void Resolve_InvalidCommunity_ReturnsEmpty_NoThrow()
+    {
+        var cfg = ConfigWith(asnLists: [new AsnList { Name = "bad", Community = "not-a-community" }]);
+        Assert.Empty(Resolver(cfg).Resolve(new CommunitySource(CommunitySourceKind.AsnList, "bad")));
+    }
+
+    [Fact]
+    public void Resolve_CachesParsedValue_SameInstance()
+    {
+        var cfg = ConfigWith(asnLists: [new AsnList { Name = "x", Community = "65000:42" }]);
+        var r = Resolver(cfg);
+        var a = r.Resolve(new CommunitySource(CommunitySourceKind.AsnList, "x"));
+        var b = r.Resolve(new CommunitySource(CommunitySourceKind.AsnList, "x"));
+        Assert.Same(a, b);
+    }
+
+    [Fact]
+    public void MakeRoute_StampsCommunitiesAndAsPath()
+    {
+        var route = BgpSession.MakeRoute(0xC0A80000, 24, 0x01020304, [65000u], [CommunityCodec.Parse("65000:100")]);
+        Assert.Equal(0xC0A80000u, route.Prefix);
+        Assert.Equal((byte)24, route.PrefixLength);
+        Assert.Equal(0x01020304u, route.NextHop);
+        Assert.Equal([65000u], route.AsPath);
+        Assert.Equal([CommunityCodec.Parse("65000:100")], route.Communities);
+    }
+
+    [Fact]
+    public void MakeRoute_NullAsPath_DefaultsEmpty()
+    {
+        var route = BgpSession.MakeRoute(0x0A000000, 8, 0, null, []);
+        Assert.Empty(route.AsPath);
+        Assert.Empty(route.Communities);
+    }
+}

--- a/BGPLite/Program.cs
+++ b/BGPLite/Program.cs
@@ -40,6 +40,14 @@ builder.Services.AddSingleton<IRouteFilter>(sp =>
     var store = sp.GetRequiredService<PeerStore>();
     return new PeerCommunityFilter(ip => store.GetCommunitiesByIp(ip));
 });
+// Per-list community resolver: stamps a configured BGP community on prefixes by source
+// (AsnList / Country / PrefixSource). ConfigCommunityResolver reads static config; Phase 2 will
+// add a DB-backed resolver for named user lists behind the same ICommunityResolver interface.
+builder.Services.AddSingleton<ICommunityResolver>(sp =>
+    new ConfigCommunityResolver(
+        sp.GetRequiredService<AppConfig>(),
+        sp.GetRequiredService<BgpConfig>(),
+        sp.GetService<ILogger<ConfigCommunityResolver>>()));
 builder.Services.AddSingleton(new BgpMetrics());
 
 // Prefix sources (file / HTTP / ...) resolved by Kind via a provider factory,
@@ -98,7 +106,8 @@ builder.Services.AddHostedService(sp =>
         sp.GetRequiredService<ILogger<BgpServer>>(),
         (ip, asn) => store.UpsertPeer(ip, asn),
         store,
-        prefixService);
+        prefixService,
+        communityResolver: sp.GetRequiredService<ICommunityResolver>());
     return bgpServer;
 });
 builder.Services.AddSingleton<ISessionManager>(sp => bgpServer!);

--- a/appsettings.Example.yml
+++ b/appsettings.Example.yml
@@ -21,6 +21,9 @@ RipeStat:
   #   - Name: tier1
   #     Description: "Tier-1 transit ASes"
   #     Asns: [3356, 1299]
+  #     Community: "65444:200"   # optional "ASN:VALUE" stamped on every prefix advertised from this list
+  # A Community (here or on a PrefixSource below) tags advertised prefixes so a peer can filter by origin;
+  # lists without a Community are advertised untagged (no behavior change).
 
 # Prefix sources loaded at startup via the provider factory (Kind: file | http).
 # "http" fetches any direct raw-file URL (raw.githubusercontent.com, a gist, self-hosted, ...).


### PR DESCRIPTION
## Summary
Phase 1 of #63: tag every advertised prefix with a BGP community identifying which list it came from. The community plumbing already existed but was never set in the per-peer path; this adds an extensible resolver + stamps at the choke point + exposes it via API.

## Changes
- **`ICommunityResolver`** (`BGPLite.Routing`) — extension point: `Resolve(CommunitySource) -> uint[]`, with `CommunitySourceKind` (AsnList/PrefixSource/Country/Custom/Default) + `NullCommunityResolver`. Shape is extensible for Phase 2 (DB-backed named user lists).
- **`ConfigCommunityResolver`** (`BGPLite.Server`) — reads `AsnList.Community` (new) and `PrefixSourceConfig.Community` from static config; caches parsed values; logs+skips malformed (never throws during a send).
- **`AsnList.Community`** — new config field (`appsettings.Example.yml` updated).
- **`BgpSession.SendAllRoutesAsync`** — stamps communities at all 8 `Route` sites. ASN subscriptions reshaped to **per-list** iteration (so each list's community is in scope; `PrefixService` caches per ASN so no extra RIPEstat traffic). ASN path is now **per-list resilient** (one failing list doesn't drop the others — intentional improvement over the old single-batch all-or-nothing).
- **Per-peer outgoing filter** applied on the configured-peer path (`routes.Where(AcceptOutgoing)` before send) — unconfigured/unknown/fallback paths unchanged.
- **`GET /api/asn-lists`** now returns `community` per list (UI can render it upfront).

## Why no community concatenation on aggregation
`ExactUnionPrefixAggregator` already groups routes by community set **before** merging, so prefixes from different lists are never merged together — community is never mixed or lost. Trade-off: lists don't share aggregation, but each prefix carries exactly its list's identity.

## Verification
- `dotnet build` — 0 errors.
- `dotnet test` — **177 passed** (+11 `CommunityResolverTests`).
- Adversarial OLD-vs-NEW review of `SendAllRoutesAsync`: control flow, branches, all non-ASN try/catch, logging, side-effects, AsPath (via `MakeRoute`), and filter placement all EQUIVALENT; only intended diffs (community stamping, configured-path filter, per-list ASN resilience).

## Out of scope (Phase 2)
`PrefixList` entity (id, owner, name, community) + `DbCommunityResolver` + API for named user lists; optional `AppConfig.DefaultCommunity`.

Refs #63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tagging advertised prefixes with BGP communities from configured lists and prefix sources.
  * Communities can now be set in configuration and applied automatically during route advertisement.

* **Bug Fixes**
  * Improved route generation so one problematic list won’t block other routes from being advertised.
  * Invalid community values are handled safely without stopping startup or route processing.

* **Documentation**
  * Updated example configuration notes to explain how community tagging works and when prefixes remain untagged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->