### PR TITLE
fix(api): restore reverse-proxy IP resolution for /api/me

### DIFF
--- a/BGPLite.Api/BGPLite.Api.csproj
+++ b/BGPLite.Api/BGPLite.Api.csproj
@@ -17,4 +17,8 @@
     <ProjectReference Include="..\BGPLite.Server\BGPLite.Server.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="BGPLite.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/BGPLite.Api/BgpDbContext.cs
+++ b/BGPLite.Api/BgpDbContext.cs
@@ -26,7 +26,6 @@ public class BgpDbContext : DbContext
         db.Database.ExecuteSqlRaw("DROP INDEX IF EXISTS IX_Peers_Ip;");
         db.Database.ExecuteSqlRaw(
             "CREATE UNIQUE INDEX IF NOT EXISTS UX_Peers_Ip_Asn ON Peers (Ip, Asn);");
-
         db.Peers.Where(p => p.Status == "active").ExecuteUpdate(
             s => s.SetProperty(p => p.Status, "inactive"));
     }

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -643,9 +643,27 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
     #region Helpers
 
+    internal static string ResolveClientIp(string? xRealIp, string? xForwardedFor, string? remoteEndPoint)
+    {
+        if (!string.IsNullOrWhiteSpace(xRealIp))
+            return xRealIp.Trim();
+
+        if (!string.IsNullOrWhiteSpace(xForwardedFor))
+        {
+            var forwardedIp = xForwardedFor.Split(',')[0].Trim();
+            if (!string.IsNullOrEmpty(forwardedIp))
+                return forwardedIp;
+        }
+
+        return remoteEndPoint ?? "unknown";
+    }
+
     private static string GetClientIp(HttpListenerContext ctx)
     {
-        return ctx.Request.RemoteEndPoint?.Address.ToString() ?? "unknown";
+        return ResolveClientIp(
+            ctx.Request.Headers["X-Real-IP"],
+            ctx.Request.Headers["X-Forwarded-For"],
+            ctx.Request.RemoteEndPoint?.Address.ToString());
     }
 
     private static async Task WriteResponse(HttpListenerContext ctx, ApiResponse response)

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -359,7 +359,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         var subscriptions = _store.GetSubscriptions(peer.Id);
         var customPrefixes = _store.GetCustomPrefixes(peer.Id);
         var customAsns = _store.GetCustomAsns(peer.Id);
