### PR TITLE
fix(api): gate forwarding headers on trusted proxies

### DIFF
--- a/BGPLite.Api/BGPLite.Api.csproj
+++ b/BGPLite.Api/BGPLite.Api.csproj
@@ -17,4 +17,8 @@
     <ProjectReference Include="..\BGPLite.Server\BGPLite.Server.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="BGPLite.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -652,6 +652,11 @@ public sealed class ManagementApi : IHostedService, IDisposable
     {
         if (remote is null) return "unknown";
 
+        // HttpListener on a dual-stack (http://+) listener reports IPv4 peers as IPv4-mapped IPv6
+        // (::ffff:x.x.x.x); normalize so IPv4 trusted-proxy CIDRs match and the returned string is clean.
+        IPAddress Normalize(IPAddress ip) => ip.IsIPv4MappedToIPv6 ? ip.MapToIPv4() : ip;
+        remote = Normalize(remote);
+
         bool IsTrusted(IPAddress ip) => trustedProxies.Count > 0 && trustedProxies.Any(n => n.Contains(ip));
 
         // Direct (non-proxy) client: never trust client-supplied forwarding headers.
@@ -667,8 +672,11 @@ public sealed class ManagementApi : IHostedService, IDisposable
             {
                 var hop = raw.Trim();
                 if (hop.Length == 0) continue;
-                if (IPAddress.TryParse(hop, out var ip) && !IsTrusted(ip))
-                    return hop;
+                if (IPAddress.TryParse(hop, out var ip))
+                {
+                    var normalized = Normalize(ip);
+                    if (!IsTrusted(normalized)) return normalized.ToString();
+                }
             }
         }
 

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -24,6 +24,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
     private readonly ISessionManager? _sessionManager;
     private readonly ILogger<ManagementApi> _logger;
     private readonly int _port;
+    private readonly IReadOnlyList<IPNetwork> _trustedProxyNetworks;
     private HttpListener? _listener;
     private Task? _listenTask;
     private CancellationTokenSource _cts = new();
@@ -47,6 +48,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         _sessionManager = sessionManager;
         _logger = logger;
         _port = config.ApiPort;
+        _trustedProxyNetworks = ParseTrustedProxies(config.TrustedProxies);
     }
 
     public Task StartAsync(CancellationToken cancellationToken)
@@ -631,19 +633,75 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
     #region Helpers
 
