### PR TITLE
fix(config): strict YAML deserialization — unknown keys fail-loud (#102)

### DIFF
--- a/BGPLite.Configuration/ConfigLoader.cs
+++ b/BGPLite.Configuration/ConfigLoader.cs
@@ -4,8 +4,10 @@ namespace BGPLite.Configuration;
 
 public static class ConfigLoader
 {
+    // Strict deserialization: unknown/typo'd YAML keys throw at load time (fail-loud) rather than
+    // being silently swallowed. Operators get a clear "(Lin: N): Property 'X' not found" error at
+    // startup pointing to the typo (#102).
     private static readonly IDeserializer Deserializer = new DeserializerBuilder()
-        .IgnoreUnmatchedProperties()
         .Build();
 
     public static AppConfig Load(string path)

--- a/BGPLite.Tests/ConfigurationTests.cs
+++ b/BGPLite.Tests/ConfigurationTests.cs
@@ -5,6 +5,20 @@ namespace BGPLite.Tests;
 public class ConfigurationTests
 {
     [Fact]
+    public void LoadFromText_UnknownKey_Throws()
+    {
+        // #102: strict YAML — unknown/typo'd keys must fail-loud at deserialization (not silently
+        // ignored). Operator gets a clear "(Lin: N): Property 'X' not found" pointing to the typo.
+        var yaml = """
+            Bgp:
+              Asn: 65444
+              TypoKey: 42
+            """;
+        var ex = Assert.ThrowsAny<Exception>(() => ConfigLoader.LoadFromText(yaml));
+        Assert.Contains("TypoKey", ex.Message);
+    }
+
+    [Fact]
     public void LoadFromText_ParsesValidYaml()
     {
         var yaml = """


### PR DESCRIPTION
Closes #102

## Problem
ConfigLoader used .IgnoreUnmatchedProperties(), silently dropping unknown/typo'd YAML keys (e.g. 'ApiProt:' → ApiPort falls back to default, wrong port, no error). Combined with the lack of validation, invalid config only surfaced as runtime exceptions deep in BgpSession/RipeStatProvider.

## Fix
Remove .IgnoreUnmatchedProperties() → strict deserialization. Unknown keys throw YamlDotNetException with the property name + line number at startup → clear fail-loud error. Combined with #89's AppConfig.Validate() (already merged: Asn/RouterId/HoldTime/ApiPort/peer-address checks), config is now validated twice: **structure** (unknown keys → this PR) + **semantics** (#89).

## ⚠️ Deviation from the issue's full prescription
#102 proposed migrating to the IOptions<T>/IOptionsMonitor<T> pipeline. Deliberately NOT done: BGPLite uses YAML (not JSON IConfiguration), so IOptions.Bind doesn't apply directly; the current Validate()+AddSingleton flow already runs at startup; and IOptionsMonitor hot-reload is **largely inapplicable** (Asn/RouterId/HoldTime are baked into established BGP sessions — can't hot-reload without teardown). The genuinely-remaining gap was IgnoreUnmatchedProperties (this fix). Hot-reload for soft-config (sources/CORS/rate-limit/TrustedProxies) filed as a separate issue.

## Verification
- build 0 errors; **343 tests** (+1 LoadFromText_UnknownKey_Throws); format clean.
- Existing ConfigurationTests (valid YAML) all pass — no valid key is rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration loading now fails when YAML includes unknown or misspelled keys, instead of silently ignoring them.
  * Error messages are clearer, making invalid configuration entries easier to spot and correct.

* **Tests**
  * Added coverage to verify that loading configuration with an unexpected key raises an exception and reports the key name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->