### PR TITLE
perf(api): collapse SendAllRoutesAsync peer loads into one roundtrip

### DIFF
--- a/BGPLite.Api/PeerStore.cs
+++ b/BGPLite.Api/PeerStore.cs
@@ -98,6 +98,40 @@ public sealed class PeerStore : IPeerStore
         return peer is null ? null : MapToInfo(peer);
     }
 
+    /// <summary>
+    /// Single-roundtrip replacement for the <c>GetPeer</c> + <c>UpdateSessionStatus</c> +
+    /// <c>GetSubscriptions</c> + <c>GetCustomPrefixes</c> + <c>GetCustomAsns</c> sequence the BGP
+    /// send path used to issue as FIVE separate <c>DbContext</c>s (issue #84). Loads the peer by
+    /// <c>(Ip, Asn)</c> with the three routing-relevant child collections <c>Include</c>'d in ONE
+    /// <c>AsNoTracking</c> query (read-only intent, consistent with the other getters), then folds
+    /// the "session active" status write into the SAME <c>DbContext</c> via <c>ExecuteUpdate</c> —
+    /// so the whole read+update is one connection (six statements on five connections → two
+    /// statements on one). The returned collection shapes match the standalone getters exactly.
+    /// </summary>
+    public PeerRoutingView? LoadPeerRoutingView(string ip, uint asn)
+    {
+        using var db = _dbFactory.CreateDbContext();
+        var peer = db.Peers.AsNoTracking()
+            .Include(p => p.Subscriptions)
+            .Include(p => p.CustomPrefixes)
+            .Include(p => p.CustomAsns)
+            .FirstOrDefault(p => p.Ip == ip && p.Asn == asn);
+        if (peer is null) return null;
+
+        // Fold the status update (was UpdateSessionStatus(active:true) on its own DbContext) into
+        // this one. ExecuteUpdate is scoped by (Ip, Asn) — identical effect, no extra connection.
+        db.Peers.Where(p => p.Ip == ip && p.Asn == asn)
+            .ExecuteUpdate(s => s
+                .SetProperty(p => p.Status, "active")
+                .SetProperty(p => p.LastSessionAt, DateTime.UtcNow));
+
+        return new PeerRoutingView(
+            peer.Id,
+            peer.Subscriptions.Select(s => s.AsnListName).ToList(),
+            peer.CustomPrefixes.Select(c => c.Prefix + "/" + c.PrefixLength).ToList(),
+            peer.CustomAsns.Select(c => c.Asn).ToList());
+    }
+
     public void SetDescription(string id, string description)
     {
         using var db = _dbFactory.CreateDbContext();

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -542,14 +542,15 @@ public sealed class BgpSession : IDisposable
 
         if (_peerStore is not null && _prefixService is not null && _appConfig is not null)
         {
-            var peer = _peerStore.GetPeer(_peerConfig.Address, _remoteAsn);
+            var peer = _peerStore.LoadPeerRoutingView(_peerConfig.Address, _remoteAsn);
             if (peer is not null)
             {
-                _peerStore.UpdateSessionStatus(_peerConfig.Address, _remoteAsn, true);
-
-                var subscriptionIds = _peerStore.GetSubscriptions(peer.Id);
-                var customPrefixes = _peerStore.GetCustomPrefixes(peer.Id);
-                var customAsns = _peerStore.GetCustomAsns(peer.Id);
+                // LoadPeerRoutingView folds GetPeer + UpdateSessionStatus + GetSubscriptions +
+                // GetCustomPrefixes + GetCustomAsns into a single DbContext (one read+write
+                // roundtrip), replacing five separate PeerStore calls (issue #84).
+                var subscriptionIds = peer.Subscriptions;
+                var customPrefixes = peer.CustomPrefixes;
+                var customAsns = peer.CustomAsns;
 
                 // Unconfigured peer — send RU defaults
                 if (subscriptionIds.Count == 0 && customPrefixes.Count == 0 && customAsns.Count == 0)

--- a/BGPLite.Server/IPeerStore.cs
+++ b/BGPLite.Server/IPeerStore.cs
@@ -17,6 +17,18 @@ public interface IPeerStore
     void SetCommunities(string peerId, HashSet<uint> communities);
     void ClearCommunities(string peerId);
     void SetDescription(string id, string description);
+
+    /// <summary>
+    /// Loads a peer by its durable identity <c>(Ip, Asn)</c> together with the routing-relevant
+    /// child data (<see cref="Subscriptions"/>, <see cref="CustomPrefixes"/>, <see cref="CustomAsns"/>)
+    /// in a SINGLE query, and folds the "session active" status update (Status="active",
+    /// LastSessionAt=now) into the SAME DbContext — so the BGP send path does one read+write
+    /// roundtrip instead of the five separate <c>GetPeer</c>/<c>UpdateSessionStatus</c>/
+    /// <c>GetSubscriptions</c>/<c>GetCustomPrefixes</c>/<c>GetCustomAsns</c> calls it used to make
+    /// (issue #84). Returns <c>null</c> when the peer is unknown (the caller then auto-registers).
+    /// The collection shapes match the standalone getters exactly (no behavior change).
+    /// </summary>
+    PeerRoutingView? LoadPeerRoutingView(string ip, uint asn);
 }
 
 public class PeerInfo
@@ -29,3 +41,15 @@ public class PeerInfo
     public string CreatedAt { get; init; } = "";
     public string? LastSessionAt { get; init; }
 }
+
+/// <summary>
+/// The slice of peer data the BGP send path consumes, loaded in one query for issue #84.
+/// Field shapes are identical to the standalone getters so the caller behavior is unchanged:
+/// <c>Subscriptions</c> = <c>GetSubscriptions</c>, <c>CustomPrefixes</c> = <c>"prefix/length"</c>
+/// strings like <c>GetCustomPrefixes</c>, <c>CustomAsns</c> = <c>GetCustomAsns</c>.
+/// </summary>
+public sealed record PeerRoutingView(
+    string PeerId,
+    List<string> Subscriptions,
+    List<string> CustomPrefixes,
+    List<uint> CustomAsns);

--- a/BGPLite.Tests/PeerStoreKeyingTests.cs
+++ b/BGPLite.Tests/PeerStoreKeyingTests.cs
@@ -102,6 +102,64 @@ public class PeerStoreKeyingTests
         Assert.Equal("active", store.GetDbPeerById(idB)!.Status);
     }
 
