### PR TITLE
perf(api): AsNoTracking on all PeerStore read paths

### DIFF
--- a/BGPLite.Api/PeerStore.cs
+++ b/BGPLite.Api/PeerStore.cs
@@ -105,6 +105,7 @@ public sealed class PeerStore : IPeerStore
             s => s.SetProperty(p => p.Description, description));
     }
 
+    // AsNoTracking is a read-only-intent marker here — a no-op for this scalar projection (no entities are materialized to track).
     public HashSet<uint> GetCommunities(string peerId)
     {
         using var db = _dbFactory.CreateDbContext();
@@ -115,6 +116,7 @@ public sealed class PeerStore : IPeerStore
             .ToHashSet();
     }
 
+    // AsNoTracking is a read-only-intent marker here — a no-op for this scalar projection (no entities are materialized to track).
     public HashSet<uint> GetCommunities(string ip, uint asn)
     {
         using var db = _dbFactory.CreateDbContext();
@@ -125,6 +127,7 @@ public sealed class PeerStore : IPeerStore
             .ToHashSet();
     }
 
+    // AsNoTracking is a read-only-intent marker here — a no-op for this scalar projection (no entities are materialized to track).
     public HashSet<uint> GetCommunitiesByIp(string ip)
     {
         using var db = _dbFactory.CreateDbContext();
@@ -150,6 +153,7 @@ public sealed class PeerStore : IPeerStore
         db.Set<PeerCommunity>().Where(c => c.PeerId == peerId).ExecuteDelete();
     }
 
+    // AsNoTracking is a read-only-intent marker here — a no-op for this scalar projection (no entities are materialized to track).
     public List<string> GetSubscriptions(string peerId)
     {
         using var db = _dbFactory.CreateDbContext();
@@ -168,6 +172,7 @@ public sealed class PeerStore : IPeerStore
         db.SaveChanges();
     }
 
+    // AsNoTracking is a read-only-intent marker here — a no-op for this scalar projection (no entities are materialized to track).
     public List<string> GetCustomPrefixes(string peerId)
     {
         using var db = _dbFactory.CreateDbContext();
@@ -186,6 +191,7 @@ public sealed class PeerStore : IPeerStore
         db.SaveChanges();
     }
 
