### PR TITLE
fix(api): make ManagementApi.Dispose() idempotent (#141)

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -988,6 +988,10 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         _cts.Cancel();
         _cts.Dispose();
+        // At shutdown no requests are in-flight, so disposing the current limiters is safe
+        // (unlike ApplyConfig mid-flight where we leave old ones for GC per #137's CodeRabbit fix).
+        Volatile.Read(ref _rateLimiter)?.Dispose();
+        Volatile.Read(ref _concurrencyLimiter)?.Dispose();
         _listener?.Close();
     }
 

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -979,14 +979,15 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
     #endregion
 
+    private bool _disposed;
+
     public void Dispose()
     {
+        if (_disposed) return;
+        _disposed = true;
+
         _cts.Cancel();
         _cts.Dispose();
-        // Dispose the limiters currently in effect at shutdown (#136); limiters replaced mid-flight by
-        // ApplyConfig are already disposed there.
-        Volatile.Read(ref _rateLimiter)?.Dispose();
-        Volatile.Read(ref _concurrencyLimiter)?.Dispose();
         _listener?.Close();
     }
 


### PR DESCRIPTION
Closes #141

## Problem
ManagementApi registered as both AddSingleton + AddHostedService (for #136). On shutdown, Dispose() called twice → second _cts.Cancel() → ObjectDisposedException → unhandled crash → Docker restarts container.

## Fix
Guard with _disposed flag (standard IDisposable idempotent pattern). Double-dispose is now a no-op.

## Verification
build 0 errors; 353 tests green; format clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown/cleanup behavior so repeated stop/dispose calls are safe and won’t execute the cleanup logic multiple times.
  * Reduced teardown-related errors by preventing duplicate disposal of internal resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->