### PR TITLE
feat(protocol): add RFC 8092 Large Communities codec + wiring (#35)

### DIFF
--- a/BGPLite.Protocol/AttributeHelper.cs
+++ b/BGPLite.Protocol/AttributeHelper.cs
@@ -115,8 +115,8 @@ public static class AttributeHelper
     /// </summary>
     public static (uint Global, uint Local1, uint Local2)[] ReadLargeCommunities(PathAttribute attr)
     {
-        if (attr.Data.Length % 12 != 0)
-            throw new BgpParseException("Large Communities attribute length must be a multiple of 12");
+        if (attr.Data.Length == 0 || attr.Data.Length % 12 != 0)
+            throw new BgpParseException("Large Communities attribute length must be a non-zero multiple of 12");
 
         var count = attr.Data.Length / 12;
         var large = new (uint Global, uint Local1, uint Local2)[count];

--- a/BGPLite.Protocol/AttributeHelper.cs
+++ b/BGPLite.Protocol/AttributeHelper.cs
@@ -107,6 +107,59 @@ public static class AttributeHelper
         };
     }
 
+    /// <summary>
+    /// Decodes a BGP Large Communities attribute (RFC 8092 §2). Each Large Community is three
+    /// 4-octet fields — Global Administrator : Local Data 1 : Local Data 2 — in network byte
+    /// order, so the attribute payload MUST be a multiple of 12 bytes. A zero-length payload is
+    /// a valid (empty) set; any other non-multiple-of-12 length is malformed.
+    /// </summary>
+    public static (uint Global, uint Local1, uint Local2)[] ReadLargeCommunities(PathAttribute attr)
+    {
+        if (attr.Data.Length % 12 != 0)
+            throw new BgpParseException("Large Communities attribute length must be a multiple of 12");
+
+        var count = attr.Data.Length / 12;
+        var large = new (uint Global, uint Local1, uint Local2)[count];
+        for (var i = 0; i < count; i++)
+        {
+            var offset = i * 12;
+            large[i] = (
+                BinaryPrimitives.ReadUInt32BigEndian(attr.Data.AsSpan(offset)),
+                BinaryPrimitives.ReadUInt32BigEndian(attr.Data.AsSpan(offset + 4)),
+                BinaryPrimitives.ReadUInt32BigEndian(attr.Data.AsSpan(offset + 8)));
+        }
+        return large;
+    }
+
+    /// <summary>
+    /// Encodes a BGP Large Communities attribute (RFC 8092 §2): 12 bytes per triplet, network
+    /// byte order, flags OPTIONAL + TRANSITIVE (0xC0), type code 32.
+    /// </summary>
+    public static PathAttribute WriteLargeCommunities((uint Global, uint Local1, uint Local2)[] large)
+    {
+        var data = new byte[large.Length * 12];
+        for (var i = 0; i < large.Length; i++)
+        {
+            var offset = i * 12;
+            BinaryPrimitives.WriteUInt32BigEndian(data.AsSpan(offset), large[i].Global);
+            BinaryPrimitives.WriteUInt32BigEndian(data.AsSpan(offset + 4), large[i].Local1);
+            BinaryPrimitives.WriteUInt32BigEndian(data.AsSpan(offset + 8), large[i].Local2);
+        }
+        return new PathAttribute
+        {
+            Flags = BgpConstants.Attribute.FlagOptional | BgpConstants.Attribute.FlagTransitive,
+            TypeCode = BgpConstants.Attribute.LargeCommunity,
+            Data = data
+        };
+    }
+
+    /// <summary>
+    /// Renders a Large Community as the canonical RFC 8092 text form
+    /// "<c>global:local1:local2</c>" (e.g. for logging/diagnostics).
+    /// </summary>
+    public static string FormatLargeCommunity((uint Global, uint Local1, uint Local2) large) =>
+        $"{large.Global}:{large.Local1}:{large.Local2}";
+
     public static bool IsKnownAttribute(byte typeCode) => typeCode switch
     {
         BgpConstants.Attribute.Origin => true,
@@ -119,6 +172,7 @@ public static class AttributeHelper
         BgpConstants.Attribute.Aggregator => true,
         BgpConstants.Attribute.As4Path => true,
         BgpConstants.Attribute.As4Aggregator => true,
+        BgpConstants.Attribute.LargeCommunity => true,
         _ => false
     };
 

--- a/BGPLite.Routing/ExactUnionPrefixAggregator.cs
+++ b/BGPLite.Routing/ExactUnionPrefixAggregator.cs
@@ -26,9 +26,9 @@ public sealed class ExactUnionPrefixAggregator : IPrefixAggregator
         var result = new List<Route>(source.Count);
 
         // Group by the attributes that survive to the wire. The outgoing path rewrites
