### PR TITLE
fix: reject IPv6 next hops and honor well-known communities

### DIFF
--- a/BGPLite.Api/PeerStore.cs
+++ b/BGPLite.Api/PeerStore.cs
@@ -115,6 +115,16 @@ public sealed class PeerStore : IPeerStore
             .ToHashSet();
     }
 
+    public HashSet<uint> GetCommunities(string ip, uint asn)
+    {
+        using var db = _dbFactory.CreateDbContext();
+        return db.Peers.Include(p => p.Communities)
+            .Where(p => p.Ip == ip && p.Asn == asn)
+            .SelectMany(p => p.Communities)
+            .Select(c => (uint)c.Community)
+            .ToHashSet();
+    }
+
     public HashSet<uint> GetCommunitiesByIp(string ip)
     {
         using var db = _dbFactory.CreateDbContext();

--- a/BGPLite.Protocol/BgpConstants.cs
+++ b/BGPLite.Protocol/BgpConstants.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Sockets;
 
 namespace BGPLite.Protocol;
 
@@ -97,8 +98,21 @@ public static class BgpConstants
         public const byte Unicast = 1;
     }
 
+    /// <summary>RFC 1997 well-known communities.</summary>
+    public static class Community
+    {
+        public const uint NoExport = 0xFFFFFF01u;
+        public const uint NoAdvertise = 0xFFFFFF02u;
+        public const uint NoExportSubconfed = 0xFFFFFF03u;
+    }
+
     public static uint IPAddressToUint(IPAddress address)
     {
+        ArgumentNullException.ThrowIfNull(address);
+
+        if (address.AddressFamily != AddressFamily.InterNetwork)
+            throw new ArgumentException("IPv4 address required", nameof(address));
+
         var bytes = address.GetAddressBytes();
         return (uint)(bytes[0] << 24 | bytes[1] << 16 | bytes[2] << 8 | bytes[3]);
     }

--- a/BGPLite.Routing/BGPLite.Routing.csproj
+++ b/BGPLite.Routing/BGPLite.Routing.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\BGPLite.Configuration\BGPLite.Configuration.csproj" />
+    <ProjectReference Include="..\BGPLite.Protocol\BGPLite.Protocol.csproj" />
   </ItemGroup>
 
 </Project>

