### PR TITLE
feat(api): per-client-IP token-bucket rate limiting

### DIFF
--- a/BGPLite.Api/BGPLite.Api.csproj
+++ b/BGPLite.Api/BGPLite.Api.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
+    <PackageReference Include="System.Threading.RateLimiting" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -720,8 +720,10 @@ public sealed class ManagementApi : IHostedService, IDisposable
         }
 
         // Single-hop proxies commonly set X-Real-IP instead of (or alongside) X-Forwarded-For.
-        if (!string.IsNullOrWhiteSpace(xRealIp))
-            return xRealIp.Trim();
+        // Validate + normalize so a malformed header can't surface garbage (e.g. newlines for log
+        // forging) — fall back to the proxy address if it isn't a parseable IP.
+        if (!string.IsNullOrWhiteSpace(xRealIp) && IPAddress.TryParse(xRealIp.Trim(), out var realAddr))
+            return Normalize(realAddr).ToString();
 
         return remote.ToString();
     }

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Text;
+using System.Threading.RateLimiting;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using BGPLite.Api.Entities;
@@ -25,6 +26,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
     private readonly ILogger<ManagementApi> _logger;
     private readonly int _port;
     private readonly IReadOnlyList<IPNetwork> _trustedProxyNetworks;
+    private readonly PartitionedRateLimiter<string>? _rateLimiter;
     private HttpListener? _listener;
     private Task? _listenTask;
     private CancellationTokenSource _cts = new();
@@ -49,6 +51,9 @@ public sealed class ManagementApi : IHostedService, IDisposable
         _logger = logger;
         _port = config.ApiPort;
         _trustedProxyNetworks = ParseTrustedProxies(config.TrustedProxies);
+        // Opt-in (#116): no rate limiting unless an ApiRateLimit section is configured, so the live
+        // service's behavior is unchanged until the operator enables it.
+        _rateLimiter = config.ApiRateLimit is { Enabled: true } cfg ? CreateRateLimiter(cfg) : null;
     }
 
     public Task StartAsync(CancellationToken cancellationToken)
@@ -101,6 +106,19 @@ public sealed class ManagementApi : IHostedService, IDisposable
             ctx.Response.StatusCode = 204;
             ctx.Response.Close();
             return;
+        }
+
+        // Per-client-IP rate limit (#116) — 429 once the resolved client's token bucket is drained.
+        if (_rateLimiter is not null)
+        {
+            var clientIp = GetClientIp(ctx);
+            using var lease = await _rateLimiter.AcquireAsync(clientIp);
+            if (!lease.IsAcquired)
+            {
+                _logger.LogWarning("API rate limit exceeded for {Ip}", clientIp);
+                await WriteResponse(ctx, ApiResponse.Error("Too many requests", 429));
+                return;
+            }
         }
 
         var path = ctx.Request.Url!.AbsolutePath;
@@ -639,6 +657,27 @@ public sealed class ManagementApi : IHostedService, IDisposable
             ctx.Request.Headers["X-Forwarded-For"],
             ctx.Request.Headers["X-Real-IP"],
             _trustedProxyNetworks);
+
+    /// <summary>
+    /// Builds the per-client-IP token-bucket rate limiter for the management API (#116). Each distinct
+    /// resolved client IP (see <see cref="GetClientIp"/>) gets its own token bucket; a request is
+    /// rejected with 429 once its bucket is exhausted. Tunable via <see cref="ApiRateLimitConfig"/>; the
+    /// limiter is only created when the operator opts in (ApiRateLimit section present + Enabled).
+    /// Extracted as a pure factory for unit tests.
+    /// </summary>
+    internal static PartitionedRateLimiter<string> CreateRateLimiter(ApiRateLimitConfig cfg)
+    {
+        var options = new TokenBucketRateLimiterOptions
+        {
+            TokenLimit = Math.Max(1, cfg.TokenLimit),
+            TokensPerPeriod = Math.Max(1, cfg.TokensPerPeriod),
+            ReplenishmentPeriod = TimeSpan.FromSeconds(Math.Max(1, cfg.PeriodSeconds)),
+            QueueLimit = 0,         // deny immediately (429) when no tokens — never queue
+            AutoReplenishment = true
+        };
+        return PartitionedRateLimiter.Create<string, string>(
+            ip => RateLimitPartition.GetTokenBucketLimiter(ip, _ => options));
+    }
 
     /// <summary>
     /// Resolves the real client IP from the connection's remote endpoint and forwarding headers.

