### PR TITLE
protocol: harden OPEN and UPDATE validation

### DIFF
--- a/BGPLite.Protocol/AttributeHelper.cs
+++ b/BGPLite.Protocol/AttributeHelper.cs
@@ -118,7 +118,7 @@ public static class AttributeHelper
         BgpConstants.Attribute.AtomicAggregate => true,
         BgpConstants.Attribute.Aggregator => true,
         BgpConstants.Attribute.As4Path => true,
-        BgpConstants.Attribute.As4PathAggregator => true,
+        BgpConstants.Attribute.As4Aggregator => true,
         _ => false
     };
 
@@ -159,6 +159,9 @@ public static class AttributeHelper
 
     private static byte[] WritePathData(uint[] ases, int asSize, string attributeName)
     {
+        // Intentionally emits a single AS_SEQUENCE segment. For the current route-server use case,
+        // paths longer than 255 ASNs are treated as out of scope instead of being split into
+        // multiple segments.
         if (ases.Length > byte.MaxValue)
             throw new ArgumentOutOfRangeException(nameof(ases), $"{attributeName} segment length cannot exceed 255 ASNs.");
 

--- a/BGPLite.Protocol/AttributeHelper.cs
+++ b/BGPLite.Protocol/AttributeHelper.cs
@@ -34,10 +34,6 @@ public static class AttributeHelper
         };
     }
 
-    /// <summary>
-    /// Writes AS4_PATH attribute (type 17) per RFC 6793 §6.
-    /// Carries the true 4-byte AS sequence when sending to a 2-byte-only peer.
-    /// </summary>
     public static PathAttribute WriteAs4Path(uint[] ases)
     {
         return new PathAttribute
@@ -48,91 +44,32 @@ public static class AttributeHelper
         };
     }
 
-    /// <summary>
-    /// Reads AS4_PATH attribute (type 17) per RFC 6793 §6.
-    /// Returns the 4-byte AS sequence for reconstruction when receiving from a 2-byte-only peer.
-    /// NOTE: AS_SET segments are not preserved — returns a flat AS sequence (matching ReadAsPath).
-    /// </summary>
     public static uint[] ReadAs4Path(PathAttribute attr)
     {
         return ReadPathData(attr.Data, 4, "AS4_PATH");
     }
 
-    private static uint[] ReadPathData(ReadOnlySpan<byte> data, int asSize, string attributeName)
-    {
-        var ases = new List<uint>();
-        var offset = 0;
-
-        while (offset + 2 <= data.Length)
-        {
-            // segment header: [type][length]
-            var segmentType = data[offset++];
-            var segmentLength = data[offset++];
-
-            if (segmentType != BgpConstants.AsPath.AsSequence &&
-                segmentType != BgpConstants.AsPath.AsSet)
-                throw new BgpParseException($"Invalid {attributeName} segment type: {segmentType}");
-
-            var segBytes = segmentLength * asSize;
-            if (offset + segBytes > data.Length)
-                throw new BgpParseException($"Truncated {attributeName} segment");
-
-            for (var i = 0; i < segmentLength; i++)
-            {
-                ases.Add(ReadAsn(data.Slice(offset, asSize), asSize));
-                offset += asSize;
-            }
-        }
-
-        if (offset != data.Length)
-            throw new BgpParseException($"Malformed {attributeName} attribute");
-
-        return ases.ToArray();
-    }
-
-    private static byte[] WritePathData(uint[] ases, int asSize, string attributeName)
-    {
-        if (ases.Length > byte.MaxValue)
-            throw new ArgumentOutOfRangeException(nameof(ases), $"{attributeName} segment length cannot exceed 255 ASNs.");
-
-        var data = new byte[2 + ases.Length * asSize];
-        data[0] = BgpConstants.AsPath.AsSequence;
-        data[1] = (byte)ases.Length;
-
-        var offset = 2;
-        foreach (var asn in ases)
-        {
-            WriteAsn(data.AsSpan(offset, asSize), asn, asSize);
-            offset += asSize;
-        }
-
-        return data;
-    }
-
-    private static uint ReadAsn(ReadOnlySpan<byte> data, int asSize) => asSize switch
-    {
-        2 => BinaryPrimitives.ReadUInt16BigEndian(data),
-        4 => BinaryPrimitives.ReadUInt32BigEndian(data),
-        _ => throw new ArgumentOutOfRangeException(nameof(asSize))
-    };
-
-    private static void WriteAsn(Span<byte> data, uint asn, int asSize)
-    {
-        switch (asSize)
-        {
-            case 2:
-                BinaryPrimitives.WriteUInt16BigEndian(data, (ushort)asn);
-                break;
-            case 4:
-                BinaryPrimitives.WriteUInt32BigEndian(data, asn);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException(nameof(asSize));
-        }
-    }
-
     public static uint ReadNextHop(PathAttribute attr)
     {
+        return BinaryPrimitives.ReadUInt32BigEndian(attr.Data);
+    }
+
+    public static uint ReadAggregatorAsn(PathAttribute attr, bool fourByteAsn)
+    {
+        var expectedLength = fourByteAsn ? 8 : 6;
+        if (attr.Data.Length != expectedLength)
+            throw new BgpParseException($"Malformed AGGREGATOR attribute: expected {expectedLength} bytes, got {attr.Data.Length}");
+
+        return fourByteAsn
+            ? BinaryPrimitives.ReadUInt32BigEndian(attr.Data)
+            : BinaryPrimitives.ReadUInt16BigEndian(attr.Data);
+    }
+
+    public static uint ReadAs4AggregatorAsn(PathAttribute attr)
+    {
+        if (attr.Data.Length != 4)
+            throw new BgpParseException($"Malformed AS4_AGGREGATOR attribute: expected 4 bytes, got {attr.Data.Length}");
+
         return BinaryPrimitives.ReadUInt32BigEndian(attr.Data);
     }
 