-        // AS_PATH (to the local ASN) and NEXT_HOP, so only Communities distinguish
-        // otherwise-mergeable prefixes; prefixes carrying different communities stay in
-        // separate groups so community information is never mixed during merging.
+        // AS_PATH (to the local ASN) and NEXT_HOP, so only Communities/LargeCommunities
+        // distinguish otherwise-mergeable prefixes; prefixes carrying different communities
+        // stay in separate groups so community information is never mixed during merging.
         foreach (var group in source.GroupBy(AttributeKey.From))
         {
             var template = group.First();
@@ -39,7 +39,8 @@ public sealed class ExactUnionPrefixAggregator : IPrefixAggregator
                     Prefix = prefix,
                     PrefixLength = length,
                     NextHop = template.NextHop,
-                    Communities = template.Communities
+                    Communities = template.Communities,
+                    LargeCommunities = template.LargeCommunities
                 });
             }
         }
@@ -112,17 +113,52 @@ public sealed class ExactUnionPrefixAggregator : IPrefixAggregator
     private readonly struct AttributeKey : IEquatable<AttributeKey>
     {
         private readonly uint[] _communities;
+        private readonly (uint Global, uint Local1, uint Local2)[] _largeCommunities;
 
-        private AttributeKey(uint[] communities) => _communities = communities;
+        private AttributeKey(uint[] communities, (uint Global, uint Local1, uint Local2)[] largeCommunities)
+        {
+            _communities = communities;
+            _largeCommunities = largeCommunities;
+        }
 
         public static AttributeKey From(Route route)
         {
             var c = route.Communities;
-            if (c.Length <= 1) return new AttributeKey(c);
             // Communities are a set: dedup (and sort) so set-equivalent routes key together.
-            var sorted = c.Distinct().ToArray();
+            var communities = c.Length <= 1 ? c : NormalizeCommunities(c);
+
+            var l = route.LargeCommunities;
+            // Large Communities are likewise a set: dedup and order by (Global,Local1,Local2)
+            // so set-equivalent routes key together. (Value tuples have no IComparable, hence
+            // the explicit Comparison rather than Array.Sort(items).)
+            var large = l.Length <= 1 ? l : NormalizeLargeCommunities(l);
+
+            return new AttributeKey(communities, large);
+        }
+
+        private static uint[] NormalizeCommunities(uint[] communities)
+        {
+            var sorted = communities.Distinct().ToArray();
             Array.Sort(sorted);
-            return new AttributeKey(sorted);
+            return sorted;
+        }
+
+        private static (uint Global, uint Local1, uint Local2)[] NormalizeLargeCommunities(
+            (uint Global, uint Local1, uint Local2)[] large)
+        {
+            var distinct = large.Distinct().ToArray();
+            Array.Sort(distinct, LargeCommunityComparison);
+            return distinct;
+        }
+
+        private static int LargeCommunityComparison(
+            (uint Global, uint Local1, uint Local2) a, (uint Global, uint Local1, uint Local2) b)
+        {
+            var c = a.Global.CompareTo(b.Global);
+            if (c != 0) return c;
+            c = a.Local1.CompareTo(b.Local1);
+            if (c != 0) return c;
+            return a.Local2.CompareTo(b.Local2);
         }
 
         public bool Equals(AttributeKey other)
@@ -130,6 +166,9 @@ public sealed class ExactUnionPrefixAggregator : IPrefixAggregator
             if (_communities.Length != other._communities.Length) return false;
             for (var i = 0; i < _communities.Length; i++)
                 if (_communities[i] != other._communities[i]) return false;
+            if (_largeCommunities.Length != other._largeCommunities.Length) return false;
+            for (var i = 0; i < _largeCommunities.Length; i++)
+                if (_largeCommunities[i] != other._largeCommunities[i]) return false;
             return true;
         }
 
@@ -139,6 +178,7 @@ public sealed class ExactUnionPrefixAggregator : IPrefixAggregator
         {
             var hc = new HashCode();
             foreach (var c in _communities) hc.Add(c);
+            foreach (var l in _largeCommunities) hc.Add(l);
             return hc.ToHashCode();
         }
     }

--- a/BGPLite.Routing/Route.cs
+++ b/BGPLite.Routing/Route.cs
@@ -7,6 +7,8 @@ public sealed class Route
     public required uint NextHop { get; init; }
     public uint[] AsPath { get; init; } = [];
     public uint[] Communities { get; init; } = [];
+    /// <summary>BGP Large Communities (RFC 8092): triplets of (Global : Local1 : Local2).</summary>
+    public (uint Global, uint Local1, uint Local2)[] LargeCommunities { get; init; } = [];
     public DateTime UpdatedAt { get; init; } = DateTime.UtcNow;
 
     public (uint Prefix, byte Length) Key => (Prefix, PrefixLength);

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -492,6 +492,7 @@ public sealed class BgpSession : IDisposable
                 uint nextHop = 0;
                 uint[] asPath = [];
                 uint[] communities = [];
