### PR TITLE
feat(api): cap concurrent management-API requests

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -28,6 +28,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
     private readonly int _port;
     private readonly IReadOnlyList<IPNetwork> _trustedProxyNetworks;
     private readonly PartitionedRateLimiter<string>? _rateLimiter;
+    private readonly ConcurrencyLimiter? _concurrencyLimiter;
     private HttpListener? _listener;
     private Task? _listenTask;
     private CancellationTokenSource _cts = new();
@@ -55,6 +56,11 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // Opt-in (#116): no rate limiting unless an ApiRateLimit section is configured, so the live
         // service's behavior is unchanged until the operator enables it.
         _rateLimiter = config.ApiRateLimit is { Enabled: true } cfg ? CreateRateLimiter(cfg) : null;
+        // Opt-in (#119): no global concurrency cap unless MaxConcurrentRequests > 0, so the live
+        // service's behavior is unchanged until the operator sets a limit. Independent of the per-IP
+        // rate: a burst passing the per-client token check still cannot run more than this many at once.
+        _concurrencyLimiter = config.ApiRateLimit is { Enabled: true, MaxConcurrentRequests: > 0 } limitCfg
+            ? CreateConcurrencyLimiter(limitCfg) : null;
     }
 
     public Task StartAsync(CancellationToken cancellationToken)
@@ -126,6 +132,22 @@ public sealed class ManagementApi : IHostedService, IDisposable
         var method = ctx.Request.HttpMethod;
         var segments = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
 
+        // Global concurrency cap (#119): hold the lease for the whole request so total in-flight work
+        // (RIPEstat fetches / DB ops) is bounded regardless of source. QueueLimit = 0 means acquisition
+        // is immediate — either granted or denied with 503 Server busy when at capacity.
+        RateLimitLease? concurrencyLease = null;
+        if (_concurrencyLimiter is not null)
+        {
+            concurrencyLease = await _concurrencyLimiter.AcquireAsync();
+            if (!concurrencyLease.IsAcquired)
+            {
+                concurrencyLease.Dispose();
+                _logger.LogWarning("API concurrency limit reached, request rejected");
+                await WriteResponse(ctx, ApiResponse.Error("Server busy", 503));
+                return;
+            }
+        }
+
         try
         {
             var response = await RouteAsync(method, segments, ctx);
@@ -136,6 +158,12 @@ public sealed class ManagementApi : IHostedService, IDisposable
             _logger.LogError(ex, "API error {Method} {Path}: {Message}",
                 SanitizeForLog(method), SanitizeForLog(path), SanitizeForLog(ex.Message));
             await WriteResponse(ctx, ApiResponse.Error(ex.InnerException?.Message ?? ex.Message, 500));
+        }
+        finally
+        {
+            // Release the slot back to the global pool (#119) — also covers the success path so the
+            // lease is held exactly for the request duration.
+            concurrencyLease?.Dispose();
         }
     }
 
@@ -738,6 +766,25 @@ public sealed class ManagementApi : IHostedService, IDisposable
     }
 
     /// <summary>
+    /// Builds the GLOBAL concurrency limiter for the management API (#119). A single non-partitioned
+    /// <see cref="ConcurrencyLimiter"/> with <see cref="ConcurrencyLimiterOptions.PermitLimit"/> =
+    /// <see cref="ApiRateLimitConfig.MaxConcurrentRequests"/> and
+    /// <see cref="ConcurrencyLimiterOptions.QueueLimit"/> = 0, so at most PermitLimit requests run at
+    /// once across ALL clients; the next is denied immediately (503) rather than queued. Only created
+    /// when the operator opts in (MaxConcurrentRequests &gt; 0 and ApiRateLimit enabled). Extracted as a
+    /// pure factory for unit tests.
+    /// </summary>
+    internal static ConcurrencyLimiter CreateConcurrencyLimiter(ApiRateLimitConfig cfg)
+    {
+        var options = new ConcurrencyLimiterOptions
+        {
+            PermitLimit = Math.Max(1, cfg.MaxConcurrentRequests),
+            QueueLimit = 0,         // deny immediately (503) when at capacity — never queue
+        };
+        return new ConcurrencyLimiter(options);
+    }
+
+    /// <summary>
     /// Resolves the real client IP from the connection's remote endpoint and forwarding headers.
     /// Forwarding headers are honored ONLY when the immediate peer (<paramref name="remote"/>) is a
     /// configured trusted proxy (#91) — a direct client cannot inject <c>X-Forwarded-For</c> /