--- a/BGPLite.Routing/PeerCommunityFilter.cs
+++ b/BGPLite.Routing/PeerCommunityFilter.cs
@@ -6,9 +6,9 @@ namespace BGPLite.Routing;
 public sealed class PeerCommunityFilter : IRouteFilter
 {
     private readonly uint _localAsn;
-    private readonly Func<string, HashSet<uint>> _getCommunities;
+    private readonly Func<string, uint?, HashSet<uint>> _getCommunities;
 
-    public PeerCommunityFilter(uint localAsn, Func<string, HashSet<uint>> getCommunities)
+    public PeerCommunityFilter(uint localAsn, Func<string, uint?, HashSet<uint>> getCommunities)
     {
         _localAsn = localAsn;
         _getCommunities = getCommunities;
@@ -23,7 +23,7 @@ public sealed class PeerCommunityFilter : IRouteFilter
         if (HasWellKnownSuppressingCommunity(route, isEbgp))
             return false;
 
-        var allowed = _getCommunities(peer.Address);
+        var allowed = _getCommunities(peer.Address, peer.RemoteAsn);
         if (allowed.Count == 0)
             return true; // no filter = all routes
 

--- a/BGPLite.Routing/PeerCommunityFilter.cs
+++ b/BGPLite.Routing/PeerCommunityFilter.cs
@@ -1,13 +1,16 @@
 using BGPLite.Configuration;
+using BGPLite.Protocol;
 
 namespace BGPLite.Routing;
 
 public sealed class PeerCommunityFilter : IRouteFilter
 {
+    private readonly uint _localAsn;
     private readonly Func<string, HashSet<uint>> _getCommunities;
 
-    public PeerCommunityFilter(Func<string, HashSet<uint>> getCommunities)
+    public PeerCommunityFilter(uint localAsn, Func<string, HashSet<uint>> getCommunities)
     {
+        _localAsn = localAsn;
         _getCommunities = getCommunities;
     }
 
@@ -15,6 +18,11 @@ public sealed class PeerCommunityFilter : IRouteFilter
 
     public bool AcceptOutgoing(Route route, PeerConfig peer)
     {
+        var isEbgp = !peer.RemoteAsn.HasValue || peer.RemoteAsn.Value != _localAsn;
+
+        if (HasWellKnownSuppressingCommunity(route, isEbgp))
+            return false;
+
         var allowed = _getCommunities(peer.Address);
         if (allowed.Count == 0)
             return true; // no filter = all routes
@@ -30,4 +38,10 @@ public sealed class PeerCommunityFilter : IRouteFilter
 
         return false;
     }
+
+    private static bool HasWellKnownSuppressingCommunity(Route route, bool isEbgp) =>
+        route.Communities.Contains(BgpConstants.Community.NoAdvertise) ||
+        (isEbgp && (
+            route.Communities.Contains(BgpConstants.Community.NoExport) ||
+            route.Communities.Contains(BgpConstants.Community.NoExportSubconfed)));
 }

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -443,6 +443,7 @@ public sealed class BgpSession : IDisposable
                 uint[] asPath = [];
                 uint[] communities = [];
                 uint[] as4Path = [];
+                var filterPeerConfig = GetFilterPeerConfig();
 
                 foreach (var attr in update.PathAttributes)
                 {
@@ -487,7 +488,7 @@ public sealed class BgpSession : IDisposable
                         Communities = communities
                     };
 
-                    if (_routeFilter.AcceptIncoming(route, _peerConfig))
+                    if (_routeFilter.AcceptIncoming(route, filterPeerConfig))
                     {
                         _routeTable.AddOrUpdate(route);
                         _logger.LogDebug("Route added: {Prefix} via {NextHop}", nlri, BgpConstants.UintToIPAddress(nextHop));

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -680,7 +680,8 @@ public sealed class BgpSession : IDisposable
                 }
 
                 // Apply the per-peer outgoing community filter (same rule as the shared-table path).
-                routes = routes.Where(r => _routeFilter.AcceptOutgoing(r, _peerConfig)).ToList();
+                var filterPeerConfig = GetFilterPeerConfig();
+                routes = routes.Where(r => _routeFilter.AcceptOutgoing(r, filterPeerConfig)).ToList();
                 await SendRoutesAsync(nextHop, routes);
                 return;
             }
@@ -710,10 +711,11 @@ public sealed class BgpSession : IDisposable
         }
 
         // Final fallback: send from shared route table (single pass — one allocation, not two)
+        var sharedFilterPeerConfig = GetFilterPeerConfig();
         var filtered = new List<Route>();
         foreach (var r in _routeTable.Enumerate())
         {
-            if (_routeFilter.AcceptOutgoing(r, _peerConfig))
+            if (_routeFilter.AcceptOutgoing(r, sharedFilterPeerConfig))
                 filtered.Add(r);
         }
         if (filtered.Count == 0) return;
@@ -916,6 +918,14 @@ public sealed class BgpSession : IDisposable
         await SendMessageAsync(update);
         _metrics.UpdateSent();
     }
+
+    private PeerConfig GetFilterPeerConfig() => new()
+    {
+        Address = _peerConfig.Address,
+        RemoteAsn = _remoteAsn,
+        Description = _peerConfig.Description,
+        Port = _peerConfig.Port
+    };
 
     /// <summary>
     /// End-of-RIB marker for IPv4 unicast (RFC 4724 §2): a minimum-length UPDATE (no withdrawn

--- a/BGPLite.Server/IPeerStore.cs
+++ b/BGPLite.Server/IPeerStore.cs
@@ -13,6 +13,7 @@ public interface IPeerStore
     List<string> GetCustomPrefixes(string peerId);
     List<uint> GetCustomAsns(string peerId);
     HashSet<uint> GetCommunities(string peerId);
+    HashSet<uint> GetCommunities(string ip, uint asn);
     void SetCommunities(string peerId, HashSet<uint> communities);
     void ClearCommunities(string peerId);
     void SetDescription(string id, string description);

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -1,4 +1,5 @@
 using System.Buffers.Binary;
+using System.Net;
 using System.Linq;
 using BGPLite.Protocol;
 