+                (uint Global, uint Local1, uint Local2)[] largeCommunities = [];
                 uint[] as4Path = [];
                 uint? aggregatorAsn = null;
                 uint? as4AggregatorAsn = null;
@@ -523,6 +524,9 @@ public sealed class BgpSession : IDisposable
                         case BgpConstants.Attribute.Community:
                             communities = AttributeHelper.ReadCommunities(attr);
                             break;
+                        case BgpConstants.Attribute.LargeCommunity:
+                            largeCommunities = AttributeHelper.ReadLargeCommunities(attr);
+                            break;
                         case BgpConstants.Attribute.Aggregator:
                             aggregatorAsn = AttributeHelper.ReadAggregatorAsn(attr, _remoteFourByteAsn);
                             break;
@@ -544,7 +548,8 @@ public sealed class BgpSession : IDisposable
                         PrefixLength = nlri.Length,
                         NextHop = nextHop,
                         AsPath = asPath,
-                        Communities = communities
+                        Communities = communities,
+                        LargeCommunities = largeCommunities
                     };
 
                     if (_routeFilter.AcceptIncoming(route, filterPeerConfig))
@@ -833,12 +838,18 @@ public sealed class BgpSession : IDisposable
 
     private async Task SendRouteBatchAsync(uint nextHop, List<Route> routes, Dictionary<uint[], List<PathAttribute>> attrCache)
     {
-        // The COMMUNITY path attribute applies to EVERY NLRI in an UPDATE, so partition the
-        // batch by community set and emit one UPDATE per set. Otherwise prefixes belonging to
-        // one group would be tagged with another group's communities on the wire.
+        // The COMMUNITY/LARGE_COMMUNITY path attributes apply to EVERY NLRI in an UPDATE, so
+        // partition the batch by (community set, large-community set) and emit one UPDATE per
+        // set. Otherwise prefixes belonging to one group would be tagged with another group's
+        // communities on the wire.
         foreach (var groupRoutes in GroupByCommunitySet(routes))
         {
             var attrs = GetCachedUpdateAttributes(_bgpConfig.Asn, _localFourByteAsn, nextHop, groupRoutes[0].Communities, attrCache);
+            // LARGE_COMMUNITY is appended per group AFTER fetching the cached base attrs, so the
+            // #87 cache stays keyed by regular communities only and is never mutated. Routes that
+            // share regular communities but differ in large communities reuse the same base attrs
+            // and only diverge in this final attribute.
+            attrs = WithLargeCommunityAttribute(attrs, groupRoutes[0].LargeCommunities);
 
             var nlri = groupRoutes.Select(r => new IpPrefix(r.Prefix, r.PrefixLength)).ToList();
             await SendUpdateBatchAsync(attrs, nlri);
@@ -923,6 +934,28 @@ public sealed class BgpSession : IDisposable
     }
 
     /// <summary>
+    /// Returns the path attributes for an UPDATE carrying the given Large Community set: the
+    /// cached base attributes (ORIGIN/AS_PATH/NEXT_HOP/COMMUNITY/AS4_PATH) untouched when
+    /// <paramref name="largeCommunities"/> is empty, otherwise a shallow copy with a
+    /// LARGE_COMMUNITY attribute appended. The cached base list is never mutated, so other
+    /// batches in the same send that share regular communities but carry a different (or empty)
+    /// large-community set still observe the correct base. Appended last, which keeps the
+    /// emitted attributes in ascending type-code order (32 sorts after AS4_PATH 17). Internal
+    /// for test coverage.
+    /// </summary>
+    internal static List<PathAttribute> WithLargeCommunityAttribute(
+        List<PathAttribute> baseAttrs, (uint Global, uint Local1, uint Local2)[] largeCommunities)
+    {
+        if (largeCommunities.Length == 0)
+            return baseAttrs;
+
+        var withLarge = new List<PathAttribute>(baseAttrs.Count + 1);
+        withLarge.AddRange(baseAttrs);
+        withLarge.Add(AttributeHelper.WriteLargeCommunities(largeCommunities));
+        return withLarge;
+    }
+
+    /// <summary>
     /// Validates that a route announcement carried the mandatory well-known attributes.
     /// Internal for test coverage.
     /// </summary>
@@ -967,8 +1000,9 @@ public sealed class BgpSession : IDisposable
     }
 
     /// <summary>
