### PR TITLE
perf(server): cache UPDATE path attributes per community set (#87)

### DIFF
--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -772,13 +772,20 @@ public sealed class BgpSession : IDisposable
         var sent = 0;
         var batch = new List<Route>(maxNlriPerUpdate);
 
+        // Path attributes for a community set are byte-identical across every 100-NLRI batch of
+        // a single send (localAsn/localFourByteAsn/nextHop are constant for the whole send), so
+        // build them once per community set and reuse instead of rebuilding on each batch (#87).
+        // Scoped to this send only: the cache dies with the dictionary, so it can never serve a
+        // later send that carries a different nextHop or renegotiated ASN.
+        var attrCache = CreateUpdateAttributeCache();
+
         foreach (var route in routes)
         {
             batch.Add(route);
             _advertisedPrefixes.Add(new IpPrefix(route.Prefix, route.PrefixLength));
             if (batch.Count >= maxNlriPerUpdate)
             {
-                await SendRouteBatchAsync(nextHop, batch);
+                await SendRouteBatchAsync(nextHop, batch, attrCache);
                 sent += batch.Count;
                 batch.Clear();
             }
@@ -786,21 +793,21 @@ public sealed class BgpSession : IDisposable
 
         if (batch.Count > 0)
         {
-            await SendRouteBatchAsync(nextHop, batch);
+            await SendRouteBatchAsync(nextHop, batch, attrCache);
             sent += batch.Count;
         }
 
         _logger.LogInformation("UpdateSent {Count} routes to {Peer}", sent, _peer);
     }
 
-    private async Task SendRouteBatchAsync(uint nextHop, List<Route> routes)
+    private async Task SendRouteBatchAsync(uint nextHop, List<Route> routes, Dictionary<uint[], List<PathAttribute>> attrCache)
     {
         // The COMMUNITY path attribute applies to EVERY NLRI in an UPDATE, so partition the
         // batch by community set and emit one UPDATE per set. Otherwise prefixes belonging to
         // one group would be tagged with another group's communities on the wire.
         foreach (var groupRoutes in GroupByCommunitySet(routes))
         {
-            var attrs = BuildUpdateAttributes(_bgpConfig.Asn, _localFourByteAsn, nextHop, groupRoutes[0].Communities);
+            var attrs = GetCachedUpdateAttributes(_bgpConfig.Asn, _localFourByteAsn, nextHop, groupRoutes[0].Communities, attrCache);
 
             var nlri = groupRoutes.Select(r => new IpPrefix(r.Prefix, r.PrefixLength)).ToList();
             await SendUpdateBatchAsync(attrs, nlri);
@@ -853,6 +860,34 @@ public sealed class BgpSession : IDisposable
         if (asPathAttrs.Count > 1)
             attrs.Add(asPathAttrs[1]);
 
+        return attrs;
+    }
+
+    /// <summary>
+    /// Creates a per-send cache of built UPDATE path attributes, keyed by community set. The
+    /// cache is scoped to a single <see cref="SendRoutesAsync"/> invocation: the ASN/nextHop
+    /// inputs are constant for that whole send, so identical community sets yield byte-identical
+    /// <see cref="PathAttribute"/> lists that can be reused across the N 100-NLRI batches (#87).
+    /// Internal for test coverage.
+    /// </summary>
+    internal static Dictionary<uint[], List<PathAttribute>> CreateUpdateAttributeCache() =>
+        new(CommunitySetComparer.Instance);
+
+    /// <summary>
+    /// Returns the UPDATE path attributes for <paramref name="communities"/>, building them on
+    /// first request for a community set and returning the cached list thereafter. The cached
+    /// <see cref="PathAttribute"/> payloads are immutable, so the same list is safely shared by
+    /// every UPDATE emitted for that community set. Internal for test coverage.
+    /// </summary>
+    internal static List<PathAttribute> GetCachedUpdateAttributes(
+        uint localAsn, bool localFourByteAsn, uint nextHop, uint[] communities,
+        Dictionary<uint[], List<PathAttribute>> cache)
+    {
+        if (cache.TryGetValue(communities, out var cached))
+            return cached;
+
+        var attrs = BuildUpdateAttributes(localAsn, localFourByteAsn, nextHop, communities);
+        cache[communities] = attrs;
         return attrs;
     }
 

--- a/BGPLite.Tests/BgpSessionBuildUpdateAttributesTests.cs
+++ b/BGPLite.Tests/BgpSessionBuildUpdateAttributesTests.cs
@@ -1,0 +1,93 @@
+using BGPLite.Protocol;
+using BGPLite.Server;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// Covers the per-send UPDATE path-attribute cache introduced for #87: identical community
+/// sets must reuse one built <see cref="List{T}"/> of <see cref="PathAttribute"/> across batches,
+/// and the cached payload must serialize to the same bytes as a fresh build (no wire change).
+/// </summary>
+public class BgpSessionBuildUpdateAttributesTests
+{
+    private const uint Asn = 200000u;
+    private const uint NextHop = 0x0A000001u; // 10.0.0.1
+
+    [Fact]
+    public void GetCachedUpdateAttributes_EqualCommunitySet_ReturnsSameInstance()
+    {
+        // Distinct array instances holding the same community values — the cache must treat them
+        // as one key and hand back the already-built list (reference-equal).
+        var cache = BgpSession.CreateUpdateAttributeCache();
+        var communitiesA = new uint[] { 1234u, 5678u };
+        var communitiesB = new uint[] { 1234u, 5678u };
+
+        var first = BgpSession.GetCachedUpdateAttributes(Asn, localFourByteAsn: true, NextHop, communitiesA, cache);
+        var second = BgpSession.GetCachedUpdateAttributes(Asn, localFourByteAsn: true, NextHop, communitiesB, cache);
+
+        Assert.Same(first, second);
+        Assert.Single(cache);
+    }
+
+    [Fact]
+    public void GetCachedUpdateAttributes_DistinctCommunitySets_BuildsOnceEach()
+    {
+        var cache = BgpSession.CreateUpdateAttributeCache();
+
+        var withComms = BgpSession.GetCachedUpdateAttributes(Asn, localFourByteAsn: true, NextHop, [1234u], cache);
+        var noComms = BgpSession.GetCachedUpdateAttributes(Asn, localFourByteAsn: true, NextHop, [], cache);
+        var withCommsAgain = BgpSession.GetCachedUpdateAttributes(Asn, localFourByteAsn: true, NextHop, [1234u], cache);
+
+        Assert.NotSame(withComms, noComms);
+        Assert.Same(withComms, withCommsAgain);
+        Assert.Equal(2, cache.Count);
+    }
+
+    [Fact]
+    public void GetCachedUpdateAttributes_CachedMatchesFreshBuild_OnTheWire()
+    {
+        // The cached list is reused across batches; assert it serializes byte-identically to a
+        // fresh BuildUpdateAttributes call so caching introduces no behavior change (#87).
+        var cache = BgpSession.CreateUpdateAttributeCache();
+        var communities = new uint[] { 1234u, 5678u };
+
+        var cached = BgpSession.GetCachedUpdateAttributes(Asn, localFourByteAsn: false, NextHop, communities, cache);
+        var fresh = BgpSession.BuildUpdateAttributes(Asn, localFourByteAsn: false, NextHop, communities);
+
+        Assert.Equal(SerializeAttributes(fresh), SerializeAttributes(cached));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void GetCachedUpdateAttributes_ReusedAcrossManyBatches_StaysStable(bool localFourByteAsn)
+    {
+        // Models the real send path: many sequential lookups for the same community set, as the
+        // 100-NLRI batches of one send would issue. Every result must be the same instance and
+        // keep serializing to the original bytes.
+        var cache = BgpSession.CreateUpdateAttributeCache();
+        var communities = new uint[] { 999u };
+
+        var first = BgpSession.GetCachedUpdateAttributes(Asn, localFourByteAsn, NextHop, communities, cache);
+        var firstBytes = SerializeAttributes(first);
+
+        for (var i = 0; i < 50; i++)
+        {
+            var again = BgpSession.GetCachedUpdateAttributes(Asn, localFourByteAsn, NextHop, new uint[] { 999u }, cache);
+            Assert.Same(first, again);
+            Assert.Equal(firstBytes, SerializeAttributes(again));
+        }
+
+        Assert.Single(cache);
+    }
+
+    private static byte[] SerializeAttributes(List<PathAttribute> attrs)
+    {
+        // Wrap in a minimal UPDATE and serialize via the real writer — this is exactly the bytes
+        // that go on the wire for the attribute section.
+        var msg = new BgpUpdateMessage { PathAttributes = attrs };
+        var buffer = new byte[BgpMessageWriter.GetBufferSize(msg)];
+        BgpMessageWriter.WriteMessage(msg, buffer);
+        return buffer;
+    }
+}


### PR DESCRIPTION
Closes #87

## Problem
`BgpSession.BuildUpdateAttributes` (send path) rebuilt identical ORIGIN/AS_PATH/NEXT_HOP/COMMUNITY `PathAttribute` byte payloads on **every** 100-NLRI send batch. Within a single `SendRoutesAsync` the inputs `localAsn`, `localFourByteAsn` and `nextHop` are constant, and only the community set varies — so for a given (peer, community-set) the built list is byte-identical across all N batches of one send/refresh, yet it was rebuilt N times.

## Fix
Cache the built `List<PathAttribute>` **per community set**, scoped to a single `SendRoutesAsync` invocation:
- `SendRoutesAsync` creates a `Dictionary<uint[], List<PathAttribute>>` (keyed via the existing `CommunitySetComparer`) and passes it down to each `SendRouteBatchAsync` call.
- New internal helpers `CreateUpdateAttributeCache()` / `GetCachedUpdateAttributes(...)` build once per community set and return the cached list thereafter. `BuildUpdateAttributes` itself is unchanged.
- The cache dies with the dictionary at the end of the send, so it can never serve a later send carrying a different `nextHop` or a renegotiated ASN — exactly the lifetime requested in the issue (per-send, not cross-send).

Safe to share one list across UPDATE messages: `PathAttribute`/`BgpUpdateMessage` are init-only/immutable and `BgpMessageWriter` only **reads** `attr.Data` (never mutates). Batches are emitted sequentially via `await`, so there is no concurrent access to the cached list.

Localized to the build-attributes caching only; does not touch the overlapping send-path area called out for #86.

## Behavior change
**None** — pure perf. Same bytes on the wire (covered by a test that serializes cached vs. fresh-built attributes via `BgpMessageWriter` and asserts byte equality).

## Verification
- `dotnet build BGPLite.sln -c Debug -clp:ErrorsOnly` → 0 errors
- `dotnet test BGPLite.sln -c Debug --nologo` → 295 passed / 0 failed
- `dotnet format BGPLite.sln --no-restore --severity warn` → clean
- Added focused tests in `BgpSessionBuildUpdateAttributesTests.cs`: cache hit returns the same instance for an equal-but-distinct community array, distinct sets are built once each, cached vs. fresh build serialize identically, and reuse across 50 batch lookups stays byte-stable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route update handling so repeated batches can reuse previously built attributes, reducing duplicate work during large sends.
  * Kept the on-the-wire UPDATE format unchanged while making repeated lookups more efficient and consistent.

* **Tests**
  * Added coverage for attribute reuse across identical community sets, distinct community sets, and repeated batch sends.
  * Verified cached and freshly built UPDATE attributes serialize to the same bytes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->