@@ -180,6 +117,73 @@ public static class AttributeHelper
         BgpConstants.Attribute.LocalPref => true,
         BgpConstants.Attribute.AtomicAggregate => true,
         BgpConstants.Attribute.Aggregator => true,
+        BgpConstants.Attribute.As4Path => true,
+        BgpConstants.Attribute.As4PathAggregator => true,
         _ => false
     };
+
+    private static uint[] ReadPathData(ReadOnlySpan<byte> data, int asSize, string attributeName)
+    {
+        var ases = new List<uint>();
+        var offset = 0;
+
+        while (offset + 2 <= data.Length)
+        {
+            var segmentType = data[offset++];
+            var segmentLength = data[offset++];
+
+            if (segmentType != BgpConstants.AsPath.AsSequence && segmentType != BgpConstants.AsPath.AsSet)
+                throw new BgpParseException($"Invalid {attributeName} segment type: {segmentType}");
+
+            var segBytes = segmentLength * asSize;
+            if (offset + segBytes > data.Length)
+                throw new BgpParseException($"Truncated {attributeName} segment");
+
+            for (var i = 0; i < segmentLength; i++)
+            {
+                ases.Add(asSize switch
+                {
+                    2 => BinaryPrimitives.ReadUInt16BigEndian(data.Slice(offset, asSize)),
+                    4 => BinaryPrimitives.ReadUInt32BigEndian(data.Slice(offset, asSize)),
+                    _ => throw new ArgumentOutOfRangeException(nameof(asSize))
+                });
+                offset += asSize;
+            }
+        }
+
+        if (offset != data.Length)
+            throw new BgpParseException($"Malformed {attributeName} attribute");
+
+        return ases.ToArray();
+    }
+
+    private static byte[] WritePathData(uint[] ases, int asSize, string attributeName)
+    {
+        if (ases.Length > byte.MaxValue)
+            throw new ArgumentOutOfRangeException(nameof(ases), $"{attributeName} segment length cannot exceed 255 ASNs.");
+
+        var data = new byte[2 + ases.Length * asSize];
+        data[0] = BgpConstants.AsPath.AsSequence;
+        data[1] = (byte)ases.Length;
+
+        var offset = 2;
+        foreach (var asn in ases)
+        {
+            switch (asSize)
+            {
+                case 2:
+                    BinaryPrimitives.WriteUInt16BigEndian(data.AsSpan(offset, asSize), (ushort)asn);
+                    break;
+                case 4:
+                    BinaryPrimitives.WriteUInt32BigEndian(data.AsSpan(offset, asSize), asn);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(asSize));
+            }
+
+            offset += asSize;
+        }
+
+        return data;
+    }
 }

