### PR TITLE
fix(api): enable SQLite WAL + busy_timeout for peer-store resilience

### DIFF
--- a/BGPLite.Api/BGPLite.Api.csproj
+++ b/BGPLite.Api/BGPLite.Api.csproj
@@ -11,10 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="BGPLite.Tests" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\BGPLite.Configuration\BGPLite.Configuration.csproj" />
     <ProjectReference Include="..\BGPLite.Providers\BGPLite.Providers.csproj" />
     <ProjectReference Include="..\BGPLite.Routing\BGPLite.Routing.csproj" />

--- a/BGPLite.Api/BGPLite.Api.csproj
+++ b/BGPLite.Api/BGPLite.Api.csproj
@@ -11,6 +11,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="BGPLite.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\BGPLite.Configuration\BGPLite.Configuration.csproj" />
     <ProjectReference Include="..\BGPLite.Providers\BGPLite.Providers.csproj" />
     <ProjectReference Include="..\BGPLite.Routing\BGPLite.Routing.csproj" />

--- a/BGPLite.Api/SqlitePragmasInterceptor.cs
+++ b/BGPLite.Api/SqlitePragmasInterceptor.cs
@@ -1,0 +1,53 @@
+using System.Data.Common;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace BGPLite.Api;
+
+/// <summary>
+/// Applies connection-level SQLite PRAGMAs the moment EF Core opens a connection, so every
+/// <see cref="BgpDbContext"/> (<c>IDbContextFactory</c> creates one per PeerStore operation) gets
+/// them. Resilience + concurrency for the peer store (#95):
+/// <list type="bullet">
+/// <item><c>journal_mode=WAL</c> — writers no longer block readers (and vice-versa); massively cuts
+/// writer contention. Persists in the DB file, so re-applying is an idempotent no-op.</item>
+/// <item><c>synchronous=NORMAL</c> — the standard WAL companion: keeps durability for committed WAL
+/// frames while cutting fsync cost vs FULL. Peer state is reconstructable from BGP sessions, so
+/// NORMAL is the right tradeoff.</item>
+/// <item><c>busy_timeout=5000</c> — SQLite itself waits and retries the lock for up to 5s before
+/// returning <c>SQLITE_BUSY</c>. This is the engine-level retry #95 asks for; a separate app-level
+/// Polly loop would only double-retry the rare &gt;5s contention.</item>
+/// </list>
+/// <c>synchronous</c>/<c>busy_timeout</c> are per-connection, so they are re-applied on every open.
+/// </summary>
+internal sealed class SqlitePragmasInterceptor : DbConnectionInterceptor
+{
+    private const int BusyTimeoutMs = 5000;
+
+    public override void ConnectionOpened(DbConnection connection, ConnectionEndEventData eventData)
+        => ApplyPragmas(connection);
+
+    public override Task ConnectionOpenedAsync(
+        DbConnection connection, ConnectionEndEventData eventData, CancellationToken cancellationToken = default)
+    {
+        ApplyPragmas(connection);
+        return Task.CompletedTask;
+    }
+
+    private static void ApplyPragmas(DbConnection connection)
+    {
+        if (connection is not SqliteConnection sqlite) return;
+        // Microsoft.Data.Sqlite runs only the first statement of a multi-statement command, so issue
+        // each PRAGMA separately.
+        Execute(sqlite, $"PRAGMA journal_mode=WAL;");
+        Execute(sqlite, "PRAGMA synchronous=NORMAL;");
+        Execute(sqlite, $"PRAGMA busy_timeout={BusyTimeoutMs};");
+    }
+
+    private static void Execute(SqliteConnection sqlite, string pragma)
+    {
+        using var cmd = sqlite.CreateCommand();
+        cmd.CommandText = pragma;
+        cmd.ExecuteNonQuery();
+    }
+}

--- a/BGPLite.Api/SqlitePragmasInterceptor.cs
+++ b/BGPLite.Api/SqlitePragmasInterceptor.cs
@@ -27,12 +27,9 @@ public sealed class SqlitePragmasInterceptor : DbConnectionInterceptor
     public override void ConnectionOpened(DbConnection connection, ConnectionEndEventData eventData)
         => ApplyPragmas(connection);
 
