### PR TITLE
feat(routing): static communities for custom prefixes/AS + /api/community-scheme

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -147,6 +147,10 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (IsGet(method, segments, "api", "asn-lists"))
             return HandleGetAsnListsAsync().GetAwaiter().GetResult();
 
+        // /api/community-scheme
+        if (IsGet(method, segments, "api", "community-scheme"))
+            return HandleGetCommunityScheme();
+
         // /api/sessions
         if (IsGet(method, segments, "api", "sessions"))
             return HandleGetSessions();
@@ -544,6 +548,24 @@ public sealed class ManagementApi : IHostedService, IDisposable
         }
 
         return ApiResponse.Ok(result);
+    }
+
+    #endregion
+
+    #region GET /api/community-scheme
+
+    // Static community scheme for the per-peer custom categories, so the UI can show the community
+    // a peer's custom prefixes / custom-AS prefixes will carry before they are advertised.
+    // Config overrides win; otherwise the hardcoded defaults "<Asn>:100" / "<Asn>:200".
+    private ApiResponse HandleGetCommunityScheme()
+    {
+        var asn = _config.Bgp.Asn;
+        return ApiResponse.Ok(new
+        {
+            asn,
+            customPrefixes = _config.CustomPrefixCommunity ?? $"{asn}:100",
+            customAsns = _config.CustomAsnCommunity ?? $"{asn}:200"
+        });
     }
 
     #endregion

--- a/BGPLite.Configuration/AppConfig.cs
+++ b/BGPLite.Configuration/AppConfig.cs
@@ -23,4 +23,12 @@ public sealed class AppConfig
     /// <summary>Name of the source served as the RU/default set for unconfigured peers.</summary>
     [YamlMember(Alias = "DefaultPrefixSource")]
     public string? DefaultPrefixSource { get; init; }
+
+    /// <summary>Optional override for the community stamped on per-peer custom prefixes (default <c>&lt;Asn&gt;:100</c>).</summary>
+    [YamlMember(Alias = "CustomPrefixCommunity")]
+    public string? CustomPrefixCommunity { get; init; }
+
+    /// <summary>Optional override for the community stamped on per-peer custom-AS-originated prefixes (default <c>&lt;Asn&gt;:200</c>).</summary>
+    [YamlMember(Alias = "CustomAsnCommunity")]
+    public string? CustomAsnCommunity { get; init; }
 }

--- a/BGPLite.Routing/ICommunityResolver.cs
+++ b/BGPLite.Routing/ICommunityResolver.cs
@@ -9,8 +9,10 @@ public enum CommunitySourceKind
     PrefixSource,
     /// <summary>A country-based <c>AsnList</c> (resolved like an AsnList by name).</summary>
     Country,
-    /// <summary>Per-peer custom prefixes / custom ASNs (no list identity in Phase 1).</summary>
+    /// <summary>Per-peer custom prefixes (static community <c>&lt;Asn&gt;:100</c>, overridable via config).</summary>
     Custom,
+    /// <summary>Per-peer custom AS-originated prefixes (static community <c>&lt;Asn&gt;:200</c>, overridable via config).</summary>
+    CustomAsn,
     /// <summary>Fallback / default source when nothing else applies.</summary>
     Default
 }

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -631,24 +631,27 @@ public sealed class BgpSession : IDisposable
                 _logger.LogInformation("Peer {Peer} has {SubRoutes} subscription routes + {CustomCount} custom prefixes",
                     _peer, routes.Count, customPrefixes.Count);
 
-                var customComms = _communityResolver.Resolve(new CommunitySource(CommunitySourceKind.Custom));
+                // Custom prefixes carry the static "custom prefix" community (<Asn>:100).
+                var customPrefixComms = _communityResolver.Resolve(new CommunitySource(CommunitySourceKind.Custom));
                 foreach (var cidr in customPrefixes)
                 {
                     var slash = cidr.IndexOf('/');
                     var ip = IPAddress.Parse(cidr[..slash]);
                     var length = byte.Parse(cidr[(slash + 1)..]);
                     var prefix = BgpConstants.IPAddressToUint(ip);
-                    routes.Add(MakeRoute(prefix, length, nextHop, null, customComms));
+                    routes.Add(MakeRoute(prefix, length, nextHop, null, customPrefixComms));
                 }
 
