### PR TITLE
fix(config): validate YAML at startup (#89)

### DIFF
--- a/BGPLite.Configuration/AppConfig.cs
+++ b/BGPLite.Configuration/AppConfig.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Net.Sockets;
 using YamlDotNet.Serialization;
 
 namespace BGPLite.Configuration;
@@ -57,4 +59,33 @@ public sealed class AppConfig
     /// </summary>
     [YamlMember(Alias = "CorsAllowedOrigins")]
     public List<string>? CorsAllowedOrigins { get; init; }
+
+    /// <summary>
+    /// Validates the whole configuration, throwing <see cref="InvalidOperationException"/> with a
+    /// clear message on the first violation (fail-loud). Called from Program.cs right after the YAML
+    /// is loaded and before the host is built, so invalid config (bad ASN, RouterId=0.0.0.0,
+    /// HoldTime=2, out-of-range ApiPort, malformed peer address, ...) aborts startup instead of
+    /// failing later at runtime (#89). Intentional behavior change: previously-silent invalid
+    /// config now throws — the operator must fix their YAML.
+    /// </summary>
+    public void Validate()
+    {
+        Bgp.Validate();
+
+        if (ApiPort < 1 || ApiPort > 65535)
+            throw new InvalidOperationException(
+                $"Invalid configuration: ApiPort must be between 1 and 65535 (got {ApiPort}).");
+
+        for (var i = 0; i < Peers.Count; i++)
+        {
+            var peer = Peers[i];
+            if (!IPAddress.TryParse(peer.Address, out var address)
+                || address.AddressFamily != AddressFamily.InterNetwork)
+            {
+                throw new InvalidOperationException(
+                    $"Invalid configuration: Peers[{i}].Address must be a valid IPv4 address " +
+                    $"(got '{peer.Address}').");
+            }
+        }
+    }
 }

--- a/BGPLite.Configuration/BgpConfig.cs
+++ b/BGPLite.Configuration/BgpConfig.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Sockets;
 using YamlDotNet.Serialization;
 
 namespace BGPLite.Configuration;
@@ -36,4 +37,43 @@ public sealed class BgpConfig
     public bool GracefulRestartForwardingState { get; init; } = true;
 
     public IPAddress GetRouterIdAddress() => IPAddress.Parse(RouterId);
+
+    /// <summary>
+    /// Validates the BGP settings, throwing <see cref="InvalidOperationException"/> with a clear
+    /// message on the first violation. Called from <see cref="AppConfig.Validate"/> at startup so
+    /// invalid YAML fails loud before the host is built (rather than surfacing later as a peer
+    /// OPEN rejection / wrong-port bind). Rules follow RFC 4271 §4.2/§6.8.
+    /// </summary>
+    public void Validate()
+    {
+        if (Asn == 0)
+            throw new InvalidOperationException(
+                $"Invalid configuration: Bgp.Asn must be greater than 0 (got 0).");
+
+        // RFC 4271 §6.8: the BGP Identifier (RouterId) must be a non-zero IPv4 address. The peer-side
+        // OPEN validator already rejects 0.0.0.0; this catches the local side before it is advertised.
+        var routerIdValid = IPAddress.TryParse(RouterId, out var routerIdAddress)
+            && routerIdAddress.AddressFamily == AddressFamily.InterNetwork
+            && !routerIdAddress.Equals(IPAddress.Any);
+        if (!routerIdValid)
+            throw new InvalidOperationException(
+                $"Invalid configuration: Bgp.RouterId must be a non-zero IPv4 address (got '{RouterId}').");
+
+        // RFC 4271 §4.2: a Hold Time of 0 disables KeepAlive processing; any other value must be >= 3s.
+        if (HoldTime != 0 && HoldTime < 3)
+            throw new InvalidOperationException(
+                $"Invalid configuration: Bgp.HoldTime must be 0 (disabled) or at least 3 seconds (got {HoldTime}).");
+
+        // KeepAlive is only meaningful when a Hold Time is negotiated. The session computes its
+        // keepalive interval as max(HoldTime/3, 1) (BgpSession OPEN negotiation), so the configured
+        // value must fit within the same window: 1..max(HoldTime/3, 1).
+        if (HoldTime > 0)
+        {
+            var maxKeepAlive = Math.Max(HoldTime / 3, 1);
+            if (KeepAlive < 1 || KeepAlive > maxKeepAlive)
+                throw new InvalidOperationException(
+                    $"Invalid configuration: Bgp.KeepAlive must be between 1 and {maxKeepAlive} seconds " +
+                    $"for HoldTime={HoldTime} (got {KeepAlive}).");
+        }
+    }
 }

