### PR TITLE
fix(api): validate custom-prefix CIDRs in peer create/update

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -399,10 +399,13 @@ public sealed class ManagementApi : IHostedService, IDisposable
             return ApiResponse.Error("Invalid request body", 400);
 
         // Validate ALL custom prefixes BEFORE any mutation so a bad prefix rejects the whole
-        // request with a 400 without partial mutation (#100).
-        var parsedPrefixes = new List<(string Prefix, byte Length)>();
+        // request with a 400 without partial mutation (#100). parsedPrefixes stays null when the
+        // field is omitted so existing prefixes are preserved (partial-update semantics: omitting a
+        // field must not wipe it — same as Description/Lists above and CustomAsns below).
+        List<(string Prefix, byte Length)>? parsedPrefixes = null;
         if (data.CustomPrefixes is not null)
         {
+            parsedPrefixes = [];
             foreach (var cidr in data.CustomPrefixes)
             {
                 var parsed = ParseCustomPrefix(cidr);
@@ -413,7 +416,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         }
 
         _logger.LogInformation("UpdatePeer {Id}: CustomPrefixes={Count}, CustomAsns={AsnCount}",
-            SanitizeForLog(peerId), parsedPrefixes.Count, (data.CustomAsns ?? []).Count);
+            SanitizeForLog(peerId), parsedPrefixes?.Count ?? 0, data.CustomAsns?.Count ?? 0);
 
         if (data.Description is not null)
             _store.SetDescription(peerId, data.Description);
@@ -421,8 +424,10 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (data.Lists is not null)
             _store.SetSubscriptions(peerId, data.Lists);
 
-        _store.SetCustomPrefixes(peerId, parsedPrefixes);
-        _store.SetCustomAsns(peerId, data.CustomAsns ?? []);
+        if (parsedPrefixes is not null)
+            _store.SetCustomPrefixes(peerId, parsedPrefixes);
+        if (data.CustomAsns is not null)
+            _store.SetCustomAsns(peerId, data.CustomAsns);
 
         _logger.LogInformation("Updated peer {Id}", SanitizeForLog(peerId));
 

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Sockets;
 using System.Text;
 using System.Threading.RateLimiting;
 using System.Text.Json;
@@ -322,12 +323,10 @@ public sealed class ManagementApi : IHostedService, IDisposable
         {
             foreach (var cidr in data.CustomPrefixes)
             {
-                var slash = cidr.IndexOf('/');
-                if (slash < 0)
+                var parsed = ParseCustomPrefix(cidr);
+                if (parsed is null)
                     return ApiResponse.Error($"Invalid CIDR: {cidr}", 400);
-                var prefix = cidr[..slash];
-                var length = byte.Parse(cidr[(slash + 1)..]);
-                customPrefixes.Add((prefix, length));
+                customPrefixes.Add(parsed.Value);
             }
         }
 
@@ -399,24 +398,30 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (data is null)
             return ApiResponse.Error("Invalid request body", 400);
 
+        // Validate ALL custom prefixes BEFORE any mutation so a bad prefix rejects the whole
+        // request with a 400 without partial mutation (#100).
+        var parsedPrefixes = new List<(string Prefix, byte Length)>();
+        if (data.CustomPrefixes is not null)
+        {
+            foreach (var cidr in data.CustomPrefixes)
+            {
+                var parsed = ParseCustomPrefix(cidr);
+                if (parsed is null)
+                    return ApiResponse.Error($"Invalid CIDR: {cidr}", 400);
+                parsedPrefixes.Add(parsed.Value);
+            }
+        }
+
+        _logger.LogInformation("UpdatePeer {Id}: CustomPrefixes={Count}, CustomAsns={AsnCount}",
+            SanitizeForLog(peerId), parsedPrefixes.Count, (data.CustomAsns ?? []).Count);
+
         if (data.Description is not null)
             _store.SetDescription(peerId, data.Description);
 
         if (data.Lists is not null)
             _store.SetSubscriptions(peerId, data.Lists);
 
