### PR TITLE
feat(providers): AsnPrefixProvider — support Kind: asn in PrefixSources

### DIFF
--- a/BGPLite.Providers/AsnPrefixProvider.cs
+++ b/BGPLite.Providers/AsnPrefixProvider.cs
@@ -1,0 +1,36 @@
+using BGPLite.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace BGPLite.Providers;
+
+/// <summary>
+/// Loads the prefixes originated by a single AS via RIPEstat (Kind = <c>"asn"</c>).
+/// Requires <see cref="PrefixSourceConfig.Asn"/>. Shares the RIPEstat client, retry, and per-ASN
+/// caching of <see cref="RipeStatProvider"/>/PrefixService, so adding it as a <c>Kind: asn</c>
+/// source under <c>PrefixSources</c> does not multiply RIPEstat traffic.
+/// </summary>
+public sealed class AsnPrefixProvider : IPrefixSourceProvider
+{
+    private readonly RipeStatProvider _ripe;
+    private readonly ILogger<AsnPrefixProvider> _logger;
+
+    public AsnPrefixProvider(RipeStatProvider ripe, ILogger<AsnPrefixProvider> logger)
+    {
+        _ripe = ripe;
+        _logger = logger;
+    }
+
+    public string Kind => "asn";
+
+    public async Task<IReadOnlyList<(uint Prefix, byte Length)>> LoadAsync(PrefixSourceConfig source, CancellationToken ct = default)
+    {
+        if (!source.Asn.HasValue)
+            throw new InvalidOperationException($"Prefix source '{source.Name}': Kind=asn requires an Asn.");
+
+        var prefixes = await _ripe.GetPrefixesAsync(source.Asn.Value, ct);
+        _logger.LogInformation(
+            "Source '{Name}' (asn AS{Asn}): loaded {Count} prefixes via RIPEstat",
+            source.Name, source.Asn.Value, prefixes.Count);
+        return prefixes.Select(p => (Prefix: p.Prefix, Length: p.PrefixLength)).ToList();
+    }
+}

--- a/BGPLite.Tests/AsnPrefixProviderTests.cs
+++ b/BGPLite.Tests/AsnPrefixProviderTests.cs
@@ -1,0 +1,20 @@
+using BGPLite.Configuration;
+using BGPLite.Providers;
+using Xunit;
+
+namespace BGPLite.Tests;
+
+public class AsnPrefixProviderTests
+{
+    [Fact]
+    public void Kind_IsAsn() => Assert.Equal("asn", new AsnPrefixProvider(null!, null!).Kind);
+
+    [Fact]
+    public async Task LoadAsync_MissingAsn_Throws()
+    {
+        // Asn is checked before RipeStatProvider is touched, so null deps are safe here.
+        var provider = new AsnPrefixProvider(null!, null!);
+        var source = new PrefixSourceConfig { Name = "cloudflare", Kind = "asn" };
+        await Assert.ThrowsAsync<InvalidOperationException>(() => provider.LoadAsync(source));
+    }
+}

--- a/BGPLite/Program.cs
+++ b/BGPLite/Program.cs
@@ -83,6 +83,11 @@ builder.Services.AddSingleton(sp => new RipeStatProvider(
     sp.GetRequiredService<ILogger<RipeStatProvider>>(),
     ripeStatConfig));
 
+// AS-originated prefix source (Kind: "asn") — fetches an AS's prefixes via RIPEstat through the
+// provider factory, so `Kind: asn` entries under PrefixSources load like any other source.
+builder.Services.AddSingleton<AsnPrefixProvider>();
+builder.Services.AddSingleton<IPrefixSourceProvider>(sp => sp.GetRequiredService<AsnPrefixProvider>());
+
 builder.Services.AddSingleton<IPrefixService>(sp =>
 {
     var ripe = sp.GetRequiredService<RipeStatProvider>();

--- a/appsettings.Example.yml
+++ b/appsettings.Example.yml
@@ -38,6 +38,14 @@ PrefixSources:
     # Headers:                    # optional request headers (Authorization, X-API-Key, ...)
     #   Authorization: "Bearer <token>"
 
+  # Kind: asn — fetch all prefixes originated by an AS via RIPEstat (cached per ASN).
+  # Optional Community tags the prefixes advertised from this source.
+  - Kind: asn
+    Name: cloudflare
+    Description: "AS13335 Cloudflare Inc."
+    Asn: 13335
+    Community: "65444:101"
+
   - Kind: file
     Name: local
     Description: "Local override list"


### PR DESCRIPTION
## Summary
`Kind: asn` under `PrefixSources` was silently broken — the provider factory only knew `file`/`http`, so ASN entries threw `Unknown prefix source kind: 'asn'` (caught → 0 prefixes). This adds an `AsnPrefixProvider` so `Kind: asn` works as a first-class source.

## Changes
- **`AsnPrefixProvider`** (`Kind="asn"`) — fetches the AS's prefixes via the existing `RipeStatProvider` (shares the per-ASN cache/retry, no extra RIPEstat traffic). Requires `PrefixSourceConfig.Asn`.
- Registered in `Program.cs` as both `AsnPrefixProvider` and `IPrefixSourceProvider`, so `PrefixSourceProviderFactory` picks it up by kind.
- `appsettings.Example.yml` — documents a `Kind: asn` source.
- 2 tests (kind discriminator; missing `Asn` throws).

## Effect
After this, a `Kind: asn` entry under `PrefixSources` loads at startup, is subscribable by name, and (combined with the community work in #64/#66) gets its `Community` stamped on advertised prefixes and surfaced in `GET /api/asn-lists`. `prefixCount` is no longer 0 for ASN sources.

## Verification
`dotnet build` — 0 errors; `dotnet test` — **185 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading prefix sources by ASN, expanding the available source types.
  * Included a new example configuration entry showing how to set up an ASN-based prefix source.

* **Bug Fixes**
  * Added validation to ensure required ASN settings are present before loading prefixes.

* **Tests**
  * Added coverage for ASN source identification and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->