### PR TITLE
refactor(server): extract testable pure ValidateOpen

### DIFF
--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -1182,6 +1182,52 @@ public sealed class BgpSession : IDisposable
 
     private void ValidateOpen(BgpOpenMessage open)
     {
+        var localRouterId = BgpConstants.IPAddressToUint(_bgpConfig.GetRouterIdAddress());
+        var negotiation = ValidateOpen(open, _peerConfig.RemoteAsn, localRouterId);
+
+        _remoteAsn = negotiation.RemoteAsn;
+        _remoteFourByteAsn = negotiation.RemoteFourByteAsn;
+        _localFourByteAsn = negotiation.LocalFourByteAsn;
+        _remoteRouteRefresh = negotiation.RemoteRouteRefresh;
+        _negotiatedHoldTime = negotiation.NegotiatedHoldTime;
+        _keepAliveInterval = negotiation.KeepAliveInterval;
+
+        // Announce/persist the peer only after the OPEN passes validation. Previously this fired
+        // before the expected-ASN check, upserting a configured peer that declared a mismatched ASN
+        // (BadPeerAs) just before the session was torn down.
+        _onPeerIdentified?.Invoke(_peerConfig.Address, _remoteAsn);
+
+        var peerGr = CapabilityHelper.GetGracefulRestart(open);
+        _logger.LogInformation("Peer {Peer} Graceful Restart: {State}",
+            _peer,
+            peerGr.HasValue
+                ? $"supported (restartState={peerGr.Value.RestartState}, restartTime={peerGr.Value.RestartTime}s, IPv4/Unicast forwarding={peerGr.Value.Ipv4UnicastForwarding})"
+                : "not supported");
+    }
+
+    /// <summary>
+    /// Negotiated OPEN parameters produced by <see cref="ValidateOpen(BgpOpenMessage, uint?, uint)"/>.
+    /// </summary>
+    internal sealed record OpenNegotiation(
+        uint RemoteAsn,
+        bool RemoteFourByteAsn,
+        bool LocalFourByteAsn,
+        bool RemoteRouteRefresh,
+        ushort NegotiatedHoldTime,
+        TimeSpan KeepAliveInterval);
+
+    /// <summary>
+    /// Pure OPEN validation + capability negotiation. Verifies BGP version, 4-octet-ASN capability
+    /// well-formedness, the expected peer ASN (RFC 4271 §6.2 — <paramref name="expectedRemoteAsn"/>
+    /// is null for auto-registered/unknown peers, accepting any declared ASN), the hold time
+    /// (RFC 4271 §4.2 — 0 or ≥ 3), and the BGP Identifier (non-zero, no collision with the local
+    /// router ID), then derives the negotiated session parameters. Throws
+    /// <see cref="BgpNotificationException"/> with the RFC-mandated error/sub-error on rejection.
+    /// Extracted as <c>internal static</c> so every branch is unit-testable without a live socket
+    /// (mirrors <see cref="GetMalformedFourOctetAsnCapabilityData"/> / MergeAsPathWithAs4Path).
+    /// </summary>
+    internal static OpenNegotiation ValidateOpen(BgpOpenMessage open, uint? expectedRemoteAsn, uint localRouterId)
+    {
         if (open.Version != BgpConstants.BgpVersion)
             throw new BgpNotificationException(BgpConstants.Error.OpenMessageError, BgpConstants.SubError.UnsupportedVersion, $"Unsupported BGP version: {open.Version}");
 
@@ -1195,16 +1241,12 @@ public sealed class BgpSession : IDisposable
                 malformedFourOctetAsnCapability);
         }
 
-        _remoteFourByteAsn = CapabilityHelper.GetRemoteAsn(open).HasValue;
-        _remoteAsn = CapabilityHelper.GetEffectiveAsn(open);
-        // RFC 6793 §6: derive AS_PATH encoding format from negotiated capability
-        _localFourByteAsn = _remoteFourByteAsn;
-        _remoteRouteRefresh = open.Capabilities.Any(c => c.Code == BgpConstants.Capability.RouteRefresh);
+        var remoteFourByteAsn = CapabilityHelper.GetRemoteAsn(open).HasValue;
+        var remoteAsn = CapabilityHelper.GetEffectiveAsn(open);
+        var remoteRouteRefresh = open.Capabilities.Any(c => c.Code == BgpConstants.Capability.RouteRefresh);
 
