### PR TITLE
fix(providers): thread CancellationToken through IPrefixService

### DIFF
--- a/BGPLite.Providers/IPrefixSourceService.cs
+++ b/BGPLite.Providers/IPrefixSourceService.cs
@@ -10,14 +10,14 @@ namespace BGPLite.Providers;
 public interface IPrefixSourceService
 {
     /// <summary>All configured sources with their cached prefix lists.</summary>
-    Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>> LoadAllAsync();
+    Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>> LoadAllAsync(CancellationToken ct = default);
 
     /// <summary>One source by name (cache-through). Empty list if missing or failed.</summary>
-    Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name);
+    Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name, CancellationToken ct = default);
 
     /// <summary>The source named by <c>AppConfig.DefaultPrefixSource</c>. Empty list if unset/missing.</summary>
-    Task<IReadOnlyList<(uint Prefix, byte Length)>> GetDefaultAsync();
+    Task<IReadOnlyList<(uint Prefix, byte Length)>> GetDefaultAsync(CancellationToken ct = default);
 
     /// <summary>Prime the in-memory cache for all sources.</summary>
-    Task WarmUpAsync();
+    Task WarmUpAsync(CancellationToken ct = default);
 }

--- a/BGPLite.Providers/PrefixService.cs
+++ b/BGPLite.Providers/PrefixService.cs
@@ -20,26 +20,26 @@ public sealed class PrefixService : IPrefixService
         _cacheTtl = cacheTtl ?? TimeSpan.FromHours(1);
     }
 
-    public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn)
+    public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
     {
         if (_cache.TryGetValue(asn, out var cached) && DateTime.UtcNow - cached.CachedAt < _cacheTtl)
             return cached.Data;
 
         if (_ripeStat is null) return [];
 
-        var prefixes = await _ripeStat.GetPrefixesAsync(asn);
+        var prefixes = await _ripeStat.GetPrefixesAsync(asn, ct);
         _cache[asn] = (prefixes, DateTime.UtcNow);
         return prefixes;
     }
 
-    public async Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns)
+    public async Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
     {
         var result = new List<(uint Prefix, byte Length, uint Asn)>();
         foreach (var asn in asns)
         {
             try
             {
-                var prefixes = await GetPrefixesAsync(asn);
+                var prefixes = await GetPrefixesAsync(asn, ct);
                 foreach (var (prefix, length) in prefixes)
                     result.Add((prefix, length, asn));
             }
@@ -51,9 +51,9 @@ public sealed class PrefixService : IPrefixService
         return result;
     }
 
-    public async Task<int> GetPrefixCountAsync(uint asn)
+    public async Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default)
     {
-        var prefixes = await GetPrefixesAsync(asn);
+        var prefixes = await GetPrefixesAsync(asn, ct);
         return prefixes.Count;
     }
 
@@ -63,22 +63,22 @@ public sealed class PrefixService : IPrefixService
     private List<(uint Prefix, byte Length, uint Asn)>? _ruProjected;
     private DateTime _ruCachedAt;
 
-    public async Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync()
+    public async Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
     {
         if (_ruProjected is not null && DateTime.UtcNow - _ruCachedAt < _cacheTtl)
             return _ruProjected;
 
-        var prefixes = await _prefixSources.GetDefaultAsync();
+        var prefixes = await _prefixSources.GetDefaultAsync(ct);
         _ruProjected = prefixes.Select(p => (p.Prefix, p.Length, 0u)).ToList();
         _ruCachedAt = DateTime.UtcNow;
         return _ruProjected;
     }
 
     /// <summary>Prefixes of a configured source by name (cache-through).</summary>
-    public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name) =>
-        _prefixSources.GetAsync(name);
+    public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default) =>
+        _prefixSources.GetAsync(name, ct);
 
