### PR TITLE
security(providers): SSRF URL validation + max response size (#144)

### DIFF
--- a/BGPLite.Providers/BGPLite.Providers.csproj
+++ b/BGPLite.Providers/BGPLite.Providers.csproj
@@ -17,4 +17,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="BGPLite.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/BGPLite.Providers/HttpPrefixProvider.cs
+++ b/BGPLite.Providers/HttpPrefixProvider.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Text;
 using BGPLite.Configuration;
 using Microsoft.Extensions.Http;
 using Microsoft.Extensions.Logging;
@@ -9,12 +11,20 @@ namespace BGPLite.Providers;
 /// raw-file URL works — raw.githubusercontent.com, a gist, a pastebin, a self-hosted list, etc.
 /// The URL is fetched as-is. Uses <see cref="IHttpClientFactory"/> so the handler pool is recycled
 /// by the factory (the provider is stateless and safe to hold as a singleton).
+/// <para>SSRF defense (#144): each URL is validated (DNS resolves to a public IP) before fetch,
+/// and the response body is capped at <see cref="MaxResponseBytes"/> to prevent OOM.</para>
 /// </summary>
-public sealed class HttpPrefixProvider(IHttpClientFactory httpFactory, ILogger<HttpPrefixProvider> logger)
+public sealed class HttpPrefixProvider(
+    IHttpClientFactory httpFactory,
+    ILogger<HttpPrefixProvider> logger,
+    Func<string, CancellationToken, ValueTask<IPAddress[]>>? dnsResolver = null)
     : IPrefixSourceProvider
 {
     /// <summary>Named-client key registered with <c>IHttpClientFactory</c>.</summary>
     public const string ClientName = "http";
+
+    /// <summary>Maximum response body size (10 MB) — defends against OOM from huge/malicious files (#144).</summary>
+    internal const int MaxResponseBytes = 10 * 1024 * 1024;
 
     public string Kind => "http";
 
@@ -24,22 +34,46 @@ public sealed class HttpPrefixProvider(IHttpClientFactory httpFactory, ILogger<H
             throw new InvalidOperationException($"Prefix source '{source.Name}': Kind=http requires a Url.");
 
         var url = source.Url;
+
+        // SSRF defense (#144): validate the URL host resolves to a public IP before fetch.
+        var (isValid, error) = await PrefixSourceUrlValidator.ValidateUrlAsync(url, dnsResolver, ct);
+        if (!isValid)
+            throw new InvalidOperationException($"Prefix source '{source.Name}': {error}");
+
         var http = httpFactory.CreateClient(ClientName);
         if (source.Timeout is int seconds && seconds > 0)
             http.Timeout = TimeSpan.FromSeconds(seconds);
         if (source.Headers is { Count: > 0 } headers)
             foreach (var (key, value) in headers)
             {
-                // A per-source User-Agent replaces the named-client default instead of appending a second value.
                 if (key.Equals("User-Agent", StringComparison.OrdinalIgnoreCase))
                     http.DefaultRequestHeaders.Remove(key);
                 if (!http.DefaultRequestHeaders.TryAddWithoutValidation(key, value))
                     logger.LogWarning("Source '{Name}': could not add request header '{Header}'.", source.Name, key);
             }
-        using var response = await http.GetAsync(url, ct);
+
+        // Stream-read with size cap (#144): ResponseHeadersRead gets headers first (fast Content-Length
+        // check), then stream the body with a hard cap to prevent OOM from huge/malicious files.
+        using var response = await http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct);
         response.EnsureSuccessStatusCode();
 
-        var text = await response.Content.ReadAsStringAsync(ct);
+        if (response.Content.Headers.ContentLength is long contentLength && contentLength > MaxResponseBytes)
+            throw new InvalidOperationException(
+                $"Prefix source '{source.Name}': response too large ({contentLength} bytes, max {MaxResponseBytes}).");
+
+        using var stream = await response.Content.ReadAsStreamAsync(ct);
+        using var ms = new MemoryStream();
+        var buffer = new byte[8192];
+        int read;
+        while ((read = await stream.ReadAsync(buffer, ct)) > 0)
+        {
+            ms.Write(buffer, 0, read);
+            if (ms.Length > MaxResponseBytes)
+                throw new InvalidOperationException(
+                    $"Prefix source '{source.Name}': response exceeded {MaxResponseBytes} bytes during stream.");
+        }
+
+        var text = Encoding.UTF8.GetString(ms.GetBuffer(), 0, (int)ms.Length);
         var prefixes = PrefixListParser.Parse(text);
         logger.LogInformation("Source '{Name}' (http): loaded {Count} prefixes from {Url}", source.Name, prefixes.Count, url);
         return prefixes;

--- a/BGPLite.Providers/HttpPrefixProvider.cs
+++ b/BGPLite.Providers/HttpPrefixProvider.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using System.Text;
 using BGPLite.Configuration;
 using Microsoft.Extensions.Http;
@@ -11,16 +10,15 @@ namespace BGPLite.Providers;
 /// raw-file URL works — raw.githubusercontent.com, a gist, a pastebin, a self-hosted list, etc.
 /// The URL is fetched as-is. Uses <see cref="IHttpClientFactory"/> so the handler pool is recycled
 /// by the factory (the provider is stateless and safe to hold as a singleton).
-/// <para>SSRF defense (#144): each URL is validated (DNS resolves to a public IP) before fetch,
-/// and the response body is capped at <see cref="MaxResponseBytes"/> to prevent OOM.</para>
+/// <para>SSRF defense (#144): the named-client's <c>SocketsHttpHandler.ConnectCallback</c> validates
+/// every connection's DNS resolution at the socket level — no TOCTOU race, no redirect bypass.
+/// Response body is capped at <see cref="MaxResponseBytes"/> to prevent OOM.</para>
 /// </summary>
 public sealed class HttpPrefixProvider(
     IHttpClientFactory httpFactory,
-    ILogger<HttpPrefixProvider> logger,
-    Func<string, CancellationToken, ValueTask<IPAddress[]>>? dnsResolver = null)
+    ILogger<HttpPrefixProvider> logger)
     : IPrefixSourceProvider
 {
-    /// <summary>Named-client key registered with <c>IHttpClientFactory</c>.</summary>
     public const string ClientName = "http";
 
     /// <summary>Maximum response body size (10 MB) — defends against OOM from huge/malicious files (#144).</summary>
@@ -34,12 +32,6 @@ public sealed class HttpPrefixProvider(
             throw new InvalidOperationException($"Prefix source '{source.Name}': Kind=http requires a Url.");
 
         var url = source.Url;
-
-        // SSRF defense (#144): validate the URL host resolves to a public IP before fetch.
-        var (isValid, error) = await PrefixSourceUrlValidator.ValidateUrlAsync(url, dnsResolver, ct);
-        if (!isValid)
-            throw new InvalidOperationException($"Prefix source '{source.Name}': {error}");
-
         var http = httpFactory.CreateClient(ClientName);
         if (source.Timeout is int seconds && seconds > 0)
             http.Timeout = TimeSpan.FromSeconds(seconds);
@@ -53,7 +45,8 @@ public sealed class HttpPrefixProvider(
             }
 
         // Stream-read with size cap (#144): ResponseHeadersRead gets headers first (fast Content-Length
-        // check), then stream the body with a hard cap to prevent OOM from huge/malicious files.
+        // check), then stream the body with a hard cap to prevent OOM. SSRF validation is at the
+        // handler level (SocketsHttpHandler.ConnectCallback in Program.cs) — no pre-resolve here.
         using var response = await http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct);
         response.EnsureSuccessStatusCode();
 

--- a/BGPLite.Providers/PrefixSourceUrlValidator.cs
+++ b/BGPLite.Providers/PrefixSourceUrlValidator.cs
@@ -45,7 +45,7 @@ public static class PrefixSourceUrlValidator
     /// then connects to the first valid one. No TOCTOU (the validated IP IS the connected IP).
     /// SocketsHttpHandler does NOT follow redirects (no 302-to-internal-IP bypass).
     /// </summary>
-    internal static async ValueTask<Stream> CreateValidatedConnectionAsync(
+    public static async ValueTask<Stream> CreateValidatedConnectionAsync(
         SocketsHttpConnectionContext context, CancellationToken ct)
     {
         var host = context.DnsEndPoint.Host;

--- a/BGPLite.Providers/PrefixSourceUrlValidator.cs
+++ b/BGPLite.Providers/PrefixSourceUrlValidator.cs
@@ -10,16 +10,20 @@ internal static class PrefixSourceUrlValidator
 {
     private static readonly IPNetwork[] BlockedRanges =
     [
-        IPNetwork.Parse("127.0.0.0/8"),        // loopback
+        IPNetwork.Parse("0.0.0.0/8"),           // unspecified / current-network
         IPNetwork.Parse("10.0.0.0/8"),          // private (RFC 1918)
+        IPNetwork.Parse("100.64.0.0/10"),       // CGNAT (RFC 6598)
+        IPNetwork.Parse("127.0.0.0/8"),         // loopback
+        IPNetwork.Parse("169.254.0.0/16"),      // link-local (incl. cloud metadata 169.254.169.254)
         IPNetwork.Parse("172.16.0.0/12"),       // private (RFC 1918, incl. Docker bridge 172.17.x.x)
         IPNetwork.Parse("192.168.0.0/16"),      // private (RFC 1918)
-        IPNetwork.Parse("169.254.0.0/16"),      // link-local (incl. cloud metadata 169.254.169.254)
-        IPNetwork.Parse("0.0.0.0/8"),           // unspecified / current-network
+        IPNetwork.Parse("198.18.0.0/15"),       // benchmarking (RFC 2544)
+        IPNetwork.Parse("224.0.0.0/4"),         // multicast
+        IPNetwork.Parse("240.0.0.0/4"),         // reserved (future use)
         IPNetwork.Parse("::1/128"),             // IPv6 loopback
+        IPNetwork.Parse("::/128"),              // IPv6 unspecified
         IPNetwork.Parse("fc00::/7"),            // IPv6 unique-local
         IPNetwork.Parse("fe80::/10"),           // IPv6 link-local
-        IPNetwork.Parse("::/128"),              // IPv6 unspecified
     ];
 
     /// <summary>True if the address falls in a blocked (non-public) range.</summary>
@@ -55,7 +59,7 @@ internal static class PrefixSourceUrlValidator
         {
             addresses = await resolver(host, ct);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             return (false, $"DNS resolution failed for '{host}': {ex.Message}");
         }

--- a/BGPLite.Providers/PrefixSourceUrlValidator.cs
+++ b/BGPLite.Providers/PrefixSourceUrlValidator.cs
@@ -1,12 +1,17 @@
 using System.Net;
+using System.Net.Sockets;
 
 namespace BGPLite.Providers;
 
 /// <summary>
-/// SSRF defense for user-supplied prefix-list URLs (#144): validates that a URL's host resolves
-/// to a public IP (not private/loopback/link-local/cloud-metadata) before fetch.
+/// SSRF defense for user-supplied prefix-list URLs (#144). Two layers:
+/// <list type="bullet">
+/// <item><see cref="CreateValidatedConnectionAsync"/> — wired into SocketsHttpHandler.ConnectCallback;
+/// resolves DNS ONCE and validates/connects the same IP (no TOCTOU race, no redirect bypass).</item>
+/// <item><see cref="IsBlockedAddress"/> — pure IP check, reused by the callback and by tests.</item>
+/// </list>
 /// </summary>
-internal static class PrefixSourceUrlValidator
+public static class PrefixSourceUrlValidator
 {
     private static readonly IPNetwork[] BlockedRanges =
     [
@@ -29,7 +34,6 @@ internal static class PrefixSourceUrlValidator
     /// <summary>True if the address falls in a blocked (non-public) range.</summary>
     internal static bool IsBlockedAddress(IPAddress address)
     {
-        // Normalize IPv4-mapped IPv6 (::ffff:x.x.x.x) so IPv4 CIDRs match (CodeRabbit #117 lesson).
         var normalized = address.IsIPv4MappedToIPv6 ? address.MapToIPv4() : address;
         foreach (var range in BlockedRanges)
             if (range.Contains(normalized)) return true;
@@ -37,10 +41,51 @@ internal static class PrefixSourceUrlValidator
     }
 
     /// <summary>
-    /// Validates that a URL is well-formed, uses http/https, and resolves to a public IP.
-    /// Returns (true, null) if safe; (false, reason) if blocked/malformed.
+    /// SocketsHttpHandler.ConnectCallback: resolves DNS, validates ALL resolved IPs are public,
+    /// then connects to the first valid one. No TOCTOU (the validated IP IS the connected IP).
+    /// SocketsHttpHandler does NOT follow redirects (no 302-to-internal-IP bypass).
     /// </summary>
-    /// <param name="dnsResolver">Injectable DNS resolver (for testing); default uses real DNS.</param>
+    internal static async ValueTask<Stream> CreateValidatedConnectionAsync(
+        SocketsHttpConnectionContext context, CancellationToken ct)
+    {
+        var host = context.DnsEndPoint.Host;
+        var port = context.DnsEndPoint.Port;
+
+        IPAddress[] addresses;
+        try
+        {
+            addresses = await Dns.GetHostAddressesAsync(host, ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new InvalidOperationException($"DNS resolution failed for '{host}': {ex.Message}", ex);
+        }
+
+        foreach (var addr in addresses)
+        {
+            if (IsBlockedAddress(addr))
+                throw new InvalidOperationException(
+                    $"SSRF blocked: '{host}' resolves to non-public address {addr}.");
+        }
+
+        var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+        try
+        {
+            await socket.ConnectAsync(addresses[0], port, ct);
+            return new NetworkStream(socket, ownsSocket: true);
+        }
+        catch
+        {
+            socket.Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Validates that a URL is well-formed, uses http/https, and resolves to a public IP.
+    /// For future API-level validation (when a user submits a URL, validate before storing).
+    /// The actual fetch-time defense is <see cref="CreateValidatedConnectionAsync"/>.
+    /// </summary>
     internal static async Task<(bool IsValid, string? Error)> ValidateUrlAsync(
         string url,
         Func<string, CancellationToken, ValueTask<IPAddress[]>>? dnsResolver = null,

--- a/BGPLite.Providers/PrefixSourceUrlValidator.cs
+++ b/BGPLite.Providers/PrefixSourceUrlValidator.cs
@@ -1,0 +1,77 @@
+using System.Net;
+
+namespace BGPLite.Providers;
+
+/// <summary>
+/// SSRF defense for user-supplied prefix-list URLs (#144): validates that a URL's host resolves
+/// to a public IP (not private/loopback/link-local/cloud-metadata) before fetch.
+/// </summary>
+internal static class PrefixSourceUrlValidator
+{
+    private static readonly IPNetwork[] BlockedRanges =
+    [
+        IPNetwork.Parse("127.0.0.0/8"),        // loopback
+        IPNetwork.Parse("10.0.0.0/8"),          // private (RFC 1918)
+        IPNetwork.Parse("172.16.0.0/12"),       // private (RFC 1918, incl. Docker bridge 172.17.x.x)
+        IPNetwork.Parse("192.168.0.0/16"),      // private (RFC 1918)
+        IPNetwork.Parse("169.254.0.0/16"),      // link-local (incl. cloud metadata 169.254.169.254)
+        IPNetwork.Parse("0.0.0.0/8"),           // unspecified / current-network
+        IPNetwork.Parse("::1/128"),             // IPv6 loopback
+        IPNetwork.Parse("fc00::/7"),            // IPv6 unique-local
+        IPNetwork.Parse("fe80::/10"),           // IPv6 link-local
+        IPNetwork.Parse("::/128"),              // IPv6 unspecified
+    ];
+
+    /// <summary>True if the address falls in a blocked (non-public) range.</summary>
+    internal static bool IsBlockedAddress(IPAddress address)
+    {
+        // Normalize IPv4-mapped IPv6 (::ffff:x.x.x.x) so IPv4 CIDRs match (CodeRabbit #117 lesson).
+        var normalized = address.IsIPv4MappedToIPv6 ? address.MapToIPv4() : address;
+        foreach (var range in BlockedRanges)
+            if (range.Contains(normalized)) return true;
+        return false;
+    }
+
+    /// <summary>
+    /// Validates that a URL is well-formed, uses http/https, and resolves to a public IP.
+    /// Returns (true, null) if safe; (false, reason) if blocked/malformed.
+    /// </summary>
+    /// <param name="dnsResolver">Injectable DNS resolver (for testing); default uses real DNS.</param>
+    internal static async Task<(bool IsValid, string? Error)> ValidateUrlAsync(
+        string url,
+        Func<string, CancellationToken, ValueTask<IPAddress[]>>? dnsResolver = null,
+        CancellationToken ct = default)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            return (false, $"Invalid URL: '{url}'.");
+
+        if (uri.Scheme is not ("http" or "https"))
+            return (false, $"URL scheme must be http or https: '{url}'.");
+
+        var host = uri.Host;
+        var resolver = dnsResolver ?? DefaultDnsResolver;
+        IPAddress[] addresses;
+        try
+        {
+            addresses = await resolver(host, ct);
+        }
+        catch (Exception ex)
+        {
+            return (false, $"DNS resolution failed for '{host}': {ex.Message}");
+        }
+
+        if (addresses.Length == 0)
+            return (false, $"DNS returned no addresses for '{host}'.");
+
+        foreach (var addr in addresses)
+        {
+            if (IsBlockedAddress(addr))
+                return (false, $"URL host '{host}' resolves to blocked address {addr} (private/loopback/link-local).");
+        }
+
+        return (true, null);
+    }
+
+    private static async ValueTask<IPAddress[]> DefaultDnsResolver(string host, CancellationToken ct)
+        => await Dns.GetHostAddressesAsync(host, ct);
+}

--- a/BGPLite.Tests/HttpPrefixProviderTests.cs
+++ b/BGPLite.Tests/HttpPrefixProviderTests.cs
@@ -9,10 +9,6 @@ namespace BGPLite.Tests;
 
 public class HttpPrefixProviderTests
 {
-    // Mock DNS resolver for SSRF validation (#144) — returns a public IP so tests don't hit real DNS.
-    private static readonly Func<string, CancellationToken, ValueTask<IPAddress[]>> MockDns =
-        (_, _) => ValueTask.FromResult<IPAddress[]>([IPAddress.Parse("93.184.216.34")]);
-
     private sealed class StubHandler : HttpMessageHandler
     {
         private readonly HttpStatusCode _status;
@@ -70,7 +66,7 @@ public class HttpPrefixProviderTests
     }
 
     private static HttpPrefixProvider Provider(StubHandler handler) =>
-        new(new StubFactory(handler), NullLogger<HttpPrefixProvider>.Instance, MockDns);
+        new(new StubFactory(handler), NullLogger<HttpPrefixProvider>.Instance);
 
     private static PrefixSourceConfig HttpSource(string url) =>
         new() { Name = "t", Kind = "http", Url = url };
@@ -100,7 +96,7 @@ public class HttpPrefixProviderTests
     public async Task AppliesPerSourceTimeout()
     {
         var factory = new StubFactory(new StubHandler(HttpStatusCode.OK, "1.2.3.0/24\n"));
-        var provider = new HttpPrefixProvider(factory, NullLogger<HttpPrefixProvider>.Instance, MockDns);
+        var provider = new HttpPrefixProvider(factory, NullLogger<HttpPrefixProvider>.Instance);
 
         await provider.LoadAsync(new PrefixSourceConfig { Name = "t", Kind = "http", Url = "https://example.com/x.txt", Timeout = 7 });
 
@@ -112,7 +108,7 @@ public class HttpPrefixProviderTests
     public async Task AppliesPerSourceHeaders()
     {
         var factory = new StubFactory(new StubHandler(HttpStatusCode.OK, "1.2.3.0/24\n"));
-        var provider = new HttpPrefixProvider(factory, NullLogger<HttpPrefixProvider>.Instance, MockDns);
+        var provider = new HttpPrefixProvider(factory, NullLogger<HttpPrefixProvider>.Instance);
 
         await provider.LoadAsync(new PrefixSourceConfig
         {
@@ -133,7 +129,7 @@ public class HttpPrefixProviderTests
         // CreateClient returns a fresh HttpClient per call, so per-source headers stay isolated
         // even when many sources are fetched concurrently through the singleton provider.
         var handler = new RecordingHandler();
-        var provider = new HttpPrefixProvider(new StubFactory(handler), NullLogger<HttpPrefixProvider>.Instance, MockDns);
+        var provider = new HttpPrefixProvider(new StubFactory(handler), NullLogger<HttpPrefixProvider>.Instance);
 
         var srcA = new PrefixSourceConfig { Name = "a", Kind = "http", Url = "https://a.example/x.txt", Headers = new() { ["Authorization"] = "Bearer AAA" } };
         var srcB = new PrefixSourceConfig { Name = "b", Kind = "http", Url = "https://b.example/x.txt", Headers = new() { ["Authorization"] = "Bearer BBB" } };
@@ -150,7 +146,7 @@ public class HttpPrefixProviderTests
     public async Task DefaultUserAgent_AppliedWhenNoOverride()
     {
         var handler = new RecordingHandler();
-        var provider = new HttpPrefixProvider(new StubFactory(handler, defaultUserAgent: "BGPLite/1.0"), NullLogger<HttpPrefixProvider>.Instance, MockDns);
+        var provider = new HttpPrefixProvider(new StubFactory(handler, defaultUserAgent: "BGPLite/1.0"), NullLogger<HttpPrefixProvider>.Instance);
 
         await provider.LoadAsync(new PrefixSourceConfig { Name = "t", Kind = "http", Url = "https://x.example/y.txt" });
 
@@ -161,7 +157,7 @@ public class HttpPrefixProviderTests
     public async Task PerSourceUserAgent_OverridesDefault()
     {
         var handler = new RecordingHandler();
-        var provider = new HttpPrefixProvider(new StubFactory(handler, defaultUserAgent: "BGPLite/1.0"), NullLogger<HttpPrefixProvider>.Instance, MockDns);
+        var provider = new HttpPrefixProvider(new StubFactory(handler, defaultUserAgent: "BGPLite/1.0"), NullLogger<HttpPrefixProvider>.Instance);
 
         await provider.LoadAsync(new PrefixSourceConfig
         {

--- a/BGPLite.Tests/HttpPrefixProviderTests.cs
+++ b/BGPLite.Tests/HttpPrefixProviderTests.cs
@@ -9,6 +9,10 @@ namespace BGPLite.Tests;
 
 public class HttpPrefixProviderTests
 {
+    // Mock DNS resolver for SSRF validation (#144) — returns a public IP so tests don't hit real DNS.
+    private static readonly Func<string, CancellationToken, ValueTask<IPAddress[]>> MockDns =
+        (_, _) => ValueTask.FromResult<IPAddress[]>([IPAddress.Parse("93.184.216.34")]);
+
     private sealed class StubHandler : HttpMessageHandler
     {
         private readonly HttpStatusCode _status;
@@ -66,7 +70,7 @@ public class HttpPrefixProviderTests
     }
 
     private static HttpPrefixProvider Provider(StubHandler handler) =>
-        new(new StubFactory(handler), NullLogger<HttpPrefixProvider>.Instance);
+        new(new StubFactory(handler), NullLogger<HttpPrefixProvider>.Instance, MockDns);
 
     private static PrefixSourceConfig HttpSource(string url) =>
         new() { Name = "t", Kind = "http", Url = url };
@@ -96,7 +100,7 @@ public class HttpPrefixProviderTests
     public async Task AppliesPerSourceTimeout()
     {
         var factory = new StubFactory(new StubHandler(HttpStatusCode.OK, "1.2.3.0/24\n"));
-        var provider = new HttpPrefixProvider(factory, NullLogger<HttpPrefixProvider>.Instance);
+        var provider = new HttpPrefixProvider(factory, NullLogger<HttpPrefixProvider>.Instance, MockDns);
 
         await provider.LoadAsync(new PrefixSourceConfig { Name = "t", Kind = "http", Url = "https://example.com/x.txt", Timeout = 7 });
 
@@ -108,7 +112,7 @@ public class HttpPrefixProviderTests
     public async Task AppliesPerSourceHeaders()
     {
         var factory = new StubFactory(new StubHandler(HttpStatusCode.OK, "1.2.3.0/24\n"));
-        var provider = new HttpPrefixProvider(factory, NullLogger<HttpPrefixProvider>.Instance);
+        var provider = new HttpPrefixProvider(factory, NullLogger<HttpPrefixProvider>.Instance, MockDns);
 
         await provider.LoadAsync(new PrefixSourceConfig
         {
@@ -129,7 +133,7 @@ public class HttpPrefixProviderTests
         // CreateClient returns a fresh HttpClient per call, so per-source headers stay isolated
         // even when many sources are fetched concurrently through the singleton provider.
         var handler = new RecordingHandler();
-        var provider = new HttpPrefixProvider(new StubFactory(handler), NullLogger<HttpPrefixProvider>.Instance);
+        var provider = new HttpPrefixProvider(new StubFactory(handler), NullLogger<HttpPrefixProvider>.Instance, MockDns);
 
         var srcA = new PrefixSourceConfig { Name = "a", Kind = "http", Url = "https://a.example/x.txt", Headers = new() { ["Authorization"] = "Bearer AAA" } };
         var srcB = new PrefixSourceConfig { Name = "b", Kind = "http", Url = "https://b.example/x.txt", Headers = new() { ["Authorization"] = "Bearer BBB" } };
@@ -146,7 +150,7 @@ public class HttpPrefixProviderTests
     public async Task DefaultUserAgent_AppliedWhenNoOverride()
     {
         var handler = new RecordingHandler();
-        var provider = new HttpPrefixProvider(new StubFactory(handler, defaultUserAgent: "BGPLite/1.0"), NullLogger<HttpPrefixProvider>.Instance);
+        var provider = new HttpPrefixProvider(new StubFactory(handler, defaultUserAgent: "BGPLite/1.0"), NullLogger<HttpPrefixProvider>.Instance, MockDns);
 
         await provider.LoadAsync(new PrefixSourceConfig { Name = "t", Kind = "http", Url = "https://x.example/y.txt" });
 
@@ -157,7 +161,7 @@ public class HttpPrefixProviderTests
     public async Task PerSourceUserAgent_OverridesDefault()
     {
         var handler = new RecordingHandler();
-        var provider = new HttpPrefixProvider(new StubFactory(handler, defaultUserAgent: "BGPLite/1.0"), NullLogger<HttpPrefixProvider>.Instance);
+        var provider = new HttpPrefixProvider(new StubFactory(handler, defaultUserAgent: "BGPLite/1.0"), NullLogger<HttpPrefixProvider>.Instance, MockDns);
 
         await provider.LoadAsync(new PrefixSourceConfig
         {

--- a/BGPLite.Tests/PrefixSourceUrlValidatorTests.cs
+++ b/BGPLite.Tests/PrefixSourceUrlValidatorTests.cs
@@ -17,6 +17,10 @@ public class PrefixSourceUrlValidatorTests
     [InlineData("169.254.169.254")]  // cloud metadata
     [InlineData("0.0.0.0")]          // unspecified
     [InlineData("::1")]              // IPv6 loopback
+    [InlineData("100.64.0.1")]      // CGNAT (RFC 6598)
+    [InlineData("198.18.0.1")]      // benchmarking
+    [InlineData("224.0.0.1")]       // multicast
+    [InlineData("240.0.0.1")]       // reserved
     [InlineData("fc00::1")]          // IPv6 unique-local
     [InlineData("fe80::1")]          // IPv6 link-local
     public void IsBlockedAddress_Rejects_Internal(string ip)

--- a/BGPLite.Tests/PrefixSourceUrlValidatorTests.cs
+++ b/BGPLite.Tests/PrefixSourceUrlValidatorTests.cs
@@ -1,0 +1,86 @@
+using System.Net;
+using BGPLite.Providers;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// Tests for <see cref="PrefixSourceUrlValidator"/> (#144): SSRF defense — validates that URLs
+/// resolve to public IPs (not private/loopback/link-local/cloud-metadata).
+/// </summary>
+public class PrefixSourceUrlValidatorTests
+{
+    [Theory]
+    [InlineData("127.0.0.1")]        // loopback
+    [InlineData("10.0.0.1")]         // private (RFC 1918)
+    [InlineData("172.17.0.1")]       // private (Docker bridge!)
+    [InlineData("192.168.1.1")]      // private
+    [InlineData("169.254.169.254")]  // cloud metadata
+    [InlineData("0.0.0.0")]          // unspecified
+    [InlineData("::1")]              // IPv6 loopback
+    [InlineData("fc00::1")]          // IPv6 unique-local
+    [InlineData("fe80::1")]          // IPv6 link-local
+    public void IsBlockedAddress_Rejects_Internal(string ip)
+        => Assert.True(PrefixSourceUrlValidator.IsBlockedAddress(IPAddress.Parse(ip)));
+
+    [Theory]
+    [InlineData("93.184.216.34")]  // example.com
+    [InlineData("8.8.8.8")]        // Google DNS
+    [InlineData("1.1.1.1")]        // Cloudflare DNS
+    [InlineData("45.148.244.55")]  // BGPLite peer
+    public void IsBlockedAddress_Accepts_Public(string ip)
+        => Assert.False(PrefixSourceUrlValidator.IsBlockedAddress(IPAddress.Parse(ip)));
+
+    [Fact]
+    public void IsBlockedAddress_Normalizes_IPv4Mapped_IPv6()
+    {
+        var mapped = IPAddress.Parse("::ffff:127.0.0.1");
+        Assert.True(PrefixSourceUrlValidator.IsBlockedAddress(mapped));
+    }
+
+    [Fact]
+    public async Task ValidateUrlAsync_Rejects_Loopback()
+    {
+        var (isValid, error) = await PrefixSourceUrlValidator.ValidateUrlAsync(
+            "http://localhost/api/secret",
+            (_, _) => ValueTask.FromResult<IPAddress[]>([IPAddress.Loopback]));
+        Assert.False(isValid);
+        Assert.Contains("blocked", error);
+    }
+
+    [Fact]
+    public async Task ValidateUrlAsync_Rejects_CloudMetadata()
+    {
+        var (isValid, error) = await PrefixSourceUrlValidator.ValidateUrlAsync(
+            "http://169.254.169.254/latest/meta-data/",
+            (_, _) => ValueTask.FromResult<IPAddress[]>([IPAddress.Parse("169.254.169.254")]));
+        Assert.False(isValid);
+        Assert.Contains("blocked", error);
+    }
+
+    [Fact]
+    public async Task ValidateUrlAsync_Accepts_PublicHost()
+    {
+        var (isValid, error) = await PrefixSourceUrlValidator.ValidateUrlAsync(
+            "https://example.com/list.txt",
+            (_, _) => ValueTask.FromResult<IPAddress[]>([IPAddress.Parse("93.184.216.34")]));
+        Assert.True(isValid);
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public async Task ValidateUrlAsync_Rejects_NonHttpScheme()
+    {
+        var (isValid, error) = await PrefixSourceUrlValidator.ValidateUrlAsync(
+            "ftp://example.com/list.txt");
+        Assert.False(isValid);
+        Assert.Contains("scheme", error);
+    }
+
+    [Fact]
+    public async Task ValidateUrlAsync_Rejects_MalformedUrl()
+    {
+        var (isValid, error) = await PrefixSourceUrlValidator.ValidateUrlAsync("not-a-url");
+        Assert.False(isValid);
+        Assert.Contains("Invalid URL", error);
+    }
+}

--- a/BGPLite/Program.cs
+++ b/BGPLite/Program.cs
@@ -82,9 +82,11 @@ builder.Services.AddHttpClient(HttpPrefixProvider.ClientName, c =>
     c.Timeout = TimeSpan.FromSeconds(30);
     c.DefaultRequestHeaders.UserAgent.ParseAdd("BGPLite/1.0");
 })
-.ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+.ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
 {
-    AllowAutoRedirect = false // SSRF defense (#144): prevent redirect-based bypass of URL validation
+    // SSRF defense (#144): validate DNS resolution at the socket level — no TOCTOU race, no
+    // redirect bypass (SocketsHttpHandler does not follow redirects, unlike HttpClientHandler).
+    ConnectCallback = PrefixSourceUrlValidator.CreateValidatedConnectionAsync
 });
 builder.Services.AddSingleton<HttpPrefixProvider>();
 builder.Services.AddSingleton<FilePrefixProvider>();

--- a/BGPLite/Program.cs
+++ b/BGPLite/Program.cs
@@ -81,6 +81,10 @@ builder.Services.AddHttpClient(HttpPrefixProvider.ClientName, c =>
 {
     c.Timeout = TimeSpan.FromSeconds(30);
     c.DefaultRequestHeaders.UserAgent.ParseAdd("BGPLite/1.0");
+})
+.ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+{
+    AllowAutoRedirect = false // SSRF defense (#144): prevent redirect-based bypass of URL validation
 });
 builder.Services.AddSingleton<HttpPrefixProvider>();
 builder.Services.AddSingleton<FilePrefixProvider>();


### PR DESCRIPTION
Closes #144

## What
Prerequisite for #143 (user-supplied prefix-list URLs). Two defenses:
1. **SSRF validation** — `PrefixSourceUrlValidator`: DNS-resolves the URL host, rejects if any IP is in a blocked range (private/loopback/link-local/cloud-metadata/IPv6-ULA).
2. **Max response size** — `HttpPrefixProvider`: streams with 10MB cap (ResponseHeadersRead + manual size check) instead of ReadAsStringAsync (which loaded the entire body).

## Verification
build 0 errors; **372 tests** (+19 `PrefixSourceUrlValidatorTests`); format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safer URL validation for user-provided prefix-list sources, reducing exposure to internal/private network targets.
* **Bug Fixes**
  * Improved prefix download robustness by enforcing a maximum response size and using streaming reads instead of loading entire responses into memory.
  * Tightened HTTP handling to validate response headers and prevent oversized payloads.
* **Tests**
  * Added comprehensive coverage for SSRF protections and URL validation scenarios, including edge IP ranges and scheme/format errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->