-    public override Task ConnectionOpenedAsync(
+    public override async Task ConnectionOpenedAsync(
         DbConnection connection, ConnectionEndEventData eventData, CancellationToken cancellationToken = default)
-    {
-        ApplyPragmas(connection);
-        return Task.CompletedTask;
-    }
+        => await ApplyPragmasAsync(connection, cancellationToken);
 
     private static void ApplyPragmas(DbConnection connection)
     {
@@ -44,10 +41,25 @@ public sealed class SqlitePragmasInterceptor : DbConnectionInterceptor
         Execute(sqlite, $"PRAGMA busy_timeout={BusyTimeoutMs};");
     }
 
+    private static async Task ApplyPragmasAsync(DbConnection connection, CancellationToken cancellationToken)
+    {
+        if (connection is not SqliteConnection sqlite) return;
+        await ExecuteAsync(sqlite, $"PRAGMA journal_mode=WAL;", cancellationToken);
+        await ExecuteAsync(sqlite, "PRAGMA synchronous=NORMAL;", cancellationToken);
+        await ExecuteAsync(sqlite, $"PRAGMA busy_timeout={BusyTimeoutMs};", cancellationToken);
+    }
+
     private static void Execute(SqliteConnection sqlite, string pragma)
     {
         using var cmd = sqlite.CreateCommand();
         cmd.CommandText = pragma;
         cmd.ExecuteNonQuery();
+    }
+
+    private static async Task ExecuteAsync(SqliteConnection sqlite, string pragma, CancellationToken cancellationToken)
+    {
+        using var cmd = sqlite.CreateCommand();
+        cmd.CommandText = pragma;
+        await cmd.ExecuteNonQueryAsync(cancellationToken);
     }
 }

--- a/BGPLite.Api/SqlitePragmasInterceptor.cs
+++ b/BGPLite.Api/SqlitePragmasInterceptor.cs
@@ -20,7 +20,7 @@ namespace BGPLite.Api;
 /// </list>
 /// <c>synchronous</c>/<c>busy_timeout</c> are per-connection, so they are re-applied on every open.
 /// </summary>