-        _onPeerIdentified?.Invoke(_peerConfig.Address, _remoteAsn);
-
-        if (_peerConfig.RemoteAsn.HasValue && _remoteAsn != _peerConfig.RemoteAsn.Value)
-            throw new BgpNotificationException(BgpConstants.Error.OpenMessageError, BgpConstants.SubError.BadPeerAs, $"Unexpected ASN: expected {_peerConfig.RemoteAsn}, got {_remoteAsn}");
+        if (expectedRemoteAsn.HasValue && remoteAsn != expectedRemoteAsn.Value)
+            throw new BgpNotificationException(BgpConstants.Error.OpenMessageError, BgpConstants.SubError.BadPeerAs, $"Unexpected ASN: expected {expectedRemoteAsn}, got {remoteAsn}");
 
         var holdTime = open.HoldTime;
         if (holdTime != 0 && holdTime < 3)
@@ -1214,21 +1256,20 @@ public sealed class BgpSession : IDisposable
         if (open.RouterId == 0)
             throw new BgpNotificationException(BgpConstants.Error.OpenMessageError, BgpConstants.SubError.BadBgpIdentifier, "Invalid BGP identifier: 0.0.0.0");
 
-        var localRouterId = BgpConstants.IPAddressToUint(_bgpConfig.GetRouterIdAddress());
         if (open.RouterId == localRouterId)
             throw new BgpNotificationException(BgpConstants.Error.OpenMessageError, BgpConstants.SubError.BadBgpIdentifier, "BGP identifier collision with local RouterId");
 
-        var peerGr = CapabilityHelper.GetGracefulRestart(open);
-        _logger.LogInformation("Peer {Peer} Graceful Restart: {State}",
-            _peer,
-            peerGr.HasValue
-                ? $"supported (restartState={peerGr.Value.RestartState}, restartTime={peerGr.Value.RestartTime}s, IPv4/Unicast forwarding={peerGr.Value.Ipv4UnicastForwarding})"
-                : "not supported");
-
-        _negotiatedHoldTime = holdTime;
-        _keepAliveInterval = holdTime == 0
+        var keepAliveInterval = holdTime == 0
             ? TimeSpan.Zero
             : TimeSpan.FromSeconds(Math.Max(holdTime / 3, 1));
+
+        return new OpenNegotiation(
+            remoteAsn,
+            remoteFourByteAsn,
+            remoteFourByteAsn, // RFC 6793 §6: AS_PATH encoding follows the negotiated capability
+            remoteRouteRefresh,
+            holdTime,
+            keepAliveInterval);
     }
 
     internal static byte[] GetMalformedFourOctetAsnCapabilityData(BgpOpenMessage open)

