### PR TITLE
fix(api): gate CORS on configurable origin allowlist (#99)

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -780,9 +780,37 @@ public sealed class ManagementApi : IHostedService, IDisposable
         ctx.Response.Close();
     }
 
-    private static void AddCorsHeaders(HttpListenerContext ctx)
+    /// <summary>
+    /// Resolves the CORS <c>Access-Control-Allow-Origin</c> value for a request (#99). Returns the
+    /// request's own <paramref name="requestOrigin"/> when it is non-empty AND exactly matches an
+    /// entry in <paramref name="allowed"/> (case-insensitive) — never <c>"*"</c> and never a
+    /// non-allowlisted origin, so an untrusted client cannot trick the API into reflecting an
+    /// arbitrary origin. Returns <c>null</c> for an absent/empty origin or an empty/absent
+    /// allowlist, which <see cref="AddCorsHeaders"/> maps to "no CORS headers emitted" (CORS
+    /// disabled — the secure default). Extracted as a pure function for unit tests.
+    /// </summary>
+    internal static string? ResolveCorsOrigin(string? requestOrigin, IReadOnlyList<string>? allowed)
     {
-        ctx.Response.Headers.Add("Access-Control-Allow-Origin", "*");
+        if (string.IsNullOrEmpty(requestOrigin)) return null;
+        if (allowed is null || allowed.Count == 0) return null;
+        foreach (var entry in allowed)
+        {
+            if (string.Equals(entry, requestOrigin, StringComparison.OrdinalIgnoreCase))
+                return requestOrigin;
+        }
+        return null;
+    }
+
+    private void AddCorsHeaders(HttpListenerContext ctx)
+    {
+        // #99: gate CORS on an explicit origin allowlist. ResolveCorsOrigin returns the request's
+        // own Origin only when allowlisted, else null. Null => emit NO Access-Control-Allow-Origin
+        // (CORS disabled — secure default); matched => reflect the origin with Vary: Origin so caches
+        // key by origin. Allow-Methods/Allow-Headers are emitted only alongside a real ACAO.
+        var origin = ResolveCorsOrigin(ctx.Request.Headers["Origin"], _config.CorsAllowedOrigins);
+        if (origin is null) return;
+        ctx.Response.Headers.Add("Access-Control-Allow-Origin", origin);
+        ctx.Response.Headers.Add("Vary", "Origin");
         ctx.Response.Headers.Add("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
         ctx.Response.Headers.Add("Access-Control-Allow-Headers", "Content-Type");
     }

--- a/BGPLite.Configuration/AppConfig.cs
+++ b/BGPLite.Configuration/AppConfig.cs
@@ -45,4 +45,16 @@ public sealed class AppConfig
     /// <summary>Per-client-IP rate limiting for the management API (#116). Null = defaults applied.</summary>
     [YamlMember(Alias = "ApiRateLimit")]
     public ApiRateLimitConfig? ApiRateLimit { get; init; }
+
+    /// <summary>
+    /// Origins allowed to make cross-origin (CORS) requests to the management API (#99), e.g.
+    /// <c>["https://operator.example.com", "https://bgp.example.net"]</c>. A request's
+    /// <c>Origin</c> header is echoed back as <c>Access-Control-Allow-Origin</c> only when it
+    /// exactly matches an entry here (case-insensitive); otherwise <c>no</c> CORS headers are
+    /// emitted and the browser blocks the cross-origin request. Null/empty (default) = CORS fully
+    /// disabled (secure default, consistent with <see cref="TrustedProxies"/> opt-in) — the
+    /// previous blanket <c>"*"</c> was a drive-by CSRF hole on the unauthenticated mutating routes.
+    /// </summary>
+    [YamlMember(Alias = "CorsAllowedOrigins")]
+    public List<string>? CorsAllowedOrigins { get; init; }
 }