--- a/BGPLite.Configuration/ApiRateLimitConfig.cs
+++ b/BGPLite.Configuration/ApiRateLimitConfig.cs
@@ -1,0 +1,27 @@
+using YamlDotNet.Serialization;
+
+namespace BGPLite.Configuration;
+
+/// <summary>
+/// Per-client-IP token-bucket rate limiting for the management API (#116). Limits are generous by
+/// default so normal management-API usage never trips them; they exist to protect the process from
+/// request floods. Set <see cref="Enabled"/> = false to disable.
+/// </summary>
+public sealed class ApiRateLimitConfig
+{
+    /// <summary>Master switch. Default <c>true</c> (protection out of the box).</summary>
+    [YamlMember(Alias = "Enabled")]
+    public bool Enabled { get; init; } = true;
+
+    /// <summary>Token-bucket capacity — the largest burst allowed at once (default 120).</summary>
+    [YamlMember(Alias = "TokenLimit")]
+    public int TokenLimit { get; init; } = 120;
+
+    /// <summary>Tokens replenished each period (default 120).</summary>
+    [YamlMember(Alias = "TokensPerPeriod")]
+    public int TokensPerPeriod { get; init; } = 120;
+
+    /// <summary>Replenishment period in seconds (default 60).</summary>
+    [YamlMember(Alias = "PeriodSeconds")]
+    public int PeriodSeconds { get; init; } = 60;
+}

--- a/BGPLite.Configuration/AppConfig.cs
+++ b/BGPLite.Configuration/AppConfig.cs
@@ -41,4 +41,8 @@ public sealed class AppConfig
     /// </summary>
     [YamlMember(Alias = "TrustedProxies")]
     public List<string> TrustedProxies { get; init; } = [];
+
+    /// <summary>Per-client-IP rate limiting for the management API (#116). Null = defaults applied.</summary>
+    [YamlMember(Alias = "ApiRateLimit")]
+    public ApiRateLimitConfig? ApiRateLimit { get; init; }
 }

--- a/BGPLite.Tests/ApiRateLimiterTests.cs
+++ b/BGPLite.Tests/ApiRateLimiterTests.cs
@@ -1,0 +1,43 @@
+using System.Threading.RateLimiting;
+using BGPLite.Api;
+using BGPLite.Configuration;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// Tests for <see cref="ManagementApi.CreateRateLimiter"/> (#116): a per-IP token bucket that allows
+/// up to the burst then denies (429), partitioned independently per client IP.
+/// </summary>
+public class ApiRateLimiterTests
+{
+    private static ApiRateLimitConfig Cfg(int tokenLimit, int tokensPerPeriod, int periodSeconds = 60) => new()
+    {
+        TokenLimit = tokenLimit,
+        TokensPerPeriod = tokensPerPeriod,
+        PeriodSeconds = periodSeconds
+    };
+
+    private static async Task<bool> TryAcquire(PartitionedRateLimiter<string> limiter, string ip)
+    {
+        using var lease = await limiter.AcquireAsync(ip); // RateLimitLease is IDisposable, not IAsyncDisposable
+        return lease.IsAcquired;
+    }
+
+    [Fact]
+    public async Task Allows_UpToTokenLimit_Then_Denies()
+    {
+        await using var limiter = ManagementApi.CreateRateLimiter(Cfg(2, 2, 60));
+        Assert.True(await TryAcquire(limiter, "198.51.100.1"));
+        Assert.True(await TryAcquire(limiter, "198.51.100.1"));
+        Assert.False(await TryAcquire(limiter, "198.51.100.1")); // bucket exhausted → would 429
+    }
+
+    [Fact]
+    public async Task Partitions_ByIp_Independently()
+    {
+        await using var limiter = ManagementApi.CreateRateLimiter(Cfg(1, 1, 60));
+        Assert.True(await TryAcquire(limiter, "198.51.100.1"));
+        Assert.True(await TryAcquire(limiter, "198.51.100.2")); // separate bucket — still allowed
+        Assert.False(await TryAcquire(limiter, "198.51.100.1")); // first IP's bucket exhausted
+    }
+}

--- a/BGPLite.Tests/ClientIpResolverTests.cs
+++ b/BGPLite.Tests/ClientIpResolverTests.cs
@@ -55,6 +55,14 @@ public class ClientIpResolverTests
             ManagementApi.ResolveClientIp(IPAddress.Parse("127.0.0.1"), null, "198.51.100.5", Proxy));
 
     [Fact]
+    public void TrustedProxy_Malformed_XRealIp_FallsBack_To_Remote()
+    {
+        // A garbage X-Real-IP (e.g. with log-forging newlines) must not be returned verbatim.
+        Assert.Equal("127.0.0.1",
+            ManagementApi.ResolveClientIp(IPAddress.Parse("127.0.0.1"), null, "not-an-ip\nFAKE", Proxy));
+    }
+
+    [Fact]
     public void NoTrustedProxies_Always_Returns_Remote() =>
         Assert.Equal("203.0.113.9",
             ManagementApi.ResolveClientIp(IPAddress.Parse("203.0.113.9"), "198.51.100.5", "1.2.3.4", Array.Empty<IPNetwork>()));

