### PR TITLE
perf(routing): resolve peer community allow-set once per send

### DIFF
--- a/BGPLite.Routing/AllowAllFilter.cs
+++ b/BGPLite.Routing/AllowAllFilter.cs
@@ -4,8 +4,13 @@ namespace BGPLite.Routing;
 
 public sealed class AllowAllFilter : IRouteFilter
 {
+    private static readonly IReadOnlySet<uint> EmptyAllowSet = new HashSet<uint>();
+
     public static AllowAllFilter Instance { get; } = new();
 
     public bool AcceptIncoming(Route route, PeerConfig peer) => true;
-    public bool AcceptOutgoing(Route route, PeerConfig peer) => true;
+
+    public IReadOnlySet<uint> ResolveOutgoingAllowSet(PeerConfig peer) => EmptyAllowSet;
+
+    public bool AcceptOutgoing(Route route, PeerConfig peer, IReadOnlySet<uint> allowSet) => true;
 }

--- a/BGPLite.Routing/IRouteFilter.cs
+++ b/BGPLite.Routing/IRouteFilter.cs
@@ -5,5 +5,20 @@ namespace BGPLite.Routing;
 public interface IRouteFilter
 {
     bool AcceptIncoming(Route route, PeerConfig peer);
-    bool AcceptOutgoing(Route route, PeerConfig peer);
+
+    /// <summary>
+    /// Resolves the per-peer state the outgoing filter needs, ONCE per send (the community
+    /// allow-set, which may require a database roundtrip). The returned set is passed to
+    /// <see cref="AcceptOutgoing"/> for every route in that send, so the resolution happens once
+    /// per peer per refresh rather than once per advertised route. An empty set means "no
+    /// community restriction" (all routes pass).
+    /// </summary>
+    IReadOnlySet<uint> ResolveOutgoingAllowSet(PeerConfig peer);
+
+    /// <summary>
+    /// Per-route outgoing decision. <paramref name="allowSet"/> is the value returned by
+    /// <see cref="ResolveOutgoingAllowSet"/> for the current send and must not perform any
+    /// per-route I/O.
+    /// </summary>
+    bool AcceptOutgoing(Route route, PeerConfig peer, IReadOnlySet<uint> allowSet);
 }

--- a/BGPLite.Routing/PeerCommunityFilter.cs
+++ b/BGPLite.Routing/PeerCommunityFilter.cs
@@ -16,15 +16,21 @@ public sealed class PeerCommunityFilter : IRouteFilter
 
     public bool AcceptIncoming(Route route, PeerConfig peer) => true;
 
-    public bool AcceptOutgoing(Route route, PeerConfig peer)
+    /// <summary>
+    /// Resolves the peer's community allow-set once per send. This is the only place the
+    /// (potentially database-backed) resolver runs on the advertise path — never per route.
+    /// </summary>
+    public IReadOnlySet<uint> ResolveOutgoingAllowSet(PeerConfig peer)
+        => _getCommunities(peer.Address, peer.RemoteAsn);
+
+    public bool AcceptOutgoing(Route route, PeerConfig peer, IReadOnlySet<uint> allowSet)
     {
         var isEbgp = !peer.RemoteAsn.HasValue || peer.RemoteAsn.Value != _localAsn;
 
         if (HasWellKnownSuppressingCommunity(route, isEbgp))
             return false;
 
-        var allowed = _getCommunities(peer.Address, peer.RemoteAsn);
-        if (allowed.Count == 0)
+        if (allowSet.Count == 0)
             return true; // no filter = all routes
 
         if (route.Communities.Length == 0)
@@ -32,7 +38,7 @@ public sealed class PeerCommunityFilter : IRouteFilter
 
         foreach (var c in route.Communities)
         {
-            if (allowed.Contains(c))
+            if (allowSet.Contains(c))
                 return true;
         }
 

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -690,8 +690,10 @@ public sealed class BgpSession : IDisposable
                 }
 
                 // Apply the per-peer outgoing community filter (same rule as the shared-table path).
+                // Resolve the community allow-set ONCE for the whole send — not once per route (#79).
                 var filterPeerConfig = GetFilterPeerConfig();
-                routes = routes.Where(r => _routeFilter.AcceptOutgoing(r, filterPeerConfig)).ToList();
+                var allowSet = _routeFilter.ResolveOutgoingAllowSet(filterPeerConfig);
+                routes = routes.Where(r => _routeFilter.AcceptOutgoing(r, filterPeerConfig, allowSet)).ToList();
                 await SendRoutesAsync(nextHop, routes);
                 return;
             }
@@ -722,10 +724,11 @@ public sealed class BgpSession : IDisposable
 
         // Final fallback: send from shared route table (single pass — one allocation, not two)
         var sharedFilterPeerConfig = GetFilterPeerConfig();
