### PR TITLE
perf(server): short-circuit GroupByCommunitySet for single-set batches

### DIFF
--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -904,7 +904,27 @@ public sealed class BgpSession : IDisposable
     /// Partitions routes into groups that share an identical community set, so each emitted
     /// UPDATE carries a single COMMUNITY attribute. Internal for test coverage.
     /// </summary>
-    internal static List<List<Route>> GroupByCommunitySet(IReadOnlyList<Route> routes) =>
+    internal static List<List<Route>> GroupByCommunitySet(IReadOnlyList<Route> routes)
+    {
+        if (routes.Count == 0)
+            return [];
+
+        // Fast path: the common case where every route in the batch carries the same
+        // community set. Skip the GroupBy lookup-dictionary allocation (and the per-route
+        // hashing it implies) and emit a single group directly. Output is identical to the
+        // GroupBy path: one group holding every route in original order.
+        var firstCommunities = routes[0].Communities;
+        for (var i = 1; i < routes.Count; i++)
+        {
+            if (!CommunitySetComparer.Instance.Equals(firstCommunities, routes[i].Communities))
+                return PartitionByCommunitySet(routes);
+        }
+
+        return [new List<Route>(routes)];
+    }
+
+    /// <summary>Slow path: partition a batch whose routes span more than one community set.</summary>
+    private static List<List<Route>> PartitionByCommunitySet(IReadOnlyList<Route> routes) =>
         routes.GroupBy(r => r.Communities, CommunitySetComparer.Instance)
               .Select(g => g.ToList())
               .ToList();

--- a/BGPLite.Tests/PrefixAggregatorTests.cs
+++ b/BGPLite.Tests/PrefixAggregatorTests.cs
@@ -233,4 +233,73 @@ public class PrefixAggregatorTests
         Assert.Contains(groups, g => g.Count == 2 && g[0].Communities.Contains(0xC1u));
         Assert.Contains(groups, g => g.Count == 1 && g[0].Communities.Contains(0xC2u));
     }
+
+    [Fact]
+    public void GroupByCommunitySet_SingleCommunitySet_FastPathCollapsesToOneGroup()
+    {
+        // The common send-batch case: every route carries the same community set. Each entry
+        // uses a distinct array instance with identical contents, so the short-circuit must
+        // compare by value (not reference) and collapse the batch into a single group while
+        // preserving original order — identical to what GroupBy would emit.
+        var routes = new List<Route>
+        {
+            R(0xC0A80100, 24, [0xC1u, 0xC2u]),
+            R(0xC0A80200, 24, [0xC1u, 0xC2u]),
+            R(0xC0A80300, 24, [0xC1u, 0xC2u]),
+        };
+
+        var groups = BgpSession.GroupByCommunitySet(routes);
+
+        var group = Assert.Single(groups);
+        Assert.Equal(3, group.Count);
+        Assert.Equal(0xC0A80100u, group[0].Prefix);
+        Assert.Equal(0xC0A80200u, group[1].Prefix);
+        Assert.Equal(0xC0A80300u, group[2].Prefix);
+        Assert.All(group, r => Assert.Equal([0xC1u, 0xC2u], r.Communities));
+    }
+
+    [Fact]
+    public void GroupByCommunitySet_EmptyCommunitiesAllShared_FastPathOneGroup()
+    {
+        // A batch with no communities anywhere is still a single community set (the empty set)
+        // and must take the fast path → one group.
+        var routes = new List<Route>
+        {
+            R(0x0A000100, 24),
+            R(0x0A000200, 24),
+        };
+
+        var groups = BgpSession.GroupByCommunitySet(routes);
+
+        var group = Assert.Single(groups);
+        Assert.Equal(2, group.Count);
+        Assert.All(group, r => Assert.Empty(r.Communities));
+    }
+
+    [Fact]
+    public void GroupByCommunitySet_MixedSets_FallsBackToPartitioning()
+    {
+        // When the batch spans more than one community set the fast path must defer to the
+        // GroupBy partition, preserving first-occurrence group order and per-group identity.
+        var routes = new List<Route>
+        {
+            R(0xC0A80100, 24, [0xC1u]),
+            R(0xC0A80200, 24, [0xC2u, 0xC3u]),
+            R(0xC0A80300, 24, [0xC1u]),
+        };
+
+        var groups = BgpSession.GroupByCommunitySet(routes);
+
+        Assert.Equal(2, groups.Count);
+        Assert.Equal([0xC1u], groups[0][0].Communities);
+        Assert.Equal(2, groups[0].Count);
+        Assert.Equal([0xC2u, 0xC3u], groups[1][0].Communities);
+        Assert.Single(groups[1]);
+    }
+
+    [Fact]
+    public void GroupByCommunitySet_EmptyBatch_ReturnsNoGroups()
+    {
+        Assert.Empty(BgpSession.GroupByCommunitySet([]));
+    }
 }


### PR DESCRIPTION
Closes #86

## Problem
`GroupByCommunitySet` (BGPLite.Server/BgpSession.cs, send path) ran a full LINQ `GroupBy(CommunitySetComparer).Select(g => g.ToList()).ToList()` per 100-prefix send batch even when the whole batch shared a single community set — the common case (~200x per 20k refresh). `GroupBy` allocates a lookup dictionary and hashes every route's community array each batch.

## Fix
Short-circuit the single-community-set case in `GroupByCommunitySet`:
- When the batch is empty, return no groups.
- Otherwise compare every route's community array to the first route's set **by value** (reusing `CommunitySetComparer.Instance.Equals`, so distinct array instances with identical contents are treated as one set). If all match, return a single group containing all routes in original order, skipping the `GroupBy` allocation entirely.
- If any route differs, defer to the unchanged `GroupBy` partition (now extracted as `PartitionByCommunitySet`).

Change is localized to `GroupByCommunitySet`; its only runtime caller (`SendRouteBatchAsync`) is untouched, and the output shape is identical to the previous `GroupBy` output (one group, original order preserved).

Note: the issue's suggested heuristic ("first vs last community array equal") is insufficient — it would misclassify batches like `[A, B, A]` as single-set. This implementation checks **all** routes, which is required for correctness.

## Verification
- `dotnet build BGPLite.sln -c Debug -clp:ErrorsOnly` — 0 errors.
- `dotnet test BGPLite.sln -c Debug --nologo` — 294 passed, 0 failed (290 baseline + 4 new).
- `dotnet format BGPLite.sln --no-restore --severity warn` — clean.

## Behavior change
None (perf only). Output of `GroupByCommunitySet` is observationally identical for empty, single-set, and multi-set inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved community-based route grouping to handle empty batches cleanly and keep route order intact.
  * Ensured routes with identical or empty community sets are grouped consistently, while mixed sets are still split correctly.

* **Tests**
  * Added coverage for single-group, empty-community, mixed-community, and empty-input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->