-        var communities = _store.GetCommunitiesByIp(peer.Ip);
+        var communities = _store.GetCommunities(peer.Id);
 
         return ApiResponse.Ok(new
         {
@@ -645,16 +645,6 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
     private static string GetClientIp(HttpListenerContext ctx)
     {
-        var realIp = ctx.Request.Headers["X-Real-IP"];
-        if (!string.IsNullOrEmpty(realIp)) return realIp;
-
-        var forwarded = ctx.Request.Headers["X-Forwarded-For"];
-        if (!string.IsNullOrEmpty(forwarded))
-        {
-            var first = forwarded.Split(',')[0].Trim();
-            if (first.Length > 0) return first;
-        }
-
         return ctx.Request.RemoteEndPoint?.Address.ToString() ?? "unknown";
     }
 

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -243,18 +243,30 @@ public sealed class ManagementApi : IHostedService, IDisposable
     {
         var clientIp = GetClientIp(ctx);
 
-        var peerInfo = _store.GetPeerByIp(clientIp);
-        if (peerInfo is null)
+        var peers = _store.GetPeersByIp(clientIp);
+        var asnRaw = ctx.Request.QueryString["asn"];
+        if (!string.IsNullOrWhiteSpace(asnRaw))
+        {
+            if (!uint.TryParse(asnRaw, out var asn))
+                return ApiResponse.Error("Invalid ASN", 400);
+
+            peers = peers.Where(p => p.Asn == asn).ToList();
+        }
+
+        if (peers.Count == 0)
             return ApiResponse.Ok(new { ip = clientIp, peer = (object?)null });
 
-        var peer = _store.GetDbPeerById(peerInfo.Id);
+        if (peers.Count > 1)
+            return ApiResponse.Error("Ambiguous peer; specify ?asn=", 409);
+
+        var peer = _store.GetDbPeerById(peers[0].Id);
         if (peer is null)
             return ApiResponse.Ok(new { ip = clientIp, peer = (object?)null });
 
         var subscriptions = _store.GetSubscriptions(peer.Id);
         var customPrefixes = _store.GetCustomPrefixes(peer.Id);
         var customAsns = _store.GetCustomAsns(peer.Id);
-        var communities = _store.GetCommunitiesByIp(clientIp);
+        var communities = peer.Communities.Select(c => (uint)c.Community).ToHashSet();
 
         return ApiResponse.Ok(new
         {

--- a/BGPLite.Api/PeerStore.cs
+++ b/BGPLite.Api/PeerStore.cs
@@ -89,19 +89,7 @@ public sealed class PeerStore : IPeerStore
     public List<PeerInfo> GetPeersByIp(string ip)
     {
         using var db = _dbFactory.CreateDbContext();
-        return db.Peers
-            .Where(p => p.Ip == ip)
-            .Select(p => new PeerInfo
-            {
-                Id = p.Id,
-                Ip = p.Ip,
-                Asn = p.Asn,
-                Description = p.Description,
-                Status = p.Status,
-                CreatedAt = p.CreatedAt.ToString("O"),
-                LastSessionAt = p.LastSessionAt.HasValue ? p.LastSessionAt.Value.ToString("O") : null
-            })
-            .ToList();
+        return db.Peers.Where(p => p.Ip == ip).ToList().Select(MapToInfo).ToList();
     }
 
     /// <summary>

--- a/BGPLite.Api/PeerStore.cs
+++ b/BGPLite.Api/PeerStore.cs
@@ -86,6 +86,24 @@ public sealed class PeerStore : IPeerStore
         return peer is null ? null : MapToInfo(peer);
     }
 
+    public List<PeerInfo> GetPeersByIp(string ip)
+    {
+        using var db = _dbFactory.CreateDbContext();
+        return db.Peers
+            .Where(p => p.Ip == ip)
+            .Select(p => new PeerInfo
+            {
+                Id = p.Id,
+                Ip = p.Ip,
+                Asn = p.Asn,
+                Description = p.Description,
+                Status = p.Status,
+                CreatedAt = p.CreatedAt.ToString("O"),
+                LastSessionAt = p.LastSessionAt.HasValue ? p.LastSessionAt.Value.ToString("O") : null
+            })
+            .ToList();
+    }
+
     /// <summary>
     /// Resolves a peer by its durable identity <c>(Ip, Asn)</c> — the form a BGP session knows once
     /// it has parsed the peer's OPEN (issue #19). Several peers may share a source IP with distinct

--- a/BGPLite.Tests/BGPLite.Tests.csproj
+++ b/BGPLite.Tests/BGPLite.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\BGPLite.Api\BGPLite.Api.csproj" />
     <ProjectReference Include="..\BGPLite.Protocol\BGPLite.Protocol.csproj" />
     <ProjectReference Include="..\BGPLite.Providers\BGPLite.Providers.csproj" />
     <ProjectReference Include="..\BGPLite.Server\BGPLite.Server.csproj" />

--- a/BGPLite.Tests/BGPLite.Tests.csproj
+++ b/BGPLite.Tests/BGPLite.Tests.csproj
@@ -15,7 +15,6 @@
     <ProjectReference Include="..\BGPLite.Server\BGPLite.Server.csproj" />
     <ProjectReference Include="..\BGPLite.Routing\BGPLite.Routing.csproj" />
     <ProjectReference Include="..\BGPLite.Configuration\BGPLite.Configuration.csproj" />
-    <ProjectReference Include="..\BGPLite.Api\BGPLite.Api.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BGPLite.Tests/ManagementApiClientIpTests.cs
+++ b/BGPLite.Tests/ManagementApiClientIpTests.cs
@@ -1,0 +1,36 @@
+using BGPLite.Api;
+
+namespace BGPLite.Tests;
+
+public class ManagementApiClientIpTests
+{
+    [Fact]
+    public void ResolveClientIp_Prefers_XRealIp()
+    {
+        var ip = ManagementApi.ResolveClientIp(
+            "198.51.100.10",
+            "203.0.113.10, 203.0.113.11",
+            "10.0.0.1");
+
+        Assert.Equal("198.51.100.10", ip);
+    }
+
+    [Fact]
+    public void ResolveClientIp_Uses_FirstForwardedForHop()
+    {
+        var ip = ManagementApi.ResolveClientIp(
+            null,
+            "198.51.100.10, 203.0.113.11",
+            "10.0.0.1");
+
+        Assert.Equal("198.51.100.10", ip);
+    }
+
+    [Fact]
+    public void ResolveClientIp_FallsBack_ToRemoteEndpoint()
+    {
+        var ip = ManagementApi.ResolveClientIp(null, null, "10.0.0.1");
+
+        Assert.Equal("10.0.0.1", ip);
+    }
+}

--- a/BGPLite.Tests/PeerStoreKeyingTests.cs
+++ b/BGPLite.Tests/PeerStoreKeyingTests.cs
@@ -115,6 +115,42 @@ public class PeerStoreKeyingTests
         Assert.Equal("second", store.GetDbPeerById(id1)!.Description);
     }
 
+<<<<<<< HEAD
+=======
+    [Fact]
+    public void GetPeersByIp_Returns_All_Peers_On_One_Source_Ip()
+    {
+        var (store, connection) = NewStore();
+        using var conn = connection;
+
+        var idA = store.CreatePeer(SharedIp, 64512, "A");
+        var idB = store.CreatePeer(SharedIp, 64513, "B");
+
+        var peers = store.GetPeersByIp(SharedIp);
+
+        Assert.Equal(2, peers.Count);
+        Assert.Contains(peers, p => p.Id == idA && p.Asn == 64512);
+        Assert.Contains(peers, p => p.Id == idB && p.Asn == 64513);
+    }
+
+    [Fact]
+    public void Communities_Are_Stored_Per_PeerId_Not_Per_Ip()
+    {
+        var (store, connection) = NewStore();
+        using var conn = connection;
+
+        var idA = store.CreatePeer(SharedIp, 64512, "A");
+        var idB = store.CreatePeer(SharedIp, 64513, "B");
+
+        store.SetCommunities(idA, new HashSet<uint> { 0x0000FF01 });
+        store.SetCommunities(idB, new HashSet<uint> { 0x0000FF02 });
+
+        Assert.Equal(new HashSet<uint> { 0x0000FF01 }, store.GetCommunities(idA));
+        Assert.Equal(new HashSet<uint> { 0x0000FF02 }, store.GetCommunities(idB));
+        Assert.Equal(new HashSet<uint> { 0x0000FF01, 0x0000FF02 }, store.GetCommunitiesByIp(SharedIp));
+    }
+
+>>>>>>> 02703cd (fix(api): disambiguate /api/me for shared IPs)
     /// <summary>
     /// Hard requirement: existing peer data on the server must survive the index change. Simulates a
     /// database created by a previous (Ip-only-unique) version holding a real peer row, runs the

--- a/BGPLite.Tests/PeerStoreKeyingTests.cs
+++ b/BGPLite.Tests/PeerStoreKeyingTests.cs
@@ -86,23 +86,6 @@ public class PeerStoreKeyingTests
     }
 
     [Fact]
-    public void UpdateSessionStatus_Is_Scoped_To_IpAsn()
-    {
-        var (store, connection) = NewStore();
-        using var conn = connection;
-
-        var idA = store.CreatePeer(SharedIp, 64512, "A");
-        var idB = store.CreatePeer(SharedIp, 64513, "B");
-        store.UpdateSessionStatus(SharedIp, 64512, active: true);
-
-        Assert.Equal("active", store.GetDbPeerById(idA)!.Status);
-        Assert.Equal("inactive", store.GetDbPeerById(idB)!.Status); // untouched — different AS
-
-        store.UpdateSessionStatus(SharedIp, 64513, active: true);
-        Assert.Equal("active", store.GetDbPeerById(idB)!.Status);
-    }
-
-    [Fact]
     public void CreatePeer_Is_Idempotent_On_IpAsn()
     {
         var (store, connection) = NewStore();
@@ -115,8 +98,23 @@ public class PeerStoreKeyingTests
         Assert.Equal("second", store.GetDbPeerById(id1)!.Description);
     }
 
-<<<<<<< HEAD
-=======
+    [Fact]
+    public void UpdateSessionStatus_Is_Scoped_To_IpAsn()
+    {
+        var (store, connection) = NewStore();
+        using var conn = connection;
+
+        var idA = store.CreatePeer(SharedIp, 64512, "A");
+        var idB = store.CreatePeer(SharedIp, 64513, "B");
+        store.UpdateSessionStatus(SharedIp, 64512, true);
+
+        Assert.Equal("active", store.GetDbPeerById(idA)!.Status);
+        Assert.Equal("inactive", store.GetDbPeerById(idB)!.Status); // untouched — different AS
+
+        store.UpdateSessionStatus(SharedIp, 64513, true);
+        Assert.Equal("active", store.GetDbPeerById(idB)!.Status);
+    }
+
     [Fact]
     public void GetPeersByIp_Returns_All_Peers_On_One_Source_Ip()
     {
@@ -150,7 +148,6 @@ public class PeerStoreKeyingTests
         Assert.Equal(new HashSet<uint> { 0x0000FF01, 0x0000FF02 }, store.GetCommunitiesByIp(SharedIp));
     }
 
->>>>>>> 02703cd (fix(api): disambiguate /api/me for shared IPs)
     /// <summary>
     /// Hard requirement: existing peer data on the server must survive the index change. Simulates a
     /// database created by a previous (Ip-only-unique) version holding a real peer row, runs the

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Available on port **5000**.
 ### Peers
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `GET` | `/api/me` | Returns the caller's peer record; `?asn=` disambiguates shared-IP peers (`409` if ambiguous) |
+| `GET` | `/api/me` | Returns the caller's peer record from the request source IP; `?asn=` disambiguates shared-IP peers (`409` if ambiguous) |
 | `POST` | `/api/peers` | Register a new peer |
 | `GET`  | `/api/peers` | List all peers |
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Available on port **5000**.
 ### Peers
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `GET` | `/api/me` | Returns the caller's peer record from the request source IP; `?asn=` disambiguates shared-IP peers (`409` if ambiguous) |
+| `GET` | `/api/me` | Returns the caller's peer record from the request IP (honors `X-Real-IP` / `X-Forwarded-For` behind a proxy); `?asn=` disambiguates shared-IP peers (`409` if ambiguous) |
 | `POST` | `/api/peers` | Register a new peer |
 | `GET`  | `/api/peers` | List all peers |
 

--- a/README.md
+++ b/README.md
@@ -194,8 +194,8 @@ Available on port **5000**.
 ### Peers
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `GET`  | `/api/my-ip` | Returns the caller's IP |
-| `POST` | `/api/peers` | Register a peer |
+| `GET` | `/api/me` | Returns the caller's peer record; `?asn=` disambiguates shared-IP peers (`409` if ambiguous) |
+| `POST` | `/api/peers` | Register a new peer |
 | `GET`  | `/api/peers` | List all peers |
 
 ```bash


### PR DESCRIPTION
## Summary
- Restore `X-Real-IP` / `X-Forwarded-For` resolution in `/api/me` before peer lookup.
- Keep `?asn=` disambiguation for shared-IP peers.
- Add regression tests for client-IP resolution.

## Why
- Reverse-proxied deployments (nginx) were seeing the proxy IP instead of the real client.

## Validation
- `dotnet test BGPLite.Tests/BGPLite.Tests.csproj --no-restore`
- `dotnet format BGPLite.sln --verify-no-changes`

## Risk
- `/api/me` again trusts standard reverse-proxy headers when present, matching the prior behavior.

Closes #23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved peer lookup for the “me” endpoint, including support for identifying the correct peer when multiple peers share an IP by using an ASN filter.
  * Client IP detection is now more reliable behind proxies, using forwarded headers before falling back to the remote address.

* **Bug Fixes**
  * Communities are now returned from the correct peer record, ensuring peer-specific data is shown accurately.
  * Peer records are now treated as unique per IP and ASN combination, reducing ambiguity and duplicate matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->