--- a/BGPLite.Tests/ConfigurationTests.cs
+++ b/BGPLite.Tests/ConfigurationTests.cs
@@ -52,6 +52,29 @@ public class ConfigurationTests
     }
 
     [Fact]
+    public void LoadFromText_ParsesApiRateLimit()
+    {
+        var yaml = """
+            Bgp:
+              Asn: 65444
+              RouterId: 10.0.0.1
+            ApiRateLimit:
+              Enabled: true
+              TokenLimit: 60
+              TokensPerPeriod: 60
+              PeriodSeconds: 60
+            """;
+
+        var config = ConfigLoader.LoadFromText(yaml);
+
+        Assert.NotNull(config.ApiRateLimit);
+        Assert.True(config.ApiRateLimit!.Enabled);
+        Assert.Equal(60, config.ApiRateLimit.TokenLimit);
+        Assert.Equal(60, config.ApiRateLimit.TokensPerPeriod);
+        Assert.Equal(60, config.ApiRateLimit.PeriodSeconds);
+    }
+
+    [Fact]
     public void LoadFromText_MultiplePeers()
     {
         var yaml = """

--- a/appsettings.Example.yml
+++ b/appsettings.Example.yml
@@ -71,3 +71,13 @@ DefaultPrefixSource: ru
 #   - "127.0.0.0/8"
 #   - "10.0.0.0/8"
 
+# Management API — per-client-IP rate limiting (#116). Opt-in: absent = no limiting (live behavior
+# unchanged). When present, each resolved client IP (via TrustedProxies) gets a token bucket; a
+# request is rejected with 429 once its bucket drains. Defaults are generous (normal management-API
+# usage never trips them); set Enabled: false to turn off.
+# ApiRateLimit:
+#   Enabled: true
+#   TokenLimit: 120        # burst capacity (default 120)
+#   TokensPerPeriod: 120   # tokens replenished per period (default 120)
+#   PeriodSeconds: 60      # replenishment period in seconds (default 60)
+


### PR DESCRIPTION
Closes #116

## Problem
The management API had no rate limiting. `ListenAsync` dispatches each request fire-and-forget (concurrent), so anyone reaching :5000 could flood it — each request potentially triggering RIPEstat prefix-fetches or DB writes.

## Fix
Opt-in per-client-IP rate limiting:
- **`ApiRateLimitConfig`** (`Enabled`/`TokenLimit`/`TokensPerPeriod`/`PeriodSeconds`) in `BGPLite.Configuration`, generous defaults (120/120/60s) so normal management-API usage never trips it.
- **`ManagementApi.CreateRateLimiter`** builds a `PartitionedRateLimiter<string>` keyed by the resolved client IP (`GetClientIp`, post-**#91**), each IP its own `TokenBucketRateLimiter` (burst capacity + replenishment).
- **`HandleAsync`** acquires a token up front; a drained bucket responds **429** and skips processing.

## Design choices (questioned per review discipline)
- **Opt-in (absent section = no limiter).** A live production route-server shouldn't gain a new 429 path unless the operator enables it. Add an `ApiRateLimit:` section to opt in (defaults are ready). Set `Enabled: false` to turn off.
- **Per-IP via `GetClientIp`** (post-#91) — meaningful behind the reverse proxy (the resolved real client IP), not the proxy's IP. This is why #91 was a prerequisite.
- **Token bucket (rate + burst), not a concurrency cap** — matches #116's primary ask; bounds flood rate per client. Partition growth (one bucket per distinct IP) is bounded in practice by the firewall (nftables) + #91 (XFF spoofing requires being the trusted proxy); TTL eviction is a possible future refinement.
- Complements **#90** (auth = who can call; rate-limit = how fast) — both are needed.

## Verification
- `dotnet build` — 0 errors (added `System.Threading.RateLimiting` 10.0.9 package ref).
- `dotnet test` — **236 passed** (+2 `ApiRateLimiterTests`: allows up to TokenLimit then denies; partitions per IP independently; +1 config-parse test).
- `dotnet format` — clean. Documented in `appsettings.Example.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional per-client-IP rate limiting for management API requests.
  * Added new `ApiRateLimit` configuration (enable/disable, token limit, token refill, and period) and wired it into app configuration.
* **Bug Fixes**
  * Requests over the limit now short-circuit with a `429 Too Many Requests` response.
  * Improved client IP resolution by validating `X-Real-IP` and safely falling back when it’s malformed.
* **Documentation**
  * Updated the example configuration file with the new commented rate-limiting section and defaults.
* **Tests**
  * Added coverage for rate limiter behavior and configuration parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->