### PR TITLE
fix: Cease subcode (RFC 4486) + /api/asn-lists type by Kind

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -542,7 +542,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
                     Country = (string?)null,
                     Community = source.Community,
                     prefixCount = prefixes.Count,
-                    type = "list"
+                    type = source.Kind == "asn" ? "asn" : "list"
                 });
             }
         }

--- a/BGPLite.Protocol/BgpConstants.cs
+++ b/BGPLite.Protocol/BgpConstants.cs
@@ -39,6 +39,13 @@ public static class BgpConstants
         public const byte MissingWellKnownAttribute = 3;
         public const byte BadBgpIdentifier = 3;
         public const byte UnacceptableHoldTime = 6;
+
+        // RFC 4486 Cease subcodes (apply when ErrorCode = Cease = 6)
+        public const byte CeaseMaxPrefixes = 1;
+        public const byte CeaseAdministrativeShutdown = 2;
+        public const byte CeasePeerDeconfigured = 3;
+        public const byte CeaseAdministrativeReset = 6;
+        public const byte CeaseConnectionRejected = 7;
     }
 
     public static class Attribute

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -1120,7 +1120,7 @@ public sealed class BgpSession : IDisposable
 
         try
         {
-            await SendNotificationAsync(BgpConstants.Error.Cease, BgpConstants.SubError.Unspecific);
+            await SendNotificationAsync(BgpConstants.Error.Cease, BgpConstants.SubError.CeaseAdministrativeReset);
             _logger.LogInformation("Cease sent to {Peer} on shutdown", _peer);
         }
         catch (Exception ex)

--- a/BGPLite.Tests/BgpSessionShutdownTests.cs
+++ b/BGPLite.Tests/BgpSessionShutdownTests.cs
@@ -69,7 +69,7 @@ public class BgpSessionShutdownTests
         var msg = BgpMessageReader.ReadMessage(buf.AsSpan(0, len));
         var notif = Assert.IsType<BgpNotificationMessage>(msg);
         Assert.Equal(BgpConstants.Error.Cease, notif.ErrorCode);
-        Assert.Equal(BgpConstants.SubError.Unspecific, notif.SubErrorCode);
+        Assert.Equal(BgpConstants.SubError.CeaseAdministrativeReset, notif.SubErrorCode);
     }
 
     [Fact]


### PR DESCRIPTION
Two small diagnostics/correctness fixes for the 1.2.1 batch.\n\n- **#70**: `NotifyCeaseAsync` → Cease/Administrative Reset (6/6, RFC 4486) instead of 6/0 (unspecific). Adds RFC 4486 Cease subcodes to `BgpConstants.SubError`.\n- **#71**: `/api/asn-lists` — a PrefixSource's `type` now follows its `Kind` ("asn" vs "list"), so the UI distinguishes AS-originated sources.\n\nBuild clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RFC 4486 BGP Cease subcodes, including administrative shutdown, peer deconfigured, administrative reset, connection rejected, and max prefixes.
* **Bug Fixes**
  * Corrected the reported type for appended ASN-related list entries so it matches the originating source.
  * Updated local Cease notifications to use the administrative reset subcode instead of a generic value.
* **Tests**
  * Adjusted shutdown notification expectations to match the updated administrative reset subcode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->