### PR TITLE
fix(server): harden BGP listener against connection floods

### DIFF
--- a/BGPLite.Configuration/BgpConfig.cs
+++ b/BGPLite.Configuration/BgpConfig.cs
@@ -36,6 +36,30 @@ public sealed class BgpConfig
     [YamlMember(Alias = "GracefulRestartForwardingState")]
     public bool GracefulRestartForwardingState { get; init; } = true;
 
+    /// <summary>
+    /// Connect-to-OPEN timeout in seconds (#115, Slowloris defense). Bounds how long a freshly
+    /// accepted TCP connection may wait for the peer's OPEN before being dropped. The negotiated
+    /// hold timer only starts AFTER the handshake, so without this bound a connection that opens
+    /// TCP but never sends OPEN pins a BgpSession + task + socket FD until the OS TCP timeout
+    /// (minutes). 30s comfortably exceeds a legitimate peer's OPEN latency. 0 = disabled (legacy
+    /// behavior). Peers that complete OPEN within the window are unaffected.
+    /// </summary>
+    [YamlMember(Alias = "OpenTimeoutSeconds")]
+    public int OpenTimeoutSeconds { get; init; } = 30;
+
+    /// <summary>
+    /// Per-source-IP accept throttle for the BGP listener (#115): the maximum number of inbound TCP
+    /// connects accepted from a single remote IP within any rolling 60s window. An IP exceeding the
+    /// limit has its just-accepted socket closed immediately WITHOUT spawning a session — no
+    /// FD/task/session pinned — defending one-IP accept floods. This deliberately does NOT cap the
+    /// count of legitimate established sessions (a route server is designed to hold many peers —
+    /// that is capacity/business logic, not a security control); it only bounds incomplete-handshake
+    /// floods. 0 = disabled (legacy behavior). Default 60/min is generous for legitimate peers (one
+    /// connect per session) while still throttling a flood.
+    /// </summary>
+    [YamlMember(Alias = "MaxAcceptsPerIpPerMinute")]
+    public int MaxAcceptsPerIpPerMinute { get; init; } = 60;
+
     public IPAddress GetRouterIdAddress() => IPAddress.Parse(RouterId);
 
     /// <summary>
@@ -75,5 +99,16 @@ public sealed class BgpConfig
                     $"Invalid configuration: Bgp.KeepAlive must be between 1 and {maxKeepAlive} seconds " +
                     $"for HoldTime={HoldTime} (got {KeepAlive}).");
         }
+
+        // Listener hardening (#115): the connect-to-OPEN timeout and per-source-IP accept throttle
+        // are non-negative integers; 0 disables each (legacy behavior). Reject negatives at startup
+        // rather than letting them surprise the operator (negative → treated as disabled silently).
+        if (OpenTimeoutSeconds < 0)
+            throw new InvalidOperationException(
+                $"Invalid configuration: Bgp.OpenTimeoutSeconds must be >= 0 (got {OpenTimeoutSeconds}).");
+
+        if (MaxAcceptsPerIpPerMinute < 0)
+            throw new InvalidOperationException(
+                $"Invalid configuration: Bgp.MaxAcceptsPerIpPerMinute must be >= 0 (got {MaxAcceptsPerIpPerMinute}).");
     }
 }

--- a/BGPLite.Server/BgpServer.cs
+++ b/BGPLite.Server/BgpServer.cs
@@ -28,6 +28,9 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
     // entries. Keying by IP only made them clobber each other (issue #18).
     private readonly ConcurrentDictionary<SessionKey, BgpSession> _sessions = new();
     private readonly CancellationTokenSource _cts = new();
+    // Per-source-IP accept throttle (#115): bounds inbound-connect floods from a single IP. Disabled
+    // (always-allow) when Bgp.MaxAcceptsPerIpPerMinute <= 0.
+    private readonly IpAcceptThrottle _acceptThrottle;
     private int _acceptingConnections = 1;
     private Socket? _listener;
     private Task? _acceptTask;