--- a/BGPLite.Protocol/BgpConstants.cs
+++ b/BGPLite.Protocol/BgpConstants.cs
@@ -39,6 +39,7 @@ public static class BgpConstants
         public const byte MissingWellKnownAttribute = 3;
         public const byte BadBgpIdentifier = 3;
         public const byte UnacceptableHoldTime = 6;
+        public const byte UnsupportedCapability = 7;
 
         // RFC 4486 Cease subcodes (apply when ErrorCode = Cease = 6)
         public const byte CeaseMaxPrefixes = 1;
@@ -61,8 +62,8 @@ public static class BgpConstants
         public const byte OriginatorId = 9;
         public const byte ClusterList = 10;
         public const byte ExtendedCommunity = 16;
-        public const byte As4Path = 17;       // RFC 6793 §6 — 4-byte AS path for 2-byte peers
-        public const byte As4PathAggregator = 18; // RFC 6793 — 4-byte aggregator
+        public const byte As4Path = 17;
+        public const byte As4PathAggregator = 18;
         public const byte LargeCommunity = 32;
 
         public const byte FlagOptional = 0x80;

--- a/BGPLite.Protocol/BgpConstants.cs
+++ b/BGPLite.Protocol/BgpConstants.cs
@@ -63,7 +63,7 @@ public static class BgpConstants
         public const byte ClusterList = 10;
         public const byte ExtendedCommunity = 16;
         public const byte As4Path = 17;
-        public const byte As4PathAggregator = 18;
+        public const byte As4Aggregator = 18;
         public const byte LargeCommunity = 32;
 
         public const byte FlagOptional = 0x80;

--- a/BGPLite.Protocol/BgpNotificationException.cs
+++ b/BGPLite.Protocol/BgpNotificationException.cs
@@ -8,7 +8,9 @@ namespace BGPLite.Protocol;
 /// </summary>
 public sealed class BgpNotificationException(byte errorCode, byte subErrorCode, string message, byte[]? notificationData = null) : Exception(message)
 {
+    private readonly byte[]? _notificationData = notificationData is null ? null : (byte[])notificationData.Clone();
+
     public byte ErrorCode { get; } = errorCode;
     public byte SubErrorCode { get; } = subErrorCode;
-    public byte[]? NotificationData { get; } = notificationData is null ? null : (byte[])notificationData.Clone();
+    public byte[]? NotificationData => _notificationData is null ? null : (byte[])_notificationData.Clone();
 }

--- a/BGPLite.Protocol/BgpNotificationException.cs
+++ b/BGPLite.Protocol/BgpNotificationException.cs
@@ -6,8 +6,9 @@ namespace BGPLite.Protocol;
 /// (per RFC 4271 §6) so the session handler sends the right ones instead of a generic
 /// Message Header Error.
 /// </summary>
-public sealed class BgpNotificationException(byte errorCode, byte subErrorCode, string message) : Exception(message)
+public sealed class BgpNotificationException(byte errorCode, byte subErrorCode, string message, byte[]? notificationData = null) : Exception(message)
 {
     public byte ErrorCode { get; } = errorCode;
     public byte SubErrorCode { get; } = subErrorCode;
+    public byte[]? NotificationData { get; } = notificationData is null ? null : (byte[])notificationData.Clone();
 }

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -1233,7 +1233,8 @@ public sealed class BgpSession : IDisposable
         foreach (var cap in open.Capabilities)
         {
             if (cap.Code == BgpConstants.Capability.FourOctetAsn && cap.Data.Length != 4)
-                return [BgpConstants.Capability.FourOctetAsn, (byte)cap.Data.Length, ..cap.Data];
+                return [BgpConstants.Capability.FourOctetAsn, (byte)cap.Data.Length,
+                    ..cap.Data];
         }
 
         return [];

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -476,7 +476,7 @@ public sealed class BgpSession : IDisposable
                         case BgpConstants.Attribute.Aggregator:
                             aggregatorAsn = AttributeHelper.ReadAggregatorAsn(attr, _remoteFourByteAsn);
                             break;