-                // Add custom AS prefixes (already loaded above)
+                // Add custom AS prefixes (already loaded above). Custom-AS routes carry the static
+                // "custom AS" community (<Asn>:200).
                 if (customAsns.Count > 0)
                 {
                     try
                     {
+                        var customAsnComms = _communityResolver.Resolve(new CommunitySource(CommunitySourceKind.CustomAsn));
                         var asnPrefixes = await _prefixService.GetPrefixesForAsns(customAsns);
                         foreach (var (prefix, length, asn) in asnPrefixes)
-                            routes.Add(MakeRoute(prefix, length, nextHop, [asn], customComms));
+                            routes.Add(MakeRoute(prefix, length, nextHop, [asn], customAsnComms));
                         _logger.LogInformation("Peer {Peer} custom AS: {Asns} -> {Count} prefixes",
                             _peer, string.Join(",", customAsns), asnPrefixes.Count);
                     }

--- a/BGPLite.Server/ConfigCommunityResolver.cs
+++ b/BGPLite.Server/ConfigCommunityResolver.cs
@@ -6,11 +6,12 @@ using Microsoft.Extensions.Logging;
 namespace BGPLite.Server;
 
 /// <summary>
-/// Resolves communities from static config: <see cref="AsnList.Community"/> (for AsnList/Country)
-/// and <see cref="PrefixSourceConfig.Community"/> (for PrefixSource, incl. the default source).
-/// Parsed values are cached; malformed communities are logged and treated as none (never throw
-/// during a peer send). <see cref="CommunitySourceKind.Custom"/>/<see cref="CommunitySourceKind.Default"/>
-/// without a list name resolve to none in Phase 1.
+/// Resolves communities from static config: <see cref="AsnList.Community"/> (AsnList/Country),
+/// <see cref="PrefixSourceConfig.Community"/> (PrefixSource, incl. the default source), and two
+/// static per-category communities for the per-peer custom paths — custom prefixes (<c>&lt;Asn&gt;:100</c>)
+/// and custom AS (<c>&lt;Asn&gt;:200</c>), each overridable via <see cref="AppConfig.CustomPrefixCommunity"/>
+/// / <see cref="AppConfig.CustomAsnCommunity"/>. Malformed values are logged and fall back to the
+/// default (never throw during a peer send).
 /// </summary>
 public sealed class ConfigCommunityResolver : ICommunityResolver
 {
@@ -19,24 +20,29 @@ public sealed class ConfigCommunityResolver : ICommunityResolver
     private readonly Dictionary<string, uint[]> _parsed = new();
     private static readonly uint[] Empty = [];
 
+    // Static communities for the per-peer custom categories, resolved once in the ctor.
+    private readonly uint[] _customPrefixComms;
+    private readonly uint[] _customAsnComms;
+
     public ConfigCommunityResolver(AppConfig config, BgpConfig bgpConfig, ILogger<ConfigCommunityResolver>? logger = null)
     {
         _config = config;
         _logger = logger;
+        _customPrefixComms = ResolveStaticCommunity(config.CustomPrefixCommunity, bgpConfig.Asn, 100, nameof(config.CustomPrefixCommunity));
+        _customAsnComms = ResolveStaticCommunity(config.CustomAsnCommunity, bgpConfig.Asn, 200, nameof(config.CustomAsnCommunity));
     }
 
-    public uint[] Resolve(CommunitySource source)
+    public uint[] Resolve(CommunitySource source) => source.Kind switch
     {
-        var raw = source.Kind switch
-        {
-            CommunitySourceKind.AsnList => FindAsnListCommunity(source.ListName),
-            CommunitySourceKind.Country => FindAsnListCommunity(source.ListName),
-            CommunitySourceKind.PrefixSource => FindPrefixSourceCommunity(source.ListName ?? _config.DefaultPrefixSource),
-            // Custom / Default carry no list identity in Phase 1 → untagged.
-            _ => null,
-        };
-        return string.IsNullOrWhiteSpace(raw) ? Empty : ParseCached(raw!);
-    }
+        CommunitySourceKind.AsnList => ParseOrDefault(FindAsnListCommunity(source.ListName)),
+        CommunitySourceKind.Country => ParseOrDefault(FindAsnListCommunity(source.ListName)),
+        CommunitySourceKind.PrefixSource => ParseOrDefault(FindPrefixSourceCommunity(source.ListName ?? _config.DefaultPrefixSource)),
+        CommunitySourceKind.Custom => _customPrefixComms,
+        CommunitySourceKind.CustomAsn => _customAsnComms,
+        _ => Empty, // Default
+    };
+
+    private uint[] ParseOrDefault(string? raw) => string.IsNullOrWhiteSpace(raw) ? Empty : ParseCached(raw!);
 
     private string? FindAsnListCommunity(string? name) =>
         name is null ? null : _config.RipeStat?.AsnLists.FirstOrDefault(l => l.Name == name)?.Community;
@@ -44,14 +50,36 @@ public sealed class ConfigCommunityResolver : ICommunityResolver
     private string? FindPrefixSourceCommunity(string? name) =>
         name is null ? null : _config.PrefixSources.FirstOrDefault(s => s.Name == name)?.Community;
 
+    /// <summary>
+    /// Static category community: the config override if set and valid, otherwise the hardcoded
+    /// default <c>"&lt;Asn&gt;:&lt;defaultValue&gt;"</c>. Returns empty if the local ASN exceeds 16 bits.
+    /// </summary>
+    private uint[] ResolveStaticCommunity(string? overrideValue, uint asn, int defaultValue, string fieldName)
+    {
+        if (!string.IsNullOrWhiteSpace(overrideValue))
+        {
+            try { return [CommunityCodec.Parse(overrideValue!)]; }
+            catch (FormatException ex)
+            {
+                _logger?.LogWarning(ex,
+                    "Invalid community '{Community}' in config ({Field}); falling back to default {Asn}:{Default}.",
+                    overrideValue, fieldName, asn, defaultValue);
+            }
+        }
+        if (asn > 0xFFFF)
+        {
+            _logger?.LogWarning("Local ASN {Asn} > 65535; cannot form the default {Field} community '{Asn}:{Default}' — these prefixes will be untagged.",
+                asn, fieldName, asn, defaultValue);
+            return Empty;
+        }
+        return [(asn << 16) | (uint)(defaultValue & 0xFFFF)];
+    }
+
     private uint[] ParseCached(string community)
     {
         if (_parsed.TryGetValue(community, out var cached)) return cached;
         uint[] result;
-        try
-        {
-            result = [CommunityCodec.Parse(community)];
-        }
+        try { result = [CommunityCodec.Parse(community)]; }
         catch (FormatException ex)
         {
             _logger?.LogWarning(ex,

--- a/BGPLite.Tests/CommunityResolverTests.cs
+++ b/BGPLite.Tests/CommunityResolverTests.cs
@@ -70,10 +70,9 @@ public class CommunityResolverTests
     }
 
     [Fact]
-    public void Resolve_Custom_And_Default_ReturnEmpty()
+    public void Resolve_Default_ReturnsEmpty()
     {
         var r = Resolver(ConfigWith());
-        Assert.Empty(r.Resolve(new CommunitySource(CommunitySourceKind.Custom)));
         Assert.Empty(r.Resolve(new CommunitySource(CommunitySourceKind.Default)));
     }
 
@@ -111,5 +110,51 @@ public class CommunityResolverTests
         var route = BgpSession.MakeRoute(0x0A000000, 8, 0, null, []);
         Assert.Empty(route.AsPath);
         Assert.Empty(route.Communities);
+    }
+
+    [Fact]
+    public void Resolve_Custom_DefaultsToAsn100()
+    {
+        var r = new ConfigCommunityResolver(new AppConfig(), new BgpConfig { Asn = 65444 }, null);
+        Assert.Equal([CommunityCodec.Parse("65444:100")], r.Resolve(new CommunitySource(CommunitySourceKind.Custom)));
+    }
+
+    [Fact]
+    public void Resolve_CustomAsn_DefaultsToAsn200()
+    {
+        var r = new ConfigCommunityResolver(new AppConfig(), new BgpConfig { Asn = 65444 }, null);
+        Assert.Equal([CommunityCodec.Parse("65444:200")], r.Resolve(new CommunitySource(CommunitySourceKind.CustomAsn)));
+    }
+
+    [Fact]
+    public void Resolve_Custom_ConfigOverrideWins()
+    {
+        var cfg = new AppConfig { CustomPrefixCommunity = "65000:999" };
+        var r = new ConfigCommunityResolver(cfg, new BgpConfig { Asn = 65444 }, null);
+        Assert.Equal([CommunityCodec.Parse("65000:999")], r.Resolve(new CommunitySource(CommunitySourceKind.Custom)));
+    }
+
+    [Fact]
+    public void Resolve_CustomAsn_ConfigOverrideWins()
+    {
+        var cfg = new AppConfig { CustomAsnCommunity = "65000:888" };
+        var r = new ConfigCommunityResolver(cfg, new BgpConfig { Asn = 65444 }, null);
+        Assert.Equal([CommunityCodec.Parse("65000:888")], r.Resolve(new CommunitySource(CommunitySourceKind.CustomAsn)));
+    }
+
+    [Fact]
+    public void Resolve_Custom_InvalidOverride_FallsBackToDefault()
+    {
+        var cfg = new AppConfig { CustomPrefixCommunity = "not-a-community" };
+        var r = new ConfigCommunityResolver(cfg, new BgpConfig { Asn = 65444 }, null);
+        Assert.Equal([CommunityCodec.Parse("65444:100")], r.Resolve(new CommunitySource(CommunitySourceKind.Custom)));
+    }
+
+    [Fact]
+    public void Resolve_Custom_FourByteAsn_DefaultUnformed_Empty()
+    {
+        // ASN > 65535 cannot form an "ASN:VALUE" community → untagged.
+        var r = new ConfigCommunityResolver(new AppConfig(), new BgpConfig { Asn = 200000 }, null);
+        Assert.Empty(r.Resolve(new CommunitySource(CommunitySourceKind.Custom)));
     }
 }

--- a/appsettings.Example.yml
+++ b/appsettings.Example.yml
@@ -46,3 +46,9 @@ PrefixSources:
 
 # Name of the source served as the RU/default set for unconfigured peers.
 DefaultPrefixSource: ru
+
+# Optional overrides for the static communities stamped on per-peer custom categories.
+# Defaults: custom prefixes → "<Asn>:100", custom AS-originated prefixes → "<Asn>:200".
+# CustomPrefixCommunity: "65444:100"
+# CustomAsnCommunity: "65444:200"
+


### PR DESCRIPTION
## Summary
Completes a fully static, UI-visible community scheme. Phase 1 (#64) tagged **static config lists**; this tags the **per-peer custom categories** with hardcoded communities (config-overridable). No DB/migrations.

## Scheme
| Category | Community |
|----------|-----------|
| AsnList / Country / PrefixSource (incl. RU default) | from config (Phase 1) |
| **Custom prefixes** | `<Asn>:100` (override: `CustomPrefixCommunity`) |
| **Custom AS** | `<Asn>:200` (override: `CustomAsnCommunity`) |

## Changes
- `CommunitySourceKind.CustomAsn` (new) — `BgpSession` site 6 (custom AS) now resolves its own community instead of reusing the custom-prefix one.
- `ConfigCommunityResolver` resolves `Custom`/`CustomAsn` to the hardcoded defaults (or config overrides) once in the ctor; malformed override → log + default; ASN > 65535 → untagged.
- `AppConfig.CustomPrefixCommunity` / `CustomAsnCommunity` optional overrides.
- **`GET /api/community-scheme`** → `{ asn, customPrefixes, customAsns }` so the UI renders the custom-category communities up front (static-list communities already in `/api/asn-lists`).

## Verification
- `dotnet build` — 0 errors; `dotnet test` — **183 passed** (+6 new resolver tests).
- Manual: peer with `customPrefixes` + `customAsns` → custom-prefix NLRI carry `<Asn>:100`, custom-AS NLRI carry `<Asn>:200`; config override changes them.

## Deferred
DB-backed `PrefixList` / named user lists — not needed under the static scheme; `ICommunityResolver` still supports a future `UserList` kind without touching this.

Refs #63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint that returns community scheme information.
  * Introduced separate community values for custom prefixes and AS-originated custom routes, with optional configuration overrides.

* **Bug Fixes**
  * Custom route tagging now applies the correct community for each route type.
  * Invalid or missing override values now fall back to safe defaults.

* **Documentation**
  * Updated the example configuration to show the new optional community settings and defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->