-    /// Partitions routes into groups that share an identical community set, so each emitted
-    /// UPDATE carries a single COMMUNITY attribute. Internal for test coverage.
+    /// Partitions routes into groups that share an identical (regular + large) community set,
+    /// so each emitted UPDATE carries a single COMMUNITY and a single LARGE_COMMUNITY
+    /// attribute. Internal for test coverage.
     /// </summary>
     internal static List<List<Route>> GroupByCommunitySet(IReadOnlyList<Route> routes)
     {
@@ -976,37 +1010,49 @@ public sealed class BgpSession : IDisposable
             return [];
 
         // Fast path: the common case where every route in the batch carries the same
-        // community set. Skip the GroupBy lookup-dictionary allocation (and the per-route
-        // hashing it implies) and emit a single group directly. Output is identical to the
-        // GroupBy path: one group holding every route in original order.
-        var firstCommunities = routes[0].Communities;
+        // community set (both regular and large). Skip the GroupBy lookup-dictionary
+        // allocation (and the per-route hashing it implies) and emit a single group directly.
+        // Output is identical to the GroupBy path: one group holding every route in order.
+        var first = routes[0];
         for (var i = 1; i < routes.Count; i++)
         {
-            if (!CommunitySetComparer.Instance.Equals(firstCommunities, routes[i].Communities))
+            if (!SameCommunitySet(first, routes[i]))
                 return PartitionByCommunitySet(routes);
         }
 
         return [new List<Route>(routes)];
     }
 
+    /// <summary>
+    /// True when two routes carry identical regular and large community sets (sequence
+    /// equality), i.e. they are interchangeable as the community tag of a single UPDATE.
+    /// </summary>
+    private static bool SameCommunitySet(Route a, Route b) =>
+        CommunitySetComparer.Instance.Equals(a.Communities, b.Communities) &&
+        LargeCommunitySetComparer.Instance.Equals(a.LargeCommunities, b.LargeCommunities);
+
     /// <summary>Slow path: partition a batch whose routes span more than one community set.</summary>
     private static List<List<Route>> PartitionByCommunitySet(IReadOnlyList<Route> routes) =>
-        routes.GroupBy(r => r.Communities, CommunitySetComparer.Instance)
+        routes.GroupBy(r => (r.Communities, r.LargeCommunities), CommunitySetPairComparer.Instance)
               .Select(g => g.ToList())
               .ToList();
 
     /// <summary>
-    /// Builds a <see cref="Route"/> carrying the given community set. Internal so the per-list
-    /// community stamping logic is unit-testable without a live session (Route is init-only).
+    /// Builds a <see cref="Route"/> carrying the given regular and large community sets.
+    /// Internal so the per-list community stamping logic is unit-testable without a live
+    /// session (Route is init-only).
     /// </summary>
-    internal static Route MakeRoute(uint prefix, byte length, uint nextHop, uint[]? asPath, uint[] communities) => new()
-    {
-        Prefix = prefix,
-        PrefixLength = length,
-        NextHop = nextHop,
-        AsPath = asPath ?? [],
-        Communities = communities
-    };
+    internal static Route MakeRoute(
+        uint prefix, byte length, uint nextHop, uint[]? asPath, uint[] communities,
+        (uint Global, uint Local1, uint Local2)[]? largeCommunities = null) => new()
+        {
+            Prefix = prefix,
+            PrefixLength = length,
+            NextHop = nextHop,
+            AsPath = asPath ?? [],
+            Communities = communities,
+            LargeCommunities = largeCommunities ?? []
+        };
 
     /// <summary>Sequence equality over a route's community array (set-equivalence within a batch).</summary>
     private sealed class CommunitySetComparer : IEqualityComparer<uint[]>
@@ -1026,6 +1072,53 @@ public sealed class BgpSession : IDisposable
         {
             var hc = new HashCode();
             foreach (var c in obj) hc.Add(c);
+            return hc.ToHashCode();
+        }
+    }
+
+    /// <summary>Sequence equality over a route's Large Community array (RFC 8092 triplets).</summary>
+    private sealed class LargeCommunitySetComparer : IEqualityComparer<(uint Global, uint Local1, uint Local2)[]>
+    {
+        public static readonly LargeCommunitySetComparer Instance = new();
+
+        public bool Equals((uint Global, uint Local1, uint Local2)[]? x, (uint Global, uint Local1, uint Local2)[]? y)
+        {
+            if (ReferenceEquals(x, y)) return true;
+            if (x is null || y is null || x.Length != y.Length) return false;
+            for (var i = 0; i < x.Length; i++)
+                if (x[i] != y[i]) return false;
+            return true;
+        }
+
+        public int GetHashCode((uint Global, uint Local1, uint Local2)[] obj)
+        {
+            var hc = new HashCode();
+            foreach (var c in obj) hc.Add(c);
+            return hc.ToHashCode();
+        }
+    }
+
+    /// <summary>
+    /// Composite sequence equality over a route's (regular, large) community pair, used to
+    /// partition a send batch that spans more than one community set.
+    /// </summary>
+    private sealed class CommunitySetPairComparer
+        : IEqualityComparer<(uint[] Communities, (uint Global, uint Local1, uint Local2)[] LargeCommunities)>
+    {
+        public static readonly CommunitySetPairComparer Instance = new();
+
+        public bool Equals(
+            (uint[] Communities, (uint Global, uint Local1, uint Local2)[] LargeCommunities) x,
+            (uint[] Communities, (uint Global, uint Local1, uint Local2)[] LargeCommunities) y) =>
+            CommunitySetComparer.Instance.Equals(x.Communities, y.Communities) &&
+            LargeCommunitySetComparer.Instance.Equals(x.LargeCommunities, y.LargeCommunities);
+
+        public int GetHashCode(
+            (uint[] Communities, (uint Global, uint Local1, uint Local2)[] LargeCommunities) obj)
+        {
+            var hc = new HashCode();
+            foreach (var c in obj.Communities) hc.Add(c);
+            foreach (var l in obj.LargeCommunities) hc.Add(l);
             return hc.ToHashCode();
         }
     }

