### PR TITLE
perf(providers): parallelize PrefixService ASN resolution (#83)

### DIFF
--- a/BGPLite.Providers/PrefixService.cs
+++ b/BGPLite.Providers/PrefixService.cs
@@ -31,23 +31,52 @@ public sealed class PrefixService : IPrefixService
         return prefixes;
     }
 
+    /// <summary>Bounds how many ASNs are resolved against RIPEstat concurrently on a cold cache
+    /// (warm traffic is cache-flat). Keeps cold-start fan-out from tripping RIPEstat rate limits.</summary>
+    private const int MaxDegreeOfParallelism = 8;
+
     public async Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
     {
+        // Materialize once: we enumerate for fan-out and again for ordered assembly.
+        var asnList = asns as IList<uint> ?? asns.ToList();
+        if (asnList.Count == 0) return [];
+
+        // Resolve every ASN concurrently (bounded) — latency is max, not sum, on cold RIPEstat misses.
+        // Each ASN keeps its own try/catch so one failure (incl. cancellation) can't drop the others,
+        // matching the previous sequential semantics; results are reassembled in input order.
+        using var gate = new SemaphoreSlim(MaxDegreeOfParallelism, MaxDegreeOfParallelism);
+        var resolved = new Task<IReadOnlyList<(uint Prefix, byte Length)>>[asnList.Count];
+        for (var i = 0; i < asnList.Count; i++)
+            resolved[i] = ResolveAsnAsync(asnList[i], gate, ct);
+
+        await Task.WhenAll(resolved);
+
         var result = new List<(uint Prefix, byte Length, uint Asn)>();
-        foreach (var asn in asns)
+        for (var i = 0; i < asnList.Count; i++)
+            foreach (var (prefix, length) in resolved[i].Result)
+                result.Add((prefix, length, asnList[i]));
+        return result;
+    }
+
+    private async Task<IReadOnlyList<(uint Prefix, byte Length)>> ResolveAsnAsync(uint asn, SemaphoreSlim gate, CancellationToken ct)
+    {
+        try
         {
+            await gate.WaitAsync(ct);
             try
             {
-                var prefixes = await GetPrefixesAsync(asn, ct);
-                foreach (var (prefix, length) in prefixes)
-                    result.Add((prefix, length, asn));
+                return await GetPrefixesAsync(asn, ct);
             }
-            catch
+            finally
             {
-                // skip failed ASN, continue with others
+                gate.Release();
             }
         }
-        return result;
+        catch
+        {
+            // skip failed ASN (incl. cancellation while queued), continue with the others
+            return [];
+        }
     }
 
     public async Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default)

--- a/BGPLite.Providers/PrefixService.cs
+++ b/BGPLite.Providers/PrefixService.cs
@@ -41,20 +41,23 @@ public sealed class PrefixService : IPrefixService
         var asnList = asns as IList<uint> ?? asns.ToList();
         if (asnList.Count == 0) return [];
 
-        // Resolve every ASN concurrently (bounded) — latency is max, not sum, on cold RIPEstat misses.
-        // Each ASN keeps its own try/catch so one failure (incl. cancellation) can't drop the others,
-        // matching the previous sequential semantics; results are reassembled in input order.
+        // Resolve each DISTINCT ASN concurrently (bounded) — latency is max, not sum, on cold
+        // RIPEstat misses. Duplicates are coalesced for the fan-out so they cannot race the cold
+        // per-ASN cache and double-fetch (CodeRabbit #130); output multiplicity is preserved below.
+        // Each ASN keeps its own try/catch so one failure (incl. cancellation) can't drop the others.
         using var gate = new SemaphoreSlim(MaxDegreeOfParallelism, MaxDegreeOfParallelism);
-        var resolved = new Task<IReadOnlyList<(uint Prefix, byte Length)>>[asnList.Count];
-        for (var i = 0; i < asnList.Count; i++)
-            resolved[i] = ResolveAsnAsync(asnList[i], gate, ct);
+        var resolvedByAsn = new Dictionary<uint, Task<IReadOnlyList<(uint Prefix, byte Length)>>>();
+        foreach (var asn in asnList.Distinct())
+            resolvedByAsn[asn] = ResolveAsnAsync(asn, gate, ct);
 
-        await Task.WhenAll(resolved);
+        await Task.WhenAll(resolvedByAsn.Values);
 
+        // Reassemble in ORIGINAL input order (and multiplicity) — byte-for-byte identical to the
+        // prior sequential output, including for duplicate ASNs.
         var result = new List<(uint Prefix, byte Length, uint Asn)>();