--- a/BGPLite.Tests/BgpSessionValidateOpenTests.cs
+++ b/BGPLite.Tests/BgpSessionValidateOpenTests.cs
@@ -1,0 +1,150 @@
+using BGPLite.Protocol;
+using BGPLite.Server;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// Direct unit tests for the pure <see cref="BgpSession.ValidateOpen(BgpOpenMessage, uint?, uint)"/>
+/// extraction (#97). Every OPEN-validation branch is exercised without standing up a BgpSession
+/// over a live socket — mirroring how the RFC-6793 tests exercise MergeAsPathWithAs4Path.
+/// </summary>
+public class BgpSessionValidateOpenTests
+{
+    private const uint LocalRouterId = 0x0A000001u; // 10.0.0.1
+    private const uint PeerRouterId = 0x0A000002u;  // 10.0.0.2
+    private const uint AsnFourOctet = 200000u;      // > 16 bits → exercises the 4-octet capability
+
+    private static BgpOpenMessage Open(
+        ushort holdTime = 180,
+        uint routerId = PeerRouterId,
+        List<BgpCapabilityInfo>? capabilities = null,
+        byte version = BgpConstants.BgpVersion,
+        ushort asn = 65002) =>
+        new()
+        {
+            Version = version,
+            Asn = asn,
+            HoldTime = holdTime,
+            RouterId = routerId,
+            Capabilities = capabilities ?? [BgpCapabilityInfo.FourOctetAsn(AsnFourOctet)]
+        };
+
+    [Fact]
+    public void ValidOpen_NegotiatesFourByteAsn_RouteRefresh_KeepAlive()
+    {
+        var open = Open(capabilities:
+        [
+            BgpCapabilityInfo.FourOctetAsn(AsnFourOctet),
+            new() { Code = BgpConstants.Capability.RouteRefresh }
+        ]);
+
+        var n = BgpSession.ValidateOpen(open, expectedRemoteAsn: AsnFourOctet, LocalRouterId);
+
+        Assert.Equal(AsnFourOctet, n.RemoteAsn);
+        Assert.True(n.RemoteFourByteAsn);
+        Assert.True(n.LocalFourByteAsn); // RFC 6793 §6 — AS_PATH encoding follows negotiated capability
+        Assert.True(n.RemoteRouteRefresh);
+        Assert.Equal(180, n.NegotiatedHoldTime);
+        Assert.Equal(TimeSpan.FromSeconds(60), n.KeepAliveInterval); // max(180/3, 1) = 60
+    }
+
+    [Fact]
+    public void TwoByteAsn_NegotiatesFourByteFalse()
+    {
+        var open = Open(asn: 65002, capabilities: []); // no 4-octet capability, no route refresh
+
+        var n = BgpSession.ValidateOpen(open, expectedRemoteAsn: 65002, LocalRouterId);
+
+        Assert.Equal(65002u, n.RemoteAsn);
+        Assert.False(n.RemoteFourByteAsn);
+        Assert.False(n.LocalFourByteAsn);
+        Assert.False(n.RemoteRouteRefresh);
+    }
+
+    [Fact]
+    public void HoldTime_Zero_Accepted_WithZeroKeepAlive()
+    {
+        var n = BgpSession.ValidateOpen(Open(holdTime: 0), AsnFourOctet, LocalRouterId);
+
+        Assert.Equal(0, n.NegotiatedHoldTime);
+        Assert.Equal(TimeSpan.Zero, n.KeepAliveInterval);
+    }
+
+    [Fact]
+    public void HoldTime_Three_Accepted_KeepAliveClampedToOne()
+    {
+        var n = BgpSession.ValidateOpen(Open(holdTime: 3), AsnFourOctet, LocalRouterId);
+
+        Assert.Equal(TimeSpan.FromSeconds(1), n.KeepAliveInterval); // max(3/3, 1) = 1
+    }
+
+    [Fact]
+    public void UnsupportedVersion_Throws()
+    {
+        var ex = Assert.Throws<BgpNotificationException>(
+            () => BgpSession.ValidateOpen(Open(version: 3), AsnFourOctet, LocalRouterId));
+
+        Assert.Equal(BgpConstants.Error.OpenMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.UnsupportedVersion, ex.SubErrorCode);
+    }
+
+    [Fact]
+    public void MalformedFourOctetAsnCapability_Throws()
+    {
+        var open = Open(capabilities:
+        [
+            new() { Code = BgpConstants.Capability.FourOctetAsn, Data = [0x01, 0x02, 0x03] } // 3 bytes, not 4
+        ]);
+
+        var ex = Assert.Throws<BgpNotificationException>(
+            () => BgpSession.ValidateOpen(open, expectedRemoteAsn: null, LocalRouterId));
+
+        Assert.Equal(BgpConstants.Error.OpenMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.UnsupportedCapability, ex.SubErrorCode);
+        Assert.NotNull(ex.NotificationData); // carries the malformed capability TLV
+    }
+
+    [Fact]
+    public void UnexpectedAsn_Throws_BadPeerAs()
+    {
+        var ex = Assert.Throws<BgpNotificationException>(
+            () => BgpSession.ValidateOpen(Open(), expectedRemoteAsn: 65010, LocalRouterId));
+
+        Assert.Equal(BgpConstants.SubError.BadPeerAs, ex.SubErrorCode);
+    }
+
+    [Fact]
+    public void ExpectedAsn_Null_AcceptsAnyAsn() // auto-register / unknown-peer path
+    {
+        var n = BgpSession.ValidateOpen(Open(), expectedRemoteAsn: null, LocalRouterId);
+
+        Assert.Equal(AsnFourOctet, n.RemoteAsn);
+    }
+
+    [Fact]
+    public void HoldTime_TooLow_Throws_UnacceptableHoldTime()
+    {
+        var ex = Assert.Throws<BgpNotificationException>(
+            () => BgpSession.ValidateOpen(Open(holdTime: 2), AsnFourOctet, LocalRouterId));
+
+        Assert.Equal(BgpConstants.SubError.UnacceptableHoldTime, ex.SubErrorCode);
+    }
+
+    [Fact]
+    public void RouterId_Zero_Throws_BadBgpIdentifier()
+    {
+        var ex = Assert.Throws<BgpNotificationException>(
+            () => BgpSession.ValidateOpen(Open(routerId: 0), AsnFourOctet, LocalRouterId));
+
+        Assert.Equal(BgpConstants.SubError.BadBgpIdentifier, ex.SubErrorCode);
+    }
+
+    [Fact]
+    public void RouterId_CollisionWithLocal_Throws_BadBgpIdentifier()
+    {
+        var ex = Assert.Throws<BgpNotificationException>(
+            () => BgpSession.ValidateOpen(Open(routerId: LocalRouterId), AsnFourOctet, LocalRouterId));
+
+        Assert.Equal(BgpConstants.SubError.BadBgpIdentifier, ex.SubErrorCode);
+    }
+}


