### PR TITLE
fix(server): keep session up on a single malformed UPDATE

### DIFF
--- a/BGPLite.Server/BgpMetrics.cs
+++ b/BGPLite.Server/BgpMetrics.cs
@@ -8,18 +8,22 @@ public sealed class BgpMetrics
     private int _routeCount;
     private long _updatesReceived;
     private long _updatesSent;
+    private long _updatesRejected;
     private int _activeSessions;
 
     public int PeerCount => Volatile.Read(ref _peerCount);
     public int RouteCount => Volatile.Read(ref _routeCount);
     public long UpdatesReceived => Interlocked.Read(ref _updatesReceived);
     public long UpdatesSent => Interlocked.Read(ref _updatesSent);
+    /// <summary>UPDATEs rejected for malformed/invalid content without tearing down the session (RFC 7606).</summary>
+    public long UpdatesRejected => Interlocked.Read(ref _updatesRejected);
     public int ActiveSessions => Volatile.Read(ref _activeSessions);
 
     public void PeerConnected() => Interlocked.Increment(ref _peerCount);
     public void PeerDisconnected() => Interlocked.Decrement(ref _peerCount);
     public void UpdateReceived() => Interlocked.Increment(ref _updatesReceived);
     public void UpdateSent() => Interlocked.Increment(ref _updatesSent);
+    public void UpdateRejected() => Interlocked.Increment(ref _updatesRejected);
     public void SessionEstablished() => Interlocked.Increment(ref _activeSessions);
     public void SessionClosed() => Interlocked.Decrement(ref _activeSessions);
     public void SetRouteCount(int count) => Volatile.Write(ref _routeCount, count);

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -341,7 +341,26 @@ public sealed class BgpSession : IDisposable
             {
                 case BgpUpdateMessage update:
                     _metrics.UpdateReceived();
-                    await HandleUpdateAsync(update);
+                    try
+                    {
+                        await HandleUpdateAsync(update);
+                    }
+                    catch (BgpNotificationException ex) when (ex.ErrorCode == BgpConstants.Error.UpdateMessageError)
+                    {
+                        // Per-UPDATE content error (malformed attribute, missing mandatory attr, bad
+                        // AS_PATH/AS4_PATH merge, …): the message was framed correctly, so this is one bad
+                        // route, not a broken stream. RFC 7606 "treat-as-withdraw": discard the UPDATE and
+                        // keep the session — a route-server should not lose a long-lived session over a
+                        // single bad/adversarial UPDATE (#94). Reserve teardown for stream-level errors
+                        // (FSM / message-header), which surface as other error codes and propagate.
+                        // NOTE: deliberately do NOT send a NOTIFICATION — RFC 4271 §6.1 requires the
+                        // receiver of a NOTIFICATION to tear down, so notifying would make the peer kill
+                        // the very session we are trying to preserve.
+                        _metrics.UpdateRejected();
+                        _logger.LogWarning(
+                            "Rejected malformed UPDATE from {Peer}: {Error}/{SubError} — {Reason}; session stays up",
+                            _peer, ex.ErrorCode, ex.SubErrorCode, ex.Message);
+                    }
                     break;
                 case BgpKeepaliveMessage:
                     _logger.LogDebug("KeepAliveReceived from {Peer}", _peer);

--- a/BGPLite.Tests/BgpSessionShutdownTests.cs
+++ b/BGPLite.Tests/BgpSessionShutdownTests.cs
@@ -351,6 +351,55 @@ public class BgpSessionShutdownTests
     }
 
     /// <summary>