-        var customPrefixes = data.CustomPrefixes ?? [];
-        _logger.LogInformation("UpdatePeer {Id}: CustomPrefixes={Count}, CustomAsns={AsnCount}",
-            SanitizeForLog(peerId), customPrefixes.Count, (data.CustomAsns ?? []).Count);
-        var parsed = new List<(string, byte)>();
-        foreach (var cidr in customPrefixes)
-        {
-            var slash = cidr.IndexOf('/');
-            if (slash < 0) return ApiResponse.Error($"Invalid CIDR: {cidr}", 400);
-            parsed.Add((cidr[..slash], byte.Parse(cidr[(slash + 1)..])));
-        }
-        _store.SetCustomPrefixes(peerId, parsed);
-
+        _store.SetCustomPrefixes(peerId, parsedPrefixes);
         _store.SetCustomAsns(peerId, data.CustomAsns ?? []);
 
         _logger.LogInformation("Updated peer {Id}", SanitizeForLog(peerId));
@@ -666,6 +671,37 @@ public sealed class ManagementApi : IHostedService, IDisposable
             if (sb.Length >= maxLength) { sb.Append('…'); break; }
         }
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Parses a single user-supplied custom prefix CIDR ("<prefix>/<length>") into a validated
+    /// (prefix, mask length) tuple. Splitting is done on the first '/', requiring exactly two
+    /// parts. The prefix is validated with <see cref="IPAddress.TryParse"/> (IPv4 only — IPv6 is
+    /// rejected); the length must parse as a byte in 0..32. Returns null on any failure so callers
+    /// can reject the whole request with a 400 before touching the store (no partial mutation).
+    /// Extracted as a pure helper for unit tests (#100).
+    /// </summary>
+    internal static (string Prefix, byte Length)? ParseCustomPrefix(string? cidr)
+    {
+        if (string.IsNullOrWhiteSpace(cidr))
+            return null;
+
+        var parts = cidr.Split('/');
+        if (parts.Length != 2)
+            return null;
+
+        var prefix = parts[0];
+        var lengthStr = parts[1];
+
+        // IPv4 only: reject IPv6 (and any non-IP string).
+        if (!IPAddress.TryParse(prefix, out var addr) || addr.AddressFamily != AddressFamily.InterNetwork)
+            return null;
+
+        // Length must be a byte in the valid IPv4 range 0..32 (rejects 33..255, negatives, non-numeric).
+        if (!byte.TryParse(lengthStr, out byte length) || length > 32)
+            return null;
+
+        return (prefix, length);
     }
 
     private string GetClientIp(HttpListenerContext ctx) =>

--- a/BGPLite.Tests/CustomPrefixValidationTests.cs
+++ b/BGPLite.Tests/CustomPrefixValidationTests.cs
@@ -1,0 +1,56 @@
+using BGPLite.Api;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// Tests for <see cref="ManagementApi.ParseCustomPrefix"/> (#100): custom-prefix CIDRs supplied
+/// via the management API are validated (IPv4 only, mask 0..32) before reaching the store.
+/// Previously the parser only checked for a '/' and ran <c>byte.Parse</c> on the tail, accepting
+/// garbage like <c>1.2.3.4/250</c> (length 250) or non-IP prefixes, which corrupted export sets.
+/// </summary>
+public class CustomPrefixValidationTests
+{
+    [Theory]
+    [InlineData("1.2.3.0/24", "1.2.3.0", 24)]
+    [InlineData("10.0.0.0/8", "10.0.0.0", 8)]
+    [InlineData("0.0.0.0/0", "0.0.0.0", 0)]   // boundary: default route
+    [InlineData("255.255.255.255/32", "255.255.255.255", 32)] // boundary: single host
+    public void Parses_Valid_IPv4_CIDR(string cidr, string expectedPrefix, byte expectedLength)
+    {
+        var result = ManagementApi.ParseCustomPrefix(cidr);
+
+        Assert.NotNull(result);
+        Assert.Equal(expectedPrefix, result!.Value.Prefix);
+        Assert.Equal(expectedLength, result.Value.Length);
+    }
+
+    [Theory]
+    [InlineData("1.2.3.4")]              // no slash
+    [InlineData("not-an-ip/24")]         // non-IP prefix
+    [InlineData("1.2.3.4/33")]           // length out of range (just over)
+    [InlineData("1.2.3.4/250")]          // length far out of range — previously stored as 250
+    [InlineData("1.2.3.4/-1")]           // negative length
+    [InlineData("1.2.3.4/abc")]          // non-numeric length
+    [InlineData("::1/128")]              // IPv6 prefix (rejected — IPv4 only)
+    [InlineData("2001:db8::/32")]        // IPv6 prefix (rejected — IPv4 only)
+    [InlineData("1.2.3.4/")]             // slash at end — empty length
+    [InlineData("1.2.3.4/24/extra")]     // more than one slash
+    [InlineData("/24")]                  // empty prefix
+    [InlineData("")]                     // empty input
+    public void Rejects_Invalid_CIDR(string cidr)
+    {
+        Assert.Null(ManagementApi.ParseCustomPrefix(cidr));
+    }
+
+    [Fact]
+    public void Rejects_Null_Input()
+    {
+        Assert.Null(ManagementApi.ParseCustomPrefix(null));
+    }
+
+    [Fact]
+    public void Rejects_Whitespace_Only_Input()
+    {
+        Assert.Null(ManagementApi.ParseCustomPrefix("   "));
+    }
+}