-                        case BgpConstants.Attribute.As4PathAggregator when !_remoteFourByteAsn:
+                        case BgpConstants.Attribute.As4Aggregator when !_remoteFourByteAsn:
                             as4AggregatorAsn = AttributeHelper.ReadAs4AggregatorAsn(attr);
                             break;
                     }

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -244,7 +244,7 @@ public sealed class BgpSession : IDisposable
             // close (RFC 4724 §4) / no-reply (RFC 4271 §6.3) and exactly-one-NOTIFICATION (§8.1).
             if (Interlocked.CompareExchange(ref _teardownReason, (int)TeardownReason.LocalCease, (int)TeardownReason.None) == (int)TeardownReason.None)
             {
-                try { await SendNotificationAsync(ex.ErrorCode, ex.SubErrorCode); }
+                try { await SendNotificationAsync(ex.ErrorCode, ex.SubErrorCode, ex.NotificationData); }
                 catch { /* best-effort */ }
             }
         }
@@ -443,6 +443,8 @@ public sealed class BgpSession : IDisposable
                 uint[] asPath = [];
                 uint[] communities = [];
                 uint[] as4Path = [];
+                uint? aggregatorAsn = null;
+                uint? as4AggregatorAsn = null;
                 var filterPeerConfig = GetFilterPeerConfig();
 
                 foreach (var attr in update.PathAttributes)
@@ -471,11 +473,18 @@ public sealed class BgpSession : IDisposable
                         case BgpConstants.Attribute.Community:
                             communities = AttributeHelper.ReadCommunities(attr);
                             break;
+                        case BgpConstants.Attribute.Aggregator:
+                            aggregatorAsn = AttributeHelper.ReadAggregatorAsn(attr, _remoteFourByteAsn);
+                            break;
+                        case BgpConstants.Attribute.As4PathAggregator when !_remoteFourByteAsn:
+                            as4AggregatorAsn = AttributeHelper.ReadAs4AggregatorAsn(attr);
+                            break;
                     }
                 }
 
                 ValidateMandatoryAttributes(originSeen, asPathSeen, nextHopSeen);
                 asPath = MergeAsPathWithAs4Path(asPath, as4Path);
+                ValidateAggregatorReconstruction(aggregatorAsn, as4AggregatorAsn);
 
                 foreach (var nlri in update.Nlri)
                 {
@@ -848,16 +857,20 @@ public sealed class BgpSession : IDisposable
         if (as4Path.Length == 0)
             return asPath;
 
-        if (as4Path.Length >= asPath.Length)
-        {
-            if (as4Path.Length > asPath.Length)
-                return asPath;
+        if (as4Path.Length > asPath.Length)
+            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, "AS4_PATH longer than AS_PATH");
 
+        if (as4Path.Length == asPath.Length)
             return as4Path;
+
+        var leadingCount = asPath.Length - as4Path.Length;
+        for (var i = 0; i < leadingCount; i++)
+        {
+            if (asPath[i] == BgpConstants.AsPath.AsTrans)
+                throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, "Unresolved AS_TRANS in AS_PATH");
         }
 
         var merged = new uint[asPath.Length];
-        var leadingCount = asPath.Length - as4Path.Length;
         Array.Copy(asPath, 0, merged, 0, leadingCount);
         Array.Copy(as4Path, 0, merged, leadingCount, as4Path.Length);
 
@@ -1097,7 +1110,17 @@ public sealed class BgpSession : IDisposable
 
     private async Task SendNotificationAsync(byte errorCode, byte subErrorCode)
     {
-        var notification = new BgpNotificationMessage { ErrorCode = errorCode, SubErrorCode = subErrorCode };
+        await SendNotificationAsync(errorCode, subErrorCode, null);
+    }
+
+    private async Task SendNotificationAsync(byte errorCode, byte subErrorCode, byte[]? data)
+    {
+        var notification = new BgpNotificationMessage
+        {
+            ErrorCode = errorCode,
+            SubErrorCode = subErrorCode,
+            Data = data is null ? null : (byte[])data.Clone()
+        };
         await SendMessageAsync(notification);
         _logger.LogInformation("NotificationSent to {Peer}: {Error}/{SubError}", _peer, errorCode, subErrorCode);
     }
@@ -1159,6 +1182,16 @@ public sealed class BgpSession : IDisposable
         if (open.Version != BgpConstants.BgpVersion)
             throw new BgpNotificationException(BgpConstants.Error.OpenMessageError, BgpConstants.SubError.UnsupportedVersion, $"Unsupported BGP version: {open.Version}");
 