-internal sealed class SqlitePragmasInterceptor : DbConnectionInterceptor
+public sealed class SqlitePragmasInterceptor : DbConnectionInterceptor
 {
     private const int BusyTimeoutMs = 5000;
 

--- a/BGPLite.Tests/SqlitePragmasInterceptorTests.cs
+++ b/BGPLite.Tests/SqlitePragmasInterceptorTests.cs
@@ -1,0 +1,47 @@
+using BGPLite.Api;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// Verifies the connection-level SQLite PRAGMAs applied by <see cref="SqlitePragmasInterceptor"/>
+/// (#95): WAL mode, a 5s busy_timeout, and synchronous=NORMAL. Uses a temp file because WAL does
+/// not apply to an in-memory database.
+/// </summary>
+public class SqlitePragmasInterceptorTests
+{
+    [Fact]
+    public async Task Connection_Open_Applies_Wal_BusyTimeout_Synchronous()
+    {
+        var file = Path.Combine(Path.GetTempPath(), $"bgplite-pragma-{Guid.NewGuid():N}.db");
+        try
+        {
+            var options = new DbContextOptionsBuilder<BgpDbContext>()
+                .UseSqlite($"Data Source={file}")
+                .AddInterceptors(new SqlitePragmasInterceptor())
+                .Options;
+
+            await using var db = new BgpDbContext(options);
+            await db.Database.OpenConnectionAsync(); // triggers ConnectionOpenedAsync → PRAGMAs
+
+            var conn = (SqliteConnection)db.Database.GetDbConnection();
+            Assert.Equal("wal", Scalar(conn, "PRAGMA journal_mode;"));
+            Assert.Equal("5000", Scalar(conn, "PRAGMA busy_timeout;"));
+            Assert.Equal("1", Scalar(conn, "PRAGMA synchronous;")); // NORMAL = 1
+        }
+        finally
+        {
+            File.Delete(file);
+            File.Delete(file + "-wal");
+            File.Delete(file + "-shm");
+        }
+    }
+
+    private static string Scalar(SqliteConnection conn, string sql)
+    {
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        return cmd.ExecuteScalar()?.ToString() ?? "";
+    }
+}

--- a/BGPLite/Program.cs
+++ b/BGPLite/Program.cs
@@ -34,11 +34,15 @@ builder.Services.AddSingleton(config);
 builder.Services.AddSingleton(config.Bgp);
 builder.Services.AddSingleton(routeTable);
 
+// SQLite resilience (#95): WAL (readers don't block writers), synchronous=NORMAL, and a 5s
+// busy_timeout (engine-level lock retry) applied on every connection via a DbConnectionInterceptor,
+// so both the factory-created and scoped contexts get the same settings.
+var sqlitePragmas = new SqlitePragmasInterceptor();
 builder.Services.AddDbContextFactory<BgpDbContext>(options =>
-    options.UseSqlite($"Data Source={dbPath}"));
+    options.UseSqlite($"Data Source={dbPath}").AddInterceptors(sqlitePragmas));
 
 builder.Services.AddDbContext<BgpDbContext>(options =>
-    options.UseSqlite($"Data Source={dbPath}"), ServiceLifetime.Scoped);
+    options.UseSqlite($"Data Source={dbPath}").AddInterceptors(sqlitePragmas), ServiceLifetime.Scoped);
 
 builder.Services.AddSingleton<PeerStore>();
 builder.Services.AddSingleton<IRouteFilter>(sp =>
@@ -141,7 +145,17 @@ if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
 using (var scope = host.Services.CreateScope())
 {
     var db = scope.ServiceProvider.GetRequiredService<BgpDbContext>();
-    BgpDbContext.Initialize(db);
+    try
+    {
+        BgpDbContext.Initialize(db);
+    }
+    catch (Exception ex)
+    {
+        // Fail loud at startup with a human-readable cause (read-only FS, disk full, locked file)
+        // rather than surfacing later as a per-request 'database is locked' 500 (#95).
+        Console.Error.WriteLine($"FATAL: peer database at '{dbPath}' is not writable or could not be initialized: {ex.Message}");
+        throw;
+    }
     var peerCount = db.Peers.Count();
     Console.WriteLine(peerCount == 0
         ? "Created new database"


### PR DESCRIPTION
Closes #95

## Problem
The peer SQLite database ran with default settings (no WAL). Writers serialized hard against readers and each other, and a transient `SQLITE_BUSY` ("database is locked") from concurrent writers (management API, per-session `UpsertPeer` on OPEN, `UpdateSessionStatus`) threw straight out — `UpsertPeer` surfaced as a Cease during OPEN handling; `SetCommunities`/`SetSubscriptions` as a per-request 500 with no retry.

## Fix
A `DbConnectionInterceptor` (`SqlitePragmasInterceptor`) applies connection-level PRAGMAs on **every** EF connection open — `IDbContextFactory` creates a context per PeerStore operation, so this covers every op uniformly:
- `journal_mode=WAL` — readers no longer block writers (and vice-versa); persists in the DB file.
- `synchronous=NORMAL` — the standard WAL companion (committed WAL frames stay durable; cheaper than FULL; peer state is reconstructable from sessions).
- `busy_timeout=5000` — SQLite itself waits/retries the lock for up to 5s before `SQLITE_BUSY`.

Startup now fails **loud** with a human-readable cause if the DB is not writable (read-only FS / disk full / locked) instead of surfacing later as a per-request 500.

## ⚠️ Deviation from the issue's proposed solution (questioned per review discipline)
The issue suggested adding a **Polly/app-level retry loop** on top. Deliberately omitted: `busy_timeout=5000` **is** the engine-level retry/wait (SQLite blocks & retries internally for up to 5s), so an app layer would only double-retry the rare >5s contention for this low-write workload — and would add a new dependency. If real-world >5s contention is observed, a small `ExecutionStrategy` retry is a clean follow-up. `async PeerStore` is #10; `AsNoTracking` on read paths is #110 — both separate (1:1).

## Verification
- `dotnet build` — 0 errors.
- `dotnet test` — **223 passed** (+1 `Connection_Open_Applies_Wal_BusyTimeout_Synchronous`: builds a `BgpDbContext` on a temp file with the interceptor, opens the connection, asserts `journal_mode=wal`, `busy_timeout=5000`, `synchronous=1` (NORMAL) via raw `SqliteCommand`). Existing `PeerStoreKeyingTests` (real in-memory SQLite) stay green.
- `dotnet format` — clean.

(Note: EF Core 10 simplified the `DbConnectionInterceptor.ConnectionOpened` API to `void`/`Task` without `InterceptionResult` — handled.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically applies SQLite connection settings (WAL mode, busy timeout, and NORMAL sync behavior) to improve reliability during database use.

* **Bug Fixes**
  * Improved startup resilience: initialization failures now show a clearer fatal error indicating the database path is not writable or could not be initialized, and startup fails immediately.
  * Added tests to verify the expected SQLite connection PRAGMA settings are applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->