-    private static string GetClientIp(HttpListenerContext ctx)
-    {
-        var realIp = ctx.Request.Headers["X-Real-IP"];
-        if (!string.IsNullOrEmpty(realIp)) return realIp;
+    private string GetClientIp(HttpListenerContext ctx) =>
+        ResolveClientIp(
+            ctx.Request.RemoteEndPoint?.Address,
+            ctx.Request.Headers["X-Forwarded-For"],
+            ctx.Request.Headers["X-Real-IP"],
+            _trustedProxyNetworks);
 
-        var forwarded = ctx.Request.Headers["X-Forwarded-For"];
-        if (!string.IsNullOrEmpty(forwarded))
+    /// <summary>
+    /// Resolves the real client IP from the connection's remote endpoint and forwarding headers.
+    /// Forwarding headers are honored ONLY when the immediate peer (<paramref name="remote"/>) is a
+    /// configured trusted proxy (#91) — a direct client cannot inject <c>X-Forwarded-For</c> /
+    /// <c>X-Real-IP</c>. <c>X-Forwarded-For</c> is walked right-to-left and the first hop that is not
+    /// itself a trusted proxy is returned, defeating injection through the proxy. Extracted as a pure
+    /// function so the security logic is unit-testable without an HttpListener.
+    /// </summary>
+    internal static string ResolveClientIp(IPAddress? remote, string? xForwardedFor, string? xRealIp, IReadOnlyList<IPNetwork> trustedProxies)
+    {
+        if (remote is null) return "unknown";
+
+        bool IsTrusted(IPAddress ip) => trustedProxies.Count > 0 && trustedProxies.Any(n => n.Contains(ip));
+
+        // Direct (non-proxy) client: never trust client-supplied forwarding headers.
+        if (!IsTrusted(remote))
+            return remote.ToString();
+
+        // Trusted proxy: recover the original client from X-Forwarded-For, walking right-to-left past
+        // trusted hops (the proxy appends the real client on the right; attacker-controlled entries
+        // land on the left and are skipped).
+        if (!string.IsNullOrWhiteSpace(xForwardedFor))
         {
-            var first = forwarded.Split(',')[0].Trim();
-            if (first.Length > 0) return first;
+            foreach (var raw in xForwardedFor.Split(',').Reverse())
+            {
+                var hop = raw.Trim();
+                if (hop.Length == 0) continue;
+                if (IPAddress.TryParse(hop, out var ip) && !IsTrusted(ip))
+                    return hop;
+            }
         }
 
-        return ctx.Request.RemoteEndPoint?.Address.ToString() ?? "unknown";
+        // Single-hop proxies commonly set X-Real-IP instead of (or alongside) X-Forwarded-For.
+        if (!string.IsNullOrWhiteSpace(xRealIp))
+            return xRealIp.Trim();
+
+        return remote.ToString();
+    }
+
+    /// <summary>Parses configured TrustedProxies CIDRs (or bare IPs → /32 or /128) into IPNetworks.
+    /// Unparseable entries are logged and skipped (that CIDR simply won't be trusted).</summary>
+    private IReadOnlyList<IPNetwork> ParseTrustedProxies(List<string>? cidrs)
+    {
+        var nets = new List<IPNetwork>();
+        if (cidrs is null || cidrs.Count == 0) return nets;
+
+        foreach (var entry in cidrs)
+        {
+            var s = entry.Trim();
+            if (s.Length == 0) continue;
+
+            if (IPNetwork.TryParse(s, out var net)) { nets.Add(net); continue; }
+
+            if (IPAddress.TryParse(s, out var ip))
+            {
+                nets.Add(new IPNetwork(ip, ip.GetAddressBytes().Length * 8)); // /32 (IPv4) or /128 (IPv6)
+                continue;
+            }
+
+            _logger.LogWarning("Ignoring unparseable TrustedProxies entry '{Entry}'.", s);
+        }
+        return nets;
     }
 
     private static async Task WriteResponse(HttpListenerContext ctx, ApiResponse response)

--- a/BGPLite.Configuration/AppConfig.cs
+++ b/BGPLite.Configuration/AppConfig.cs
@@ -31,4 +31,14 @@ public sealed class AppConfig
     /// <summary>Optional override for the community stamped on per-peer custom-AS-originated prefixes (default <c>&lt;Asn&gt;:200</c>).</summary>
     [YamlMember(Alias = "CustomAsnCommunity")]
     public string? CustomAsnCommunity { get; init; }
+
+    /// <summary>
+    /// Trusted reverse-proxy CIDRs whose <c>X-Forwarded-For</c> / <c>X-Real-IP</c> headers are
+    /// honored when resolving the management-API client IP (e.g. <c>["127.0.0.0/8", "10.0.0.0/8"]</c>).
+    /// Empty (default) = never trust forwarding headers — the direct <c>RemoteEndPoint</c> is used,
+    /// and any client-supplied <c>X-Forwarded-For</c> is ignored (#91). When the API runs behind a
+    /// reverse proxy, list the proxy's CIDR here so the real client IP is resolved.
+    /// </summary>
+    [YamlMember(Alias = "TrustedProxies")]
+    public List<string> TrustedProxies { get; init; } = [];
 }

--- a/BGPLite.Tests/ClientIpResolverTests.cs
+++ b/BGPLite.Tests/ClientIpResolverTests.cs
@@ -63,4 +63,16 @@ public class ClientIpResolverTests
     public void Null_Remote_Returns_Unknown() =>
         Assert.Equal("unknown",
             ManagementApi.ResolveClientIp(null, "198.51.100.5", null, Proxy));