@@ -862,6 +909,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
     {
         _cts.Cancel();
         _cts.Dispose();
+        _concurrencyLimiter?.Dispose();
         _listener?.Close();
     }
 

--- a/BGPLite.Configuration/ApiRateLimitConfig.cs
+++ b/BGPLite.Configuration/ApiRateLimitConfig.cs
@@ -3,9 +3,11 @@ using YamlDotNet.Serialization;
 namespace BGPLite.Configuration;
 
 /// <summary>
-/// Per-client-IP token-bucket rate limiting for the management API (#116). Limits are generous by
-/// default so normal management-API usage never trips them; they exist to protect the process from
-/// request floods. Set <see cref="Enabled"/> = false to disable.
+/// Per-client-IP token-bucket rate limiting for the management API (#116), plus an opt-in GLOBAL
+/// concurrency cap on in-flight requests (#119). The per-IP limits are generous by default so normal
+/// management-API usage never trips them; they exist to protect the process from request floods.
+/// The concurrency cap bounds total resource use regardless of source (defense in depth with the
+/// per-IP rate, which only bounds flood speed per client). Set <see cref="Enabled"/> = false to disable.
 /// </summary>
 public sealed class ApiRateLimitConfig
 {
@@ -24,4 +26,14 @@ public sealed class ApiRateLimitConfig
     /// <summary>Replenishment period in seconds (default 60).</summary>
     [YamlMember(Alias = "PeriodSeconds")]
     public int PeriodSeconds { get; init; } = 60;
+
+    /// <summary>
+    /// GLOBAL cap on concurrently in-flight management-API requests (#119). Default <c>0</c> = no
+    /// concurrency cap (live behavior unchanged — opt-in, consistent with the per-IP rate). When
+    /// greater than zero and <see cref="Enabled"/> is true, at most this many requests run at once
+    /// across ALL clients; the next is rejected with 503 until an in-flight request completes. Bounds
+    /// total resource use (in-flight RIPEstat fetches / DB ops) regardless of how fast clients flood.
+    /// </summary>
+    [YamlMember(Alias = "MaxConcurrentRequests")]
+    public int MaxConcurrentRequests { get; init; } = 0;
 }

--- a/BGPLite.Tests/ApiConcurrencyLimiterTests.cs
+++ b/BGPLite.Tests/ApiConcurrencyLimiterTests.cs
@@ -1,0 +1,51 @@
+using System.Threading.RateLimiting;
+using BGPLite.Api;
+using BGPLite.Configuration;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// Tests for <see cref="ManagementApi.CreateConcurrencyLimiter"/> (#119): a GLOBAL cap that allows up
+/// to PermitLimit in-flight requests then denies the next (503 path), releasing the slot on completion.
+/// </summary>
+public class ApiConcurrencyLimiterTests
+{
+    private static ApiRateLimitConfig Cfg(int maxConcurrent) => new() { MaxConcurrentRequests = maxConcurrent };
+
+    [Fact]
+    public async Task Allows_UpToPermitLimit_Then_Denies_Next()
+    {
+        await using var limiter = ManagementApi.CreateConcurrencyLimiter(Cfg(2));
+        var held = new List<RateLimitLease>(2);
+
+        var first = await limiter.AcquireAsync();
+        var second = await limiter.AcquireAsync();
+        held.Add(first);
+        held.Add(second);
+        Assert.True(first.IsAcquired);
+        Assert.True(second.IsAcquired);
+
+        // Capacity full (both slots held open) → next acquire is denied (the 503 path).
+        // RateLimitLease is IDisposable, not IAsyncDisposable.
+        using var third = await limiter.AcquireAsync();
+        Assert.False(third.IsAcquired);
+
+        foreach (var lease in held) lease.Dispose();
+    }
+
+    [Fact]
+    public async Task Releasing_Lease_Frees_Slot_For_Next_Acquire()
+    {
+        await using var limiter = ManagementApi.CreateConcurrencyLimiter(Cfg(1));
+
+        var first = await limiter.AcquireAsync();
+        Assert.True(first.IsAcquired);
+
+        using var blocked = await limiter.AcquireAsync();
+        Assert.False(blocked.IsAcquired); // the single slot is held
+
+        first.Dispose(); // request completes → slot returned to the pool
+        using var after = await limiter.AcquireAsync();
+        Assert.True(after.IsAcquired); // slot available again
+    }
+}