+    /// #94 / RFC 7606: a single malformed inbound UPDATE (here: NLRI present but the mandatory ORIGIN
+    /// attribute is missing → MissingWellKnownAttribute) must NOT tear down the session. The read loop
+    /// catches BgpNotificationException(UpdateMessageError), logs + counts it, and keeps going — a
+    /// route-server should not lose a long-lived session over one bad/adversarial UPDATE. Stream-level
+    /// errors (FSM / message header) still propagate and tear down.
+    /// </summary>
+    [Fact]
+    public async Task MalformedUpdate_Does_Not_Tear_Down_Session()
+    {
+        var (server, client) = ConnectedPair();
+        using var clientSock = client;
+        var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
+        var metrics = new BgpMetrics();
+        using var session = new BgpSession(
+            server,
+            new PeerConfig { Address = "127.0.0.1" },
+            bgpConfig,
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            metrics,
+            new NopLogger<BgpSession>());
+
+        var runTask = await EstablishSessionAsync(session, client, bgpConfig);
+
+        // Malformed UPDATE: announces NLRI but omits the mandatory ORIGIN attribute.
+        var malformed = new BgpUpdateMessage
+        {
+            Nlri = [new IpPrefix(0xC0A80100u, 24)],
+            PathAttributes = []
+        };
+        var buf = new byte[BgpMessageWriter.GetBufferSize(malformed)];
+        var len = BgpMessageWriter.WriteMessage(malformed, buf);
+        client.Send(buf, 0, len, SocketFlags.None);
+
+        // Let the read loop receive and reject the bad UPDATE.
+        await Task.Delay(TimeSpan.FromMilliseconds(500));
+
+        Assert.True(session.IsEstablished, "session must survive a single malformed UPDATE (#94)");
+        Assert.True(metrics.UpdatesRejected >= 1, "the malformed UPDATE must be counted as rejected");
+
+        // No NOTIFICATION on the wire — we keep the session instead of notifying/tearing down.
+        var sent = await DrainAsync(client, TimeSpan.FromSeconds(2));
+        Assert.DoesNotContain(sent, m => m is BgpNotificationMessage);
+
+        session.MarkSilentClose();
+        await runTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    /// <summary>
     /// RFC 4724 §4 / §8.1: a Graceful-Restart-aware silent close (MarkSilentClose) must not emit a
     /// NOTIFICATION — the TCP connection is dropped so the peer retains routes across the restart.
     /// Regression for the bug where StopAsync with GR enabled skipped NotifyCeaseAsync but then


### PR DESCRIPTION
Closes #94

## Problem
A single malformed inbound UPDATE (bad attribute, missing mandatory ORIGIN/AS_PATH/NEXT_HOP, bad AS4_PATH merge) threw `BgpNotificationException` from `HandleUpdateAsync`; `ReadLoopAsync` dispatched `await HandleUpdateAsync(update)` with no try/catch, so the exception unwound the read loop and tore down the entire session. For a route-server this is the wrong granularity — one bad/adversarial UPDATE from a peer killed a long-lived session that may be hard to re-establish.

## Fix
Wrap the per-UPDATE dispatch in a try/catch **filtered to `BgpNotificationException` with `ErrorCode == UpdateMessageError`**: log a warning + increment a new `UpdatesRejected` metric + continue the loop. Stream-level errors (FSM / message-header), which surface as other error codes, still propagate and tear down. This is RFC 7606 "treat-as-withdraw"-style resilience.

## ⚠️ Deviation from the issue's proposed solution (questioned per review discipline)
The issue suggested *"send a NOTIFICATION (Update Message Error) and continue"*. That is **self-defeating**: RFC 4271 §6.1 requires the **receiver** of a NOTIFICATION to tear down — so sending one would make the peer kill the very session we are trying to preserve. Instead we **silently skip** the bad UPDATE (RFC 7606 treat-as-withdraw) and keep the session. The new `UpdatesRejected` metric makes these silent skips observable so an operator can spot a persistently-malforming peer.

Rationale for the `when (ErrorCode == UpdateMessageError)` filter: errors thrown from `HandleUpdateAsync` are all per-UPDATE content errors (every throw site uses `UpdateMessageError`); reserving teardown for genuinely different error codes keeps stream-corruption handling intact.

## Verification
- `dotnet build` — 0 errors.
- `dotnet test` — **222 passed** (+1 new `MalformedUpdate_Does_Not_Tear_Down_Session`): establishes a session, sends an UPDATE with NLRI but no ORIGIN (`MissingWellKnownAttribute`), asserts the session stays `Established`, `metrics.UpdatesRejected >= 1`, and **no NOTIFICATION** on the wire. The existing teardown tests (hold-timer, remote-NOTIFICATION, silent-close, unexpected-teardown Cease) stay green — confirming stream-level teardown is unchanged.
- `dotnet format` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Malformed update messages are now rejected without disconnecting an established session.
  * Rejected updates are tracked separately in metrics for better visibility.
  * Sessions no longer send a notification for this specific update error, helping keep connections stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->