+        var malformedFourOctetAsnCapability = GetMalformedFourOctetAsnCapabilityData(open);
+        if (malformedFourOctetAsnCapability.Length > 0)
+        {
+            throw new BgpNotificationException(
+                BgpConstants.Error.OpenMessageError,
+                BgpConstants.SubError.UnsupportedCapability,
+                "Malformed 4-octet ASN capability",
+                malformedFourOctetAsnCapability);
+        }
+
         _remoteFourByteAsn = CapabilityHelper.GetRemoteAsn(open).HasValue;
         _remoteAsn = CapabilityHelper.GetEffectiveAsn(open);
         // RFC 6793 §6: derive AS_PATH encoding format from negotiated capability
@@ -1193,6 +1226,26 @@ public sealed class BgpSession : IDisposable
         _keepAliveInterval = holdTime == 0
             ? TimeSpan.Zero
             : TimeSpan.FromSeconds(Math.Max(holdTime / 3, 1));
+    }
+
+    internal static byte[] GetMalformedFourOctetAsnCapabilityData(BgpOpenMessage open)
+    {
+        foreach (var cap in open.Capabilities)
+        {
+            if (cap.Code == BgpConstants.Capability.FourOctetAsn && cap.Data.Length != 4)
+                return [BgpConstants.Capability.FourOctetAsn, (byte)cap.Data.Length, ..cap.Data];
+        }
+
+        return [];
+    }
+
+    internal static void ValidateAggregatorReconstruction(uint? aggregatorAsn, uint? as4AggregatorAsn)
+    {
+        if (aggregatorAsn == BgpConstants.AsPath.AsTrans && as4AggregatorAsn is null)
+            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, "Missing AS4_AGGREGATOR for AGGREGATOR AS_TRANS");
+
+        if (!aggregatorAsn.HasValue && as4AggregatorAsn.HasValue)
+            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, "Missing AGGREGATOR attribute for AS4_AGGREGATOR");
     }
 
     #endregion

--- a/BGPLite.Tests/BgpSessionRfc6793Tests.cs
+++ b/BGPLite.Tests/BgpSessionRfc6793Tests.cs
@@ -1,148 +1,97 @@
 using BGPLite.Protocol;
-using BGPLite.Routing;
 using BGPLite.Server;
 
 namespace BGPLite.Tests;
 