+        var sharedAllowSet = _routeFilter.ResolveOutgoingAllowSet(sharedFilterPeerConfig);
         var filtered = new List<Route>();
         foreach (var r in _routeTable.Enumerate())
         {
-            if (_routeFilter.AcceptOutgoing(r, sharedFilterPeerConfig))
+            if (_routeFilter.AcceptOutgoing(r, sharedFilterPeerConfig, sharedAllowSet))
                 filtered.Add(r);
         }
         if (filtered.Count == 0) return;

--- a/BGPLite.Tests/PeerCommunityFilterTests.cs
+++ b/BGPLite.Tests/PeerCommunityFilterTests.cs
@@ -22,6 +22,11 @@ public class PeerCommunityFilterTests
     private static PeerCommunityFilter NewFilter(Func<string, uint?, HashSet<uint>>? resolver = null) =>
         new(LocalAsn, resolver ?? ((_, _) => new HashSet<uint>()));
 
+    // Exercises the resolve-once-per-send contract used by the advertise hot path: resolve the
+    // peer's allow-set once, then make the per-route decision against the pre-resolved set.
+    private static bool Outgoing(PeerCommunityFilter filter, Route route, PeerConfig peer)
+        => filter.AcceptOutgoing(route, peer, filter.ResolveOutgoingAllowSet(peer));
+
     [Theory]
     [InlineData(BgpConstants.Community.NoExport)]
     [InlineData(BgpConstants.Community.NoAdvertise)]
@@ -30,7 +35,7 @@ public class PeerCommunityFilterTests
     {
         var filter = NewFilter();
 
-        Assert.False(filter.AcceptOutgoing(RouteWith(community), EbgpPeer));
+        Assert.False(Outgoing(filter, RouteWith(community), EbgpPeer));
     }
 
     [Fact]
@@ -50,10 +55,10 @@ public class PeerCommunityFilterTests
         var peerA = new PeerConfig { Address = SharedIp, RemoteAsn = 64512 };
         var peerB = new PeerConfig { Address = SharedIp, RemoteAsn = 64513 };
 
-        Assert.True(filter.AcceptOutgoing(RouteWith(0x0000FF01), peerA));
-        Assert.False(filter.AcceptOutgoing(RouteWith(0x0000FF01), peerB));
-        Assert.True(filter.AcceptOutgoing(RouteWith(0x0000FF02), peerB));
-        Assert.False(filter.AcceptOutgoing(RouteWith(0x0000FF02), peerA));
+        Assert.True(Outgoing(filter, RouteWith(0x0000FF01), peerA));
+        Assert.False(Outgoing(filter, RouteWith(0x0000FF01), peerB));
+        Assert.True(Outgoing(filter, RouteWith(0x0000FF02), peerB));
+        Assert.False(Outgoing(filter, RouteWith(0x0000FF02), peerA));
     }
 
     [Fact]
@@ -66,8 +71,8 @@ public class PeerCommunityFilterTests
 
         var peerNullAsn = new PeerConfig { Address = SharedIp, RemoteAsn = null };
 
-        Assert.True(filter.AcceptOutgoing(RouteWith(0x0000FF03), peerNullAsn));
-        Assert.False(filter.AcceptOutgoing(RouteWith(0x0000FF01), peerNullAsn));
+        Assert.True(Outgoing(filter, RouteWith(0x0000FF03), peerNullAsn));
+        Assert.False(Outgoing(filter, RouteWith(0x0000FF01), peerNullAsn));
     }
 
     [Theory]
@@ -79,7 +84,7 @@ public class PeerCommunityFilterTests
         var allowed = new HashSet<uint> { community };
         var filter = NewFilter((_, _) => allowed);
 
-        Assert.False(filter.AcceptOutgoing(RouteWith(community), EbgpPeer));
+        Assert.False(Outgoing(filter, RouteWith(community), EbgpPeer));
     }
 
     [Theory]
@@ -91,8 +96,7 @@ public class PeerCommunityFilterTests
         var allowed = new HashSet<uint> { 0x0000FF01 };
         var filter = NewFilter((_, _) => allowed);
 
-        Assert.False(filter.AcceptOutgoing(
-            RouteWith(0x0000FF01, community), EbgpPeer));
+        Assert.False(Outgoing(filter, RouteWith(0x0000FF01, community), EbgpPeer));
     }
 
     [Theory]
@@ -102,7 +106,7 @@ public class PeerCommunityFilterTests
     {
         var filter = NewFilter();
 
-        Assert.True(filter.AcceptOutgoing(RouteWith(community), IbgpPeer));
+        Assert.True(Outgoing(filter, RouteWith(community), IbgpPeer));
     }
 
     [Fact]
@@ -110,7 +114,7 @@ public class PeerCommunityFilterTests
     {
         var filter = NewFilter();
 
-        Assert.False(filter.AcceptOutgoing(RouteWith(BgpConstants.Community.NoAdvertise), IbgpPeer));
+        Assert.False(Outgoing(filter, RouteWith(BgpConstants.Community.NoAdvertise), IbgpPeer));
     }
 
     [Fact]