+    // AsNoTracking is a read-only-intent marker here — a no-op for this scalar projection (no entities are materialized to track).
     public List<uint> GetCustomAsns(string peerId)
     {
         using var db = _dbFactory.CreateDbContext();

--- a/BGPLite.Api/PeerStore.cs
+++ b/BGPLite.Api/PeerStore.cs
@@ -63,26 +63,26 @@ public sealed class PeerStore : IPeerStore
     public List<Peer> GetAllPeers()
     {
         using var db = _dbFactory.CreateDbContext();
-        return db.Peers.Include(p => p.Communities).ToList();
+        return db.Peers.AsNoTracking().Include(p => p.Communities).ToList();
     }
 
     public Peer? GetDbPeerById(string id)
     {
         using var db = _dbFactory.CreateDbContext();
-        return db.Peers.Include(p => p.Communities).FirstOrDefault(p => p.Id == id);
+        return db.Peers.AsNoTracking().Include(p => p.Communities).FirstOrDefault(p => p.Id == id);
     }
 
     PeerInfo? IPeerStore.GetPeerById(string id)
     {
         using var db = _dbFactory.CreateDbContext();
-        var peer = db.Peers.Include(p => p.Communities).FirstOrDefault(p => p.Id == id);
+        var peer = db.Peers.AsNoTracking().Include(p => p.Communities).FirstOrDefault(p => p.Id == id);
         return peer is null ? null : MapToInfo(peer);
     }
 
     public PeerInfo? GetPeerByIp(string ip)
     {
         using var db = _dbFactory.CreateDbContext();
-        var peer = db.Peers.Include(p => p.Communities).FirstOrDefault(p => p.Ip == ip);
+        var peer = db.Peers.AsNoTracking().Include(p => p.Communities).FirstOrDefault(p => p.Ip == ip);
         return peer is null ? null : MapToInfo(peer);
     }
 
@@ -94,7 +94,7 @@ public sealed class PeerStore : IPeerStore
     public PeerInfo? GetPeer(string ip, uint asn)
     {
         using var db = _dbFactory.CreateDbContext();
-        var peer = db.Peers.Include(p => p.Communities).FirstOrDefault(p => p.Ip == ip && p.Asn == asn);
+        var peer = db.Peers.AsNoTracking().Include(p => p.Communities).FirstOrDefault(p => p.Ip == ip && p.Asn == asn);
         return peer is null ? null : MapToInfo(peer);
     }
 
@@ -108,7 +108,7 @@ public sealed class PeerStore : IPeerStore
     public HashSet<uint> GetCommunities(string peerId)
     {
         using var db = _dbFactory.CreateDbContext();
-        return db.Peers.Include(p => p.Communities)
+        return db.Peers.AsNoTracking().Include(p => p.Communities)
             .Where(p => p.Id == peerId)
             .SelectMany(p => p.Communities)
             .Select(c => (uint)c.Community)
@@ -118,7 +118,7 @@ public sealed class PeerStore : IPeerStore
     public HashSet<uint> GetCommunities(string ip, uint asn)
     {
         using var db = _dbFactory.CreateDbContext();
-        return db.Peers.Include(p => p.Communities)
+        return db.Peers.AsNoTracking().Include(p => p.Communities)
             .Where(p => p.Ip == ip && p.Asn == asn)
             .SelectMany(p => p.Communities)
             .Select(c => (uint)c.Community)
@@ -128,7 +128,7 @@ public sealed class PeerStore : IPeerStore
     public HashSet<uint> GetCommunitiesByIp(string ip)
     {
         using var db = _dbFactory.CreateDbContext();
-        return db.Peers.Include(p => p.Communities)
+        return db.Peers.AsNoTracking().Include(p => p.Communities)
             .Where(p => p.Ip == ip)
             .SelectMany(p => p.Communities)
             .Select(c => (uint)c.Community)
@@ -153,7 +153,7 @@ public sealed class PeerStore : IPeerStore
     public List<string> GetSubscriptions(string peerId)
     {
         using var db = _dbFactory.CreateDbContext();
-        return db.Set<PeerSubscription>()
+        return db.Set<PeerSubscription>().AsNoTracking()
             .Where(s => s.PeerId == peerId)
             .Select(s => s.AsnListName)
             .ToList();
@@ -171,7 +171,7 @@ public sealed class PeerStore : IPeerStore
     public List<string> GetCustomPrefixes(string peerId)
     {
         using var db = _dbFactory.CreateDbContext();
-        return db.Set<PeerCustomPrefix>()
+        return db.Set<PeerCustomPrefix>().AsNoTracking()
             .Where(c => c.PeerId == peerId)
             .Select(c => c.Prefix + "/" + c.PrefixLength)
             .ToList();
@@ -189,7 +189,7 @@ public sealed class PeerStore : IPeerStore
     public List<uint> GetCustomAsns(string peerId)
     {
         using var db = _dbFactory.CreateDbContext();
-        return db.Set<PeerCustomAsn>()
+        return db.Set<PeerCustomAsn>().AsNoTracking()
             .Where(c => c.PeerId == peerId)
             .Select(c => c.Asn)
             .ToList();


### PR DESCRIPTION
Closes #110

## Change
Add `.AsNoTracking()` to all 11 PeerStore **read** methods.

- **Entity-loading reads** (`GetAllPeers`, `GetDbPeerById`, `GetPeerById`, `GetPeerByIp`, `GetPeer`) — real perf win: avoids EF building identity-map + change-tracking entries for the materialized `Peer` + eagerly-loaded `Communities` on the per-refresh hot path.
- **Scalar-projection reads** (`GetCommunities` ×3, `GetSubscriptions`, `GetCustomPrefixes`, `GetCustomAsns`) — `AsNoTracking` is technically a no-op here (projections to `uint`/`string` materialize no entities), but kept as a **uniform read-only-intent marker** across all read methods.

**Write methods untouched** — they mutate entities and `SaveChanges`.

## Safety (verified, per the "question the issue" discipline)
- `GetDbPeerById` returns a `Peer` entity, but its callers in `ManagementApi` only **read** properties (`.Status`, `.CreatedAt`, `.Id`, `.Ip`) to build responses — they never mutate-and-save the returned entity (mutations go through `SetCommunities`/`SetSubscriptions`/etc.).
- `GetDbPeerById` already disposes its context at method exit, so the returned entity is detached regardless; `AsNoTracking` only avoids the per-query tracking work.
- Output is unchanged (disconnected read results either way).

## Verification
- `dotnet build` — 0 errors.
- `dotnet test` — **223 passed**. `AsNoTracking` is output-preserving, so existing `PeerStoreKeyingTests` (which exercise these read paths) confirm functional equivalence.
- `dotnet format` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved read-only peer and related data retrieval to avoid unnecessary Entity Framework tracking.
  * Updated peer lookup and list endpoints to return results without tracking, reducing overhead and improving responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->