--- a/appsettings.Example.yml
+++ b/appsettings.Example.yml
@@ -77,9 +77,14 @@ DefaultPrefixSource: ru
 # usage never trips them); set Enabled: false to turn off.
 # ApiRateLimit:
 #   Enabled: true
-#   TokenLimit: 120        # burst capacity (default 120)
-#   TokensPerPeriod: 120   # tokens replenished per period (default 120)
-#   PeriodSeconds: 60      # replenishment period in seconds (default 60)
+#   TokenLimit: 120            # burst capacity (default 120)
+#   TokensPerPeriod: 120       # tokens replenished per period (default 120)
+#   PeriodSeconds: 60          # replenishment period in seconds (default 60)
+#   # Global concurrency cap (#119). Opt-in: default 0 = no cap (live behavior unchanged). When > 0,
+#   # at most this many requests run at once across ALL clients; the next is rejected with 503 until an
+#   # in-flight request completes. Bounds total resource use regardless of flood source (defense in
+#   # depth with the per-IP rate, which only bounds flood speed per client).
+#   MaxConcurrentRequests: 0   # e.g. 32 to cap in-flight work (default 0 = unlimited)
 
 # Management API — CORS origin allowlist (#99). A request's Origin header is reflected back as
 # Access-Control-Allow-Origin ONLY when it matches an entry here (case-insensitive); otherwise no


### PR DESCRIPTION
Closes #119

## Problem
`ListenAsync` dispatches each request fire-and-forget (`_ = HandleAsync(ctx)`) and handling has been async since #92. The per-IP token-bucket rate limit (#116) bounds flood *speed per client* but not *concurrency*: N parallel requests from one (or many) IPs each consume a token, pass the rate check, and then run simultaneously — so a large enough parallel burst can still spawn unbounded concurrent tasks / in-flight RIPEstat fetches / DB ops.

## Fix
Defense in depth — add a GLOBAL cap on in-flight management-API requests, opt-in and independent of the per-IP rate.

- `ApiRateLimitConfig.MaxConcurrentRequests` (default `0` = no cap) — opt-in, consistent with #116.
- In the `ManagementApi` ctor: when `ApiRateLimit` is enabled **and** `MaxConcurrentRequests > 0`, create a single non-partitioned `ConcurrencyLimiter` (`PermitLimit = MaxConcurrentRequests`, `QueueLimit = 0`), stored as a field and disposed on service dispose.
- In `HandleAsync`: **after** the existing per-IP rate-limit block, acquire the concurrency lease and **hold it for the whole request** via `try/finally` (released on both success and exception). If denied (capacity full) → respond `503 Service Unavailable` (`ApiResponse.Error("Server busy", 503)`) and return without processing.
- Extracted a tiny `internal static CreateConcurrencyLimiter(ApiRateLimitConfig)` factory for testability (mirrors the existing `CreateRateLimiter`).

## Verification
- `dotnet build BGPLite.sln -c Debug -clp:ErrorsOnly` → 0 errors.
- `dotnet test BGPLite.sln -c Debug --nologo` → 292 passed / 0 failed (incl. 2 new `ApiConcurrencyLimiterTests`: allow-up-to-limit-then-deny, slot-freed-on-release).
- `dotnet format BGPLite.sln --no-restore --severity warn` → clean.

## Behavior change
Opt-in only — no concurrency cap unless `MaxConcurrentRequests > 0` **and** `ApiRateLimit` is enabled, so the live service behaves identically until an operator sets a limit. When enabled and at capacity, the API now returns `503 Server busy` instead of processing the request. Documented under the existing `ApiRateLimit` block in `appsettings.Example.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional global concurrency limit for Management API requests, helping control how many requests can run at once.
  * Updated the example configuration to show the new setting for capping in-flight requests.

* **Bug Fixes**
  * Requests now return a clear `503 Server busy` response when the concurrency limit is reached, instead of waiting indefinitely.
  * Active request slots are now released reliably after completion or errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->