### PR TITLE
fix(api): make ManagementApi routing fully async

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -107,7 +107,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         try
         {
-            var response = Route(method, segments, ctx);
+            var response = await RouteAsync(method, segments, ctx);
             await WriteResponse(ctx, response);
         }
         catch (Exception ex)
@@ -117,7 +117,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         }
     }
 
-    private ApiResponse Route(string method, string[] segments, HttpListenerContext ctx)
+    private async Task<ApiResponse> RouteAsync(string method, string[] segments, HttpListenerContext ctx)
     {
         // /api/server
         if (IsGet(method, segments, "api", "server"))
@@ -129,23 +129,23 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         // /api/peers
         if (IsPost(method, segments, "api", "peers"))
-            return HandleCreatePeer(ctx).GetAwaiter().GetResult();
+            return await HandleCreatePeer(ctx);
 
         // /api/peers/{id}
         if (segments.Length == 3 && segments[0] == "api" && segments[1] == "peers" && method == "GET")
             return HandleGetPeer(segments[2]);
         if (segments.Length == 3 && segments[0] == "api" && segments[1] == "peers" && method == "PUT")
-            return HandleUpdatePeer(segments[2], ctx).GetAwaiter().GetResult();
+            return await HandleUpdatePeer(segments[2], ctx);
         if (segments.Length == 3 && segments[0] == "api" && segments[1] == "peers" && method == "DELETE")
             return HandleDeletePeer(segments[2]);
 
         // /api/peers/{id}/prefixes
         if (segments.Length == 4 && segments[0] == "api" && segments[1] == "peers" && segments[3] == "prefixes" && method == "GET")
-            return HandleExportPrefixes(segments[2], ctx);
+            return await HandleExportPrefixes(segments[2], ctx);
 
         // /api/asn-lists
         if (IsGet(method, segments, "api", "asn-lists"))
-            return HandleGetAsnListsAsync().GetAwaiter().GetResult();
+            return await HandleGetAsnListsAsync();
 
         // /api/community-scheme
         if (IsGet(method, segments, "api", "community-scheme"))
@@ -161,7 +161,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         // /api/as/{asn}/prefixes
         if (segments.Length == 4 && segments[0] == "api" && segments[1] == "as" && segments[3] == "prefixes" && method == "GET")
-            return HandleGetAsnPrefixes(segments[2], ctx);
+            return await HandleGetAsnPrefixes(segments[2], ctx);
 
         return ApiResponse.Error("Not found", 404);
     }
@@ -422,13 +422,13 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
     #region /api/peers/{id}/prefixes
 
-    private ApiResponse HandleExportPrefixes(string peerId, HttpListenerContext ctx)
+    private async Task<ApiResponse> HandleExportPrefixes(string peerId, HttpListenerContext ctx)
     {
         var peer = _store.GetDbPeerById(peerId);
         if (peer is null)
             return ApiResponse.Error("Peer not found", 404);
 
-        var prefixes = CollectPeerPrefixes(peerId).GetAwaiter().GetResult();
+        var prefixes = await CollectPeerPrefixes(peerId);
 
         var format = ctx.Request.QueryString["format"] ?? "txt";
         if (format == "json")
@@ -601,7 +601,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
     #region GET /api/as/{asn}/prefixes
 
-    private ApiResponse HandleGetAsnPrefixes(string asnStr, HttpListenerContext ctx)
+    private async Task<ApiResponse> HandleGetAsnPrefixes(string asnStr, HttpListenerContext ctx)
     {
         if (!uint.TryParse(asnStr, out var asn))
             return ApiResponse.Error("Invalid ASN", 400);
@@ -615,7 +615,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
             try
             {
-                var count = _prefixService.GetPrefixCountAsync(asn).GetAwaiter().GetResult();
+                var count = await _prefixService.GetPrefixCountAsync(asn);
                 return ApiResponse.Ok(new { asn, prefixCount = count });
             }
             catch (Exception ex)


### PR DESCRIPTION
Closes #92

## Problem
`Route()` was synchronous but invoked async handlers via `.GetAwaiter().GetResult()` (sync-over-async) at 5 sites. `ListenAsync` dispatches each request as `_ = HandleAsync(ctx)` (fire-and-forget → concurrent), so under concurrent API load every in-flight request blocked a threadpool thread for the full duration of its async work — RIPEstat HTTP, which can take minutes (per `RipeStatProvider`) — exhausting the threadpool.

## Fix
`Route` → `async Task<ApiResponse> RouteAsync`, awaiting all five async handlers instead of blocking:
- `HandleCreatePeer`, `HandleUpdatePeer`, `HandleGetAsnListsAsync` (in Route)
- `HandleExportPrefixes`, `HandleGetAsnPrefixes` (made `async`, now `await CollectPeerPrefixes` / `await GetPrefixCountAsync`)

`HandleAsync` awaits `RouteAsync`. No `.GetAwaiter().GetResult()` remains. Route's purely-sync handlers (`HandleGetServer/Me/Peer/DeletePeer/CommunityScheme/Sessions/Routes`) are unchanged and just return through the async method.

## ⚠️ Deviation from the issue (questioned per review discipline)
The issue also asked to **thread the listener `CancellationToken`** into the handlers so RIPEstat reads are cancellable. Deliberately deferred: `GetPrefixCountAsync`/`CollectPeerPrefixes` bottom out in `IPrefixService`, which has **no `CancellationToken`** on any member (#101), so full CT propagation is blocked until #101 lands. The critical fix (sync-over-async → threadpool exhaustion) does not depend on it; CT-threading is a clean follow-up once #101 is in.

## Verification
- `dotnet build` — 0 errors (no test called the now-async `Route` directly).
- `dotnet test` — **223 passed** (unchanged; functional behavior preserved).
- `dotnet format` — clean. `grep GetAwaiter` → none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved request handling to use non-blocking async processing for several management endpoints.
  * Some responses that previously waited on background work now complete more smoothly, especially for peer prefix export and ASN prefix lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->