### PR DESCRIPTION
Closes #100

## Problem
Custom-prefix parsing in `ManagementApi` (`HandleCreatePeer` and `HandleUpdatePeer`) only checked `cidr.IndexOf('/') >= 0` plus `byte.Parse` of the mask. There was no `IPAddress.TryParse` on the prefix, no IPv4-only check, and no `0..32` range check on the length — so garbage like `1.2.3.4/250` (stored as length 250), non-IP strings, and IPv6 prefixes silently reached `PeerStore` and corrupted the export prefix set (`CollectPeerPrefixes` emits the bad CIDR into peers' route-maps). On `byte.Parse` failure (e.g. negative or non-numeric mask) it also threw an unhandled `FormatException` swallowed by the generic 500 handler. The parsing was copy-pasted between Create and Update.

`HandleUpdatePeer` additionally mutated Description/Lists **before** validating prefixes, so one bad prefix left the peer half-updated (partial mutation).

## Fix
- Extract `internal static (string Prefix, byte Length)? ParseCustomPrefix(string? cidr)`: split on the first `/` requiring exactly two parts; `IPAddress.TryParse` the prefix (IPv4 only — IPv6 rejected via `AddressFamily`); mask via `byte.TryParse` clamped to `0..32`; return `null` on any failure.
- `HandleCreatePeer` and `HandleUpdatePeer` validate **all** prefixes via the helper before touching the store; the first `null` returns `ApiResponse.Error("Invalid CIDR: <cidr>", 400)` — no partial mutation.
- In `HandleUpdatePeer` the prefix-validation pass now runs **before** any `SetDescription`/`SetSubscriptions`/`SetCustomPrefixes`/`SetCustomAsns` call.

## Behavior change (intentional)
Malformed custom prefixes that were previously silently accepted now return HTTP 400. Affected inputs: prefix without `/`, non-IP prefix, mask outside `0..32` (e.g. `/33`, `/250`), negative or non-numeric mask, more than one `/`, and IPv6 prefixes (`::1/128`, `2001:db8::/32`). Previously-stored garbage will be rejected on the next Create/Update that resubmits it. The scope of this PR is limited to custom-prefix parsing; ASN and `data.Ip` validation called out in #100 are intentionally left for follow-up.

## Verification
- `dotnet build BGPLite.sln -c Debug` — 0 errors.
- `dotnet test BGPLite.sln -c Debug` — 260 passed, 0 failed (incl. new `CustomPrefixValidationTests`).
- `dotnet format BGPLite.sln --no-restore --severity warn --verify-no-changes` — clean.

New tests cover valid CIDRs (`1.2.3.0/24`, `10.0.0.0/8`, boundaries `0.0.0.0/0` and `/32`) and the full invalid set above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom prefix CIDR validation, rejecting empty/whitespace and malformed inputs.
  * Enforced IPv4-only CIDR parsing and correct handling of boundary masks like `/0` and `/32`.
  * Update operations now validate all provided custom prefixes first, returning a consistent `400` on any invalid value to prevent partial changes.

* **Tests**
  * Added automated tests covering valid IPv4 CIDRs and many invalid cases (missing/extra slashes, non-numeric or out-of-range masks, IPv6, empty inputs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->