@@ -61,6 +64,7 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
         _prefixService = prefixService;
         _prefixAggregator = prefixAggregator ?? new ExactUnionPrefixAggregator();
         _communityResolver = communityResolver ?? NullCommunityResolver.Instance;
+        _acceptThrottle = new IpAcceptThrottle(config.Bgp.MaxAcceptsPerIpPerMinute);
     }
 
     public Task StartAsync(CancellationToken cancellationToken)
@@ -153,6 +157,20 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
                 // PeerStore, which is still keyed by IP.
                 var key = new SessionKey(remoteEndpoint.Address, remoteEndpoint.Port);
                 var peerAddress = remoteEndpoint.Address.ToString();
+
+                // Per-source-IP accept throttle (#115): defend one-IP accept floods. If this IP has
+                // already exceeded MaxAcceptsPerIpPerMinute within the rolling 60s window, close the
+                // just-accepted socket immediately WITHOUT spawning a session — no FD/task/session
+                // pinned. The rejected attempt is logged and the loop continues (continue, not break:
+                // this is a per-IP limit, not a server-wide stop). Disabled when the limit is 0.
+                if (!_acceptThrottle.TryAccept(peerAddress))
+                {
+                    _logger.LogWarning(
+                        "Accept throttle: closing connection from {Peer} (over {Limit} accepts/min, #115)",
+                        peerAddress, _config.Bgp.MaxAcceptsPerIpPerMinute);
+                    socket.Dispose();
+                    continue;
+                }
 
                 _logger.LogInformation("Incoming connection from {Peer} ({Key})", peerAddress, key);
 

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -158,8 +158,39 @@ public sealed class BgpSession : IDisposable
             _metrics.PeerConnected();
             _logger.LogInformation("PeerConnected {Peer}", _peer);
 
