### PR TITLE
fix(api): sanitize user input in logs + drop raw-body logging

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -132,7 +132,8 @@ public sealed class ManagementApi : IHostedService, IDisposable
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "API error {Method} {Path}: {Message}", method, path, ex.Message);
+            _logger.LogError(ex, "API error {Method} {Path}: {Message}",
+                SanitizeForLog(method), SanitizeForLog(path), SanitizeForLog(ex.Message));
             await WriteResponse(ctx, ApiResponse.Error(ex.InnerException?.Message ?? ex.Message, 500));
         }
     }
@@ -313,7 +314,6 @@ public sealed class ManagementApi : IHostedService, IDisposable
         var asnLists = data.AsnLists ?? [];
         var customPrefixes = new List<(string Prefix, byte Length)>();
 
-        _logger.LogInformation("CreatePeer raw body: {Body}", body);
         _logger.LogInformation("CreatePeer deserialized: AsnLists={Lists}, CustomPrefixes={Prefixes}, CustomAsns={Asns}",
             string.Join(",", asnLists), string.Join(",", data.CustomPrefixes ?? []),
             string.Join(",", data.CustomAsns ?? []));
@@ -406,8 +406,8 @@ public sealed class ManagementApi : IHostedService, IDisposable
             _store.SetSubscriptions(peerId, data.Lists);
 
         var customPrefixes = data.CustomPrefixes ?? [];
-        _logger.LogInformation("UpdatePeer {Id}: CustomPrefixes={Count}, CustomAsns={AsnCount}, raw={Raw}",
-            peerId, customPrefixes.Count, (data.CustomAsns ?? []).Count, body);
+        _logger.LogInformation("UpdatePeer {Id}: CustomPrefixes={Count}, CustomAsns={AsnCount}",
+            SanitizeForLog(peerId), customPrefixes.Count, (data.CustomAsns ?? []).Count);
         var parsed = new List<(string, byte)>();
         foreach (var cidr in customPrefixes)
         {
@@ -419,7 +419,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         _store.SetCustomAsns(peerId, data.CustomAsns ?? []);
 
-        _logger.LogInformation("Updated peer {Id}", peerId);
+        _logger.LogInformation("Updated peer {Id}", SanitizeForLog(peerId));
 
         if (_sessionManager is not null)
             _ = _sessionManager.RefreshPeerAsync(peer.Ip);
@@ -434,7 +434,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
             return ApiResponse.Error("Peer not found", 404);
 
         _store.DeletePeer(peerId);
-        _logger.LogInformation("Deleted peer {Id} ({Ip})", peerId, peer.Ip);
+        _logger.LogInformation("Deleted peer {Id} ({Ip})", SanitizeForLog(peerId), peer.Ip);
         return ApiResponse.Ok(new { id = peerId, deleted = true });
     }
 
@@ -650,6 +650,24 @@ public sealed class ManagementApi : IHostedService, IDisposable
     #endregion
 
     #region Helpers
+
+    /// <summary>
+    /// Strips CR/LF and other control characters (and truncates) from a user-controlled string so it
+    /// cannot forge log lines when rendered by a log sink (CodeQL cs/log-forging). Structured logging
+    /// (<c>{...}</c> placeholders) is the primary mitigation; this is defense-in-depth on the value.
+    /// </summary>
+    internal static string SanitizeForLog(string? value, int maxLength = 200)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+        var sb = new StringBuilder(value.Length);
+        foreach (var ch in value)
+        {
+            if (char.IsControl(ch)) { sb.Append(' '); continue; }
+            sb.Append(ch);
+            if (sb.Length >= maxLength) { sb.Append('…'); break; }
+        }
+        return sb.ToString();
+    }
 
     private string GetClientIp(HttpListenerContext ctx) =>
         ResolveClientIp(

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -662,8 +662,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         var sb = new StringBuilder(value.Length);
         foreach (var ch in value)
         {
-            if (char.IsControl(ch)) { sb.Append(' '); continue; }
-            sb.Append(ch);
+            sb.Append(char.IsControl(ch) ? ' ' : ch);
             if (sb.Length >= maxLength) { sb.Append('…'); break; }
         }
         return sb.ToString();

--- a/BGPLite.Tests/LogSanitizationTests.cs
+++ b/BGPLite.Tests/LogSanitizationTests.cs
@@ -35,6 +35,15 @@ public class LogSanitizationTests
     }
 
     [Fact]