@@ -189,6 +190,19 @@ public class BgpMessageTests
     {
         for (var i = 0; i < 16; i++)
             Assert.Equal(0xFF, BgpConstants.Marker[i]);
+    }
+
+    [Fact]
+    public void IpAddressToUint_Ipv6_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            BgpConstants.IPAddressToUint(IPAddress.Parse("2001:db8::1")));
+    }
+
+    [Fact]
+    public void IpAddressToUint_Null_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => BgpConstants.IPAddressToUint(null!));
     }
 
     [Fact]

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -206,6 +206,13 @@ public class BgpMessageTests
     }
 
     [Fact]
+    public void IpAddressToUint_ValidIpv4_ReturnsExpectedValue()
+    {
+        var result = BgpConstants.IPAddressToUint(IPAddress.Parse("192.168.1.1"));
+        Assert.Equal(0xC0A80101u, result);
+    }
+
+    [Fact]
     public void GetBufferSize_MatchesWriteSize()
     {
         var open = new BgpOpenMessage

--- a/BGPLite.Tests/PeerCommunityFilterTests.cs
+++ b/BGPLite.Tests/PeerCommunityFilterTests.cs
@@ -9,6 +9,7 @@ public class PeerCommunityFilterTests
     private const uint LocalAsn = 65001;
     private static readonly PeerConfig EbgpPeer = new() { Address = "192.0.2.1", RemoteAsn = 65002 };
     private static readonly PeerConfig IbgpPeer = new() { Address = "192.0.2.2", RemoteAsn = LocalAsn };
+    private const string SharedIp = "192.0.2.10";
 
     private static Route RouteWith(params uint[] communities) => new()
     {
@@ -18,8 +19,8 @@ public class PeerCommunityFilterTests
         Communities = communities
     };
 
-    private static PeerCommunityFilter NewFilter(HashSet<uint>? allowed = null) =>
-        new(LocalAsn, _ => allowed ?? new HashSet<uint>());
+    private static PeerCommunityFilter NewFilter(Func<string, uint?, HashSet<uint>>? resolver = null) =>
+        new(LocalAsn, resolver ?? ((_, _) => new HashSet<uint>()));
 
     [Theory]
     [InlineData(BgpConstants.Community.NoExport)]
@@ -32,6 +33,43 @@ public class PeerCommunityFilterTests
         Assert.False(filter.AcceptOutgoing(RouteWith(community), EbgpPeer));
     }
 
+    [Fact]
+    public void SameIp_DifferentAsn_UsesPeerSpecificCommunities()
+    {
+        var filter = NewFilter((ip, asn) =>
+        {
+            if (ip != SharedIp || !asn.HasValue) return new HashSet<uint>();
+            return asn.Value switch
+            {
+                64512 => new HashSet<uint> { 0x0000FF01 },
+                64513 => new HashSet<uint> { 0x0000FF02 },
+                _ => new HashSet<uint>()
+            };
+        });
+
+        var peerA = new PeerConfig { Address = SharedIp, RemoteAsn = 64512 };
+        var peerB = new PeerConfig { Address = SharedIp, RemoteAsn = 64513 };
+
+        Assert.True(filter.AcceptOutgoing(RouteWith(0x0000FF01), peerA));
+        Assert.False(filter.AcceptOutgoing(RouteWith(0x0000FF01), peerB));
+        Assert.True(filter.AcceptOutgoing(RouteWith(0x0000FF02), peerB));
+        Assert.False(filter.AcceptOutgoing(RouteWith(0x0000FF02), peerA));
+    }
+
+    [Fact]
+    public void NullRemoteAsn_FallsBackToIpOnlyCommunities()
+    {
+        var filter = NewFilter((ip, asn) =>
+            asn.HasValue
+                ? new HashSet<uint> { 0x0000FF01 }
+                : new HashSet<uint> { 0x0000FF03 });
+
+        var peerNullAsn = new PeerConfig { Address = SharedIp, RemoteAsn = null };
+
+        Assert.True(filter.AcceptOutgoing(RouteWith(0x0000FF03), peerNullAsn));
+        Assert.False(filter.AcceptOutgoing(RouteWith(0x0000FF01), peerNullAsn));
+    }
+
     [Theory]
     [InlineData(BgpConstants.Community.NoExport)]
     [InlineData(BgpConstants.Community.NoAdvertise)]
@@ -39,7 +77,7 @@ public class PeerCommunityFilterTests
     public void WellKnownCommunity_BlocksOutgoing_EvenWhenAllowed_OnEbgp(uint community)
     {
         var allowed = new HashSet<uint> { community };
-        var filter = NewFilter(allowed);
+        var filter = NewFilter((_, _) => allowed);
 
         Assert.False(filter.AcceptOutgoing(RouteWith(community), EbgpPeer));
     }