+
+    [Fact]
+    public void IPv4MappedIPv6_Remote_Normalized_For_TrustCheck()
+    {
+        // Linux dual-stack HttpListener (http://+) reports IPv4 peers as ::ffff:x.x.x.x; the
+        // address must be normalized to IPv4 before matching against IPv4 trusted-proxy CIDRs,
+        // else the proxy is never trusted and XFF is ignored (CodeRabbit).
+        var mapped = IPAddress.Parse("::ffff:127.0.0.1");
+        Assert.True(mapped.IsIPv4MappedToIPv6);
+        Assert.Equal("198.51.100.5",
+            ManagementApi.ResolveClientIp(mapped, "198.51.100.5", null, Proxy));
+    }
 }

--- a/BGPLite.Tests/ClientIpResolverTests.cs
+++ b/BGPLite.Tests/ClientIpResolverTests.cs
@@ -1,0 +1,66 @@
+using System.Net;
+using BGPLite.Api;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="ManagementApi.ResolveClientIp"/> (#91): forwarding headers are honored
+/// only when the immediate peer is a configured trusted proxy, and X-Forwarded-For is walked
+/// right-to-left past trusted hops so client injection on the left is defeated.
+/// </summary>
+public class ClientIpResolverTests
+{
+    private static readonly IPNetwork[] Proxy =
+    [
+        IPNetwork.Parse("127.0.0.0/8"),
+        IPNetwork.Parse("10.0.0.0/8")
+    ];
+
+    [Fact]
+    public void DirectClient_Ignores_XForwardedFor() =>
+        Assert.Equal("203.0.113.9",
+            ManagementApi.ResolveClientIp(IPAddress.Parse("203.0.113.9"), "198.51.100.5", null, Proxy));
+
+    [Fact]
+    public void DirectClient_Ignores_XRealIp() =>
+        Assert.Equal("203.0.113.9",
+            ManagementApi.ResolveClientIp(IPAddress.Parse("203.0.113.9"), null, "198.51.100.5", Proxy));
+
+    [Fact]
+    public void TrustedProxy_Uses_XForwardedFor_Client() =>
+        Assert.Equal("198.51.100.5",
+            ManagementApi.ResolveClientIp(IPAddress.Parse("127.0.0.1"), "198.51.100.5", null, Proxy));
+
+    [Fact]
+    public void TrustedProxy_LeftInjection_Is_Defeated()
+    {
+        // Attacker spoofs a left entry; the proxy appends the real client on the right.
+        // Right-to-left walk returns the rightmost untrusted hop = the real client.
+        Assert.Equal("198.51.100.5",
+            ManagementApi.ResolveClientIp(IPAddress.Parse("127.0.0.1"), "spoofed, 198.51.100.5", null, Proxy));
+    }
+
+    [Fact]
+    public void TrustedProxy_Walks_Past_Trusted_Intermediate()
+    {
+        // client -> trusted proxy (10.x) -> us (127.x). XFF = "client, 10.0.0.1" — 10.0.0.1 is
+        // trusted (skipped), so the client is returned.
+        Assert.Equal("198.51.100.5",
+            ManagementApi.ResolveClientIp(IPAddress.Parse("127.0.0.1"), "198.51.100.5, 10.0.0.1", null, Proxy));
+    }
+
+    [Fact]
+    public void TrustedProxy_FallsBack_To_XRealIp() =>
+        Assert.Equal("198.51.100.5",
+            ManagementApi.ResolveClientIp(IPAddress.Parse("127.0.0.1"), null, "198.51.100.5", Proxy));
+
+    [Fact]
+    public void NoTrustedProxies_Always_Returns_Remote() =>
+        Assert.Equal("203.0.113.9",
+            ManagementApi.ResolveClientIp(IPAddress.Parse("203.0.113.9"), "198.51.100.5", "1.2.3.4", Array.Empty<IPNetwork>()));
+
+    [Fact]
+    public void Null_Remote_Returns_Unknown() =>
+        Assert.Equal("unknown",
+            ManagementApi.ResolveClientIp(null, "198.51.100.5", null, Proxy));
+}

--- a/BGPLite.Tests/ConfigurationTests.cs
+++ b/BGPLite.Tests/ConfigurationTests.cs
@@ -34,6 +34,24 @@ public class ConfigurationTests
     }
 
     [Fact]