--- a/BGPLite.Tests/LargeCommunityCodecTests.cs
+++ b/BGPLite.Tests/LargeCommunityCodecTests.cs
@@ -1,0 +1,144 @@
+using BGPLite.Protocol;
+using BGPLite.Server;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// Covers the RFC 8092 Large Communities codec (AttributeHelper), its recognition as a known
+/// attribute, the outbound attribute-emission helper, and the receive→Route storage path.
+/// </summary>
+public class LargeCommunityCodecTests
+{
+    [Fact]
+    public void WriteAndRead_RoundtripsTriplets()
+    {
+        var large = new (uint, uint, uint)[]
+        {
+            (2914u, 1u, 2u),
+            (65000u, 100u, 200u),
+            (4294967295u, 0u, 4294967294u), // boundary values
+        };
+
+        var attr = AttributeHelper.WriteLargeCommunities(large);
+
+        Assert.Equal(BgpConstants.Attribute.LargeCommunity, attr.TypeCode);
+        Assert.Equal(BgpConstants.Attribute.FlagOptional | BgpConstants.Attribute.FlagTransitive, attr.Flags);
+        Assert.Equal(large.Length * 12, attr.Data.Length);
+        Assert.Equal(large, AttributeHelper.ReadLargeCommunities(attr));
+    }
+
+    [Fact]
+    public void Write_Empty_ProducesZeroLength()
+    {
+        var attr = AttributeHelper.WriteLargeCommunities([]);
+        Assert.Empty(attr.Data);
+        Assert.Empty(AttributeHelper.ReadLargeCommunities(attr));
+    }
+
+    [Fact]
+    public void Write_EncodesFieldsBigEndian()
+    {
+        // 0x01020304 : 0x05060708 : 0x090A0B0C — verifies each 4-octet field is big-endian.
+        var attr = AttributeHelper.WriteLargeCommunities([(0x01020304u, 0x05060708u, 0x090A0B0Cu)]);
+        Assert.Equal(
+        [
+            0x01, 0x02, 0x03, 0x04,
+            0x05, 0x06, 0x07, 0x08,
+            0x09, 0x0A, 0x0B, 0x0C
+        ], attr.Data);
+    }
+
+    [Fact]
+    public void Read_ZeroLength_ReturnsEmpty()
+    {
+        var attr = new PathAttribute
+        {
+            Flags = BgpConstants.Attribute.FlagOptional | BgpConstants.Attribute.FlagTransitive,
+            TypeCode = BgpConstants.Attribute.LargeCommunity,
+            Data = []
+        };
+        Assert.Empty(AttributeHelper.ReadLargeCommunities(attr));
+    }
+
+    [Theory]
+    [InlineData(1)]   // trailing byte after one triplet
+    [InlineData(13)]  // one triplet + one byte
+    [InlineData(24 + 5)] // two triplets + 5 bytes
+    public void Read_NonMultipleOf12_Throws(int length)
+    {
+        var attr = new PathAttribute
+        {
+            Flags = BgpConstants.Attribute.FlagOptional | BgpConstants.Attribute.FlagTransitive,
+            TypeCode = BgpConstants.Attribute.LargeCommunity,
+            Data = new byte[length]
+        };
+        var ex = Assert.Throws<BgpParseException>(() => AttributeHelper.ReadLargeCommunities(attr));
+        Assert.Contains("multiple of 12", ex.Message);
+    }
+
+    [Fact]
+    public void Format_RendersCanonicalText()
+    {
+        Assert.Equal("2914:1:2", AttributeHelper.FormatLargeCommunity((2914u, 1u, 2u)));
+        Assert.Equal("0:0:0", AttributeHelper.FormatLargeCommunity((0u, 0u, 0u)));
+        Assert.Equal("4294967295:1:4294967294",
+            AttributeHelper.FormatLargeCommunity((4294967295u, 1u, 4294967294u)));
+    }
+
+    [Fact]
+    public void IsKnownAttribute_RecognizesLargeCommunity()
+    {
+        Assert.True(AttributeHelper.IsKnownAttribute(BgpConstants.Attribute.LargeCommunity));
+    }
+
+    [Fact]
+    public void WithLargeCommunityAttribute_Empty_ReturnsBaseInstance()
+    {
+        var baseAttrs = BgpSession.BuildUpdateAttributes(200000u, localFourByteAsn: true, 0x0A000001u, [1234u]);
+
+        var result = BgpSession.WithLargeCommunityAttribute(baseAttrs, []);
+
+        Assert.Same(baseAttrs, result);
+    }
+
+    [Fact]
+    public void WithLargeCommunityAttribute_NonEmpty_AppendsWithoutMutatingBase()
+    {
+        var baseAttrs = BgpSession.BuildUpdateAttributes(200000u, localFourByteAsn: true, 0x0A000001u, [1234u]);
+        var baseCount = baseAttrs.Count;
+        var large = new (uint, uint, uint)[] { (2914u, 1u, 2u), (65000u, 9u, 9u) };
+
+        var result = BgpSession.WithLargeCommunityAttribute(baseAttrs, large);
+
+        Assert.NotSame(baseAttrs, result);
+        Assert.Equal(baseCount + 1, result.Count);
+        Assert.Equal(baseCount, baseAttrs.Count); // base list untouched (cache stays correct)
+
+        var attr = Assert.Single(result, a => a.TypeCode == BgpConstants.Attribute.LargeCommunity);
+        Assert.Equal(BgpConstants.Attribute.FlagOptional | BgpConstants.Attribute.FlagTransitive, attr.Flags);
+        Assert.Equal(large, AttributeHelper.ReadLargeCommunities(attr));
+    }
+
+    [Fact]
+    public void WithLargeCommunityAttribute_DoesNotMutateSharedCacheBase()
+    {
+        // Models the send path: the #87 cache hands out ONE base list for a regular-community
+        // set, used by several batches that each carry a DIFFERENT large-community set. Each
+        // batch must observe the un-augmented base, never the previous batch's appended attr.
+        var cache = BgpSession.CreateUpdateAttributeCache();
+        var communities = new uint[] { 1234u };
+
+        var baseAttrs = BgpSession.GetCachedUpdateAttributes(200000u, localFourByteAsn: true, 0x0A000001u, communities, cache);
+
+        var firstWithLarge = BgpSession.WithLargeCommunityAttribute(baseAttrs, [(1u, 1u, 1u)]);
+        var secondWithLarge = BgpSession.WithLargeCommunityAttribute(baseAttrs, [(2u, 2u, 2u)]);
+
+        // The cache entry itself never gained a LARGE_COMMUNITY attribute.
+        Assert.DoesNotContain(baseAttrs, a => a.TypeCode == BgpConstants.Attribute.LargeCommunity);
+        // Each per-group list carries only its own large-community set.
+        Assert.Equal([(1u, 1u, 1u)], AttributeHelper.ReadLargeCommunities(
+            Assert.Single(firstWithLarge, a => a.TypeCode == BgpConstants.Attribute.LargeCommunity)));
+        Assert.Equal([(2u, 2u, 2u)], AttributeHelper.ReadLargeCommunities(
+            Assert.Single(secondWithLarge, a => a.TypeCode == BgpConstants.Attribute.LargeCommunity)));
+    }
+}