--- a/BGPLite.Tests/ConfigValidationTests.cs
+++ b/BGPLite.Tests/ConfigValidationTests.cs
@@ -1,0 +1,120 @@
+using BGPLite.Configuration;
+
+namespace BGPLite.Tests;
+
+public class ConfigValidationTests
+{
+    // Factory helpers keep each test mutating exactly one field so the assertion isolates the rule
+    // under test. Defaults match appsettings.Example.yml: a known-good baseline.
+    private static BgpConfig Bgp(uint asn = 65001, string routerId = "10.0.0.1", int keepAlive = 60, int holdTime = 180)
+        => new() { Asn = asn, RouterId = routerId, KeepAlive = keepAlive, HoldTime = holdTime };
+
+    private static AppConfig Config(BgpConfig? bgp = null, int apiPort = 5001, List<PeerConfig>? peers = null)
+        => new() { Bgp = bgp ?? Bgp(), ApiPort = apiPort, Peers = peers ?? [] };
+
+    [Fact]
+    public void Validate_AcceptsValidConfig()
+    {
+        var config = Config();
+
+        var act = () => config.Validate();
+
+        act();
+    }
+
+    [Fact]
+    public void Validate_AcceptsZeroHoldTime_KeepAliveSkipped()
+    {
+        // RFC 4271 §4.2: HoldTime=0 disables keepalive processing; KeepAlive is then irrelevant.
+        var config = Config(Bgp(holdTime: 0, keepAlive: 0));
+
+        var act = () => config.Validate();
+
+        act();
+    }
+
+    [Fact]
+    public void Validate_RejectsAsnZero()
+    {
+        var config = Config(Bgp(asn: 0));
+
+        var ex = Assert.Throws<InvalidOperationException>(() => config.Validate());
+        Assert.Contains("Bgp.Asn", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("0.0.0.0")]   // RFC 4271 §6.8 forbids an all-zero BGP Identifier
+    [InlineData("not-an-ip")]
+    [InlineData("::1")]        // IPv6 must be rejected
+    public void Validate_RejectsBadRouterId(string routerId)
+    {
+        var config = Config(Bgp(routerId: routerId));
+
+        var ex = Assert.Throws<InvalidOperationException>(() => config.Validate());
+        Assert.Contains("Bgp.RouterId", ex.Message);
+    }
+
+    [Theory]
+    [InlineData(2)]   // below the RFC 4271 §4.2 minimum of 3s
+    [InlineData(1)]
+    public void Validate_RejectsHoldTimeBelowThree(int holdTime)
+    {
+        var config = Config(Bgp(holdTime: holdTime, keepAlive: 1));
+
+        var ex = Assert.Throws<InvalidOperationException>(() => config.Validate());
+        Assert.Contains("Bgp.HoldTime", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_RejectsKeepAliveAboveHoldTimeThird()
+    {
+        // HoldTime=3 → max keepalive = max(3/3, 1) = 1; KeepAlive=2 exceeds it.
+        var config = Config(Bgp(holdTime: 3, keepAlive: 2));
+
+        var ex = Assert.Throws<InvalidOperationException>(() => config.Validate());
+        Assert.Contains("Bgp.KeepAlive", ex.Message);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(65536)]
+    [InlineData(-1)]
+    public void Validate_RejectsBadApiPort(int apiPort)
+    {
+        var config = Config(apiPort: apiPort);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => config.Validate());
+        Assert.Contains("ApiPort", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("not-an-ip")]
+    [InlineData("::1")]
+    public void Validate_RejectsBadPeerAddress(string address)
+    {
+        var config = Config(peers: [new PeerConfig { Address = address }]);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => config.Validate());
+        Assert.Contains("Peers[0].Address", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_AcceptsValidPeerAddress()
+    {
+        var config = Config(peers: [new PeerConfig { Address = "10.0.0.2", RemoteAsn = 65002 }]);
+
+        var act = () => config.Validate();
+
+        act();
+    }
+
+    [Fact]
+    public void Validate_BgpConfigDirectly_AcceptsValid()
+    {
+        var bgp = Bgp();
+
+        var act = () => bgp.Validate();
+
+        act();
+    }
+}

--- a/BGPLite/Program.cs
+++ b/BGPLite/Program.cs
@@ -23,6 +23,12 @@ var dataDir = Environment.GetEnvironmentVariable("BGPLITE_DATA") ?? Path.Combine
 var configPath = args.Length > 0 ? Path.GetFullPath(args[0]) : Path.Combine(baseDir, "appsettings.yml");
 var config = ConfigLoader.Load(configPath);
 
+// Fail loud on invalid YAML before the host is built / DB initialized / BGP listener started, so
+// misconfiguration (bad ASN, RouterId=0.0.0.0, HoldTime=2, bad ApiPort, malformed peer address) is
+// reported with a clear message at the earliest possible point instead of surfacing later at
+// runtime (#89). Behavior change: invalid config that previously loaded silently now throws.
+config.Validate();
+
 var routeTable = new RouteTable();
 var nextHop = BgpConstants.IPAddressToUint(config.Bgp.GetRouterIdAddress());
 


### PR DESCRIPTION
Closes #89

## Problem
`AppConfig` / `BgpConfig` are bound from YAML with no validation and carry RFC-invalid defaults (`RouterId="0.0.0.0"`, `Asn=0`). `ConfigLoader` deserializes silently, so bad config — bad ASN, `RouterId=0.0.0.0`, `HoldTime=2`, out-of-range `ApiPort`, malformed peer address — loads fine and only surfaces later at runtime (e.g. the first real peer OPEN rejects our `0.0.0.0` BGP Identifier as `BadBgpIdentifier`; an out-of-range port fails at bind time). That is the worst possible time to discover misconfiguration.

## Fix
Add `Validate()` that throws `InvalidOperationException` with a clear message on the first violation (fail-loud), per RFC 4271 §4.2/§6.8:
- `Bgp.Asn > 0`
- `Bgp.RouterId` parses as a **non-zero** IPv4 (`IPAddress.TryParse` + `AddressFamily.InterNetwork` + `!= IPAddress.Any`) — rejects `0.0.0.0` and IPv6
- `Bgp.HoldTime == 0 || >= 3`
- when `HoldTime > 0`: `KeepAlive` in `1..max(HoldTime/3, 1)`, matching the session's OPEN negotiation (`max(HoldTime/3, 1)`)
- `ApiPort` in `1..65535`
- each `Peers[i].Address` parses as IPv4

`AppConfig.Validate()` delegates BGP checks to `BgpConfig.Validate()` (so the BGP block is independently validatable) and adds the ApiPort + peer-address checks.

`AppConfig.Validate()` is called in `Program.cs` **immediately after the YAML is loaded**, before the host is built / DB initialized / BGP listener started, so misconfiguration is reported with a clear message at the earliest possible point.

## Behavior change (intentional)
Config that previously loaded but was invalid now **throws at startup** with a clear `Invalid configuration: ...` message. Operators with a broken `appsettings.yml` must fix it before the route server will start. Valid configs (incl. the shipped `appsettings.Example.yml`) are unaffected; `HoldTime=0` (keepalive disabled) is explicitly allowed.

## Verification
- `dotnet build BGPLite.sln -c Debug` — OK
- `dotnet test BGPLite.sln -c Debug` — 258 passed, 0 failed
- `dotnet format BGPLite.sln --severity warn` — clean
- End-to-end: ran the app with `Asn: 0` / `RouterId: 0.0.0.0` → it aborts at startup with `Invalid configuration: Bgp.Asn must be greater than 0 (got 0).` before the host is built.
- New `ConfigValidationTests` cover: valid config (incl. `HoldTime=0`), and rejection of `Asn=0`, bad `RouterId` (`0.0.0.0` / unparseable / IPv6), `HoldTime<3`, `KeepAlive` out of range, bad `ApiPort` (`0` / `65536` / `-1`), and bad peer address.

## Notes / out of scope
- The issue also suggested optionally logging unknown YAML keys (`IgnoreUnmatchedProperties`). That is a separate, larger change (typos like `Holdtime:` would still load) and is not included here — this PR is scoped strictly to value validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fail-fast startup configuration validation to catch invalid API port, BGP parameters, and peer IP addresses before the service fully starts.
  * Enforced BGP-specific rules for ASN, Router ID (IPv4 only), Hold Time/Keep Alive timing constraints, and peer address format with clear error messages.
* **Tests**
  * Added automated test coverage for valid and invalid configuration scenarios, ensuring validation accepts correct inputs and rejects incorrect values with expected error details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->