-    public async Task WarmUpAsync()
+    public async Task WarmUpAsync(CancellationToken ct = default)
     {
         var lists = _config.RipeStat?.AsnLists ?? [];
 
@@ -87,7 +87,7 @@ public sealed class PrefixService : IPrefixService
         {
             try
             {
-                await GetPrefixesAsync(asn);
+                await GetPrefixesAsync(asn, ct);
                 Console.WriteLine($"  WarmUp: AS{asn} cached");
             }
             catch (Exception ex)
@@ -97,6 +97,6 @@ public sealed class PrefixService : IPrefixService
         }
 
         // Pre-load all configured prefix sources (file/HTTP/...) into the in-memory cache.
-        await _prefixSources.WarmUpAsync();
+        await _prefixSources.WarmUpAsync(ct);
     }
 }

--- a/BGPLite.Providers/PrefixSourceService.cs
+++ b/BGPLite.Providers/PrefixSourceService.cs
@@ -54,6 +54,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
         }
 
         try { return await LoadCachedAsync(source, ct); }
+        catch (OperationCanceledException) { throw; }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to load prefix source '{Name}'.", name);
@@ -75,6 +76,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
         }
 
         try { return await LoadCachedAsync(source, ct); }
+        catch (OperationCanceledException) { throw; }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to load default prefix source '{Name}'.", defaultName);
@@ -89,6 +91,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
         {
             IReadOnlyList<(uint Prefix, byte Length)> prefixes;
             try { prefixes = await LoadCachedAsync(source, ct); }
+            catch (OperationCanceledException) { throw; }
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Failed to load prefix source '{Name}' ({Kind}).", source.Name, source.Kind);
@@ -124,6 +127,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
                 var provider = _factory.Get(source.Kind);
                 prefixes = await provider.LoadAsync(source, ct);
             }
+            catch (OperationCanceledException) { throw; }
             catch
             {
                 // Serve the last good copy if we have one (regardless of its age).

--- a/BGPLite.Providers/PrefixSourceService.cs
+++ b/BGPLite.Providers/PrefixSourceService.cs
@@ -44,7 +44,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
         _negativeTtl = negativeTtl ?? TimeSpan.FromSeconds(30);
     }
 
-    public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name)
+    public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name, CancellationToken ct = default)
     {
         var source = _config.PrefixSources.FirstOrDefault(s => s.Name == name);
         if (source is null)
@@ -53,7 +53,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
             return [];
         }
 
-        try { return await LoadCachedAsync(source); }
+        try { return await LoadCachedAsync(source, ct); }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to load prefix source '{Name}'.", name);
@@ -61,7 +61,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
         }
     }
 
-    public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetDefaultAsync()
+    public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetDefaultAsync(CancellationToken ct = default)
     {
         var defaultName = _config.DefaultPrefixSource;
         if (string.IsNullOrWhiteSpace(defaultName))
@@ -74,7 +74,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
             return [];
         }
 
-        try { return await LoadCachedAsync(source); }
+        try { return await LoadCachedAsync(source, ct); }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to load default prefix source '{Name}'.", defaultName);
@@ -82,13 +82,13 @@ public sealed class PrefixSourceService : IPrefixSourceService
         }
     }
 