-/// <summary>
-/// Tests for RFC 6793 compliance — AS4_PATH handling for 2-byte-only peers.
-/// </summary>
 public class BgpSessionRfc6793Tests
 {
     [Fact]
-    public void GroupByCommunitySet_GroupsRoutesWithEmptyCommunitySet()
+    public void WriteAndRead_As4Path_Roundtrip()
     {
-        // Verify that BgpSession.GroupByCommunitySet works correctly
-        // (static method, no session state needed)
-        var routes = new List<Route>
-        {
-            new() { Prefix = 0xC0A80000, PrefixLength = 24, NextHop = 0, Communities = [] },
-            new() { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 0, Communities = [] }
-        };
+        var attr = AttributeHelper.WriteAs4Path([200000u, 300000u]);
 
-        var groups = BgpSession.GroupByCommunitySet(routes);
-        Assert.Single(groups); // All routes share empty community set
-        Assert.Equal(2, groups[0].Count);
-    }
-
-    [Fact]
-    public void BuildAsPathAttributes_4BytePeer_ProducesOnlyAsPath()
-    {
-        // 4-byte peer: only 4-byte AS_PATH, no AS4_PATH
-        var attrs = BgpSession.BuildAsPathAttributes(localAsn: 200000u, localFourByteAsn: true);
-
-        var asPathAttr = Assert.Single(attrs);
-        Assert.Equal(BgpConstants.Attribute.AsPath, asPathAttr.TypeCode);
-        var ases = AttributeHelper.ReadAsPath(asPathAttr, fourByteAsn: true);
-        Assert.Equal([200000u], ases);
-    }
-
-    [Fact]
-    public void BuildAsPathAttributes_2BytePeer_LargeAsn_AsTransPlusAs4Path()
-    {
-        // 2-byte-only peer + local ASN > 65535: 2-byte AS_PATH with AS_TRANS + AS4_PATH
-        var attrs = BgpSession.BuildAsPathAttributes(localAsn: 200000u, localFourByteAsn: false);
-
-        Assert.Equal(2, attrs.Count);
-
-        var asPathAttr = attrs[0];
-        Assert.Equal(BgpConstants.Attribute.AsPath, asPathAttr.TypeCode);
-        var asPathAses = AttributeHelper.ReadAsPath(asPathAttr, fourByteAsn: false);
-        Assert.Equal([BgpConstants.AsPath.AsTrans], asPathAses);
-
-        var as4PathAttr = attrs[1];
-        Assert.Equal(BgpConstants.Attribute.As4Path, as4PathAttr.TypeCode);
-        var as4PathAses = AttributeHelper.ReadAs4Path(as4PathAttr);
-        Assert.Equal([200000u], as4PathAses);
-    }
-
-    [Fact]
-    public void BuildAsPathAttributes_2BytePeer_2ByteAsn_AsPathOnly()
-    {
-        // 2-byte-only peer + local ASN <= 65535: 2-byte AS_PATH only, no AS4_PATH
-        var attrs = BgpSession.BuildAsPathAttributes(localAsn: 65001u, localFourByteAsn: false);
-
-        var asPathAttr = Assert.Single(attrs);
-        Assert.Equal(BgpConstants.Attribute.AsPath, asPathAttr.TypeCode);
-        var ases = AttributeHelper.ReadAsPath(asPathAttr, fourByteAsn: false);
-        Assert.Equal([65001u], ases);
-    }
-
-    [Fact]
-    public void BuildUpdateAttributes_2BytePeer_LargeAsn_PlacesCommunityBeforeAs4Path()
-    {
-        var attrs = BgpSession.BuildUpdateAttributes(
-            localAsn: 200000u,
-            localFourByteAsn: false,
-            nextHop: 0xC0A80101,
-            communities: [0x0000FF01]);
-
-        Assert.Equal(
-            [
-                BgpConstants.Attribute.Origin,
-                BgpConstants.Attribute.AsPath,
-                BgpConstants.Attribute.NextHop,
-                BgpConstants.Attribute.Community,
-                BgpConstants.Attribute.As4Path
-            ],
-            attrs.Select(a => a.TypeCode).ToArray());
-
-        Assert.Equal([BgpConstants.AsPath.AsTrans], AttributeHelper.ReadAsPath(attrs[1], fourByteAsn: false));
-        Assert.Equal([200000u], AttributeHelper.ReadAs4Path(attrs[4]));
+        Assert.Equal(BgpConstants.Attribute.As4Path, attr.TypeCode);
+        Assert.Equal([200000u, 300000u], AttributeHelper.ReadAs4Path(attr));
     }
 
     [Fact]
     public void MergeAsPathWithAs4Path_ReconstructsTrueSequence()
     {
-        var merged = BgpSession.MergeAsPathWithAs4Path(
-            [65010u, BgpConstants.AsPath.AsTrans, 65001u],
-            [200000u, 65001u]);
+        var merged = BgpSession.MergeAsPathWithAs4Path([65010u, BgpConstants.AsPath.AsTrans, 65001u], [200000u, 65001u]);
 
         Assert.Equal([65010u, 200000u, 65001u], merged);
     }
 
     [Fact]
-    public void MergeAsPathWithAs4Path_As4PathLongerThanAsPath_IgnoresAs4Path()
-    {
-        var merged = BgpSession.MergeAsPathWithAs4Path([65001u], [200000u, 65002u]);
-
-        Assert.Equal([65001u], merged);
-    }
-
-    [Fact]
-    public void MergeAsPathWithAs4Path_EqualLengths_ReturnsAs4Path()
-    {
-        var merged = BgpSession.MergeAsPathWithAs4Path(
-            [BgpConstants.AsPath.AsTrans, 65001u],
-            [200000u, 65001u]);
-
-        Assert.Equal([200000u, 65001u], merged);
-    }
-
-    [Fact]
-    public void MergeAsPathWithAs4Path_EmptyAs4Path_ReturnsAsPathUnchanged()
-    {
-        var merged = BgpSession.MergeAsPathWithAs4Path([65010u, 65001u], []);
-
-        Assert.Equal([65010u, 65001u], merged);
-    }
-
-    [Theory]
-    [InlineData(false, true, true)]
-    [InlineData(true, false, true)]
-    [InlineData(true, true, false)]
-    public void ValidateMandatoryAttributes_MissingRequiredAttribute_Throws(bool originSeen, bool asPathSeen, bool nextHopSeen)
+    public void MergeAsPathWithAs4Path_UnresolvedAsTrans_Throws()
     {
         var ex = Assert.Throws<BgpNotificationException>(() =>
-            BgpSession.ValidateMandatoryAttributes(originSeen, asPathSeen, nextHopSeen));
+            BgpSession.MergeAsPathWithAs4Path([65010u, BgpConstants.AsPath.AsTrans, 65001u], [200000u]));
+
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.Unspecific, ex.SubErrorCode);
+    }
+
+    [Fact]
+    public void ValidateAggregatorReconstruction_AsTransWithAs4Aggregator_DoesNotThrow()
+    {
+        BgpSession.ValidateAggregatorReconstruction(BgpConstants.AsPath.AsTrans, 200000u);
+    }
+
+    [Fact]
+    public void ValidateAggregatorReconstruction_AsTransWithoutAs4Aggregator_Throws()
+    {
+        var ex = Assert.Throws<BgpNotificationException>(() =>
+            BgpSession.ValidateAggregatorReconstruction(BgpConstants.AsPath.AsTrans, null));
+
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.Unspecific, ex.SubErrorCode);
+    }
+
+    [Fact]
+    public void ValidateMandatoryAttributes_MissingRequiredAttribute_Throws()
+    {
+        var ex = Assert.Throws<BgpNotificationException>(() =>
+            BgpSession.ValidateMandatoryAttributes(false, true, true));
 
         Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
         Assert.Equal(BgpConstants.SubError.MissingWellKnownAttribute, ex.SubErrorCode);
     }
 
     [Fact]
