### PR TITLE
fix(logging): silence EF Core SQL spam + Docker log rotation

### DIFF
--- a/BGPLite/Program.cs
+++ b/BGPLite/Program.cs
@@ -11,6 +11,12 @@ using Microsoft.Extensions.Logging;
 
 var builder = Host.CreateApplicationBuilder(args);
 
+// EF Core logs every SQL statement at Information by default; with no appsettings.json the host
+// uses Information for everything → EF SQL is ~85% of log volume. Silence EF SQL (warnings/errors
+// still surface) without muting startup/host logs. (appsettings.yml Logging:LogLevel is NOT read
+// by the host — YAML loads only into AppConfig — so this filter is the reliable place.)
+builder.Logging.AddFilter("Microsoft.EntityFrameworkCore", LogLevel.Warning);
+
 var baseDir = AppContext.BaseDirectory;
 var dataDir = Environment.GetEnvironmentVariable("BGPLITE_DATA") ?? Path.Combine(baseDir, "data");
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,3 +17,8 @@ services:
       - ./appsettings.yml:/app/appsettings.yml:ro
       - ./data:/app/data
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"


### PR DESCRIPTION
## Summary
Fixes #72. Production logs were ~85% EF Core SQL (every query at Information) with no rotation, filling the disk.

## Why appsettings.yml doesn't fix it
`Host.CreateApplicationBuilder` reads `Logging:LogLevel` from `appsettings.json` (by convention), not from the YAML — `ConfigLoader` loads `appsettings.yml` only into `AppConfig`. There's no `appsettings.json` in the repo, so the default Information threshold applied everywhere.

## Changes
- **`Program.cs`** — `builder.Logging.AddFilter("Microsoft.EntityFrameworkCore", LogLevel.Warning)` (deterministic; doesn't depend on a config file; startup/host logs stay Informational).
- **`docker-compose.yml`** — bound the `json-file` driver: `max-size: 10m`, `max-file: 3` (~30 MB cap).

## Ops note (immediate relief before redeploy)
On the prod box, you can cap the existing container log now: `truncate -s 0 $(docker inspect --format='{{.LogPath}}' bgplite)` and `docker compose up -d --force-recreate` after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy database logs so only important warnings and errors are shown.
  * Updated container logging settings to keep log files smaller and rotate them automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->