### PR TITLE
fix(server): evict idle IPs from IpAcceptThrottle (#115 follow-up)

### DIFF
--- a/BGPLite.Server/IpAcceptThrottle.cs
+++ b/BGPLite.Server/IpAcceptThrottle.cs
@@ -10,19 +10,21 @@ namespace BGPLite.Server;
 /// here is connections from a single source, not the established-session count.
 /// <para>
 /// Thread-safe sliding-window counter: each distinct IP gets a bounded list of recent accept
-/// timestamps guarded by a per-IP lock; entries older than the window are pruned on every access so
-/// an idle IP's slot reclaims. The list per IP is bounded by <c>limit+1</c> (one over on the
-/// rejected attempt), so memory is bounded by (distinct IPs) × (limit). The OS firewall (nftables)
-/// is the PRIMARY gate; this is a cheap in-app backstop for misconfigured-firewall /
-/// misbehaving-authorized-peer cases.
+/// timestamps guarded by a per-IP lock; entries older than the window are pruned on every access.
+/// Stale entries (an IP idle longer than one window, with no recent timestamp) are evicted from the
+/// tracker on an amortized sweep so a distinct-IP flood cannot grow the tracker without bound. The
+/// list per IP is bounded by <c>limit+1</c>. The OS firewall (nftables) is the PRIMARY gate; this
+/// is a cheap in-app backstop.
 /// </para>
 /// </summary>
 internal sealed class IpAcceptThrottle
 {
+    private const int SweepEvery = 64;
     private readonly int _maxPerMinute;
     private readonly long _windowTicks;
     private readonly ConcurrentDictionary<string, Window> _byIp = new(StringComparer.Ordinal);
     private readonly Func<long> _nowTicks;
+    private int _callsSinceSweep;
 
     public IpAcceptThrottle(int maxPerMinute, Func<long>? nowTicks = null)
     {
@@ -30,6 +32,9 @@ internal sealed class IpAcceptThrottle
         _windowTicks = TimeSpan.FromMinutes(1).Ticks;
         _nowTicks = nowTicks ?? (() => DateTime.UtcNow.Ticks);
     }
+
+    /// <summary>Number of distinct IPs currently tracked (test/observability).</summary>
+    internal int TrackedCount => _byIp.Count;
 
     /// <summary>
     /// Pure sliding-window decision: prune timestamps older than the window, then allow iff the
@@ -77,12 +82,42 @@ internal sealed class IpAcceptThrottle
 
         var nowTicks = _nowTicks();
         var window = _byIp.GetOrAdd(ip, _ => new Window());
+        bool allowed;
         lock (window)
         {
-            var allowed = Decide(window.Timestamps, nowTicks, _windowTicks, _maxPerMinute, out var updated);
+            allowed = Decide(window.Timestamps, nowTicks, _windowTicks, _maxPerMinute, out var updated);
             window.Timestamps = updated;
-            return allowed;
         }
+
+        // Amortized eviction of idle IPs (no timestamp newer than one window) so the tracker can't
+        // grow without bound under a distinct-IP flood. Active/recent IPs are always retained.
+        if (Interlocked.Increment(ref _callsSinceSweep) >= SweepEvery)
+        {
+            _callsSinceSweep = 0;
+            SweepStale(nowTicks);
+        }
+        return allowed;
+    }
+
+    /// <summary>Removes tracked IPs whose every timestamp is older than one window (idle IPs).</summary>
+    internal void SweepStale(long nowTicks)
+    {
+        var cutoff = nowTicks - _windowTicks;
+        foreach (var (ip, window) in _byIp)
+        {
+            bool stale;
+            lock (window)
+                stale = window.Timestamps.Count == 0 || IsAllStale(window.Timestamps, cutoff);
+            if (stale)
+                _byIp.TryRemove(ip, out _);
+        }
+    }
+
+    private static bool IsAllStale(IReadOnlyList<long> timestamps, long cutoff)
+    {
+        for (var i = 0; i < timestamps.Count; i++)
+            if (timestamps[i] > cutoff) return false;
+        return true;
     }
 
     /// <summary>Per-IP mutable window state, guarded by locking the instance itself.</summary>

--- a/BGPLite.Tests/IpAcceptThrottleTests.cs
+++ b/BGPLite.Tests/IpAcceptThrottleTests.cs
@@ -156,4 +156,36 @@ public class IpAcceptThrottleTests
 
         Assert.Equal(limit, allowedCount);
     }
+
+    [Fact]
+    public void SweepStale_Evicts_Idle_Ips()
+    {
+        var ticks = 1_000L;
+        var throttle = new IpAcceptThrottle(maxPerMinute: 10, nowTicks: () => ticks);
+
+        Assert.True(throttle.TryAccept("1.1.1.1"));
+        Assert.True(throttle.TryAccept("2.2.2.2"));
+        Assert.True(throttle.TryAccept("3.3.3.3"));
+        Assert.Equal(3, throttle.TrackedCount);
+
+        // Advance past the 60s window — all three are now idle (stale) → sweep evicts them so the
+        // tracker can't grow without bound under a distinct-IP flood.
+        ticks += MinuteTicks + 1;
+        throttle.SweepStale(ticks);
+        Assert.Equal(0, throttle.TrackedCount);
+    }
+
+    [Fact]
+    public void SweepStale_Keeps_Recent_Ip_Evicts_Stale()
+    {
+        var ticks = 1_000L;
+        var throttle = new IpAcceptThrottle(maxPerMinute: 10, nowTicks: () => ticks);
+
+        Assert.True(throttle.TryAccept("1.1.1.1"));        // t=1000 — will go stale
+        ticks += MinuteTicks + 1;                          // >60s later
+        Assert.True(throttle.TryAccept("2.2.2.2"));        // recent (at the advanced time)
+
+        throttle.SweepStale(ticks);                        // evict 1.1.1.1, keep 2.2.2.2
+        Assert.Equal(1, throttle.TrackedCount);
+    }
 }


### PR DESCRIPTION
Follow-up to #115 (merged via #131). CodeRabbit 🟠 flagged that `IpAcceptThrottle._byIp` only grew via `GetOrAdd` and never removed entries — so under a distinct-IP flood the tracker itself grew without bound (the very attack the throttle defends against).

## Fix
Amortized `SweepStale` (runs every 64 accepts) removes tracked IPs whose every timestamp is older than one window (idle IPs). Active/recent IPs are always retained. Adds `TrackedCount` (internal, for tests/observability) + `SweepStale(nowTicks)` (internal, testable with the injected clock).

## Verification
- build 0 errors; tests green (+2 `SweepStale_*`: evicts idle IPs; keeps recent, evicts stale).
- format clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IP throttling so stale entries are cleaned up automatically, helping keep the service stable during floods of requests from many different IPs.
  * Reduced unnecessary growth in tracked IP records while preserving existing acceptance behavior for active clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->