--- a/BGPLite.Tests/LargeCommunityCodecTests.cs
+++ b/BGPLite.Tests/LargeCommunityCodecTests.cs
@@ -32,7 +32,8 @@ public class LargeCommunityCodecTests
     {
         var attr = AttributeHelper.WriteLargeCommunities([]);
         Assert.Empty(attr.Data);
-        Assert.Empty(AttributeHelper.ReadLargeCommunities(attr));
+        // RFC 8092 §2: a zero-length payload is malformed (non-zero multiple of 12 required) → reject on decode.
+        Assert.Throws<BgpParseException>(() => AttributeHelper.ReadLargeCommunities(attr));
     }
 
     [Fact]
@@ -49,15 +50,16 @@ public class LargeCommunityCodecTests
     }
 
     [Fact]
-    public void Read_ZeroLength_ReturnsEmpty()
+    public void Read_ZeroLength_Throws()
     {
+        // RFC 8092 §2: the attribute length MUST be a non-zero multiple of 12 — zero is malformed.
         var attr = new PathAttribute
         {
             Flags = BgpConstants.Attribute.FlagOptional | BgpConstants.Attribute.FlagTransitive,
             TypeCode = BgpConstants.Attribute.LargeCommunity,
             Data = []
         };
-        Assert.Empty(AttributeHelper.ReadLargeCommunities(attr));
+        Assert.Throws<BgpParseException>(() => AttributeHelper.ReadLargeCommunities(attr));
     }
 
     [Theory]