+    public void Truncates_All_Control_Char_Input()
+    {
+        // Regression: control chars must also count toward the length limit (no unbounded spaces).
+        var result = ManagementApi.SanitizeForLog(new string('\n', 1000), maxLength: 50);
+        Assert.DoesNotContain('\n', result);
+        Assert.True(result.Length <= 51);
+    }
+
+    [Fact]
     public void Preserves_Normal_Content()
     {
         Assert.Equal("198.51.100.5", ManagementApi.SanitizeForLog("198.51.100.5"));

--- a/BGPLite.Tests/LogSanitizationTests.cs
+++ b/BGPLite.Tests/LogSanitizationTests.cs
@@ -1,0 +1,43 @@
+using BGPLite.Api;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// Tests for <see cref="ManagementApi.SanitizeForLog"/> (#120): user-controlled strings logged
+/// via structured logging are also stripped of control characters so they cannot forge log lines.
+/// </summary>
+public class LogSanitizationTests
+{
+    [Fact]
+    public void Strips_Newlines_And_Other_Control_Chars()
+    {
+        // A newline-injected value must not be able to break the log line into a forged entry.
+        var result = ManagementApi.SanitizeForLog("1.2.3.4\nFAKE[ERROR] something\r\n\tbad");
+        Assert.DoesNotContain('\n', result);
+        Assert.DoesNotContain('\r', result);
+        Assert.DoesNotContain('\t', result);
+        Assert.Contains("1.2.3.4", result);
+    }
+
+    [Fact]
+    public void Empty_Or_Null_Returns_Empty()
+    {
+        Assert.Equal(string.Empty, ManagementApi.SanitizeForLog(null));
+        Assert.Equal(string.Empty, ManagementApi.SanitizeForLog(""));
+    }
+
+    [Fact]
+    public void Truncates_Long_Values()
+    {
+        var result = ManagementApi.SanitizeForLog(new string('a', 1000), maxLength: 50);
+        Assert.True(result.Length <= 51); // 50 + ellipsis
+        Assert.EndsWith("…", result);
+    }
+
+    [Fact]
+    public void Preserves_Normal_Content()
+    {
+        Assert.Equal("198.51.100.5", ManagementApi.SanitizeForLog("198.51.100.5"));
+        Assert.Equal("/api/peers/abc-123", ManagementApi.SanitizeForLog("/api/peers/abc-123"));
+    }
+}


### PR DESCRIPTION
Closes #120

## Problem
7 open CodeQL `cs/log-forging` (medium) alerts in `ManagementApi.cs`: logging user-controlled values (raw request body, request path, peerId path segment, exception message) — log-forging risk (injected `\n`/control chars forge log lines).

## Fix
- **Removed the two raw-request-body debug logs** (CreatePeer `{Body}`, UpdatePeer `raw={Raw}`). Logging full request bodies is a hygiene risk (bloat, future secrets/PII once #90 auth lands, log forging) and isn't needed — the deserialized structured summaries remain.
- **`SanitizeForLog`** (strips CR/LF/control chars, truncates) applied to the user-controlled values still logged for operations: `method`/`path`/`ex.Message` in the error handler, and `peerId` in the Updated/Deleted peer logs. Structured logging (`{...}` placeholders) is the primary mitigation; this is defense-in-depth so a rendered value cannot forge a log line.

## Note on CodeQL recognition
`SanitizeForLog` is a custom helper — CodeQL's `cs/log-forging` may not auto-model it as a sanitizer, so some alerts may persist on the PR even though the value is genuinely sanitized. If so, the residual alerts will be dismissed with rationale (structured logging + sanitized value + low SIEM-ingest risk) rather than left open. Verifying after the `analyze` run.

## Verification
- `dotnet build` — 0 errors.
- `dotnet test` — **241 passed** (+4 `LogSanitizationTests`: strips newlines/control chars; empty/null → empty; truncation; preserves normal content).
- `dotnet format` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log safety by sanitizing user- and request-derived values before writing logs.
  * Prevented log entry forging by removing control characters and truncating overly long values.
  * Reduced exposure of raw request content in peer management, including sanitized peer identifiers for create/update/delete actions.
* **Tests**
  * Added coverage for log sanitization behavior, including null/empty handling, control-character removal, and length truncation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->