-        for (var i = 0; i < asnList.Count; i++)
-            foreach (var (prefix, length) in resolved[i].Result)
-                result.Add((prefix, length, asnList[i]));
+        foreach (var asn in asnList)
+            foreach (var (prefix, length) in resolvedByAsn[asn].Result)
+                result.Add((prefix, length, asn));
         return result;
     }
 

--- a/BGPLite.Tests/PrefixServiceTests.cs
+++ b/BGPLite.Tests/PrefixServiceTests.cs
@@ -24,13 +24,14 @@ public class PrefixServiceTests
     private sealed class PerAsnHandler : HttpMessageHandler
     {
         private readonly HashSet<uint> _failures;
-        public int Calls { get; private set; }
+        private int _calls;
+        public int Calls => _calls;
 
         public PerAsnHandler(params uint[] failures) => _failures = [.. failures];
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
         {
-            Calls++;
+            Interlocked.Increment(ref _calls);
             var asn = ExtractAsn(request.RequestUri!);
             if (_failures.Contains(asn))
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));

--- a/BGPLite.Tests/PrefixServiceTests.cs
+++ b/BGPLite.Tests/PrefixServiceTests.cs
@@ -1,0 +1,137 @@
+using System.Net;
+using BGPLite.Configuration;
+using BGPLite.Providers;
+using BGPLite.Protocol;
+using Microsoft.Extensions.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace BGPLite.Tests;
+
+/// <summary>Regression coverage for <see cref="PrefixService.GetPrefixesForAsns"/> — the
+/// parallelized fan-out over ASNs (#83). Asserts that all ASNs resolve in input order and that a
+/// single failing ASN is skipped without dropping the others or throwing.</summary>
+public class PrefixServiceTests
+{
+    /// <summary>RIPEstat body with two tokens substituted per ASN. Raw-string template (no
+    /// interpolation) avoids brace-escaping clashes with JSON delimiters.</summary>
+    private const string BodyTemplate =
+        """{"status":"ok","data":{"resource":"__ASN__","prefixes":{"v4":{"originating":["__CIDR__"]},"v6":{"originating":[]}}}}""";
+
+    /// <summary>An <see cref="HttpMessageHandler"/> that answers RIPEstat ris-prefixes requests with
+    /// a single distinct prefix per ASN, except for the configured failing ASNs which 503 forever
+    /// (so <c>RipeStatProvider</c> exhausts retries and throws).</summary>
+    private sealed class PerAsnHandler : HttpMessageHandler
+    {
+        private readonly HashSet<uint> _failures;
+        public int Calls { get; private set; }
+
+        public PerAsnHandler(params uint[] failures) => _failures = [.. failures];
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Calls++;
+            var asn = ExtractAsn(request.RequestUri!);
+            if (_failures.Contains(asn))
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+
+            // Encode the ASN into the prefix so each ASN yields a distinct (Prefix, Length).
+            var hi = (int)((asn >> 8) & 0xFF);
+            var lo = (int)(asn & 0xFF);
+            var body = BodyTemplate
+                .Replace("__ASN__", asn.ToString())
+                .Replace("__CIDR__", $"10.{hi}.{lo}.1/32");
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body)
+            });
+        }
+
+        private static uint ExtractAsn(Uri uri)
+        {
+            var s = uri.AbsoluteUri;
+            var marker = "resource=AS";
+            var i = s.IndexOf(marker, StringComparison.Ordinal) + marker.Length;
+            var end = s.IndexOf('&', i);
+            if (end < 0) end = s.Length;
+            return uint.Parse(s[i..end]);
+        }
+    }
+
+    private sealed class StubFactory : IHttpClientFactory
+    {
+        private readonly HttpMessageHandler _handler;
+        public StubFactory(HttpMessageHandler handler) => _handler = handler;
+        public HttpClient CreateClient(string name) => new(_handler, disposeHandler: false);
+    }
+
+    private static PrefixService Service(PerAsnHandler handler) =>
+        new(new AppConfig(),
+            new RipeStatProvider(new StubFactory(handler),
+                NullLogger<RipeStatProvider>.Instance,
+                new RipeStatConfig { RetryAttempts = 2, RetryDelaySeconds = 0 }),
+            null!, // IPrefixSourceService is not on the GetPrefixesForAsns path
+            cacheTtl: TimeSpan.FromHours(1));
+
+    /// <summary>The single prefix uint that <see cref="PerAsnHandler"/> yields for a given ASN,
+    /// computed through the same <see cref="BgpConstants.IPAddressToUint"/> the provider uses.</summary>
+    private static uint PrefixFor(uint asn)
+    {
+        var hi = (int)((asn >> 8) & 0xFF);
+        var lo = (int)(asn & 0xFF);
+        return BgpConstants.IPAddressToUint(IPAddress.Parse($"10.{hi}.{lo}.1"));
+    }
+
+    [Fact]
+    public async Task GetPrefixesForAsns_ResolvesAllAsns_InInputOrder()
+    {
+        var handler = new PerAsnHandler();
+        var service = Service(handler);
+
+        var result = await service.GetPrefixesForAsns([100, 200, 300]);
+
+        // One prefix per ASN, reassembled in the order the ASNs were supplied.
+        Assert.Equal([100u, 200u, 300u], result.Select(r => r.Asn).ToArray());
+        Assert.Equal(PrefixFor(100), result[0].Prefix);
+        Assert.Equal(PrefixFor(200), result[1].Prefix);
+        Assert.Equal(PrefixFor(300), result[2].Prefix);
+        Assert.Equal(32, result[0].Length);
+        Assert.Equal(3, handler.Calls); // every ASN resolved (cache was cold)
+    }
+
+    [Fact]
+    public async Task GetPrefixesForAsns_SkipsFailedAsn_KeepsOthers()
+    {
+        // ASN 200 always 503s -> RipeStatProvider exhausts retries and throws; the service must
+        // swallow that single failure and still return 100 and 300, in order, without throwing.
+        var handler = new PerAsnHandler(200);
+        var service = Service(handler);
+
+        var result = await service.GetPrefixesForAsns([100, 200, 300]);
+
+        Assert.Equal([100u, 300u], result.Select(r => r.Asn).ToArray());
+        Assert.Equal(PrefixFor(100), result[0].Prefix);
+        Assert.Equal(PrefixFor(300), result[1].Prefix);
+    }
+
+    [Fact]
+    public async Task GetPrefixesForAsns_EmptyInput_ReturnsEmpty()
+    {
+        var service = Service(new PerAsnHandler());
+        var result = await service.GetPrefixesForAsns([]);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetPrefixesForAsns_RepeatedAsn_DeduplicatesViaCache()
+    {
+        // The same ASN twice: only the first occurrence hits RIPEstat, the second is a cache hit.
+        var handler = new PerAsnHandler();
+        var service = Service(handler);
+
+        var result = await service.GetPrefixesForAsns([100, 100]);
+
+        Assert.Equal([100u, 100u], result.Select(r => r.Asn).ToArray());
+        Assert.Equal(1, handler.Calls); // cache served the second lookup
+    }
+}