-    public void ValidateMandatoryAttributes_AllPresent_Succeeds()
+    public void GetMalformedFourOctetAsnCapabilityData_ReturnsMalformedCapabilityTlv()
     {
-        BgpSession.ValidateMandatoryAttributes(true, true, true);
+        var open = new BgpOpenMessage
+        {
+            Capabilities = [new BgpCapabilityInfo { Code = BgpConstants.Capability.FourOctetAsn, Data = [0x01, 0x02, 0x03] }]
+        };
+
+        Assert.Equal([BgpConstants.Capability.FourOctetAsn, 3, 0x01, 0x02, 0x03], BgpSession.GetMalformedFourOctetAsnCapabilityData(open));
+    }
+
+    [Fact]
+    public void GetMalformedFourOctetAsnCapabilityData_EmptyData_ReturnsZeroLengthTlv()
+    {
+        var open = new BgpOpenMessage
+        {
+            Capabilities = [new BgpCapabilityInfo { Code = BgpConstants.Capability.FourOctetAsn, Data = [] }]
+        };
+
+        Assert.Equal([BgpConstants.Capability.FourOctetAsn, 0], BgpSession.GetMalformedFourOctetAsnCapabilityData(open));
+    }
+
+    [Fact]
+    public void GetMalformedFourOctetAsnCapabilityData_MultipleCapabilities_ReturnsFirstMalformed()
+    {
+        var open = new BgpOpenMessage
+        {
+            Capabilities =
+            [
+                BgpCapabilityInfo.FourOctetAsn(65001),
+                new BgpCapabilityInfo { Code = BgpConstants.Capability.FourOctetAsn, Data = [0x01, 0x02] }
+            ]
+        };
+
+        Assert.Equal([BgpConstants.Capability.FourOctetAsn, 2, 0x01, 0x02], BgpSession.GetMalformedFourOctetAsnCapabilityData(open));
     }
 }

--- a/BGPLite.Tests/BgpSessionRfc6793Tests.cs
+++ b/BGPLite.Tests/BgpSessionRfc6793Tests.cs
@@ -33,9 +33,57 @@ public class BgpSessionRfc6793Tests
     }
 
     [Fact]