--- a/BGPLite.Tests/CorsOriginResolverTests.cs
+++ b/BGPLite.Tests/CorsOriginResolverTests.cs
@@ -1,0 +1,67 @@
+using BGPLite.Api;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="ManagementApi.ResolveCorsOrigin"/> (#99): the request Origin is echoed
+/// back only when it is non-empty and exactly allowlisted (case-insensitive); absent/empty Origin
+/// and an empty/absent allowlist both yield <c>null</c>, which AddCorsHeaders maps to "no CORS
+/// headers emitted" (CORS disabled — the secure default that replaces the previous blanket "*").
+/// </summary>
+public class CorsOriginResolverTests
+{
+    private static readonly string[] Allowed =
+    [
+        "https://operator.example.com",
+        "https://bgp.example.net"
+    ];
+
+    [Fact]
+    public void Allowlisted_Origin_Is_Returned() =>
+        Assert.Equal("https://operator.example.com",
+            ManagementApi.ResolveCorsOrigin("https://operator.example.com", Allowed));
+
+    [Fact]
+    public void NonAllowlisted_Origin_Returns_Null() =>
+        Assert.Null(ManagementApi.ResolveCorsOrigin("https://evil.example.org", Allowed));
+
+    [Fact]
+    public void Empty_Allowlist_Returns_Null() =>
+        // No origins configured => CORS disabled regardless of the request origin.
+        Assert.Null(ManagementApi.ResolveCorsOrigin("https://operator.example.com", Array.Empty<string>()));
+
+    [Fact]
+    public void Null_Allowlist_Returns_Null() =>
+        // Default config value (CorsAllowedOrigins unset) => CORS disabled.
+        Assert.Null(ManagementApi.ResolveCorsOrigin("https://operator.example.com", null));
+
+    [Fact]
+    public void Null_Origin_Returns_Null() =>
+        // No Origin header on the request (same-origin / non-browser client) => nothing to reflect.
+        Assert.Null(ManagementApi.ResolveCorsOrigin(null, Allowed));
+
+    [Fact]
+    public void Empty_Origin_Returns_Null() =>
+        Assert.Null(ManagementApi.ResolveCorsOrigin("", Allowed));
+
+    [Fact]
+    public void Match_Is_Case_Insensitive() =>
+        // Browsers send a canonical lowercase Origin; the operator's entry may differ in casing.
+        Assert.Equal("HTTPS://Operator.Example.COM",
+            ManagementApi.ResolveCorsOrigin("HTTPS://Operator.Example.COM", Allowed));
+
+    [Fact]
+    public void Allowlisted_Second_Entry_Is_Returned() =>
+        Assert.Equal("https://bgp.example.net",
+            ManagementApi.ResolveCorsOrigin("https://bgp.example.net", Allowed));
+
+    [Fact]
+    public void Origin_With_Trailing_Slash_Not_Matched() =>
+        // Scheme://host[:port] only — a path-prefixed spoof is not a match.
+        Assert.Null(ManagementApi.ResolveCorsOrigin("https://operator.example.com/", Allowed));
+
+    [Fact]
+    public void Partial_Origin_Not_Matched() =>
+        // A substring/embedded host must not satisfy the allowlist.
+        Assert.Null(ManagementApi.ResolveCorsOrigin("https://notoperator.example.com", Allowed));
+}

--- a/appsettings.Example.yml
+++ b/appsettings.Example.yml
@@ -81,3 +81,13 @@ DefaultPrefixSource: ru
 #   TokensPerPeriod: 120   # tokens replenished per period (default 120)
 #   PeriodSeconds: 60      # replenishment period in seconds (default 60)
 
+# Management API — CORS origin allowlist (#99). A request's Origin header is reflected back as
+# Access-Control-Allow-Origin ONLY when it matches an entry here (case-insensitive); otherwise no
+# CORS headers are emitted and the browser blocks the cross-origin request. The previous blanket
+# "Access-Control-Allow-Origin: *" on every response was a drive-by CSRF hole on the unauthenticated
+# mutating routes. Empty/absent = CORS fully disabled (secure default — consistent with
+# TrustedProxies opt-in). List the operator/frontend origins to enable cross-origin browser access.
+# CorsAllowedOrigins:
+#   - "https://operator.example.com"
+#   - "https://bgp.example.net"
+


### PR DESCRIPTION
Closes #99

## Problem
`ManagementApi.AddCorsHeaders` hard-coded `Access-Control-Allow-Origin: *` on **every** response, including the unauthenticated mutating routes (POST/PUT/DELETE). With no auth on the management API, any web page a logged-in operator visits can issue cross-origin mutating requests that reconfigure the route-server — a drive-by CSRF-equivalent that simply succeeds outright.

## Fix
- **`AppConfig.CorsAllowedOrigins`** (`List<string>?`, alias `CorsAllowedOrigins`, default `null`) — the operator/frontend origins permitted to make cross-origin requests.
- **`internal static string? ResolveCorsOrigin(string? requestOrigin, IReadOnlyList<string>? allowed)`** — a pure function that returns the request's own Origin only when it is non-empty **and** exactly allowlisted (case-insensitive); otherwise `null`. The API never emits `*` and never reflects a non-allowlisted origin, so an untrusted client cannot trick it into accrediting an arbitrary origin.
- **`AddCorsHeaders`** is now an instance method: `null` → emit **no** CORS headers (CORS disabled — secure default); a match → emit `Access-Control-Allow-Origin: <origin>` + `Vary: Origin`, and keep `Allow-Methods`/`Allow-Headers` (only alongside a real ACAO). The OPTIONS preflight path still calls `AddCorsHeaders` then returns 204.
- Documented `CorsAllowedOrigins` in `appsettings.Example.yml`.

## Behavior change (intentional)
CORS is now **disabled by default**. Operators exposing a browser frontend must set `CorsAllowedOrigins`; previously `*` was always sent. This is the secure default and is consistent with the existing `TrustedProxies` opt-in.

## Verification
- `dotnet build BGPLite.sln -c Debug -clp:ErrorsOnly` — 0 errors.
- `dotnet test BGPLite.sln -c Debug --nologo` — 252 passed, 0 failed (incl. 10 new `ResolveCorsOrigin` tests).
- `dotnet format BGPLite.sln --no-restore --severity warn` — clean.

New tests cover: matched / not-matched / empty-allowlist / null-allowlist / null-origin / empty-origin / case-insensitivity, plus trailing-slash and partial-host spoof rejection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable CORS allowlist for the management API, letting only approved origins receive CORS headers.
  * Added example configuration guidance for enabling origin-based CORS behavior.

* **Bug Fixes**
  * Removed the always-open CORS response behavior, so cross-origin access is now limited to matching origins.
  * Added correct per-origin caching behavior with `Vary: Origin` when CORS is allowed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->