### PR DESCRIPTION
Closes #83

## Problem
`PrefixService.GetPrefixesForAsns` awaited each ASN’s `GetPrefixesAsync` sequentially in a `foreach`, so cold RIPEstat latency summed across subscribed ASNs (sum-of-latencies instead of max).

## Fix
- Fan out per-ASN resolution via `Task.WhenAll`, turning cold-cache latency from Σ to max.
- Bound concurrency with a `SemaphoreSlim(8)` so a cold start (many subscribed ASNs, empty per-ASN cache) doesn’t fire a thundering herd into RIPEstat and trip 429s. Warm traffic stays cache-flat per the existing per-ASN cache, so the bound is never contended in steady state.
- Preserve the per-ASN try/catch skip-on-failure semantics: one failed ASN (including cancellation while queued on the gate) yields an empty set and never drops the others.
- Reassemble results in input order, so output content/ordering is unchanged.
- `CancellationToken` threaded through unchanged.

## Behavior change
None (perf only). Same output order/content, same skip-on-failure semantics, same cancellation handling. Bounded concurrency is a new internal characteristic that only affects how many in-flight RIPEstat requests a single cold call issues (was N, now ≤8).

## Verification
- `dotnet build BGPLite.sln -c Debug -clp:ErrorsOnly` — 0 errors.
- `dotnet test BGPLite.sln -c Debug --nologo` — 294 passed, 0 failed (4 new in `PrefixServiceTests`: ordered multi-ASN resolution, skip-on-failure, empty input, cache dedup).
- `dotnet format BGPLite.sln --no-restore --severity warn --verify-no-changes` — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-ASN prefix lookups to run more efficiently while preserving the original input order and duplicates.
  * Failures or cancellations for one ASN no longer prevent successful prefix results for other ASNs.
  * Duplicate ASN requests are reused via caching to avoid redundant lookups.
* **Tests**
  * Added regression tests covering ordering, partial failure handling (including retry scenarios), empty input, and duplicate ASN caching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->