@@ -51,7 +89,7 @@ public class PeerCommunityFilterTests
     public void WellKnownCommunity_BlocksOutgoing_EvenWhenMixedWithAllowed_OnEbgp(uint community)
     {
         var allowed = new HashSet<uint> { 0x0000FF01 };
-        var filter = NewFilter(allowed);
+        var filter = NewFilter((_, _) => allowed);
 
         Assert.False(filter.AcceptOutgoing(
             RouteWith(0x0000FF01, community), EbgpPeer));
@@ -79,7 +117,7 @@ public class PeerCommunityFilterTests
     public void ConfiguredCommunity_StillPasses_WhenNoWellKnownCommunity()
     {
         var allowed = new HashSet<uint> { 0x0000FF01 };
-        var filter = NewFilter(allowed);
+        var filter = NewFilter((_, _) => allowed);
 
         Assert.True(filter.AcceptOutgoing(RouteWith(0x0000FF01), EbgpPeer));
     }
@@ -96,7 +134,7 @@ public class PeerCommunityFilterTests
     public void RouteWithDisallowedCommunity_IsRejected()
     {
         var allowed = new HashSet<uint> { 0x0000FF01 };
-        var filter = NewFilter(allowed);
+        var filter = NewFilter((_, _) => allowed);
 
         Assert.False(filter.AcceptOutgoing(RouteWith(0x0000FF02), EbgpPeer));
     }

--- a/BGPLite.Tests/PeerCommunityFilterTests.cs
+++ b/BGPLite.Tests/PeerCommunityFilterTests.cs
@@ -1,0 +1,103 @@
+using BGPLite.Configuration;
+using BGPLite.Protocol;
+using BGPLite.Routing;
+
+namespace BGPLite.Tests;
+
+public class PeerCommunityFilterTests
+{
+    private const uint LocalAsn = 65001;
+    private static readonly PeerConfig EbgpPeer = new() { Address = "192.0.2.1", RemoteAsn = 65002 };
+    private static readonly PeerConfig IbgpPeer = new() { Address = "192.0.2.2", RemoteAsn = LocalAsn };
+
+    private static Route RouteWith(params uint[] communities) => new()
+    {
+        Prefix = 0xC0A80000,
+        PrefixLength = 24,
+        NextHop = 0x01020304,
+        Communities = communities
+    };
+
+    private static PeerCommunityFilter NewFilter(HashSet<uint>? allowed = null) =>
+        new(LocalAsn, _ => allowed ?? new HashSet<uint>());
+
+    [Theory]
+    [InlineData(BgpConstants.Community.NoExport)]
+    [InlineData(BgpConstants.Community.NoAdvertise)]
+    [InlineData(BgpConstants.Community.NoExportSubconfed)]
+    public void WellKnownCommunity_BlocksOutgoing_OnEbgp(uint community)
+    {
+        var filter = NewFilter();
+
+        Assert.False(filter.AcceptOutgoing(RouteWith(community), EbgpPeer));
+    }
+
+    [Theory]
+    [InlineData(BgpConstants.Community.NoExport)]
+    [InlineData(BgpConstants.Community.NoAdvertise)]
+    [InlineData(BgpConstants.Community.NoExportSubconfed)]
+    public void WellKnownCommunity_BlocksOutgoing_EvenWhenAllowed_OnEbgp(uint community)
+    {
+        var allowed = new HashSet<uint> { community };
+        var filter = NewFilter(allowed);
+
+        Assert.False(filter.AcceptOutgoing(RouteWith(community), EbgpPeer));
+    }
+
+    [Theory]
+    [InlineData(BgpConstants.Community.NoExport)]
+    [InlineData(BgpConstants.Community.NoAdvertise)]
+    [InlineData(BgpConstants.Community.NoExportSubconfed)]
+    public void WellKnownCommunity_BlocksOutgoing_EvenWhenMixedWithAllowed_OnEbgp(uint community)
+    {
+        var allowed = new HashSet<uint> { 0x0000FF01 };
+        var filter = NewFilter(allowed);
+
+        Assert.False(filter.AcceptOutgoing(
+            RouteWith(0x0000FF01, community), EbgpPeer));
+    }
+
+    [Theory]
+    [InlineData(BgpConstants.Community.NoExport)]
+    [InlineData(BgpConstants.Community.NoExportSubconfed)]
+    public void ExportCommunities_AreAllowed_OnIbgp(uint community)
+    {
+        var filter = NewFilter();
+
+        Assert.True(filter.AcceptOutgoing(RouteWith(community), IbgpPeer));
+    }
+
+    [Fact]
+    public void NoAdvertise_BlocksOnIbgp()
+    {
+        var filter = NewFilter();
+
+        Assert.False(filter.AcceptOutgoing(RouteWith(BgpConstants.Community.NoAdvertise), IbgpPeer));
+    }
+
+    [Fact]
+    public void ConfiguredCommunity_StillPasses_WhenNoWellKnownCommunity()
+    {
+        var allowed = new HashSet<uint> { 0x0000FF01 };
+        var filter = NewFilter(allowed);
+
+        Assert.True(filter.AcceptOutgoing(RouteWith(0x0000FF01), EbgpPeer));
+    }
+
+    [Fact]
+    public void RouteWithoutCommunity_StillPasses_WhenNoFilterConfigured()
+    {
+        var filter = NewFilter();
+
+        Assert.True(filter.AcceptOutgoing(RouteWith(), EbgpPeer));
+    }
+
+    [Fact]
+    public void RouteWithDisallowedCommunity_IsRejected()
+    {
+        var allowed = new HashSet<uint> { 0x0000FF01 };
+        var filter = NewFilter(allowed);
+
+        Assert.False(filter.AcceptOutgoing(RouteWith(0x0000FF02), EbgpPeer));
+    }
+}

--- a/BGPLite/Program.cs
+++ b/BGPLite/Program.cs
@@ -38,7 +38,8 @@ builder.Services.AddSingleton<PeerStore>();
 builder.Services.AddSingleton<IRouteFilter>(sp =>
 {
     var store = sp.GetRequiredService<PeerStore>();
-    return new PeerCommunityFilter(config.Bgp.Asn, ip => store.GetCommunitiesByIp(ip));
+    return new PeerCommunityFilter(config.Bgp.Asn, (ip, asn) =>
+        asn.HasValue ? store.GetCommunities(ip, asn.Value) : store.GetCommunitiesByIp(ip));
 });
 // Per-list community resolver: stamps a configured BGP community on prefixes by source
 // (AsnList / Country / PrefixSource). ConfigCommunityResolver reads static config; Phase 2 will

--- a/BGPLite/Program.cs
+++ b/BGPLite/Program.cs
@@ -38,7 +38,7 @@ builder.Services.AddSingleton<PeerStore>();
 builder.Services.AddSingleton<IRouteFilter>(sp =>
 {
     var store = sp.GetRequiredService<PeerStore>();
-    return new PeerCommunityFilter(ip => store.GetCommunitiesByIp(ip));
+    return new PeerCommunityFilter(config.Bgp.Asn, ip => store.GetCommunitiesByIp(ip));
 });
 // Per-list community resolver: stamps a configured BGP community on prefixes by source
 // (AsnList / Country / PrefixSource). ConfigCommunityResolver reads static config; Phase 2 will


### PR DESCRIPTION
## Summary
- Reject IPv6 addresses in the IPv4 NEXT_HOP conversion path.
- Honor RFC 1997 well-known communities in outbound route filtering.
- Add regression tests for both behaviors.

## Why
- Fixes upstream issues #13 and #34 from the planned quick-fix set.
- Prevents silent IPv6 truncation and enforces well-known community suppression semantics.

## Validation
- `ocr review --audience agent` on the clean diff: no comments generated.
- `dotnet test` could not run in this environment: `dotnet: command not found`.

## Risk
- IPv4-only NEXT_HOP encoding now fails loudly for non-IPv4 input.
- Community filtering now distinguishes eBGP vs iBGP using configured local ASN and peer ASN when available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for well-known suppressing community handling in outgoing route filtering, with distinct eBGP vs iBGP behavior.
  * Allowed-community decisions can now be resolved using both peer IP and remote ASN for more precise per-peer control.
* **Bug Fixes**
  * Route filtering during inbound and outbound processing now uses the session’s negotiated remote ASN configuration.
  * Improved IP-to-integer conversion by rejecting null and non-IPv4 inputs.
* **Tests**
  * Added unit tests covering IPv4-only/null conversion and extensive eBGP/iBGP community filtering scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->