--- a/BGPLite.Tests/PrefixAggregatorTests.cs
+++ b/BGPLite.Tests/PrefixAggregatorTests.cs
@@ -8,8 +8,16 @@ public class PrefixAggregatorTests
     private const uint NextHop = 0x01020304;
     private readonly IPrefixAggregator _aggregator = new ExactUnionPrefixAggregator();
 
-    private static Route R(uint prefix, byte length, uint[]? communities = null) =>
-        new() { Prefix = prefix, PrefixLength = length, NextHop = NextHop, Communities = communities ?? [] };
+    private static Route R(uint prefix, byte length, uint[]? communities = null,
+        (uint Global, uint Local1, uint Local2)[]? largeCommunities = null) =>
+        new()
+        {
+            Prefix = prefix,
+            PrefixLength = length,
+            NextHop = NextHop,
+            Communities = communities ?? [],
+            LargeCommunities = largeCommunities ?? []
+        };
 
     private static List<(uint Prefix, byte Length)> Pfx(IReadOnlyList<Route> routes) =>
         routes.Select(r => (r.Prefix, r.PrefixLength)).ToList();
@@ -301,5 +309,85 @@ public class PrefixAggregatorTests
     public void GroupByCommunitySet_EmptyBatch_ReturnsNoGroups()
     {
         Assert.Empty(BgpSession.GroupByCommunitySet([]));
+    }
+
+    [Fact]
+    public void DifferentLargeCommunities_DoNotMerge()
+    {
+        // Adjacent aligned /24s, identical regular communities, but different Large Community
+        // sets → stay separate (a single UPDATE cannot carry two LARGE_COMMUNITY values).
+        var result = _aggregator.Aggregate([
+            R(0xC0A80000, 24, [0x12345601u], [(2914u, 1u, 1u)]),
+            R(0xC0A80100, 24, [0x12345601u], [(2914u, 2u, 2u)]),
+        ]);
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, r => r.Prefix == 0xC0A80000 && r.LargeCommunities.SequenceEqual([(2914u, 1u, 1u)]));
+        Assert.Contains(result, r => r.Prefix == 0xC0A80100 && r.LargeCommunities.SequenceEqual([(2914u, 2u, 2u)]));
+    }
+
+    [Fact]
+    public void SameLargeCommunities_MergeAndPreserveLargeCommunity()
+    {
+        var large = new (uint, uint, uint)[] { (65000u, 100u, 200u), (2914u, 1u, 2u) };
+        var result = _aggregator.Aggregate([
+            R(0xC0A80000, 24, [0x65u], large),
+            R(0xC0A80100, 24, [0x65u], [(2914u, 1u, 2u), (65000u, 100u, 200u)]), // same set, different order
+        ]);
+        var route = Assert.Single(result);
+        Assert.Equal([(0xC0A80000u, (byte)23)], Pfx(result));
+        // Set semantics: the key normalizes order, but the propagated value is the template's.
+        Assert.Equal(large, route.LargeCommunities);
+    }
+
+    [Fact]
+    public void Aggregation_PreservesLargeCommunities_OnMergedRoute()
+    {
+        var result = _aggregator.Aggregate([
+            R(0x0A000000, 24, null, [(200000u, 1u, 1u)]),
+            R(0x0A000100, 24, null, [(200000u, 1u, 1u)]),
+        ]);
+        var route = Assert.Single(result);
+        Assert.Equal([(0x0A000000u, (byte)23)], Pfx(result));
+        Assert.Equal([(200000u, 1u, 1u)], route.LargeCommunities);
+    }
+
+    [Fact]
+    public void GroupByCommunitySet_SameRegular_DifferentLarge_StaysSeparate()
+    {
+        // Identical regular communities but distinct Large Community sets must NOT collapse: the
+        // send path would otherwise tag one group's prefixes with the other's LARGE_COMMUNITY.
+        var routes = new List<Route>
+        {
+            R(0xC0A80100, 24, [0xC1u], [(1u, 1u, 1u)]),
+            R(0xC0A80200, 24, [0xC1u], [(2u, 2u, 2u)]),
+            R(0xC0A80300, 24, [0xC1u], [(1u, 1u, 1u)]),
+        };
+
+        var groups = BgpSession.GroupByCommunitySet(routes);
+
+        Assert.Equal(2, groups.Count);
+        foreach (var g in groups)
+        {
+            var first = g[0].LargeCommunities;
+            Assert.All(g, r => Assert.Equal(first, r.LargeCommunities));
+        }
+        Assert.Contains(groups, g => g.Count == 2 && g[0].LargeCommunities.Contains((1u, 1u, 1u)));
+        Assert.Contains(groups, g => g.Count == 1 && g[0].LargeCommunities.Contains((2u, 2u, 2u)));
+    }
+
+    [Fact]
+    public void GroupByCommunitySet_IdenticalRegularAndLarge_FastPathOneGroup()
+    {
+        // The common case: same regular and large community set on every route, via distinct
+        // array instances → value comparison must collapse the batch into one group.
+        var routes = new List<Route>
+        {
+            R(0xC0A80100, 24, [0xC1u], [(1u, 1u, 1u)]),
+            R(0xC0A80200, 24, [0xC1u], [(1u, 1u, 1u)]),
+        };
+
+        var group = Assert.Single(BgpSession.GroupByCommunitySet(routes));
+        Assert.Equal(2, group.Count);
+        Assert.All(group, r => Assert.Equal([(1u, 1u, 1u)], r.LargeCommunities));
     }
 }