+    /// <summary>
+    /// Regression for issue #84: <see cref="PeerStore.LoadPeerRoutingView"/> must return the SAME
+    /// data the five standalone calls used to produce (GetPeer + GetSubscriptions + GetCustomPrefixes
+    /// + GetCustomAsns) AND fold the session-status update into the same DbContext
+    /// (<see cref="PeerStore.UpdateSessionStatus"/>(active:true)). Asserts both equivalence of shape
+    /// and the side effect (Status="active", LastSessionAt set) so a future refactor cannot silently
+    /// drop either the read or the folded write.
+    /// </summary>
+    [Fact]
+    public void LoadPeerRoutingView_Matches_Standalone_Calls_And_Folds_Status_Update()
+    {
+        var (store, connection) = NewStore();
+        using var conn = connection;
+
+        var id = store.CreatePeer(SharedIp, 64512, "routed peer");
+        store.SetSubscriptions(id, ["ru", "microsoft"]);
+        store.SetCustomPrefixes(id, [("203.0.113.0", 24), ("198.51.100.0", 25)]);
+        store.SetCustomAsns(id, [65001, 65002]);
+
+        var before = DateTime.UtcNow;
+        var view = store.LoadPeerRoutingView(SharedIp, 64512);
+
+        Assert.NotNull(view);
+        // Same peer row.
+        Assert.Equal(id, view!.PeerId);
+        // Same child-collection shapes (types) as the standalone getters.
+        Assert.IsType<List<string>>(view.Subscriptions);
+        Assert.IsType<List<string>>(view.CustomPrefixes);
+        Assert.IsType<List<uint>>(view.CustomAsns);
+        // Same ELEMENTS as the standalone getters. Order is unspecified (neither the getters nor
+        // LoadPeerRoutingView impose ORDER BY; the BGP send path treats these as sets), so compare
+        // sorted to avoid a flaky test while still pinning exact contents.
+        Assert.Equal(store.GetSubscriptions(id).Order().ToArray(), view.Subscriptions.Order().ToArray());
+        Assert.Equal(store.GetCustomPrefixes(id).Order().ToArray(), view.CustomPrefixes.Order().ToArray());
+        Assert.Equal(store.GetCustomAsns(id).Order().ToArray(), view.CustomAsns.Order().ToArray());
+        // Explicit contents (guards against a future shape regression even if getters change).
+        Assert.Equal(new[] { "microsoft", "ru" }, view.Subscriptions.Order().ToArray());
+        Assert.Equal(new[] { "198.51.100.0/25", "203.0.113.0/24" }, view.CustomPrefixes.Order().ToArray());
+        Assert.Equal(new uint[] { 65001, 65002 }, view.CustomAsns.Order().ToArray());
+
+        // The folded status write took effect: Status="active" and LastSessionAt stamped at/after
+        // the call (was a separate UpdateSessionStatus call on its own DbContext before #84).
+        var peer = store.GetDbPeerById(id)!;
+        Assert.Equal("active", peer.Status);
+        Assert.NotNull(peer.LastSessionAt);
+        Assert.True(peer.LastSessionAt >= before);
+    }
+
+    [Fact]
+    public void LoadPeerRoutingView_Returns_Null_For_Unknown_Peer()
+    {
+        var (store, connection) = NewStore();
+        using var conn = connection;
+
+        // No CreatePeer — the send path must see null so it auto-registers the unknown peer.
+        Assert.Null(store.LoadPeerRoutingView(SharedIp, 64599));
+    }
+
     [Fact]
     public void CreatePeer_Is_Idempotent_On_IpAsn()
     {


### PR DESCRIPTION
Closes #84

## Problem
`BgpSession.SendAllRoutesAsync` (BGPLite.Server/BgpSession.cs) issued **five** separate `PeerStore` calls per refresh — `GetPeer`, `UpdateSessionStatus`, `GetSubscriptions`, `GetCustomPrefixes`, `GetCustomAsns` — each opening its **own** `DbContext` (its own SQLite connection). That is six SQL statements across five connections per peer, per send.

## Fix
- New `IPeerStore.LoadPeerRoutingView(ip, asn)` (+ impl in `PeerStore`) loads the peer by `(Ip, Asn)` with `Subscriptions` / `CustomPrefixes` / `CustomAsns` `.Include(...)`'d in **one** `AsNoTracking` query, then folds the "session active" status write (`Status="active"`, `LastSessionAt=now`) into the **same** `DbContext` via `ExecuteUpdate`. Result: **six statements on five contexts → two statements on one context** (one read connection).
- Returns a small `PeerRoutingView` record (`PeerId`, `Subscriptions`, `CustomPrefixes`, `CustomAsns`) whose field shapes are identical to the standalone getters — the caller sees the same data.
- `SendAllRoutesAsync` now calls the single combined method instead of the five separate calls.

## Behavior changes
**None intended.** Same data is loaded, same status update is applied. Notes:
- The status write now happens after the child-collection read (inside the same method) rather than before; this is irrelevant because the child collections are independent of `Status`/`LastSessionAt`, so the loaded data is identical.
- Child-collection ordering is unspecified — unchanged from the prior standalone getters (none imposed `ORDER BY`); the send path consumes them as sets (`.Contains` / `.Where`).
- `RunAsync` teardown still calls `UpdateSessionStatus(active:false)` on its own — left untouched (different code path).
- No explicit transaction added, matching the original no-transaction semantics.

## Verification
- `dotnet build BGPLite.sln -c Debug -clp:ErrorsOnly` — 0 errors.
- `dotnet test BGPLite.sln -c Debug --nologo` — 244/244 passed.
- `dotnet format BGPLite.sln --no-restore --severity warn` — clean.
- Added regression tests in `PeerStoreKeyingTests`: `LoadPeerRoutingView_Matches_Standalone_Calls_And_Folds_Status_Update` (asserts shape parity with the standalone getters **and** the folded `active` + `LastSessionAt` side effect) and `LoadPeerRoutingView_Returns_Null_For_Unknown_Peer` (auto-register path).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a faster peer routing view lookup that loads peer details and related routing data in one step.
  * Updated session activity to refresh automatically when peer routing data is loaded.

* **Bug Fixes**
  * Returns no result when a peer cannot be found.
  * Keeps routing data consistent with previous lookup behavior.

* **Tests**
  * Added regression coverage for successful lookups, status updates, and missing peers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->