### PR DESCRIPTION
Closes #97

## Problem
`ValidateOpen` was `private void` and mutated six session fields (plus fired the peer-identified callback) inline, so its decision logic — version check, 4-octet-ASN capability derivation, expected-ASN / hold-time / BGP-Identifier rejection — was unreachable from a unit test without standing up a `BgpSession` over a live socket. The sibling validators (`GetMalformedFourOctetAsnCapabilityData`, `MergeAsPathWithAs4Path`) are already `internal static` with direct tests; `ValidateOpen` was the last large validation block left behind.

## Fix
Extract the pure core into:
```
internal static OpenNegotiation ValidateOpen(BgpOpenMessage open, uint? expectedRemoteAsn, uint localRouterId)
```
returning a small record (`RemoteAsn` / `RemoteFourByteAsn` / `LocalFourByteAsn` / `RemoteRouteRefresh` / `NegotiatedHoldTime` / `KeepAliveInterval`), throwing `BgpNotificationException` with the RFC-mandated error/sub-error on rejection. The instance method now just applies the result and logs Graceful Restart.

The pure method takes scalars (`expectedRemoteAsn`, `localRouterId`) rather than the whole config objects, so tests don't need to construct `PeerConfig`/`BgpConfig`.

## ⚠️ Intentional behavior change
The `_onPeerIdentified` callback (`UpsertPeer(ip, asn)`) now fires **after** validation succeeds instead of **before** the expected-ASN check. Previously, a configured peer that declared a mismatched ASN (`BadPeerAs`) was upserted into the store with the wrong ASN just before the session was torn down. It no longer is — we only persist/announce a peer whose OPEN we actually accept. Unknown peers (no `expectedRemoteAsn`) and matching peers are unaffected.

This is the one wrinkle the issue's "just assign the result and invoke the callback" prescription glossed over; flagged here for review.

## Verification
- `dotnet build` — 0 errors.
- `dotnet test` — **221 passed** (+11 new in `BgpSessionValidateOpenTests`): valid 4-octet negotiation (ASN/route-refresh/keep-alive `max(h/3,1)`), 2-byte ASN, hold-time 0 / 3 / too-low, version mismatch, malformed 4-octet capability, `BadPeerAs` (mismatch + null-expected accepts any), RouterId zero + collision — all asserting the exact RFC error/sub-error codes.
- `dotnet format` — clean.
- Existing `BgpSessionShutdownTests` / `BgpSessionRfc6793Tests` (which drive full sessions) still green — confirms the instance path is wired correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved BGP session OPEN validation for more reliable peer negotiation.
  * Better handling of capability exchange, including four-octet ASN, Route Refresh, and Graceful Restart.

* **Bug Fixes**
  * Added stricter checks for invalid BGP identifiers and peer ASN mismatches.
  * Improved keepalive timing behavior for edge cases such as very small or zero hold times.
  * Expanded validation error handling for unsupported versions and malformed capabilities.

* **Tests**
  * Added unit tests covering successful negotiation and key validation failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->