+    public void MergeAsPathWithAs4Path_EmptyAs4Path_ReturnsAsPathUnchanged()
+    {
+        var merged = BgpSession.MergeAsPathWithAs4Path([65010u, 65001u], []);
+
+        Assert.Equal([65010u, 65001u], merged);
+    }
+
+    [Fact]
+    public void MergeAsPathWithAs4Path_EqualLengths_ReturnsAs4Path()
+    {
+        var merged = BgpSession.MergeAsPathWithAs4Path([BgpConstants.AsPath.AsTrans, 65001u], [200000u, 65001u]);
+
+        Assert.Equal([200000u, 65001u], merged);
+    }
+
+    [Fact]
+    public void MergeAsPathWithAs4Path_As4PathLongerThanAsPath_Throws()
+    {
+        var ex = Assert.Throws<BgpNotificationException>(() =>
+            BgpSession.MergeAsPathWithAs4Path([65001u], [200000u, 300000u]));
+
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.Unspecific, ex.SubErrorCode);
+    }
+
+    [Fact]
     public void ValidateAggregatorReconstruction_AsTransWithAs4Aggregator_DoesNotThrow()
     {
         BgpSession.ValidateAggregatorReconstruction(BgpConstants.AsPath.AsTrans, 200000u);
+    }
+
+    [Fact]
+    public void ValidateAggregatorReconstruction_NonAsTransAggregator_DoesNotThrow()
+    {
+        BgpSession.ValidateAggregatorReconstruction(65001u, null);
+    }
+
+    [Fact]
+    public void ValidateAggregatorReconstruction_NullAggregator_DoesNotThrow()
+    {
+        BgpSession.ValidateAggregatorReconstruction(null, null);
+    }
+
+    [Fact]
+    public void ValidateAggregatorReconstruction_NullAggregatorWithAs4Aggregator_Throws()
+    {
+        var ex = Assert.Throws<BgpNotificationException>(() =>
+            BgpSession.ValidateAggregatorReconstruction(null, 200000u));
+
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.Unspecific, ex.SubErrorCode);
     }
 
     [Fact]
@@ -53,6 +101,26 @@ public class BgpSessionRfc6793Tests
     {
         var ex = Assert.Throws<BgpNotificationException>(() =>
             BgpSession.ValidateMandatoryAttributes(false, true, true));
+
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.MissingWellKnownAttribute, ex.SubErrorCode);
+    }
+
+    [Fact]
+    public void ValidateMandatoryAttributes_MissingAsPath_Throws()
+    {
+        var ex = Assert.Throws<BgpNotificationException>(() =>
+            BgpSession.ValidateMandatoryAttributes(true, false, true));
+
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.MissingWellKnownAttribute, ex.SubErrorCode);
+    }
+
+    [Fact]
+    public void ValidateMandatoryAttributes_MissingNextHop_Throws()
+    {
+        var ex = Assert.Throws<BgpNotificationException>(() =>
+            BgpSession.ValidateMandatoryAttributes(true, true, false));
 
         Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
         Assert.Equal(BgpConstants.SubError.MissingWellKnownAttribute, ex.SubErrorCode);


### PR DESCRIPTION
## Summary
Hardens BGP OPEN/UPDATE handling in the protocol layer:

- reconstructs RFC 6793 `AS4_PATH` / `AS4_AGGREGATOR` on receive
- validates mandatory UPDATE attributes before accepting NLRI
- sends `OPEN` `Unsupported Capability` notifications for malformed 4-octet ASN capability data

## Closes
- Closes #31 — `AS4_PATH` / `AS4_AGGREGATOR` reconstruction
- Closes #32 — UPDATE missing mandatory attributes
- Closes #33 — Unsupported Capability NOTIFICATION

## Why
Malformed OPEN/UPDATE inputs should fail loudly and consistently in the shared validation path instead of being accepted silently.

## Validation
```bash
dotnet test "BGPLite.Tests/BGPLite.Tests.csproj"
```

## Risk
- Narrow protocol-only change in `BGPLite.Protocol` and `BgpSession`
- Valid peer behavior is unchanged; the new behavior only affects malformed protocol inputs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `NotificationData` support to notification exceptions, enabling optional payload propagation in NOTIFICATION messages.
  * Improved handling of AS4-related path/aggregator attributes and additional well-known attribute validation.
* **Bug Fixes**
  * Tightened AS_PATH/AS4_PATH parsing to reject truncation and ensure full payload consumption.
  * Enhanced UPDATE and OPEN error handling with more precise sub-errors for malformed capabilities and reconstruction failures.
* **Tests**
  * Refined RFC 6793 tests to focus on AS4_PATH round-tripping, reconstruction edge cases, mandatory attribute validation, and malformed capability TLVs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->