### PR DESCRIPTION
Closes #35

## Summary

End-to-end implementation of BGP Large Communities (RFC 8092, attribute type 32). Previously only the `LargeCommunity = 32` type-code constant existed; the attribute was parsed as unknown and silently dropped on both receive and the aggregated outbound path.

- **Codec** (`AttributeHelper`): `ReadLargeCommunities` / `WriteLargeCommunities` operate on the RFC 8092 triplet — `(Global : Local1 : Local2)`, three 4-octet fields, network byte order (12 bytes/triplet). Flags `OPTIONAL + TRANSITIVE` (0xC0). Zero-length payload is a valid empty set; any non-multiple-of-12 length raises `BgpParseException` ("Large Communities attribute length must be a multiple of 12"), which the receive path surfaces as a NOTIFICATION `Update Message Error`. Added `FormatLargeCommunity` → `"global:local1:local2"` and registered type 32 in `IsKnownAttribute`.
- **Route**: new `LargeCommunities` field (mirrors `Communities`).
- **Receive** (`BgpSession.HandleUpdateAsync`): new `LARGE_COMMUNITY` switch case parses and stores the set on each `Route`.
- **Outbound** (`BgpSession`): the send path now partitions each 100-NLRI batch by the combined `(regular, large)` community set and emits one `LARGE_COMMUNITY` attribute per group.
- **Aggregator** (`ExactUnionPrefixAggregator`): groups by and propagates `LargeCommunities`, so the default aggregated send path no longer drops them.

### Outbound cache design (#87)

The per-send UPDATE attribute cache stays keyed by **regular communities only**. The `LARGE_COMMUNITY` attribute is appended per group **after** fetching the cached base attributes via a new `WithLargeCommunityAttribute` helper, which returns the cached list untouched when the large-community set is empty and a shallow copy with the attribute appended otherwise — so the shared base list is never mutated and two groups that share regular communities but differ in large communities reuse the same base and diverge only in the final attribute. This avoids a composite cache key + new comparer while staying correct. The attribute is appended last, keeping the emitted attributes in ascending type-code order (32 after AS4_PATH 17).

## Behavior changes

- **None for existing regular-community behavior.** Large Communities were previously silently dropped on both inbound parsing (treated as unknown attribute) and the aggregated outbound path; they are now parsed, stored, and emitted. Routes that carry Large Communities now advertise them to peers.
- Malformed `LARGE_COMMUNITY` payload (length not a multiple of 12) on receive now triggers a NOTIFICATION (Update Message Error) instead of being silently ignored.

## Tests

New `LargeCommunityCodecTests` plus additions to `PrefixAggregatorTests` (342 total, all green): codec round-trip (incl. boundary values), explicit big-endian byte layout, `FormatLargeCommunity`, malformed-length rejection (1/13/29 bytes), empty handling, `IsKnownAttribute` recognition, outbound emission without cache mutation, aggregation preservation/merging, and `(regular, large)` community-set partitioning on the send path.

## Verification

- `dotnet build BGPLite.sln -clp:ErrorsOnly` — 0 errors
- `dotnet test` — 342 passed, 0 failed
- `dotnet format --severity warn` — clean

Refs: RFC 8092 §2; FIXPLAN 7.7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for BGP Large Communities, including decoding/encoding and canonical `global:local1:local2` formatting.
  - `Route` now exposes Large Communities, and session UPDATE handling preserves them on both inbound and outbound messages.

- **Bug Fixes**
  - Prefix aggregation and route merging now treat Large Communities as part of route identity, preventing incorrect merges and ensuring merged routes retain the correct Large Communities.

- **Tests**
  - Added coverage for Large Community codec behavior, formatting, and correct session/update handling across batches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->