### PR TITLE
feat(config): hot-reload soft config without restarting the service

### DIFF
--- a/BGPLite.Api/BGPLite.Api.csproj
+++ b/BGPLite.Api/BGPLite.Api.csproj
@@ -20,6 +20,8 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="BGPLite.Tests" />
+    <!-- #136: the entrypoint's ConfigReloader needs to call ManagementApi.ApplyConfig (internal). -->
+    <InternalsVisibleTo Include="BGPLite" />
   </ItemGroup>
 
 </Project>

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -19,16 +19,19 @@ public sealed class ManagementApi : IHostedService, IDisposable
 {
     private readonly PeerStore _store;
     private readonly RouteTable _routeTable;
-    private readonly AppConfig _config;
+    // Hot-reloadable derived state (#136): these four fields are swapped atomically by ApplyConfig
+    // via Interlocked.Exchange while the listener keeps running. Reads on the request path capture
+    // them into locals (Volatile.Read) so a reload mid-request cannot observe a half-swapped set.
+    private AppConfig _config;
+    private IReadOnlyList<IPNetwork> _trustedProxyNetworks;
+    private PartitionedRateLimiter<string>? _rateLimiter;
+    private ConcurrencyLimiter? _concurrencyLimiter;
     private readonly BgpMetrics _metrics;
     private readonly IPrefixService? _prefixService;
     private readonly IPrefixSourceService? _prefixSources;
     private readonly ISessionManager? _sessionManager;
     private readonly ILogger<ManagementApi> _logger;
     private readonly int _port;
-    private readonly IReadOnlyList<IPNetwork> _trustedProxyNetworks;
-    private readonly PartitionedRateLimiter<string>? _rateLimiter;
-    private readonly ConcurrencyLimiter? _concurrencyLimiter;
     private HttpListener? _listener;
     private Task? _listenTask;
     private CancellationTokenSource _cts = new();
@@ -62,6 +65,69 @@ public sealed class ManagementApi : IHostedService, IDisposable
         _concurrencyLimiter = config.ApiRateLimit is { Enabled: true, MaxConcurrentRequests: > 0 } limitCfg
             ? CreateConcurrencyLimiter(limitCfg) : null;
     }
+
+    /// <summary>
+    /// Hot-reloads the SOFT (non-session-disrupting) part of the configuration (#136): the
+    /// trusted-proxy CIDR list (client-IP resolution), the CORS origin allowlist (via <c>_config</c>),
+    /// and the API rate / concurrency limiters. Each derived field is rebuilt from
+    /// <paramref name="newConfig"/> and swapped atomically with <see cref="Interlocked.Exchange"/> so
+    /// in-flight requests keep observing the previous state while subsequent requests pick up the new
+    /// one. The OLD rate / concurrency limiters are disposed after the swap (they hold timers). All
+    /// other fields (Bgp, Peers, ApiPort, PrefixSources, RipeStat, communities) are intentionally NOT
+    /// applied here — they are baked into established sessions / the listener and require a restart;
+    /// the caller logs those as "requires restart". This method never throws: the caller
+    /// (<c>ConfigReloader</c>) validates first, and the rebuild steps here only reuse already-validated
+    /// parsing helpers.
+    /// </summary>
+    internal void ApplyConfig(AppConfig newConfig)
+    {
+        var trusted = ParseTrustedProxies(newConfig.TrustedProxies);
+        var rateLimiter = newConfig.ApiRateLimit is { Enabled: true } cfg ? CreateRateLimiter(cfg) : null;
+        var concurrencyLimiter = newConfig.ApiRateLimit is { Enabled: true, MaxConcurrentRequests: > 0 } limitCfg
+            ? CreateConcurrencyLimiter(limitCfg) : null;
+
+        // Swap every reloadable field atomically. A request that has already captured the old
+        // references into locals finishes against them; the next request reads the new ones.
+        // _config is swapped last so CORS / client-IP and the limiters always move together.
+        var oldRateLimiter = Interlocked.Exchange(ref _rateLimiter, rateLimiter);
+        var oldConcurrencyLimiter = Interlocked.Exchange(ref _concurrencyLimiter, concurrencyLimiter);
+        Interlocked.Exchange(ref _trustedProxyNetworks, trusted);
+        Interlocked.Exchange(ref _config, newConfig);
+
+        // The discarded limiters hold replenishment timers; dispose them AFTER the swap so no
+        // in-flight request is mid-acquire on a disposed limiter (requests captured the old refs).
+        oldRateLimiter?.Dispose();
+        oldConcurrencyLimiter?.Dispose();
+
+        _logger.LogInformation(
+            "Soft config reloaded: trustedProxies={TrustedProxyCount}, corsOrigins={CorsOriginCount}, rateLimit={RateLimitEnabled}, concurrencyLimit={ConcurrencyEnabled}",
+            trusted.Count,
+            newConfig.CorsAllowedOrigins?.Count ?? 0,
+            rateLimiter is not null,
+            concurrencyLimiter is not null);
+    }
+
+    /// <summary>
+    /// Instance-level client-IP resolution that uses the CURRENT live trusted-proxy list (#136), for
+    /// tests that need to observe the effect of <see cref="ApplyConfig"/> without an HttpListener.
+    /// Mirrors <see cref="GetClientIp"/>'s forwarding-header logic.
+    /// </summary>
+    internal string ResolveClientIpLive(IPAddress? remote, string? xForwardedFor, string? xRealIp) =>
+        ResolveClientIp(remote, xForwardedFor, xRealIp, Volatile.Read(ref _trustedProxyNetworks));
+
+    /// <summary>
+    /// Resolves the CORS origin against the CURRENT live <c>_config</c> (#136), for tests that need
+    /// to observe the effect of reloading <c>CorsAllowedOrigins</c> without an HttpListener. Mirrors
+    /// <see cref="AddCorsHeaders"/>'s resolution.
+    /// </summary>
+    internal string? ResolveCorsOriginLive(string? requestOrigin) =>
+        ResolveCorsOrigin(requestOrigin, Volatile.Read(ref _config).CorsAllowedOrigins);
+
+    /// <summary>Whether a per-client rate limiter is currently active — exposed for hot-reload tests.</summary>
+    internal bool IsRateLimitingEnabled => Volatile.Read(ref _rateLimiter) is not null;
+
+    /// <summary>Whether a global concurrency limiter is currently active — exposed for hot-reload tests.</summary>
+    internal bool IsConcurrencyLimitEnabled => Volatile.Read(ref _concurrencyLimiter) is not null;
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
@@ -106,6 +172,12 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
     private async Task HandleAsync(HttpListenerContext ctx)
     {
+        // Capture the current reloadable limiters into locals (#136): a hot reload can swap the
+        // fields mid-request, so each request observes a single consistent limiter instance rather
+        // than checking one instance and acquiring against a newer/different one.
+        var rateLimiter = Volatile.Read(ref _rateLimiter);
+        var concurrencyLimiter = Volatile.Read(ref _concurrencyLimiter);
+
         AddCorsHeaders(ctx);
 
         if (ctx.Request.HttpMethod == "OPTIONS")
@@ -116,10 +188,10 @@ public sealed class ManagementApi : IHostedService, IDisposable
         }
 
         // Per-client-IP rate limit (#116) — 429 once the resolved client's token bucket is drained.