@@ -119,7 +123,7 @@ public class PeerCommunityFilterTests
         var allowed = new HashSet<uint> { 0x0000FF01 };
         var filter = NewFilter((_, _) => allowed);
 
-        Assert.True(filter.AcceptOutgoing(RouteWith(0x0000FF01), EbgpPeer));
+        Assert.True(Outgoing(filter, RouteWith(0x0000FF01), EbgpPeer));
     }
 
     [Fact]
@@ -127,7 +131,7 @@ public class PeerCommunityFilterTests
     {
         var filter = NewFilter();
 
-        Assert.True(filter.AcceptOutgoing(RouteWith(), EbgpPeer));
+        Assert.True(Outgoing(filter, RouteWith(), EbgpPeer));
     }
 
     [Fact]
@@ -136,6 +140,30 @@ public class PeerCommunityFilterTests
         var allowed = new HashSet<uint> { 0x0000FF01 };
         var filter = NewFilter((_, _) => allowed);
 
-        Assert.False(filter.AcceptOutgoing(RouteWith(0x0000FF02), EbgpPeer));
+        Assert.False(Outgoing(filter, RouteWith(0x0000FF02), EbgpPeer));
+    }
+
+    [Fact]
+    public void Resolver_IsInvokedOncePerSend_NotPerRoute()
+    {
+        // #79: the community allow-set (a database roundtrip in production) must be resolved
+        // ONCE per send, then reused for every per-route AcceptOutgoing decision — not once per
+        // advertised route (~20k queries per refresh before the fix).
+        var invocations = 0;
+        var filter = NewFilter((_, _) =>
+        {
+            invocations++;
+            return new HashSet<uint> { 0x0000FF01 };
+        });
+
+        // One resolution for the whole send.
+        var allowSet = filter.ResolveOutgoingAllowSet(EbgpPeer);
+        Assert.Equal(1, invocations);
+
+        // Many per-route decisions against the pre-resolved set must NOT re-invoke the resolver.
+        for (var i = 0; i < 1000; i++)
+            filter.AcceptOutgoing(RouteWith(0x0000FF01), EbgpPeer, allowSet);
+
+        Assert.Equal(1, invocations);
     }
 }


### PR DESCRIPTION
Closes #79

## Problem
`PeerCommunityFilter.AcceptOutgoing` called `_getCommunities(peer.Address, peer.RemoteAsn)` — an EF Core roundtrip into `PeerStore` — **on every advertised route**. A refresh to a peer with ~20k prefixes issued ~20k DB queries. Dominant bottleneck; introduced by the community work (#64/#66/#67).

## Fix
Hoist the community allow-set resolution out of the per-route loop so it happens **once per send**, then reuse the pre-resolved set for every per-route decision.

- **`IRouteFilter`** — new `ResolveOutgoingAllowSet(peer)` (resolved once per send) + `AcceptOutgoing(route, peer, allowSet)` (per-route, no I/O). The contract now expresses "resolve once, test many".
- **`PeerCommunityFilter`** — the resolver runs only in `ResolveOutgoingAllowSet`; `AcceptOutgoing` is a pure per-route decision against the provided set. Well-known-community (`NO_EXPORT`/`NO_ADVERTISE`/`NO_EXPORT_SUBCONFED`) suppression stays per-route (cheap, stateless, needs `peer` for eBGP/iBGP).
- **`AllowAllFilter`** — returns an empty allow-set and ignores it.
- **`BgpSession`** — resolves the allow-set once before each advertise loop (both the configured-peer path `:694` and the shared-table fallback `:728`).

The resolver stays injected into the filter (Routing layer stays decoupled from `Api/PeerStore` — see arch #88). Because the filter is a DI **singleton** shared across all sessions, per-instance caching would race between concurrent peers — the per-send resolution lives on each send's call stack instead, so there's no shared mutable state.

## Result
~20k queries → **1 per peer per refresh**.

## Verification
- `dotnet build` — 0 errors.
- `dotnet test` — **210 passed** (incl. new `Resolver_IsInvokedOncePerSend_NotPerRoute`, which asserts the resolver fires once per `ResolveOutgoingAllowSet` and is **not** re-invoked across 1000 per-route `AcceptOutgoing` calls — locks in the fix).
- Existing `PeerCommunityFilterTests` (well-known suppression, per-(Ip,Asn) disambiguation, no-community pass-through) all pass under the new API.
- `dotnet format` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Outgoing route filtering now resolves community allow-lists once per peer and reuses them across route checks.
  * Route filtering calls now support a precomputed allow-set for more efficient evaluation.

* **Bug Fixes**
  * Improved consistency in outbound community handling while preserving existing pass-through behavior for routes without communities.
  * Reduced redundant repeated resolution during route sending, which should improve performance on larger updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->