### PR TITLE
refactor(arch): move IPrefixService contract to Configuration (#88)

### DIFF
--- a/BGPLite.Configuration/IPrefixService.cs
+++ b/BGPLite.Configuration/IPrefixService.cs
@@ -1,5 +1,11 @@
-namespace BGPLite.Server;
+namespace BGPLite.Configuration;
 
+/// <summary>
+/// Origin-AS / source prefix lookup contract. Lives in this neutral lower layer so that the
+/// concrete <c>PrefixService</c> implementation (BGPLite.Providers, a data layer) can implement it
+/// without depending upward on BGPLite.Server — Server (the consumer) depends on this contract,
+/// giving the dependency direction Server→Configuration←Providers as peers (#88).
+/// </summary>
 public interface IPrefixService
 {
     Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default);

--- a/BGPLite.Providers/BGPLite.Providers.csproj
+++ b/BGPLite.Providers/BGPLite.Providers.csproj
@@ -9,7 +9,6 @@
   <ItemGroup>
     <ProjectReference Include="..\BGPLite.Configuration\BGPLite.Configuration.csproj" />
     <ProjectReference Include="..\BGPLite.Protocol\BGPLite.Protocol.csproj" />
-    <ProjectReference Include="..\BGPLite.Server\BGPLite.Server.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BGPLite.Providers/PrefixService.cs
+++ b/BGPLite.Providers/PrefixService.cs
@@ -1,6 +1,5 @@
 using System.Collections.Concurrent;
 using BGPLite.Configuration;
-using BGPLite.Server;
 
 namespace BGPLite.Providers;
 

--- a/BGPLite.Tests/LayeringTests.cs
+++ b/BGPLite.Tests/LayeringTests.cs
@@ -1,0 +1,31 @@
+using System.Reflection;
+using BGPLite.Providers;
+
+namespace BGPLite.Tests;
+
+// Regression guard for #88: BGPLite.Providers is a lower/data layer and must NOT depend upward on
+// BGPLite.Server. The IPrefixService contract was moved from BGPLite.Server to BGPLite.Configuration
+// so the concrete PrefixService (in Providers) implements it without referencing Server. These tests
+// fail if the Server ProjectReference is re-added to Providers or if the contract moves back to Server.
+public class LayeringTests
+{
+    [Fact]
+    public void Providers_assembly_does_not_reference_server()
+    {
+        var providers = typeof(PrefixService).Assembly;
+        var referenced = providers.GetReferencedAssemblies()
+            .Select(a => a.Name);
+        Assert.DoesNotContain("BGPLite.Server", referenced);
+    }
+
+    [Fact]
+    public void PrefixService_implements_IPrefixService_from_configuration()
+    {
+        var contract = typeof(PrefixService)
+            .GetInterfaces()
+            .SingleOrDefault(i => i.Name == "IPrefixService");
+
+        Assert.NotNull(contract);
+        Assert.Equal("BGPLite.Configuration", contract!.Namespace);
+    }
+}


### PR DESCRIPTION
Closes #88

## Problem
`BGPLite.Providers` (a lower/data layer) depended **upward** on `BGPLite.Server` (the service layer) because the `IPrefixService` contract lived in `BGPLite.Server`. The concrete `PrefixService` (in Providers) implemented that contract, so the `BGPLite.Server` `ProjectReference` on Providers existed solely to resolve `IPrefixService` — an inverted dependency (implementer below the contract).

## Fix
- Moved the **`IPrefixService` contract** from `BGPLite.Server` to `BGPLite.Configuration` (namespace `BGPLite.Configuration`). Configuration is a neutral lower layer that Providers already references, so this is the lowest-churn fix. The concrete `PrefixService` class stays in `BGPLite.Providers` and now implements the moved interface; members are byte-for-byte identical (CancellationToken defaults preserved).
- **Rationale for Configuration over a new `BGPLite.Contracts` project**: Configuration is already referenced by both Providers (implementer) and Server (consumer), so the contract can land there with zero new projects/references and a single-file move. A separate Contracts project would add churn for no extra isolation here.
- Removed the now-unneeded `<ProjectReference Include="...BGPLite.Server.csproj" />` from `BGPLite.Providers.csproj` — `IPrefixService` was the only reason for it.
- No `using` changes were needed elsewhere: every consumer (`BgpServer`, `BgpSession`, `ManagementApi`, `Program`) already had `using BGPLite.Configuration;`, so resolution is unchanged.
- Dependency direction is now `Server → Configuration ← Providers` (peers under the composition root), matching the layering `Protocol ← Routing ← Server ← Api/Providers` with Providers no longer reaching up into Server.
- Added `LayeringTests` to lock the invariant in place.

## Verification
- `dotnet build BGPLite.sln -c Debug` — 0 errors (7 pre-existing warnings, unchanged).
- `dotnet test BGPLite.sln -c Debug` — 244 passed, 0 failed (incl. 2 new layering tests).
- `dotnet format BGPLite.sln --no-restore --severity warn` — clean (exit 0, no changes).

## Behavior changes
None. This is a pure structural move of an interface plus removal of an unused project reference. Public API surface, method signatures, DI registrations, and runtime behavior are identical.

## Regression guard
`BGPLite.Tests/LayeringTests.cs` fails loudly if someone re-adds the Server reference to Providers or moves the contract back to Server:
- `Providers_assembly_does_not_reference_server` — asserts the Providers assembly's referenced assemblies do not include `BGPLite.Server`.
- `PrefixService_implements_IPrefixService_from_configuration` — asserts the `IPrefixService` implemented by `PrefixService` has namespace `BGPLite.Configuration`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Moved a shared prefix lookup contract to a more neutral configuration layer to better separate app responsibilities.

* **Tests**
  * Added regression checks to ensure provider components stay independent from server components and continue using the shared configuration contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->