+    public void LoadFromText_ParsesTrustedProxies()
+    {
+        var yaml = """
+            Bgp:
+              Asn: 65444
+              RouterId: 10.0.0.1
+
+            TrustedProxies:
+              - "127.0.0.0/8"
+              - "10.0.0.0/8"
+            """;
+
+        var config = ConfigLoader.LoadFromText(yaml);
+
+        Assert.Equal(new[] { "127.0.0.0/8", "10.0.0.0/8" }, config.TrustedProxies);
+    }
+
+    [Fact]
     public void LoadFromText_MultiplePeers()
     {
         var yaml = """

--- a/appsettings.Example.yml
+++ b/appsettings.Example.yml
@@ -60,3 +60,14 @@ DefaultPrefixSource: ru
 # CustomPrefixCommunity: "65444:100"
 # CustomAsnCommunity: "65444:200"
 
+# Management API — client-IP resolution behind a reverse proxy (#91).
+# X-Forwarded-For / X-Real-IP are honored ONLY when the immediate TCP peer is one of these trusted
+# CIDRs; otherwise the direct RemoteEndPoint is used and any client-supplied forwarding header is
+# ignored (secure default). X-Forwarded-For is walked right-to-left past trusted hops, so spoofed
+# entries injected on the left are defeated. When the API runs behind a reverse proxy, list the
+# proxy's CIDR here so /api/me (and future per-IP rate limiting, #116) see the real client.
+# Empty/absent = never trust forwarding headers.
+# TrustedProxies:
+#   - "127.0.0.0/8"
+#   - "10.0.0.0/8"
+


### PR DESCRIPTION
Closes #91

## Problem
`GetClientIp` trusted `X-Real-IP` then `X-Forwarded-For` **unconditionally** — any client could set `X-Forwarded-For: <victim-IP>` and have `/api/me` resolve — and disclose — another peer's subscriptions, custom prefixes, and the server's per-peer community stamps. Information disclosure.

## Fix
Trusted-proxy gate, in three parts:
- **`AppConfig.TrustedProxies`** — CIDR list, default **empty = never trust forwarding headers** (secure default).
- **`ManagementApi`** parses it to `IPNetwork`s at construction (single-host entries → `/32` or `/128`; unparseable entries logged + skipped).
- **`internal static ResolveClientIp`** (extracted pure, unit-tested) honors `X-Forwarded-For` / `X-Real-IP` **only when the immediate `RemoteEndPoint` is a configured trusted proxy**; otherwise the direct `RemoteEndPoint` is used. `X-Forwarded-For` is walked **right-to-left past trusted hops**, returning the first untrusted entry — so spoofed entries injected on the left are defeated.

## ⚠️ Behavior change (intentional, secure)
`X-Forwarded-For` is now honored **only when `TrustedProxies` is configured**. The prod API runs behind a reverse proxy, so the proxy's CIDR must be added to `appsettings.yml` (`TrustedProxies: ["127.0.0.0/8", ...]`) to keep `/api/me` resolving the real client IP. With no `TrustedProxies`, the direct `RemoteEndPoint` is always used (the issue's prescribed fallback). This also makes the per-IP rate limiting planned in **#116** meaningful behind a proxy.

## Verification
- `dotnet build` — 0 errors.
- `dotnet test` — **231 passed** (+8 `ClientIpResolverTests`): direct client ignores XFF/X-Real-IP; trusted proxy uses XFF client; **left-injection defeated** (`spoofed, realclient` → `realclient`); right-to-left past trusted intermediates; X-Real-IP fallback; no-trusted → remote; null remote → unknown.
- `dotnet format` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `TrustedProxies` configuration option to control when forwarding headers are trusted for Management API client IP detection.
* **Bug Fixes**
  * Improved client IP resolution to only honor `X-Forwarded-For`/`X-Real-IP` when the immediate sender matches a configured trusted proxy, walking headers to prevent trusted-hop spoofing and falling back safely when needed.
  * Normalized IPv4-mapped IPv6 remote addresses for consistent trusted-proxy checks.
* **Tests**
  * Added unit tests for trusted-proxy client IP selection and null/unknown cases, plus a configuration parsing test for `TrustedProxies`.
* **Documentation**
  * Updated the example YAML with guidance on trusted proxy behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->