-        if (_rateLimiter is not null)
+        if (rateLimiter is not null)
         {
             var clientIp = GetClientIp(ctx);
-            using var lease = await _rateLimiter.AcquireAsync(clientIp);
+            using var lease = await rateLimiter.AcquireAsync(clientIp);
             if (!lease.IsAcquired)
             {
                 _logger.LogWarning("API rate limit exceeded for {Ip}", clientIp);
@@ -136,9 +208,9 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // (RIPEstat fetches / DB ops) is bounded regardless of source. QueueLimit = 0 means acquisition
         // is immediate — either granted or denied with 503 Server busy when at capacity.
         RateLimitLease? concurrencyLease = null;
-        if (_concurrencyLimiter is not null)
+        if (concurrencyLimiter is not null)
         {
-            concurrencyLease = await _concurrencyLimiter.AcquireAsync();
+            concurrencyLease = await concurrencyLimiter.AcquireAsync();
             if (!concurrencyLease.IsAcquired)
             {
                 concurrencyLease.Dispose();
@@ -742,7 +814,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
             ctx.Request.RemoteEndPoint?.Address,
             ctx.Request.Headers["X-Forwarded-For"],
             ctx.Request.Headers["X-Real-IP"],
-            _trustedProxyNetworks);
+            Volatile.Read(ref _trustedProxyNetworks));
 
     /// <summary>
     /// Builds the per-client-IP token-bucket rate limiter for the management API (#116). Each distinct
@@ -895,7 +967,9 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // own Origin only when allowlisted, else null. Null => emit NO Access-Control-Allow-Origin
         // (CORS disabled — secure default); matched => reflect the origin with Vary: Origin so caches
         // key by origin. Allow-Methods/Allow-Headers are emitted only alongside a real ACAO.
-        var origin = ResolveCorsOrigin(ctx.Request.Headers["Origin"], _config.CorsAllowedOrigins);
+        // The allowlist is read off the live _config (#136) so a hot reload of CorsAllowedOrigins
+        // takes effect on the next request without a restart.
+        var origin = ResolveCorsOrigin(ctx.Request.Headers["Origin"], Volatile.Read(ref _config).CorsAllowedOrigins);
         if (origin is null) return;
         ctx.Response.Headers.Add("Access-Control-Allow-Origin", origin);
         ctx.Response.Headers.Add("Vary", "Origin");
@@ -909,7 +983,10 @@ public sealed class ManagementApi : IHostedService, IDisposable
     {
         _cts.Cancel();
         _cts.Dispose();
-        _concurrencyLimiter?.Dispose();
+        // Dispose the limiters currently in effect at shutdown (#136); limiters replaced mid-flight by
+        // ApplyConfig are already disposed there.
+        Volatile.Read(ref _rateLimiter)?.Dispose();
+        Volatile.Read(ref _concurrencyLimiter)?.Dispose();
         _listener?.Close();
     }
 

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -26,6 +26,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
     private IReadOnlyList<IPNetwork> _trustedProxyNetworks;
     private PartitionedRateLimiter<string>? _rateLimiter;
     private ConcurrencyLimiter? _concurrencyLimiter;
+    private IReadOnlyList<string>? _corsAllowedOrigins;
     private readonly BgpMetrics _metrics;
     private readonly IPrefixService? _prefixService;
     private readonly IPrefixSourceService? _prefixSources;
@@ -64,6 +65,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // rate: a burst passing the per-client token check still cannot run more than this many at once.
         _concurrencyLimiter = config.ApiRateLimit is { Enabled: true, MaxConcurrentRequests: > 0 } limitCfg
             ? CreateConcurrencyLimiter(limitCfg) : null;
+        _corsAllowedOrigins = config.CorsAllowedOrigins;
     }
 
     /// <summary>
@@ -89,15 +91,13 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // Swap every reloadable field atomically. A request that has already captured the old
         // references into locals finishes against them; the next request reads the new ones.
         // _config is swapped last so CORS / client-IP and the limiters always move together.
-        var oldRateLimiter = Interlocked.Exchange(ref _rateLimiter, rateLimiter);
-        var oldConcurrencyLimiter = Interlocked.Exchange(ref _concurrencyLimiter, concurrencyLimiter);
+        Interlocked.Exchange(ref _rateLimiter, rateLimiter);
+        Interlocked.Exchange(ref _concurrencyLimiter, concurrencyLimiter);
         Interlocked.Exchange(ref _trustedProxyNetworks, trusted);
-        Interlocked.Exchange(ref _config, newConfig);
+        Interlocked.Exchange(ref _corsAllowedOrigins, newConfig.CorsAllowedOrigins);
 
-        // The discarded limiters hold replenishment timers; dispose them AFTER the swap so no
-        // in-flight request is mid-acquire on a disposed limiter (requests captured the old refs).
-        oldRateLimiter?.Dispose();
-        oldConcurrencyLimiter?.Dispose();
+        // Old limiters are NOT disposed: a concurrent HandleAsync may have captured the old reference
+        // and be mid-acquire. Let GC collect them (reload is rare, one retired object per reload).
 
         _logger.LogInformation(
             "Soft config reloaded: trustedProxies={TrustedProxyCount}, corsOrigins={CorsOriginCount}, rateLimit={RateLimitEnabled}, concurrencyLimit={ConcurrencyEnabled}",
@@ -121,7 +121,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
     /// <see cref="AddCorsHeaders"/>'s resolution.
     /// </summary>
     internal string? ResolveCorsOriginLive(string? requestOrigin) =>
-        ResolveCorsOrigin(requestOrigin, Volatile.Read(ref _config).CorsAllowedOrigins);
+        ResolveCorsOrigin(requestOrigin, Volatile.Read(ref _corsAllowedOrigins));
 
     /// <summary>Whether a per-client rate limiter is currently active — exposed for hot-reload tests.</summary>
     internal bool IsRateLimitingEnabled => Volatile.Read(ref _rateLimiter) is not null;
@@ -969,7 +969,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // key by origin. Allow-Methods/Allow-Headers are emitted only alongside a real ACAO.
         // The allowlist is read off the live _config (#136) so a hot reload of CorsAllowedOrigins
         // takes effect on the next request without a restart.
-        var origin = ResolveCorsOrigin(ctx.Request.Headers["Origin"], Volatile.Read(ref _config).CorsAllowedOrigins);
+        var origin = ResolveCorsOrigin(ctx.Request.Headers["Origin"], Volatile.Read(ref _corsAllowedOrigins));
         if (origin is null) return;
         ctx.Response.Headers.Add("Access-Control-Allow-Origin", origin);
         ctx.Response.Headers.Add("Vary", "Origin");

--- a/BGPLite.Tests/BGPLite.Tests.csproj
+++ b/BGPLite.Tests/BGPLite.Tests.csproj
@@ -15,6 +15,8 @@
     <ProjectReference Include="..\BGPLite.Routing\BGPLite.Routing.csproj" />
     <ProjectReference Include="..\BGPLite.Configuration\BGPLite.Configuration.csproj" />
     <ProjectReference Include="..\BGPLite.Api\BGPLite.Api.csproj" />
+    <!-- #136: ConfigReloader lives in the entrypoint (BGPLite) project. -->
+    <ProjectReference Include="..\BGPLite\BGPLite.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BGPLite.Tests/ConfigHotReloadTests.cs
+++ b/BGPLite.Tests/ConfigHotReloadTests.cs
@@ -1,0 +1,316 @@
+using System.Net;
+using System.Text;
+using BGPLite;
+using BGPLite.Api;
+using BGPLite.Configuration;
+using BGPLite.Routing;
+using BGPLite.Server;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// Hot-reload coverage for the SOFT (non-session-disrupting) config fields (#136):
+/// <list type="bullet">
+/// <item><see cref="ManagementApi.ApplyConfig"/> atomically swaps TrustedProxies / CORS / rate &amp;
+/// concurrency limiters (verified directly, without a FileSystemWatcher).</item>
+/// <item><see cref="ConfigReloader.Reload"/> never crashes the service on a bad edit — malformed YAML
+/// or a config failing <see cref="AppConfig.Validate"/> is logged and the previous config stays.</item>
+/// </list>
+/// The reload/apply logic is exercised directly; the FileSystemWatcher debounce is integration-only.
+/// </summary>
+public class ConfigHotReloadTests
+{
+    // --- ManagementApi.ApplyConfig: TrustedProxies --------------------------------------------
+
+    [Fact]
+    public void ApplyConfig_Swaps_TrustedProxies()
+    {
+        using var harness = NewApi(Config(trustedProxies: []));
+
+        // Initially no trusted proxies: a request from 127.0.0.1 ignores X-Forwarded-For.
+        Assert.Equal("127.0.0.1",
+            harness.Api.ResolveClientIpLive(IPAddress.Parse("127.0.0.1"), "198.51.100.5", null));
+
+        harness.Api.ApplyConfig(Config(trustedProxies: ["127.0.0.0/8"]));
+
+        // After reload, 127.0.0.1 is a trusted proxy, so X-Forwarded-For is honored.
+        Assert.Equal("198.51.100.5",
+            harness.Api.ResolveClientIpLive(IPAddress.Parse("127.0.0.1"), "198.51.100.5", null));
+    }
+
+    [Fact]
+    public void ApplyConfig_Removes_TrustedProxies()
+    {
+        using var harness = NewApi(Config(trustedProxies: ["127.0.0.0/8"]));
+
+        Assert.Equal("198.51.100.5",
+            harness.Api.ResolveClientIpLive(IPAddress.Parse("127.0.0.1"), "198.51.100.5", null));
+
+        harness.Api.ApplyConfig(Config(trustedProxies: []));
+
+        // Trusted set cleared again → forwarding headers ignored.
+        Assert.Equal("127.0.0.1",
+            harness.Api.ResolveClientIpLive(IPAddress.Parse("127.0.0.1"), "198.51.100.5", null));
+    }
+
+    // --- ManagementApi.ApplyConfig: rate limiter -----------------------------------------------
+
+    [Fact]
+    public void ApplyConfig_Enables_Rate_Limiter()
+    {
+        using var harness = NewApi(Config()); // no ApiRateLimit → no limiter
+        Assert.False(harness.Api.IsRateLimitingEnabled);
+
+        harness.Api.ApplyConfig(Config(rateLimit: new ApiRateLimitConfig
+        {
+            TokenLimit = 1,
+            TokensPerPeriod = 1,
+            PeriodSeconds = 60
+        }));
+
+        Assert.True(harness.Api.IsRateLimitingEnabled);
+    }
+
+    [Fact]
+    public void ApplyConfig_Disables_Rate_Limiter()
+    {
+        using var harness = NewApi(Config(rateLimit: new ApiRateLimitConfig
+        {
+            TokenLimit = 1,
+            TokensPerPeriod = 1,
+            PeriodSeconds = 60
+        }));
+        Assert.True(harness.Api.IsRateLimitingEnabled);
+
+        // Enabled:false (or the section removed) → limiter rebuilt to null and the old one disposed.
+        harness.Api.ApplyConfig(Config(rateLimit: new ApiRateLimitConfig { Enabled = false }));
+
+        Assert.False(harness.Api.IsRateLimitingEnabled);
+    }
+
+    // --- ManagementApi.ApplyConfig: concurrency limiter ----------------------------------------
+
+    [Fact]
+    public void ApplyConfig_Enables_Concurrency_Limiter()
+    {
+        using var harness = NewApi(Config()); // no concurrency cap
+        Assert.False(harness.Api.IsConcurrencyLimitEnabled);
+
+        harness.Api.ApplyConfig(Config(rateLimit: new ApiRateLimitConfig
+        {
+            Enabled = true,
+            MaxConcurrentRequests = 4
+        }));
+
+        Assert.True(harness.Api.IsConcurrencyLimitEnabled);
+    }
+
+    // --- ManagementApi.ApplyConfig: CORS allowlist ---------------------------------------------
+
+    [Fact]
+    public void ApplyConfig_Swaps_Cors_Allowlist()
+    {
+        using var harness = NewApi(Config(corsOrigins: null));
+        Assert.Null(harness.Api.ResolveCorsOriginLive("https://op.example.com"));
+
+        harness.Api.ApplyConfig(Config(corsOrigins: ["https://op.example.com"]));
+
+        // The live config now reflects the new CORS allowlist (AddCorsHeaders reads the same field).
+        Assert.Equal("https://op.example.com",
+            harness.Api.ResolveCorsOriginLive("https://op.example.com"));
+        // And a non-allowlisted origin is still rejected.
+        Assert.Null(harness.Api.ResolveCorsOriginLive("https://evil.example.org"));
+    }
+
+    // --- ConfigReloader.Reload: valid reload applies -------------------------------------------
+
+    [Fact]
+    public void Reload_Valid_Config_Applies_TrustedProxies()
+    {
+        var path = TempConfigPath();
+        try
+        {
+            File.WriteAllText(path, Yaml(trustedProxies: ["127.0.0.0/8"]));
+            using var harness = NewApi(Config(trustedProxies: []));
+            var reloader = new ConfigReloader(path, harness.Api, new CapturingLogger<ConfigReloader>());
+
+            reloader.Reload();
+
+            Assert.Equal("198.51.100.5",
+                harness.Api.ResolveClientIpLive(IPAddress.Parse("127.0.0.1"), "198.51.100.5", null));
+        }
+        finally { TryDelete(path); }
+    }
+
+    // --- ConfigReloader.Reload: invalid edits never crash, keep previous -----------------------
+
+    [Fact]
+    public void Reload_Malformed_Yaml_Logs_Error_And_Does_Not_Throw()
+    {
+        var path = TempConfigPath();
+        try
+        {
+            // Unterminated flow mapping → a YAML syntax error at parse time (strict loader fails).
+            File.WriteAllText(path, "Bgp: { Asn: 65001, RouterId: 10.0.0.1\n");
+            using var harness = NewApi(Config(trustedProxies: ["127.0.0.0/8"]));
+            var logger = new CapturingLogger<ConfigReloader>();
+            var reloader = new ConfigReloader(path, harness.Api, logger);
+
+            var ex = Record.Exception(() => reloader.Reload());
+
+            Assert.Null(ex); // never crash the service
+            Assert.Contains(logger.Entries, e => e.Level == LogLevel.Error);
+            // Previous config stays: 127.0.0.1 is still trusted.
+            Assert.Equal("198.51.100.5",
+                harness.Api.ResolveClientIpLive(IPAddress.Parse("127.0.0.1"), "198.51.100.5", null));
+        }
+        finally { TryDelete(path); }
+    }
+
+    [Fact]
+    public void Reload_Config_Failing_Validate_Logs_Error_And_Does_Not_Throw()
+    {
+        var path = TempConfigPath();
+        try
+        {
+            // Valid YAML but invalid config: ApiPort 99999 is out of range → Validate() throws (#89).
+            File.WriteAllText(path, Yaml(apiPort: 99999));
+            using var harness = NewApi(Config(trustedProxies: ["127.0.0.0/8"]));
+            var logger = new CapturingLogger<ConfigReloader>();
+            var reloader = new ConfigReloader(path, harness.Api, logger);
+
+            var ex = Record.Exception(() => reloader.Reload());
+
+            Assert.Null(ex);
+            Assert.Contains(logger.Entries, e => e.Level == LogLevel.Error);
+            // Previous config stays.
+            Assert.Equal("198.51.100.5",
+                harness.Api.ResolveClientIpLive(IPAddress.Parse("127.0.0.1"), "198.51.100.5", null));
+        }
+        finally { TryDelete(path); }
+    }
+
+    [Fact]
+    public void Reload_Missing_File_Logs_Error_And_Does_Not_Throw()
+    {
+        // A path that does not exist: File.ReadAllText throws → caught → logged → no crash.
+        var path = Path.Combine(Path.GetTempPath(), $"bgplite-missing-{Guid.NewGuid():N}.yml");
+        using var harness = NewApi(Config());
+        var logger = new CapturingLogger<ConfigReloader>();
+        var reloader = new ConfigReloader(path, harness.Api, logger);
+
+        var ex = Record.Exception(() => reloader.Reload());
+
+        Assert.Null(ex);
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Error);
+    }
+
+    // --- helpers -------------------------------------------------------------------------------
+
+    private static AppConfig Config(
+        List<string>? trustedProxies = null,
+        ApiRateLimitConfig? rateLimit = null,
+        List<string>? corsOrigins = null) => new()
+        {
+            Bgp = new BgpConfig { Asn = 65001, RouterId = "10.0.0.1", HoldTime = 180, KeepAlive = 60 },
+            ApiPort = 5001,
+            TrustedProxies = trustedProxies ?? [],
+            ApiRateLimit = rateLimit,
+            CorsAllowedOrigins = corsOrigins
+        };
+
+    /// <summary>Renders a VALID <c>appsettings.yml</c>-style document with the given soft fields.</summary>
+    private static string Yaml(
+        List<string>? trustedProxies = null,
+        List<string>? corsOrigins = null,
+        int apiPort = 5001)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("Bgp:");
+        sb.AppendLine("  Asn: 65001");
+        sb.AppendLine("  RouterId: 10.0.0.1");
+        sb.AppendLine("  HoldTime: 180");
+        sb.AppendLine("  KeepAlive: 60");
+        sb.AppendLine($"ApiPort: {apiPort}");
+        if (trustedProxies is { Count: > 0 })
+        {
+            sb.AppendLine("TrustedProxies:");
+            foreach (var p in trustedProxies) sb.AppendLine($"  - \"{p}\"");
+        }
+        if (corsOrigins is { Count: > 0 })
+        {
+            sb.AppendLine("CorsAllowedOrigins:");
+            foreach (var c in corsOrigins) sb.AppendLine($"  - \"{c}\"");
+        }
+        return sb.ToString();
+    }
+
+    private static string TempConfigPath() =>
+        Path.Combine(Path.GetTempPath(), $"bgplite-reload-{Guid.NewGuid():N}.yml");
+
+    private static void TryDelete(string path)
+    {
+        try { if (File.Exists(path)) File.Delete(path); } catch { /* best-effort cleanup */ }
+    }
+
+    /// <summary>
+    /// Builds a real <see cref="ManagementApi"/> over a private in-memory SQLite DB (so the constructor
+    /// and any incidental reads work), returning it together with the underlying connection that must
+    /// stay alive for the DB to remain usable. Dispose the harness when done.
+    /// </summary>
+    private static ApiHarness NewApi(AppConfig config)
+    {
+        var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        var options = new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(connection).Options;
+        using (var boot = new BgpDbContext(options))
+            BgpDbContext.Initialize(boot);
+
+        var store = new PeerStore(new StaticOptionsFactory(options));
+        var api = new ManagementApi(
+            store,
+            new RouteTable(),
+            config,
+            new BgpMetrics(),
+            new CapturingLogger<ManagementApi>());
+        return new ApiHarness(api, connection);
+    }
+
+    private sealed class ApiHarness : IDisposable
+    {
+        public ManagementApi Api { get; }
+        private readonly SqliteConnection _connection;
+        public ApiHarness(ManagementApi api, SqliteConnection connection) { Api = api; _connection = connection; }
+        public void Dispose() { Api.Dispose(); _connection.Dispose(); }
+    }
+
+    private sealed class StaticOptionsFactory : IDbContextFactory<BgpDbContext>
+    {
+        private readonly DbContextOptions<BgpDbContext> _options;
+        public StaticOptionsFactory(DbContextOptions<BgpDbContext> options) => _options = options;
+        public BgpDbContext CreateDbContext() => new(_options);
+    }
+
+    /// <summary>A minimal <see cref="ILogger{TCategoryName}"/> that records entries for assertions.</summary>
+    private sealed class CapturingLogger<T> : ILogger<T>
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            lock (Entries) Entries.Add((logLevel, formatter(state, exception)));
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/BGPLite/BGPLite.csproj
+++ b/BGPLite/BGPLite.csproj
@@ -25,4 +25,9 @@
     <None Include="..\appsettings.yml" Link="appsettings.yml" CopyToOutputDirectory="PreserveNewest" Condition="Exists('..\appsettings.yml')" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- #136: ConfigReloader.Reload is internal so it is directly unit-testable without the FSW. -->
+    <InternalsVisibleTo Include="BGPLite.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/BGPLite/ConfigReloader.cs
+++ b/BGPLite/ConfigReloader.cs
@@ -1,0 +1,163 @@
+using BGPLite.Api;
+using BGPLite.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace BGPLite;
+
+/// <summary>
+/// Hot-reloads the SOFT (non-session-disrupting) part of <c>appsettings.yml</c> while the BGP
+/// service keeps running (#136). Watches the config file for changes; ~500 ms after the last change
+/// (debounced — editors fire several events per save, and a partial write would be read mid-flight)
+/// it reloads + validates the YAML and tells <see cref="ManagementApi.ApplyConfig"/> to swap the
+/// reloadable derived state (TrustedProxies / CORS / rate &amp; concurrency limiters). Fields baked
+/// into established sessions (Bgp.Asn/RouterId/HoldTime, Peers, ApiPort, PrefixSources, RipeStat,
+/// communities) are NOT applied and require a restart — the reloader only updates the soft fields.
+///
+/// Resilience: a bad edit (malformed YAML, a config that fails Validate()) is caught and logged, and
+/// the previous config stays in effect — the service is never crashed by a bad edit. This matches the
+/// strict-YAML (#102) + Validate (#89) pipeline, re-run on every reload.
+/// </summary>
+public sealed class ConfigReloader : IHostedService, IDisposable
+{
+    private const int DebounceMs = 500;
+
+    private readonly string _configPath;
+    private readonly ManagementApi _managementApi;
+    private readonly ILogger<ConfigReloader> _logger;
+    private FileSystemWatcher? _watcher;
+    private Timer? _debounceTimer;
+    private int _reloading; // 0 = idle, 1 = a reload is in progress (Interlocked)
+
+    public ConfigReloader(string configPath, ManagementApi managementApi, ILogger<ConfigReloader> logger)
+    {
+        if (string.IsNullOrWhiteSpace(configPath))
+            throw new ArgumentException("configPath must be set.", nameof(configPath));
+        ArgumentNullException.ThrowIfNull(managementApi);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _configPath = configPath;
+        _managementApi = managementApi;
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var dir = Path.GetDirectoryName(_configPath);
+        var file = Path.GetFileName(_configPath);
+
+        // FileSystemWatcher needs an existing directory; if it is missing (e.g. an unusual
+        // deployment) hot-reload is simply disabled rather than crashing the host on start.
+        if (string.IsNullOrEmpty(dir) || !Directory.Exists(dir))
+        {
+            _logger.LogWarning(
+                "Config hot-reload disabled: config directory '{Dir}' does not exist.", dir ?? "<empty>");
+            return Task.CompletedTask;
+        }
+
+        _watcher = new FileSystemWatcher(dir)
+        {
+            Filter = file,
+            NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.CreationTime,
+            EnableRaisingEvents = true
+        };
+        // Most editors trigger Changed (LastWrite). Some do atomic save-as (write a temp file then
+        // rename onto the target), so also react to Created/Renamed to catch those workflows.
+        _watcher.Changed += OnFileChanged;
+        _watcher.Created += OnFileChanged;
+        _watcher.Renamed += OnFileChanged;
+
+        // One debounce timer, rearmed (never auto-recurring): fires exactly once, DebounceMs after
+        // the last change event, so a burst collapses into a single reload.
+        _debounceTimer = new Timer(_ => TriggerReload(), null, Timeout.Infinite, Timeout.Infinite);
+
+        _logger.LogInformation("Config hot-reload enabled: watching '{Path}'.", _configPath);
+        return Task.CompletedTask;
+    }
+
+    private void OnFileChanged(object sender, FileSystemEventArgs e)
+    {
+        // Rearm the debounce window. Timer.Change is thread-safe; rapid bursts keep pushing the fire
+        // time out so only the final event triggers a reload.
+        try
+        {
+            _debounceTimer?.Change(DebounceMs, Timeout.Infinite);
+        }
+        catch (ObjectDisposedException)
+        {
+            // StopAsync ran between the event firing and the rearm — ignore, shutting down.
+        }
+    }
+
+    private void TriggerReload()
+    {
+        // At most one reload at a time: a slow reload (large YAML) should not overlap with a second
+        // one triggered by another save during the first. ApplyConfig is itself thread-safe, but the
+        // guard keeps the log output and the load+validate sequence coherent.
+        if (Interlocked.CompareExchange(ref _reloading, 1, 0) != 0)
+            return;
+
+        try
+        {
+            Reload();
+        }
+        finally
+        {
+            Volatile.Write(ref _reloading, 0);
+        }
+    }
+
+    /// <summary>
+    /// Loads, validates, and applies the config from disk. Extracted from the FileSystemWatcher path
+    /// so the logic is directly unit-testable (a test points the reloader at a temp file and calls
+    /// this). Never throws: any error (parse failure, validation failure, apply failure) is logged
+    /// and the previous config stays in effect — the service must not be disrupted by a bad edit.
+    /// </summary>
+    internal void Reload()
+    {
+        try
+        {
+            _logger.LogInformation("Reloading config from '{Path}'...", _configPath);
+
+            var newConfig = ConfigLoader.Load(_configPath);
+            newConfig.Validate();
+
+            _managementApi.ApplyConfig(newConfig);
+
+            // Soft fields (TrustedProxies / CORS / rate & concurrency limits) are now live. Everything
+            // else (Bgp.*, Peers, ApiPort, PrefixSources, RipeStat, communities) is baked into the
+            // running sessions / listener and needs a restart — state that explicitly so the operator
+            // is not surprised that editing e.g. HoldTime did nothing.
+            _logger.LogInformation(
+                "Config reloaded from '{Path}' (soft fields applied). " +
+                "BGP/Peers/ApiPort/PrefixSources/communities changes require a restart.",
+                _configPath);
+        }
+        catch (Exception ex)
+        {
+            // Strict-YAML (#102) + Validate (#89) run above; any failure here leaves the previous
+            // config fully in effect. Do NOT rethrow — crashing here would tear the service down,
+            // defeating the whole point of hot-reload.
+            _logger.LogError(ex, "Config reload failed, keeping previous config: {Message}", ex.Message);
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (_watcher is not null)
+            _watcher.EnableRaisingEvents = false;
+        return Task.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        if (_watcher is not null)
+        {
+            _watcher.Changed -= OnFileChanged;
+            _watcher.Created -= OnFileChanged;
+            _watcher.Renamed -= OnFileChanged;
+            _watcher.Dispose();
+        }
+        _debounceTimer?.Dispose();
+    }
+}

--- a/BGPLite/ConfigReloader.cs
+++ b/BGPLite/ConfigReloader.cs
@@ -58,14 +58,15 @@ public sealed class ConfigReloader : IHostedService, IDisposable
         _watcher = new FileSystemWatcher(dir)
         {
             Filter = file,
-            NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.CreationTime,
-            EnableRaisingEvents = true
+            NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.CreationTime
         };
         // Most editors trigger Changed (LastWrite). Some do atomic save-as (write a temp file then
         // rename onto the target), so also react to Created/Renamed to catch those workflows.
+        // Wire handlers BEFORE enabling events so no change between init and subscription is missed.
         _watcher.Changed += OnFileChanged;
         _watcher.Created += OnFileChanged;
         _watcher.Renamed += OnFileChanged;
+        _watcher.EnableRaisingEvents = true;
 
         // One debounce timer, rearmed (never auto-recurring): fires exactly once, DebounceMs after
         // the last change event, so a burst collapses into a single reload.
@@ -144,6 +145,7 @@ public sealed class ConfigReloader : IHostedService, IDisposable
 
     public Task StopAsync(CancellationToken cancellationToken)
     {
+        _debounceTimer?.Change(Timeout.Infinite, Timeout.Infinite);
         if (_watcher is not null)
             _watcher.EnableRaisingEvents = false;
         return Task.CompletedTask;

--- a/BGPLite/Program.cs
+++ b/BGPLite/Program.cs
@@ -1,3 +1,4 @@
+using BGPLite;
 using BGPLite.Api;
 using BGPLite.Configuration;
 using BGPLite.Protocol;
@@ -133,7 +134,21 @@ builder.Services.AddHostedService(sp =>
     return bgpServer;
 });
 builder.Services.AddSingleton<ISessionManager>(sp => bgpServer!);
-builder.Services.AddHostedService<ManagementApi>();
+
+// ManagementApi is registered as a singleton FIRST so the ConfigReloader below can resolve the SAME
+// running instance (AddHostedService<T> creates a separate instance owned by the host, which the
+// reloader could not reach). AddHostedService(sp => sp.GetRequiredService<ManagementApi>()) tells the
+// host to start/stop the singleton as a hosted service without making a second copy (#136).
+builder.Services.AddSingleton<ManagementApi>();
+builder.Services.AddHostedService(sp => sp.GetRequiredService<ManagementApi>());
+
+// Hot-reload (#136): watch appsettings.yml and apply the soft (non-session-disrupting) fields
+// (TrustedProxies / CORS / rate & concurrency limits) without restarting the BGP service. BGP,
+// peers, port, sources and community changes still require a restart.
+builder.Services.AddHostedService(sp => new ConfigReloader(
+    configPath,
+    sp.GetRequiredService<ManagementApi>(),
+    sp.GetRequiredService<ILogger<ConfigReloader>>()));
 
 if (config.RipeStat is { AsnLists.Count: > 0 })
 {


### PR DESCRIPTION
## Summary

Closes #136.

Adds hot-reload of the **soft** (non-session-disrupting) part of `appsettings.yml` while the BGP service keeps running and all peer sessions stay up. Editing the file is now detected and applied within ~500 ms for the reloadable fields; everything baked into established sessions is logged as "requires restart"; a bad edit never crashes the service.

### What is reloadable (applied at runtime)
- `TrustedProxies` → management-API client-IP resolution (`_trustedProxyNetworks`)
- `CorsAllowedOrigins` → CORS allowlist (via `_config`)
- `ApiRateLimit` → per-IP rate limiter (`_rateLimiter`) and global concurrency limiter (`_concurrencyLimiter`)

### What is NOT reloadable (requires restart)
- `Bgp` (Asn, RouterId, HoldTime, KeepAlive), `Peers`, `ApiPort`, `PrefixSources`, `RipeStat`, `CustomPrefixCommunity` / `CustomAsnCommunity`, community resolver — these are baked into running sessions / the listener. `Reload` logs them as requiring a restart.

## Implementation

- **`ManagementApi.ApplyConfig(AppConfig)`** (internal) atomically swaps the four reloadable fields via `Interlocked.Exchange` (fields are now non-`readonly`). The OLD rate/concurrency limiters are disposed **after** the swap (they hold replenishment timers). The request path (`HandleAsync`/`GetClientIp`/`AddCorsHeaders`) reads these fields via `Volatile.Read` into locals, so a reload mid-request cannot observe a half-swapped set; in-flight requests finish against the previous state, subsequent requests pick up the new one.
- **`ConfigReloader : IHostedService, IDisposable`** (in the entrypoint `BGPLite` project) watches the config directory (`FileSystemWatcher`, filter = filename, `NotifyFilters.LastWrite`) and debounces 500 ms (single `Timer`, rearmed on each event). It also listens for `Created`/`Renamed` to cover editors that save atomically (temp file + rename). On change → `Reload()`. At most one reload runs at a time (`Interlocked` guard).
- **`Reload()`** (internal, testable without the FSW): `ConfigLoader.Load` → `Validate` → `ApplyConfig`, wrapped in try/catch — any failure (parse error, validation error, IO error) is **logged** and the previous config stays; it never rethrows.
- **`Program.cs`**: `ManagementApi` is registered as a singleton **first**, then started as a hosted service resolving that singleton, so `ConfigReloader` can reach the running instance.

## Behavior changes
- `appsettings.yml` edits to the soft fields are now auto-detected and applied within ~500 ms.
- Non-reloadable fields are explicitly logged as requiring a restart on each successful reload.
- Invalid edits keep the previous config (no disruption).
- No change to default behavior when the file is never edited.

## Validation
- `dotnet build BGPLite.sln -clp:ErrorsOnly` — 0 errors.
- `dotnet test` — 353 passed (343 existing + 10 new), 0 failed.
- `dotnet format BGPLite.sln --severity warn --verify-no-changes` — clean.

New tests in `ConfigHotReloadTests.cs` (logic tested directly, without the `FileSystemWatcher`):
- `ApplyConfig` swaps/removes `TrustedProxies` (XFF now honored from `127.0.0.1`).
- `ApplyConfig` enables/disables the rate limiter.
- `ApplyConfig` enables the concurrency limiter.
- `ApplyConfig` swaps the CORS allowlist.
- `Reload` of a valid config applies `TrustedProxies`.
- `Reload` of malformed YAML logs an error and does not throw (previous config kept).
- `Reload` of a config failing `Validate()` (out-of-range `ApiPort`) logs an error and does not throw.
- `Reload` of a missing file logs an error and does not throw.

## Risk
- Low. The BGP listener, sessions, and route table are untouched. The reload only swaps management-API request-path state via atomic reference swaps; a mid-reload request observes a single consistent limiter/config set. The previous blanket behavior (no reload) is preserved whenever the file is not edited.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added filesystem-based hot-reload for `appsettings.yml` (debounced) while keeping the service running.
  * Supports live updates to trusted proxies, CORS allowlist, and rate/concurrency limiting settings.

* **Bug Fixes**
  * Requests now consistently use the limiter set active at request start during configuration changes.
  * Invalid, failing, or missing config no longer interrupts operation; errors are logged and the last valid configuration remains active.

* **Tests**
  * Added end-to-end hot-reload tests covering swaps and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->