-    public async Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>> LoadAllAsync()
+    public async Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
     {
         var result = new List<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>();
         foreach (var source in _config.PrefixSources)
         {
             IReadOnlyList<(uint Prefix, byte Length)> prefixes;
-            try { prefixes = await LoadCachedAsync(source); }
+            try { prefixes = await LoadCachedAsync(source, ct); }
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Failed to load prefix source '{Name}' ({Kind}).", source.Name, source.Kind);
@@ -99,20 +99,20 @@ public sealed class PrefixSourceService : IPrefixSourceService
         return result;
     }
 
-    public async Task WarmUpAsync()
+    public async Task WarmUpAsync(CancellationToken ct = default)
     {
-        foreach (var (source, prefixes) in await LoadAllAsync())
+        foreach (var (source, prefixes) in await LoadAllAsync(ct))
             Console.WriteLine($"  WarmUp: source '{source.Name}' — {prefixes.Count} prefixes");
     }
 
-    private async Task<IReadOnlyList<(uint Prefix, byte Length)>> LoadCachedAsync(PrefixSourceConfig source)
+    private async Task<IReadOnlyList<(uint Prefix, byte Length)>> LoadCachedAsync(PrefixSourceConfig source, CancellationToken ct)
     {
         if (TryGetFresh(source.Name, out var fresh))
             return fresh;
 
         // Serialize per-key so concurrent callers share a single fetch (no thundering herd).
         var gate = _locks.GetOrAdd(source.Name, _ => new SemaphoreSlim(1, 1));
-        await gate.WaitAsync();
+        await gate.WaitAsync(ct);
         try
         {
             if (TryGetFresh(source.Name, out var rechecked))
@@ -122,7 +122,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
             try
             {
                 var provider = _factory.Get(source.Kind);
-                prefixes = await provider.LoadAsync(source);
+                prefixes = await provider.LoadAsync(source, ct);
             }
             catch
             {

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -557,7 +557,7 @@ public sealed class BgpSession : IDisposable
                     _logger.LogInformation("Unconfigured peer {Peer}, sending RU defaults", _peer);
                     try
                     {
-                        var ruPrefixes = await _prefixService.GetRuPrefixesAsync();
+                        var ruPrefixes = await _prefixService.GetRuPrefixesAsync(_cts.Token);
                         foreach (var (prefix, length, _) in ruPrefixes)
                         {
                             routes.Add(MakeRoute(prefix, length, nextHop, null, defaultComms));
@@ -598,7 +598,7 @@ public sealed class BgpSession : IDisposable
                         {
                             var comms = _communityResolver.Resolve(
                                 new CommunitySource(CommunitySourceKind.AsnList, list.Name));
-                            var prefixes = await _prefixService.GetPrefixesForAsns(list.Asns);
+                            var prefixes = await _prefixService.GetPrefixesForAsns(list.Asns, _cts.Token);
                             foreach (var (prefix, length, asn) in prefixes)
                                 routes.Add(MakeRoute(prefix, length, nextHop, [asn], comms));
                         }
@@ -621,7 +621,7 @@ public sealed class BgpSession : IDisposable
                     {
                         var comms = _communityResolver.Resolve(
                             new CommunitySource(CommunitySourceKind.Country, countryLists[0].Name));
-                        var ruPrefixes = await _prefixService.GetRuPrefixesAsync();
+                        var ruPrefixes = await _prefixService.GetRuPrefixesAsync(_cts.Token);
                         foreach (var (prefix, length, _) in ruPrefixes)
                             routes.Add(MakeRoute(prefix, length, nextHop, null, comms));
                         _logger.LogInformation("Fetched {Count} RU prefixes for {Peer}", ruPrefixes.Count, _peer);
@@ -644,7 +644,7 @@ public sealed class BgpSession : IDisposable
                     try
                     {
                         var comms = _communityResolver.Resolve(new CommunitySource(CommunitySourceKind.PrefixSource, name));
-                        var srcPrefixes = await _prefixService.GetSourcePrefixesAsync(name);
+                        var srcPrefixes = await _prefixService.GetSourcePrefixesAsync(name, _cts.Token);
                         foreach (var (prefix, length) in srcPrefixes)
                             routes.Add(MakeRoute(prefix, length, nextHop, null, comms));
                         _logger.LogInformation("Fetched {Count} prefixes from source '{Source}' for {Peer}",
@@ -678,7 +678,7 @@ public sealed class BgpSession : IDisposable
                     try
                     {
                         var customAsnComms = _communityResolver.Resolve(new CommunitySource(CommunitySourceKind.CustomAsn));
-                        var asnPrefixes = await _prefixService.GetPrefixesForAsns(customAsns);
+                        var asnPrefixes = await _prefixService.GetPrefixesForAsns(customAsns, _cts.Token);
                         foreach (var (prefix, length, asn) in asnPrefixes)
                             routes.Add(MakeRoute(prefix, length, nextHop, [asn], customAsnComms));
                         _logger.LogInformation("Peer {Peer} custom AS: {Asns} -> {Count} prefixes",
@@ -698,7 +698,7 @@ public sealed class BgpSession : IDisposable
                     _logger.LogInformation("Peer {Peer} resolved 0 prefixes, falling back to RU defaults", _peer);
                     try
                     {
-                        var ruPrefixes = await _prefixService.GetRuPrefixesAsync();
+                        var ruPrefixes = await _prefixService.GetRuPrefixesAsync(_cts.Token);
                         foreach (var (prefix, length, _) in ruPrefixes)
                             routes.Add(MakeRoute(prefix, length, nextHop, null, defaultComms));
                     }
@@ -725,7 +725,7 @@ public sealed class BgpSession : IDisposable
 
                 try
                 {
-                    var ruPrefixes = await _prefixService.GetRuPrefixesAsync();
+                    var ruPrefixes = await _prefixService.GetRuPrefixesAsync(_cts.Token);
                     foreach (var (prefix, length, _) in ruPrefixes)
                         routes.Add(MakeRoute(prefix, length, nextHop, null, defaultComms));
                     _logger.LogInformation("Fetched {Count} RU prefixes for unknown peer {Peer}",

--- a/BGPLite.Server/IPrefixService.cs
+++ b/BGPLite.Server/IPrefixService.cs
@@ -2,10 +2,10 @@ namespace BGPLite.Server;
 
 public interface IPrefixService
 {
-    Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn);
-    Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns);
-    Task<int> GetPrefixCountAsync(uint asn);
-    Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync();
-    Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name);
-    Task WarmUpAsync();
+    Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default);
+    Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default);
+    Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default);
+    Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default);
+    Task WarmUpAsync(CancellationToken ct = default);
 }


### PR DESCRIPTION
Closes #101

## Problem
No `IPrefixService` member took a `CancellationToken`, so `BgpSession.SendAllRoutesAsync` (run from `RunAsync`, which holds a linked CT) couldn't abort a stalled RIPEstat fetch when the peer disconnected or the server shut down. The fetch — and its retry/backoff in `RipeStatProvider.GetPrefixesAsync` (which can take minutes for large ASes) — ran to completion, tying up the session task after the socket was gone.

## Fix
Add `CancellationToken ct = default` to every `IPrefixService` member and thread it end-to-end:
- **PrefixService** forwards ct to `RipeStatProvider.GetPrefixesAsync(asn, ct)` (which **already accepted** a CT — it was being silently dropped, the core bug) and to `IPrefixSourceService`.
- **IPrefixSourceService** also had no CT on any member — the issue's fix assumed `GetDefaultAsync`/`GetAsync` accepted one, but they did not. Added ct there too; **PrefixSourceService** forwards it through `LoadCachedAsync` → `gate.WaitAsync(ct)` + `provider.LoadAsync(source, ct)` (file/http providers already accept ct).
- **BgpSession** passes its session `_cts.Token` (cancelled on teardown) to all 7 `_prefixService.*` calls in `SendAllRoutesAsync` → **in-flight RIPEstat is cancelled on peer disconnect / shutdown**.

## Design notes (questioned per review discipline)
- Used `_cts.Token` (a field, cancelled on session teardown) rather than plumbing `linkedCts` through `SendAllRoutesAsync`/`RefreshRoutesAsync`/`ISessionManager` — avoids a signature cascade while still cancelling the fetch on teardown (external-cancel propagates to `_cts` via the teardown path). The issue cited `linkedCts.Token` illustratively.
- Because `ct = default`, **ManagementApi and Program.cs callers are unchanged** (they use the default; the API path stays non-cancellable as today).
- The remaining follow-up — threading the listener CT through `ManagementApi.RouteAsync` (the deferral noted in #92, now enabled by this PR) — is independent and not required for the cancel-on-teardown win.

## Verification
- `dotnet build` — 0 errors (full solution, incl. entrypoint).
- `dotnet test` — **223 passed** (no interface mocks to update; `PrefixSourceServiceTests` calls the concrete class with default ct).
- `dotnet format` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cancellation support across prefix retrieval and warm-up operations, enabling easier graceful shutdown of long-running fetches.
  * Route delivery now propagates the session’s cancellation token to all relevant prefix lookups.

* **Bug Fixes**
  * Improved cancellation handling during source loading and cache-miss fetches, reducing unnecessary work when operations are canceled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->