-            // Receive OPEN
-            var openMessage = await ReceiveMessageAsync(linkedCts.Token);
+            // Receive OPEN — bounded by a connect-to-OPEN timeout (#115, Slowloris defense). The
+            // negotiated hold timer only starts AFTER the handshake, so without this bound a
+            // connection that opens TCP but never sends OPEN pins a BgpSession + task + socket FD
+            // until the OS TCP timeout (minutes). OpenTimeoutSeconds=0 disables the timeout (legacy
+            // behavior). The timeout CTS is linked to linkedCts and disposed right after OPEN is
+            // received so later receives fall back to the session-wide linkedCts / negotiated hold
+            // timer. On a pure timeout (external/session token NOT cancelled) we drop the peer.
+            var openTimeoutSeconds = _bgpConfig.OpenTimeoutSeconds;
+            BgpMessage openMessage;
+            if (openTimeoutSeconds > 0)
+            {
+                using var openCts = CancellationTokenSource.CreateLinkedTokenSource(linkedCts.Token);
+                openCts.CancelAfter(TimeSpan.FromSeconds(openTimeoutSeconds));
+                try
+                {
+                    openMessage = await ReceiveMessageAsync(openCts.Token);
+                }
+                catch (OperationCanceledException) when (!linkedCts.IsCancellationRequested)
+                {
+                    // Only the OPEN timeout fired (the external/session token is still alive) — the
+                    // peer never completed the handshake. Drop it; do not emit a NOTIFICATION (the
+                    // FSM never reached OpenSent, and a Slowloris socket would not read it anyway).
+                    _logger.LogWarning(
+                        "No OPEN received from {Peer} within {Timeout}s — closing (Slowloris defense, #115)",
+                        _peer, openTimeoutSeconds);
+                    return;
+                }
+            }
+            else
+            {
+                openMessage = await ReceiveMessageAsync(linkedCts.Token);
+            }
+
             if (openMessage is not BgpOpenMessage remoteOpen)
             {
                 await SendNotificationAsync(BgpConstants.Error.OpenMessageError, BgpConstants.SubError.Unspecific);

--- a/BGPLite.Server/IpAcceptThrottle.cs
+++ b/BGPLite.Server/IpAcceptThrottle.cs
@@ -1,0 +1,95 @@
+using System.Collections.Concurrent;
+
+namespace BGPLite.Server;
+
+/// <summary>
+/// Per-source-IP accept throttle for the BGP listener (#115): bounds how many inbound TCP connects
+/// a single remote IP may open within a rolling 60s window. Defends one-IP accept floods without
+/// capping the count of legitimate established sessions — a route server is designed to hold many
+/// peers (1 → 9999+), which is capacity/business logic, not a security control. The flood vector
+/// here is connections from a single source, not the established-session count.
+/// <para>
+/// Thread-safe sliding-window counter: each distinct IP gets a bounded list of recent accept
+/// timestamps guarded by a per-IP lock; entries older than the window are pruned on every access so
+/// an idle IP's slot reclaims. The list per IP is bounded by <c>limit+1</c> (one over on the
+/// rejected attempt), so memory is bounded by (distinct IPs) × (limit). The OS firewall (nftables)
+/// is the PRIMARY gate; this is a cheap in-app backstop for misconfigured-firewall /
+/// misbehaving-authorized-peer cases.
+/// </para>
+/// </summary>
+internal sealed class IpAcceptThrottle
+{
+    private readonly int _maxPerMinute;
+    private readonly long _windowTicks;
+    private readonly ConcurrentDictionary<string, Window> _byIp = new(StringComparer.Ordinal);
+    private readonly Func<long> _nowTicks;
+
+    public IpAcceptThrottle(int maxPerMinute, Func<long>? nowTicks = null)
+    {
+        _maxPerMinute = maxPerMinute;
+        _windowTicks = TimeSpan.FromMinutes(1).Ticks;
+        _nowTicks = nowTicks ?? (() => DateTime.UtcNow.Ticks);
+    }
+
+    /// <summary>
+    /// Pure sliding-window decision: prune timestamps older than the window, then allow iff the
+    /// remaining count is below <paramref name="limit"/>. When allowed, the new <paramref name="nowTicks"/>
+    /// timestamp is appended. Extracted as a pure function so the windowing math is unit-testable
+    /// without threads, timers, or a clock. Returns the pruned (and possibly appended) timestamp
+    /// list so the caller can store it back atomically.
+    /// </summary>
+    /// <param name="timestamps">This IP's prior accept timestamps (any order; not mutated).</param>
+    /// <param name="nowTicks">Current UTC ticks (passed in, not read from a clock, for determinism).</param>
+    /// <param name="windowTicks">Window length in ticks (e.g. one minute).</param>
+    /// <param name="limit">Maximum accepts allowed within the window. &lt;= 0 always allows.</param>
+    /// <param name="updated">The timestamp list to store back: pruned entries, plus <paramref name="nowTicks"/>
+    /// only when allowed. When denied, holds only the pruned entries (the rejected accept is NOT
+    /// recorded, so it does not extend the window).</param>
+    /// <returns>True when this accept is within the limit; false when it must be rejected.</returns>
+    internal static bool Decide(
+        IReadOnlyList<long> timestamps, long nowTicks, long windowTicks, int limit,
+        out List<long> updated)
+    {
+        var cutoff = nowTicks - windowTicks;
+        updated = new List<long>(timestamps.Count + 1);
+        foreach (var t in timestamps)
+            if (t > cutoff)
+                updated.Add(t);
+
+        if (limit <= 0 || updated.Count < limit)
+        {
+            updated.Add(nowTicks);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Records an accept from <paramref name="ip"/> and returns whether it is within the limit.
+    /// False = over the limit for the current minute window — the caller must close the just-accepted
+    /// socket immediately WITHOUT spawning a session. When <c>maxPerMinute &lt;= 0</c> (disabled) this
+    /// always returns true and touches no state.
+    /// </summary>
+    public bool TryAccept(string ip)
+    {
+        if (_maxPerMinute <= 0) return true;
+
+        var nowTicks = _nowTicks();
+        var window = _byIp.GetOrAdd(ip, _ => new Window());
+        lock (window)
+        {
+            var allowed = Decide(window.Timestamps, nowTicks, _windowTicks, _maxPerMinute, out var updated);
+            window.Timestamps = updated;
+            return allowed;
+        }
+    }
+
+    /// <summary>Per-IP mutable window state, guarded by locking the instance itself.</summary>
+    private sealed class Window
+    {
+        // List<> (not Queue<>): Decide prunes arbitrary old entries from the middle of the window,
+        // and a List indexed walk + append is cheaper than a Queue dequeue loop for small N.
+        public List<long> Timestamps = new();
+    }
+}

--- a/BGPLite.Tests/BgpSessionShutdownTests.cs
+++ b/BGPLite.Tests/BgpSessionShutdownTests.cs
@@ -551,6 +551,90 @@ public class BgpSessionShutdownTests
         Assert.DoesNotContain(sent, m => m is BgpNotificationMessage);
     }
 
+    /// <summary>
+    /// #115 (connect-to-OPEN timeout, Slowloris defense): a peer that opens the TCP connection but
+    /// NEVER sends OPEN must be dropped within OpenTimeoutSeconds, not pinned until the OS TCP
+    /// timeout (minutes). The negotiated hold timer only starts AFTER the handshake, so without this
+    /// bound the session+task+FD would linger. Uses a short OpenTimeoutSeconds=1s and tolerates
+    /// scheduling jitter (5s ceiling). The session must end cleanly (RunAsync completes) and never
+    /// reach Established. Verifies the real BgpSession.RunAsync path via the loopback socket harness.
+    /// </summary>
+    [Fact]
+    public async Task Peer_That_Never_Sends_Open_Is_Dropped_Within_Timeout()
+    {
+        var (server, client) = ConnectedPair();
+        using var clientSock = client;
+        // OpenTimeoutSeconds=1 keeps the test fast; HoldTime=0/KeepAlive=0 (irrelevant — handshake
+        // never completes, but valid so Validate() would pass if it ran here).
+        var bgpConfig = new BgpConfig
+        {
+            Asn = 65001,
+            RouterId = "127.0.0.1",
+            HoldTime = 0,
+            KeepAlive = 0,
+            OpenTimeoutSeconds = 1
+        };
+        using var session = new BgpSession(
+            server,
+            new PeerConfig { Address = "127.0.0.1" },
+            bgpConfig,
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            new NopLogger<BgpSession>());
+
+        // Run RunAsync but NEVER send OPEN — a Slowloris socket.
+        var runTask = Task.Run(() => session.RunAsync(CancellationToken.None));
+
+        // Must complete well under the legacy OS-TCP-timeout bound. 5s ceiling tolerates scheduler
+        // jitter on top of the 1s timeout.
+        await runTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.False(session.IsEstablished, "a peer that never sends OPEN must not become Established");
+
+        // No NOTIFICATION may be sent — the FSM never reached OpenSent, and a Slowloris socket would
+        // not read it anyway. The timeout path returns without emitting anything.
+        var wire = await DrainAsync(client, TimeSpan.FromSeconds(2));
+        Assert.DoesNotContain(wire, m => m is BgpNotificationMessage);
+    }
+
+    /// <summary>
+    /// #115 positive control: when the peer DOES send OPEN within OpenTimeoutSeconds, the handshake
+    /// proceeds normally and the session reaches Established — the timeout must not fire on a fast,
+    /// legitimate peer. Guards against an off-by-one that would drop healthy peers.
+    /// </summary>
+    [Fact]
+    public async Task Peer_That_Sends_Open_Fast_Proceeds_Past_Timeout()
+    {
+        var (server, client) = ConnectedPair();
+        using var clientSock = client;
+        // A real (non-zero) timeout that the fast handshake must comfortably beat.
+        var bgpConfig = new BgpConfig
+        {
+            Asn = 65001,
+            RouterId = "127.0.0.1",
+            HoldTime = 0,
+            KeepAlive = 0,
+            OpenTimeoutSeconds = 10
+        };
+        using var session = new BgpSession(
+            server,
+            new PeerConfig { Address = "127.0.0.1" },
+            bgpConfig,
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            new NopLogger<BgpSession>());
+
+        // EstablishSessionAsync drives the full OPEN/KEEPALIVE handshake immediately.
+        var runTask = await EstablishSessionAsync(session, client, bgpConfig);
+
+        Assert.True(session.IsEstablished, "a fast legitimate peer must reach Established despite the OPEN timeout");
+
+        session.MarkSilentClose();
+        await runTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
     private static byte[] Concat(byte[] a, byte[] b)
     {
         var r = new byte[a.Length + b.Length];

--- a/BGPLite.Tests/ConfigValidationTests.cs
+++ b/BGPLite.Tests/ConfigValidationTests.cs
@@ -6,8 +6,18 @@ public class ConfigValidationTests
 {
     // Factory helpers keep each test mutating exactly one field so the assertion isolates the rule
     // under test. Defaults match appsettings.Example.yml: a known-good baseline.
-    private static BgpConfig Bgp(uint asn = 65001, string routerId = "10.0.0.1", int keepAlive = 60, int holdTime = 180)
-        => new() { Asn = asn, RouterId = routerId, KeepAlive = keepAlive, HoldTime = holdTime };
+    private static BgpConfig Bgp(
+        uint asn = 65001, string routerId = "10.0.0.1", int keepAlive = 60, int holdTime = 180,
+        int openTimeoutSeconds = 30, int maxAcceptsPerIpPerMinute = 60)
+        => new()
+        {
+            Asn = asn,
+            RouterId = routerId,
+            KeepAlive = keepAlive,
+            HoldTime = holdTime,
+            OpenTimeoutSeconds = openTimeoutSeconds,
+            MaxAcceptsPerIpPerMinute = maxAcceptsPerIpPerMinute
+        };
 
     private static AppConfig Config(BgpConfig? bgp = null, int apiPort = 5001, List<PeerConfig>? peers = null)
         => new() { Bgp = bgp ?? Bgp(), ApiPort = apiPort, Peers = peers ?? [] };
@@ -114,6 +124,50 @@ public class ConfigValidationTests
         var bgp = Bgp();
 
         var act = () => bgp.Validate();
+
+        act();
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(-100)]
+    public void Validate_RejectsNegativeOpenTimeoutSeconds(int openTimeoutSeconds)
+    {
+        var config = Config(Bgp(openTimeoutSeconds: openTimeoutSeconds));
+
+        var ex = Assert.Throws<InvalidOperationException>(() => config.Validate());
+        Assert.Contains("Bgp.OpenTimeoutSeconds", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_AcceptsZeroOpenTimeoutSeconds_Disabled()
+    {
+        // 0 = disabled (legacy behavior) — valid.
+        var config = Config(Bgp(openTimeoutSeconds: 0));
+
+        var act = () => config.Validate();
+
+        act();
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(-100)]
+    public void Validate_RejectsNegativeMaxAcceptsPerIpPerMinute(int maxPerMinute)
+    {
+        var config = Config(Bgp(maxAcceptsPerIpPerMinute: maxPerMinute));
+
+        var ex = Assert.Throws<InvalidOperationException>(() => config.Validate());
+        Assert.Contains("Bgp.MaxAcceptsPerIpPerMinute", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_AcceptsZeroMaxAcceptsPerIpPerMinute_Disabled()
+    {
+        // 0 = disabled (legacy behavior) — valid.
+        var config = Config(Bgp(maxAcceptsPerIpPerMinute: 0));
+
+        var act = () => config.Validate();
 
         act();
     }

--- a/BGPLite.Tests/IpAcceptThrottleTests.cs
+++ b/BGPLite.Tests/IpAcceptThrottleTests.cs
@@ -1,0 +1,159 @@
+using BGPLite.Server;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// Tests for <see cref="IpAcceptThrottle"/> (#115): the per-source-IP accept throttle for the BGP
+/// listener. Covers both the pure sliding-window decision (<see cref="IpAcceptThrottle.Decide"/>) and
+/// the stateful <see cref="IpAcceptThrottle.TryAccept"/> wrapper (thread-safety, per-IP isolation,
+/// disabled-mode, stale-entry pruning).
+/// </summary>
+public class IpAcceptThrottleTests
+{
+    private const long MinuteTicks = 600_000_000L; // 60s in ticks (TimeSpan.TicksPerSecond=10^7)
+
+    [Fact]
+    public void Decide_Allows_First_Accept_For_Empty_Window()
+    {
+        var allowed = IpAcceptThrottle.Decide([], nowTicks: 1_000, MinuteTicks, limit: 60, out var updated);
+
+        Assert.True(allowed);
+        var stamp = Assert.Single(updated);
+        Assert.Equal(1_000, stamp);
+    }
+
+    [Fact]
+    public void Decide_Allows_UpToLimit_Then_Denies_Next()
+    {
+        // Window [0..60s]. With limit=3, the 1st/2nd/3rd accepts in-window are allowed; the 4th is denied.
+        var inWindow = new List<long> { 1_000, 2_000, 3_000 }; // already at the limit
+        var allowed = IpAcceptThrottle.Decide(inWindow, nowTicks: 4_000, MinuteTicks, limit: 3, out var updated);
+
+        Assert.False(allowed, "4th accept within the window must be rejected");
+        // Denied attempt is NOT recorded (does not extend the window): only the 3 pruned in-window stamps.
+        Assert.Equal(3, updated.Count);
+        Assert.DoesNotContain(4_000L, updated);
+    }
+
+    [Fact]
+    public void Decide_Prunes_Stale_Timestamps_And_Allows_Again()
+    {
+        // Timestamps from > 60s ago must be pruned, so a fresh accept is allowed even though the raw
+        // count is at the limit. Use a coarse second-based scale so "older than the window" is
+        // unambiguous (1s/2s/3s vs now=70s → cutoff=10s; all three are stale).
+        var s = 10_000_000L; // 1 second in ticks
+        var stale = new List<long> { 1 * s, 2 * s, 3 * s };
+        var now = 70 * s; // 70s: 1s/2s/3s are all older than the 60s window
+
+        var allowed = IpAcceptThrottle.Decide(stale, now, MinuteTicks, limit: 3, out var updated);
+
+        Assert.True(allowed, "stale entries must be pruned so the accept is allowed");
+        var stamp = Assert.Single(updated); // only the new timestamp remains
+        Assert.Equal(now, stamp);
+    }
+
+    [Fact]
+    public void Decide_LimitZero_OrNegative_Always_Allows()
+    {
+        // limit <= 0 = disabled (matches BgpConfig.MaxAcceptsPerIpPerMinute = 0 semantics).
+        var allowed = IpAcceptThrottle.Decide(
+            new List<long> { 1, 2, 3, 4, 5 }, nowTicks: 6, MinuteTicks, limit: 0, out var updated);
+
+        Assert.True(allowed);
+        Assert.Equal(6, updated.Count); // all 5 pruned + the new one
+    }
+
+    [Fact]
+    public void Decide_KeepsOnly_Recent_Mixed_Timestamps()
+    {
+        // Mix of stale and fresh entries: only the fresh ones survive pruning.
+        var mixed = new List<long>
+        {
+            100,                // stale
+            200,                // stale
+            MinuteTicks + 500,  // fresh
+            MinuteTicks + 600   // fresh
+        };
+        var now = MinuteTicks + 1_000;
+
+        var allowed = IpAcceptThrottle.Decide(mixed, now, MinuteTicks, limit: 10, out var updated);
+
+        Assert.True(allowed);
+        Assert.Equal(3, updated.Count); // 2 fresh + the new one
+        Assert.Contains(MinuteTicks + 500, updated);
+        Assert.Contains(MinuteTicks + 600, updated);
+        Assert.Contains((long)now, updated);
+        Assert.DoesNotContain(100L, updated);
+        Assert.DoesNotContain(200L, updated);
+    }
+
+    [Fact]
+    public void TryAccept_Disabled_When_Limit_NonPositive()
+    {
+        var throttle = new IpAcceptThrottle(maxPerMinute: 0);
+
+        for (var i = 0; i < 100; i++)
+            Assert.True(throttle.TryAccept("198.51.100.1"));
+    }
+
+    [Fact]
+    public void TryAccept_Allows_UpToLimit_Then_Denies_For_SameIp()
+    {
+        // Deterministic clock so the test does not depend on wall-clock timing.
+        var ticks = 1_000L;
+        var throttle = new IpAcceptThrottle(maxPerMinute: 3, nowTicks: () => ticks);
+
+        Assert.True(throttle.TryAccept("198.51.100.1"));
+        Assert.True(throttle.TryAccept("198.51.100.1"));
+        Assert.True(throttle.TryAccept("198.51.100.1"));
+        Assert.False(throttle.TryAccept("198.51.100.1"), "4th accept from the same IP must be throttled");
+    }
+
+    [Fact]
+    public void TryAccept_Partitions_ByIp_Independently()
+    {
+        var ticks = 1_000L;
+        var throttle = new IpAcceptThrottle(maxPerMinute: 2, nowTicks: () => ticks);
+
+        Assert.True(throttle.TryAccept("198.51.100.1"));
+        Assert.True(throttle.TryAccept("198.51.100.1"));
+        Assert.False(throttle.TryAccept("198.51.100.1"));
+
+        // A different IP has its own independent window — still allowed.
+        Assert.True(throttle.TryAccept("198.51.100.2"));
+    }
+
+    [Fact]
+    public void TryAccept_Allows_Again_After_Window_Expires()
+    {
+        var ticks = 1_000L;
+        var throttle = new IpAcceptThrottle(maxPerMinute: 2, nowTicks: () => ticks);
+
+        Assert.True(throttle.TryAccept("198.51.100.1"));
+        Assert.True(throttle.TryAccept("198.51.100.1"));
+        Assert.False(throttle.TryAccept("198.51.100.1"));
+
+        // Advance the clock past the 60s window — the old accepts are pruned, accepts allowed again.
+        ticks += MinuteTicks + 1;
+        Assert.True(throttle.TryAccept("198.51.100.1"));
+    }
+
+    [Fact]
+    public async Task TryAccept_Is_ThreadSafe_Under_Concurrency()
+    {
+        // Hammer one IP from many threads: exactly `limit` accepts must be admitted, no more
+        // (a non-thread-safe counter would let more than `limit` through under contention).
+        const int limit = 50;
+        var throttle = new IpAcceptThrottle(maxPerMinute: limit);
+        var allowedCount = 0;
+
+        await Parallel.ForEachAsync(Enumerable.Range(0, 1_000), async (_, _) =>
+        {
+            if (throttle.TryAccept("198.51.100.1"))
+                Interlocked.Increment(ref allowedCount);
+            await Task.Yield();
+        });
+
+        Assert.Equal(limit, allowedCount);
+    }
+}

--- a/appsettings.Example.yml
+++ b/appsettings.Example.yml
@@ -3,6 +3,10 @@ Bgp:
   RouterId: 1.2.3.4
   KeepAlive: 60
   HoldTime: 180
+  # Listener hardening (#115) — connect-to-OPEN timeout (Slowloris defense) and per-source-IP
+  # accept throttle. Both have secure, generous defaults; set to 0 to disable either.
+  # OpenTimeoutSeconds: 30                 # drop a peer that connects but never sends OPEN (default 30, 0 = off)
+  # MaxAcceptsPerIpPerMinute: 60           # per-source-IP accept flood limit (default 60, 0 = off)
 
 Peers:
   - Address: 10.0.0.1


### PR DESCRIPTION
Closes #115

## Problem
`BgpServer.AcceptLoopAsync` accepted every inbound TCP connection to :179 with no bounds on incomplete handshakes or single-source floods:

- **No connect-to-OPEN timeout** — verified: `BgpSession.RunAsync` awaited the peer's OPEN on `linkedCts.Token` with no `CancelAfter`. The negotiated hold timer only starts AFTER the handshake, so a connection that opens TCP but never sends OPEN pinned a `BgpSession` + task + socket FD until the OS TCP timeout (minutes). Slowloris resource-exhaustion vector — highest-leverage attack.
- **No per-source-IP accept throttle** — one remote IP could open unlimited connections, saturating accept/handlers.

## Fix (two parts, one coherent "listener hardening")
1. **connect-to-OPEN timeout** (`BgpSession.RunAsync`): the OPEN receive now runs on a CTS linked to `linkedCts` with `CancelAfter(OpenTimeoutSeconds)`, disposed right after OPEN so later receives keep using `linkedCts`/the hold timer. On a pure timeout (external/session token not cancelled) the peer is dropped with a `No OPEN within Xs` log and no NOTIFICATION (FSM never reached OpenSent; a Slowloris socket wouldn't read it).
2. **per-source-IP accept throttle** (`BgpServer.AcceptLoopAsync` + new `IpAcceptThrottle`): a thread-safe sliding-window counter (60s) per remote IP; an IP over the limit has its just-accepted socket closed immediately WITHOUT spawning a session (no FD/task/session pinned). The window math is a pure `internal static` `Decide(...)` helper for testability.

Config (both 0 = disabled, defaults secure + generous):
- `Bgp.OpenTimeoutSeconds` (default 30)
- `Bgp.MaxAcceptsPerIpPerMinute` (default 60)

Both validated at startup (reject negatives).

## Behavior change (intentional)
- Peers that do not complete OPEN within `OpenTimeoutSeconds` are dropped (correct Slowloris defense).
- A single source IP exceeding `MaxAcceptsPerIpPerMinute` accepts/min has excess connects closed without a session.
- Legitimate peers (complete OPEN promptly, one connect per session) are unaffected. Established-session count is deliberately NOT capped — that is capacity/business logic, not a security control. The OS firewall (nftables) remains the PRIMARY gate; these are cheap in-app backstops for misconfigured-firewall / misbehaving-authorized-peer cases. Complements #36 (TCP-MD5) and #10 (MaxPrefix).

## Verification
- `dotnet build BGPLite.sln -c Debug` — 0 errors.
- `dotnet test BGPLite.sln -c Debug` — 308 passed, 0 failed.
- `dotnet format BGPLite.sln --no-restore --severity warn` — clean.
- New tests: throttle `Decide`/`TryAccept` (under/over limit, pruning, per-IP isolation, disabled, thread-safety under 1k concurrent); real-socket connect-without-OPEN-drops-within-timeout (1s timeout, 5s ceiling); fast-OPEN- peer- unaffected positive control; config validation for both new fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable protections for BGP connections: a timeout for sending OPEN and a per-source-IP connection rate limit.
  * Updated the example configuration to show how to tune or disable these safeguards.

* **Bug Fixes**
  * Improved handling of peers that connect but never complete the handshake.
  * Limited excessive inbound connections from the same IP to help reduce abuse and resource exhaustion.

* **Tests**
  * Added coverage for the new timeout and connection-throttling behavior, including validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->