### PR TITLE
feat(api): PeerCustomSource entity + PeerStore CRUD + REST API (#146)

### DIFF
--- a/BGPLite.Api/BgpDbContext.cs
+++ b/BGPLite.Api/BgpDbContext.cs
@@ -25,9 +25,6 @@ public class BgpDbContext : DbContext
             "Url TEXT NOT NULL, Community TEXT, " +
             "Active INTEGER NOT NULL DEFAULT 0, " +
             "FOREIGN KEY (PeerId) REFERENCES Peers(Id) ON DELETE CASCADE)");
-        db.Database.ExecuteSqlRaw(
-            "CREATE UNIQUE INDEX IF NOT EXISTS UX_PeerCustomSources_PeerId_Name " +
-            "ON PeerCustomSources (PeerId, Name);");
 
         // Peer identity is (Ip, Asn), not Ip alone, so several peers behind one source IP (distinct
         // AS) can coexist as separate rows (issue #19). EnsureCreated does not evolve an existing
@@ -87,7 +84,6 @@ public class BgpDbContext : DbContext
         {
             e.ToTable("PeerCustomSources");
             e.HasKey(c => c.Id);
-            e.HasIndex(c => new { c.PeerId, c.Name }).IsUnique().HasDatabaseName("UX_PeerCustomSources_PeerId_Name");
             e.HasOne(c => c.Peer).WithMany(p => p.CustomSources)
                 .HasForeignKey(c => c.PeerId).OnDelete(DeleteBehavior.Cascade);
         });

--- a/BGPLite.Api/BgpDbContext.cs
+++ b/BGPLite.Api/BgpDbContext.cs
@@ -18,6 +18,13 @@ public class BgpDbContext : DbContext
             "PRIMARY KEY (PeerId, Asn), " +
             "FOREIGN KEY (PeerId) REFERENCES Peers(Id) ON DELETE CASCADE)");
 
+        db.Database.ExecuteSqlRaw(
+            "CREATE TABLE IF NOT EXISTS PeerCustomSources (" +
+            "PeerId TEXT NOT NULL, Name TEXT NOT NULL, " +
+            "Url TEXT NOT NULL, Community TEXT, " +
+            "PRIMARY KEY (PeerId, Name), " +
+            "FOREIGN KEY (PeerId) REFERENCES Peers(Id) ON DELETE CASCADE)");
+
         // Peer identity is (Ip, Asn), not Ip alone, so several peers behind one source IP (distinct
         // AS) can coexist as separate rows (issue #19). EnsureCreated does not evolve an existing
         // schema, so migrate the index idempotently: drop the legacy Ip-only unique index and create
@@ -69,6 +76,14 @@ public class BgpDbContext : DbContext
             e.ToTable("PeerCustomAsns");
             e.HasKey(c => new { c.PeerId, c.Asn });
             e.HasOne(c => c.Peer).WithMany(p => p.CustomAsns)
+                .HasForeignKey(c => c.PeerId).OnDelete(DeleteBehavior.Cascade);
+        });
+
+        model.Entity<PeerCustomSource>(e =>
+        {
+            e.ToTable("PeerCustomSources");
+            e.HasKey(c => new { c.PeerId, c.Name });
+            e.HasOne(c => c.Peer).WithMany(p => p.CustomSources)
                 .HasForeignKey(c => c.PeerId).OnDelete(DeleteBehavior.Cascade);
         });
     }

--- a/BGPLite.Api/BgpDbContext.cs
+++ b/BGPLite.Api/BgpDbContext.cs
@@ -20,10 +20,14 @@ public class BgpDbContext : DbContext
 
         db.Database.ExecuteSqlRaw(
             "CREATE TABLE IF NOT EXISTS PeerCustomSources (" +
+            "Id TEXT NOT NULL PRIMARY KEY, " +
             "PeerId TEXT NOT NULL, Name TEXT NOT NULL, " +
             "Url TEXT NOT NULL, Community TEXT, " +
-            "PRIMARY KEY (PeerId, Name), " +
+            "Active INTEGER NOT NULL DEFAULT 0, " +
             "FOREIGN KEY (PeerId) REFERENCES Peers(Id) ON DELETE CASCADE)");
+        db.Database.ExecuteSqlRaw(
+            "CREATE UNIQUE INDEX IF NOT EXISTS UX_PeerCustomSources_PeerId_Name " +
+            "ON PeerCustomSources (PeerId, Name);");
 
         // Peer identity is (Ip, Asn), not Ip alone, so several peers behind one source IP (distinct
         // AS) can coexist as separate rows (issue #19). EnsureCreated does not evolve an existing
@@ -82,7 +86,8 @@ public class BgpDbContext : DbContext
         model.Entity<PeerCustomSource>(e =>
         {
             e.ToTable("PeerCustomSources");
-            e.HasKey(c => new { c.PeerId, c.Name });
+            e.HasKey(c => c.Id);
+            e.HasIndex(c => new { c.PeerId, c.Name }).IsUnique().HasDatabaseName("UX_PeerCustomSources_PeerId_Name");
             e.HasOne(c => c.Peer).WithMany(p => p.CustomSources)
                 .HasForeignKey(c => c.PeerId).OnDelete(DeleteBehavior.Cascade);
         });

--- a/BGPLite.Api/Entities/Peer.cs
+++ b/BGPLite.Api/Entities/Peer.cs
@@ -14,4 +14,5 @@ public class Peer
     public List<PeerSubscription> Subscriptions { get; set; } = [];
     public List<PeerCustomPrefix> CustomPrefixes { get; set; } = [];
     public List<PeerCustomAsn> CustomAsns { get; set; } = [];
+    public List<PeerCustomSource> CustomSources { get; set; } = [];
 }

--- a/BGPLite.Api/Entities/PeerCustomSource.cs
+++ b/BGPLite.Api/Entities/PeerCustomSource.cs
@@ -7,10 +7,14 @@ namespace BGPLite.Api.Entities;
 /// </summary>
 public class PeerCustomSource
 {
+    public string Id { get; set; } = Guid.NewGuid().ToString();
     public string PeerId { get; set; } = "";
     public string Name { get; set; } = "";
     public string Url { get; set; } = "";
     public string? Community { get; set; }
+    /// <summary>If false (default), the source is stored but NOT fetched at send time (paused).
+    /// User must explicitly activate via PATCH. DELETE removes permanently.</summary>
+    public bool Active { get; set; } = false;
 
     public Peer Peer { get; set; } = null!;
 }

--- a/BGPLite.Api/Entities/PeerCustomSource.cs
+++ b/BGPLite.Api/Entities/PeerCustomSource.cs
@@ -1,0 +1,16 @@
+namespace BGPLite.Api.Entities;
+
+/// <summary>
+/// A user-supplied URL-based prefix-list source for a peer (#143). The URL points to a CIDR-per-line
+/// file; BGPLite fetches it at send time (SendAllRoutesAsync) via HttpPrefixProvider and advertises
+/// the prefixes to this peer only. Stored as-is (not parsed at API time).
+/// </summary>
+public class PeerCustomSource
+{
+    public string PeerId { get; set; } = "";
+    public string Name { get; set; } = "";
+    public string Url { get; set; } = "";
+    public string? Community { get; set; }
+
+    public Peer Peer { get; set; } = null!;
+}

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -265,6 +265,19 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (segments.Length == 4 && segments[0] == "api" && segments[1] == "peers" && segments[3] == "prefixes" && method == "GET")
             return await HandleExportPrefixes(segments[2], ctx);
 
+        // /api/peers/{id}/sources — GET (list), POST (add) (#143)
+        if (segments.Length == 4 && segments[0] == "api" && segments[1] == "peers" && segments[3] == "sources")
+        {
+            if (method == "GET")
+                return HandleGetSources(segments[2]);
+            if (method == "POST")
+                return await HandleAddSource(segments[2], ctx);
+        }
+
+        // /api/peers/{id}/sources/{name} — DELETE (#143)
+        if (segments.Length == 5 && segments[0] == "api" && segments[1] == "peers" && segments[3] == "sources" && method == "DELETE")
+            return HandleDeleteSource(segments[2], segments[4]);
+
         // /api/asn-lists
         if (IsGet(method, segments, "api", "asn-lists"))
             return await HandleGetAsnListsAsync();
@@ -466,6 +479,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         var subscriptions = _store.GetSubscriptions(peer.Id);
         var customPrefixes = _store.GetCustomPrefixes(peer.Id);
         var customAsns = _store.GetCustomAsns(peer.Id);
+        var customSources = _store.GetCustomSources(peer.Id);
         var communities = _store.GetCommunitiesByIp(peer.Ip);
 
         return ApiResponse.Ok(new
@@ -480,6 +494,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
             lists = subscriptions,
             customPrefixes,
             customAsns,
+            customSources = customSources.Select(s => new { name = s.Name, url = s.Url, community = s.Community }),
             communities = communities.Select(CommunityCodec.Format),
             allRoutes = communities.Count == 0
         });
@@ -546,6 +561,60 @@ public sealed class ManagementApi : IHostedService, IDisposable
         _store.DeletePeer(peerId);
         _logger.LogInformation("Deleted peer {Id} ({Ip})", SanitizeForLog(peerId), peer.Ip);
         return ApiResponse.Ok(new { id = peerId, deleted = true });
+    }
+
+    #endregion
+
+    #region /api/peers/{id}/sources (#143)
+
+    private ApiResponse HandleGetSources(string peerId)
+    {
+        if (_store.GetDbPeerById(peerId) is null)
+            return ApiResponse.Error("Peer not found", 404);
+
+        var sources = _store.GetCustomSources(peerId);
+        return ApiResponse.Ok(sources.Select(s => new { name = s.Name, url = s.Url, community = s.Community }));
+    }
+
+    private async Task<ApiResponse> HandleAddSource(string peerId, HttpListenerContext ctx)
+    {
+        if (_store.GetDbPeerById(peerId) is null)
+            return ApiResponse.Error("Peer not found", 404);
+
+        using var reader = new StreamReader(ctx.Request.InputStream, Encoding.UTF8);
+        var body = await reader.ReadToEndAsync();
+        var data = JsonSerializer.Deserialize<AddSourceRequest>(body, _jsonOpts);
+
+        if (data is null || string.IsNullOrWhiteSpace(data.Name) || string.IsNullOrWhiteSpace(data.Url))
+            return ApiResponse.Error("Name and Url are required", 400);
+
+        if (!Uri.TryCreate(data.Url, UriKind.Absolute, out var uri) || uri.Scheme is not ("http" or "https"))
+            return ApiResponse.Error($"Invalid URL: {data.Url}", 400);
+
+        try
+        {
+            _store.AddCustomSource(peerId, data.Name, data.Url, data.Community);
+        }
+        catch (InvalidOperationException)
+        {
+            return ApiResponse.Error($"A source named '{data.Name}' already exists", 409);
+        }
+
+        _logger.LogInformation("Added source '{Name}' ({Url}) to peer {PeerId}",
+            SanitizeForLog(data.Name), SanitizeForLog(data.Url), SanitizeForLog(peerId));
+        return ApiResponse.Ok(new { name = data.Name, url = data.Url, community = data.Community });
+    }
+
+    private ApiResponse HandleDeleteSource(string peerId, string name)
+    {
+        if (_store.GetDbPeerById(peerId) is null)
+            return ApiResponse.Error("Peer not found", 404);
+
+        if (!_store.DeleteCustomSource(peerId, name))
+            return ApiResponse.Error($"Source '{name}' not found", 404);
+
+        _logger.LogInformation("Deleted source '{Name}' from peer {PeerId}", SanitizeForLog(name), SanitizeForLog(peerId));
+        return ApiResponse.Ok(new { name, deleted = true });
     }
 
     #endregion
@@ -997,6 +1066,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
     private record CreatePeerRequest(string Ip, uint Asn, string? Description, [property: JsonPropertyName("lists")] List<string>? AsnLists, List<string>? CustomPrefixes, List<uint>? CustomAsns);
     private record UpdatePeerRequest(string? Description, [property: JsonPropertyName("lists")] List<string>? Lists, List<string>? CustomPrefixes, List<uint>? CustomAsns);
+    private record AddSourceRequest(string Name, string Url, string? Community);
 
     private record ApiResponse(object? Body, int StatusCode = 200)
     {

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -274,9 +274,14 @@ public sealed class ManagementApi : IHostedService, IDisposable
                 return await HandleAddSource(segments[2], ctx);
         }
 
-        // /api/peers/{id}/sources/{name} — DELETE (#143)
-        if (segments.Length == 5 && segments[0] == "api" && segments[1] == "peers" && segments[3] == "sources" && method == "DELETE")
-            return HandleDeleteSource(segments[2], segments[4]);
+        // /api/peers/{id}/sources/{sourceId} — DELETE / PATCH (#143)
+        if (segments.Length == 5 && segments[0] == "api" && segments[1] == "peers" && segments[3] == "sources")
+        {
+            if (method == "DELETE")
+                return HandleDeleteSource(segments[2], segments[4]);
+            if (method == "PATCH")
+                return await HandlePatchSource(segments[2], segments[4], ctx);
+        }
 
         // /api/asn-lists
         if (IsGet(method, segments, "api", "asn-lists"))
@@ -494,7 +499,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
             lists = subscriptions,
             customPrefixes,
             customAsns,
-            customSources = customSources.Select(s => new { name = s.Name, url = s.Url, community = s.Community }),
+            customSources = customSources.Select(s => new { id = s.Id, name = s.Name, url = s.Url, community = s.Community, active = s.Active }),
             communities = communities.Select(CommunityCodec.Format),
             allRoutes = communities.Count == 0
         });
@@ -573,7 +578,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
             return ApiResponse.Error("Peer not found", 404);
 
         var sources = _store.GetCustomSources(peerId);
-        return ApiResponse.Ok(sources.Select(s => new { name = s.Name, url = s.Url, community = s.Community }));
+        return ApiResponse.Ok(sources.Select(s => new { id = s.Id, name = s.Name, url = s.Url, community = s.Community, active = s.Active }));
     }
 
     private async Task<ApiResponse> HandleAddSource(string peerId, HttpListenerContext ctx)
@@ -591,9 +596,10 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (!Uri.TryCreate(data.Url, UriKind.Absolute, out var uri) || uri.Scheme is not ("http" or "https"))
             return ApiResponse.Error($"Invalid URL: {data.Url}", 400);
 
+        PeerCustomSource source;
         try
         {
-            _store.AddCustomSource(peerId, data.Name, data.Url, data.Community);
+            source = _store.AddCustomSource(peerId, data.Name, data.Url, data.Community);
         }
         catch (InvalidOperationException)
         {
@@ -602,19 +608,38 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         _logger.LogInformation("Added source '{Name}' ({Url}) to peer {PeerId}",
             SanitizeForLog(data.Name), SanitizeForLog(data.Url), SanitizeForLog(peerId));
-        return ApiResponse.Ok(new { name = data.Name, url = data.Url, community = data.Community });
+        return ApiResponse.Ok(new { id = source.Id, name = source.Name, url = source.Url, community = source.Community, active = source.Active });
     }
 
-    private ApiResponse HandleDeleteSource(string peerId, string name)
+    private ApiResponse HandleDeleteSource(string peerId, string sourceId)
     {
         if (_store.GetDbPeerById(peerId) is null)
             return ApiResponse.Error("Peer not found", 404);
 
-        if (!_store.DeleteCustomSource(peerId, name))
-            return ApiResponse.Error($"Source '{name}' not found", 404);
+        if (!_store.DeleteCustomSource(sourceId))
+            return ApiResponse.Error($"Source '{sourceId}' not found", 404);
 
-        _logger.LogInformation("Deleted source '{Name}' from peer {PeerId}", SanitizeForLog(name), SanitizeForLog(peerId));
-        return ApiResponse.Ok(new { name, deleted = true });
+        _logger.LogInformation("Deleted source {SourceId} from peer {PeerId}", SanitizeForLog(sourceId), SanitizeForLog(peerId));
+        return ApiResponse.Ok(new { id = sourceId, deleted = true });
+    }
+
+    private async Task<ApiResponse> HandlePatchSource(string peerId, string sourceId, HttpListenerContext ctx)
+    {
+        if (_store.GetDbPeerById(peerId) is null)
+            return ApiResponse.Error("Peer not found", 404);
+
+        using var reader = new StreamReader(ctx.Request.InputStream, Encoding.UTF8);
+        var body = await reader.ReadToEndAsync();
+        var data = JsonSerializer.Deserialize<PatchSourceRequest>(body, _jsonOpts);
+
+        if (data is null || data.Active is null)
+            return ApiResponse.Error("PATCH body must contain { \"active\": true/false }", 400);
+
+        if (!_store.SetSourceActive(sourceId, data.Active.Value))
+            return ApiResponse.Error($"Source '{sourceId}' not found", 404);
+
+        _logger.LogInformation("Source {SourceId} active={Active}", SanitizeForLog(sourceId), data.Active.Value);
+        return ApiResponse.Ok(new { id = sourceId, active = data.Active.Value });
     }
 
     #endregion
@@ -1067,6 +1092,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
     private record CreatePeerRequest(string Ip, uint Asn, string? Description, [property: JsonPropertyName("lists")] List<string>? AsnLists, List<string>? CustomPrefixes, List<uint>? CustomAsns);
     private record UpdatePeerRequest(string? Description, [property: JsonPropertyName("lists")] List<string>? Lists, List<string>? CustomPrefixes, List<uint>? CustomAsns);
     private record AddSourceRequest(string Name, string Url, string? Community);
+    private record PatchSourceRequest([property: JsonPropertyName("active")] bool? Active);
 
     private record ApiResponse(object? Body, int StatusCode = 200)
     {

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -616,7 +616,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (_store.GetDbPeerById(peerId) is null)
             return ApiResponse.Error("Peer not found", 404);
 
-        if (!_store.DeleteCustomSource(sourceId))
+        if (!_store.DeleteCustomSource(peerId, sourceId))
             return ApiResponse.Error($"Source '{sourceId}' not found", 404);
 
         _logger.LogInformation("Deleted source {SourceId} from peer {PeerId}", SanitizeForLog(sourceId), SanitizeForLog(peerId));
@@ -635,7 +635,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (data is null || data.Active is null)
             return ApiResponse.Error("PATCH body must contain { \"active\": true/false }", 400);
 
-        if (!_store.SetSourceActive(sourceId, data.Active.Value))
+        if (!_store.SetSourceActive(peerId, sourceId, data.Active.Value))
             return ApiResponse.Error($"Source '{sourceId}' not found", 404);
 
         _logger.LogInformation("Source {SourceId} active={Active}", SanitizeForLog(sourceId), data.Active.Value);

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -596,15 +596,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (!Uri.TryCreate(data.Url, UriKind.Absolute, out var uri) || uri.Scheme is not ("http" or "https"))
             return ApiResponse.Error($"Invalid URL: {data.Url}", 400);
 
-        PeerCustomSource source;
-        try
-        {
-            source = _store.AddCustomSource(peerId, data.Name, data.Url, data.Community);
-        }
-        catch (InvalidOperationException)
-        {
-            return ApiResponse.Error($"A source named '{data.Name}' already exists", 409);
-        }
+        var source = _store.AddCustomSource(peerId, data.Name, data.Url, data.Community);
 
         _logger.LogInformation("Added source '{Name}' ({Url}) to peer {PeerId}",
             SanitizeForLog(data.Name), SanitizeForLog(data.Url), SanitizeForLog(peerId));

--- a/BGPLite.Api/PeerStore.cs
+++ b/BGPLite.Api/PeerStore.cs
@@ -256,31 +256,43 @@ public sealed class PeerStore : IPeerStore
             .ToList();
     }
 
-    /// <summary>Adds a URL-based prefix-list source to a peer. Throws if the name already exists.</summary>
-    public void AddCustomSource(string peerId, string name, string url, string? community)
+    /// <summary>Adds a URL-based prefix-list source to a peer. Returns the created entity (with Id).</summary>
+    public PeerCustomSource AddCustomSource(string peerId, string name, string url, string? community)
     {
         using var db = _dbFactory.CreateDbContext();
         if (db.Set<PeerCustomSource>().Any(c => c.PeerId == peerId && c.Name == name))
             throw new InvalidOperationException($"A source named '{name}' already exists for this peer.");
 
-        db.Set<PeerCustomSource>().Add(new PeerCustomSource
+        var source = new PeerCustomSource
         {
             PeerId = peerId,
             Name = name,
             Url = url,
             Community = community
-        });
+        };
+        db.Set<PeerCustomSource>().Add(source);
         db.SaveChanges();
+        return source;
     }
 
-    /// <summary>Removes a URL-based source by name. Returns true if found and removed.</summary>
-    public bool DeleteCustomSource(string peerId, string name)
+    /// <summary>Removes a URL-based source by its Id. Returns true if found and removed.</summary>
+    public bool DeleteCustomSource(string sourceId)
     {
         using var db = _dbFactory.CreateDbContext();
         var deleted = db.Set<PeerCustomSource>()
-            .Where(c => c.PeerId == peerId && c.Name == name)
+            .Where(c => c.Id == sourceId)
             .ExecuteDelete();
         return deleted > 0;
+    }
+
+    /// <summary>Toggles a source's active state (pause/resume without deleting).</summary>
+    public bool SetSourceActive(string sourceId, bool active)
+    {
+        using var db = _dbFactory.CreateDbContext();
+        var updated = db.Set<PeerCustomSource>()
+            .Where(c => c.Id == sourceId)
+            .ExecuteUpdate(s => s.SetProperty(c => c.Active, active));
+        return updated > 0;
     }
 
     private static PeerInfo MapToInfo(Peer peer) => new()

--- a/BGPLite.Api/PeerStore.cs
+++ b/BGPLite.Api/PeerStore.cs
@@ -260,9 +260,6 @@ public sealed class PeerStore : IPeerStore
     public PeerCustomSource AddCustomSource(string peerId, string name, string url, string? community)
     {
         using var db = _dbFactory.CreateDbContext();
-        if (db.Set<PeerCustomSource>().Any(c => c.PeerId == peerId && c.Name == name))
-            throw new InvalidOperationException($"A source named '{name}' already exists for this peer.");
-
         var source = new PeerCustomSource
         {
             PeerId = peerId,

--- a/BGPLite.Api/PeerStore.cs
+++ b/BGPLite.Api/PeerStore.cs
@@ -275,22 +275,22 @@ public sealed class PeerStore : IPeerStore
         return source;
     }
 
-    /// <summary>Removes a URL-based source by its Id. Returns true if found and removed.</summary>
-    public bool DeleteCustomSource(string sourceId)
+    /// <summary>Removes a URL-based source by its Id, scoped to a peer. Returns true if found and removed.</summary>
+    public bool DeleteCustomSource(string peerId, string sourceId)
     {
         using var db = _dbFactory.CreateDbContext();
         var deleted = db.Set<PeerCustomSource>()
-            .Where(c => c.Id == sourceId)
+            .Where(c => c.Id == sourceId && c.PeerId == peerId)
             .ExecuteDelete();
         return deleted > 0;
     }
 
-    /// <summary>Toggles a source's active state (pause/resume without deleting).</summary>
-    public bool SetSourceActive(string sourceId, bool active)
+    /// <summary>Toggles a source's active state, scoped to a peer. Returns true if found and updated.</summary>
+    public bool SetSourceActive(string peerId, string sourceId, bool active)
     {
         using var db = _dbFactory.CreateDbContext();
         var updated = db.Set<PeerCustomSource>()
-            .Where(c => c.Id == sourceId)
+            .Where(c => c.Id == sourceId && c.PeerId == peerId)
             .ExecuteUpdate(s => s.SetProperty(c => c.Active, active));
         return updated > 0;
     }

--- a/BGPLite.Api/PeerStore.cs
+++ b/BGPLite.Api/PeerStore.cs
@@ -244,6 +244,45 @@ public sealed class PeerStore : IPeerStore
         db.SaveChanges();
     }
 
+    /// <summary>
+    /// Lists all user-supplied URL-based prefix-list sources for a peer (#143). Sources are stored as
+    /// URLs (not parsed); fetched at send time in SendAllRoutesAsync.
+    /// </summary>
+    public List<PeerCustomSource> GetCustomSources(string peerId)
+    {
+        using var db = _dbFactory.CreateDbContext();
+        return db.Set<PeerCustomSource>().AsNoTracking()
+            .Where(c => c.PeerId == peerId)
+            .ToList();
+    }
+
+    /// <summary>Adds a URL-based prefix-list source to a peer. Throws if the name already exists.</summary>
+    public void AddCustomSource(string peerId, string name, string url, string? community)
+    {
+        using var db = _dbFactory.CreateDbContext();
+        if (db.Set<PeerCustomSource>().Any(c => c.PeerId == peerId && c.Name == name))
+            throw new InvalidOperationException($"A source named '{name}' already exists for this peer.");
+
+        db.Set<PeerCustomSource>().Add(new PeerCustomSource
+        {
+            PeerId = peerId,
+            Name = name,
+            Url = url,
+            Community = community
+        });
+        db.SaveChanges();
+    }
+
+    /// <summary>Removes a URL-based source by name. Returns true if found and removed.</summary>
+    public bool DeleteCustomSource(string peerId, string name)
+    {
+        using var db = _dbFactory.CreateDbContext();
+        var deleted = db.Set<PeerCustomSource>()
+            .Where(c => c.PeerId == peerId && c.Name == name)
+            .ExecuteDelete();
+        return deleted > 0;
+    }
+
     private static PeerInfo MapToInfo(Peer peer) => new()
     {
         Id = peer.Id,

--- a/BGPLite.Tests/PeerCustomSourceTests.cs
+++ b/BGPLite.Tests/PeerCustomSourceTests.cs
@@ -1,0 +1,144 @@
+using BGPLite.Api;
+using BGPLite.Api.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// Tests for PeerCustomSource (#143-1 / #146): URL-based prefix-list sources per peer.
+/// Mirrors the PeerStoreKeyingTests pattern (real in-memory SQLite).
+/// </summary>
+public class PeerCustomSourceTests
+{
+    private const string TestIp = "203.0.113.10";
+
+    private static (PeerStore store, SqliteConnection connection) NewStore()
+    {
+        var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        var options = new DbContextOptionsBuilder<BgpDbContext>()
+            .UseSqlite(connection)
+            .Options;
+        using (var boot = new BgpDbContext(options))
+            BgpDbContext.Initialize(boot);
+
+        return (new PeerStore(new StaticOptionsFactory(options)), connection);
+    }
+
+    private sealed class StaticOptionsFactory : IDbContextFactory<BgpDbContext>
+    {
+        private readonly DbContextOptions<BgpDbContext> _options;
+        public StaticOptionsFactory(DbContextOptions<BgpDbContext> options) => _options = options;
+        public BgpDbContext CreateDbContext() => new(_options);
+    }
+
+    [Fact]
+    public void AddCustomSource_Adds_And_GetCustomSources_Returns_It()
+    {
+        var (store, conn) = NewStore();
+        using var _ = conn;
+        var peerId = store.CreatePeer(TestIp, 65001, null);
+
+        store.AddCustomSource(peerId, "my-list", "https://example.com/list.txt", "65444:501");
+
+        var sources = store.GetCustomSources(peerId);
+        var source = Assert.Single(sources);
+        Assert.Equal("my-list", source.Name);
+        Assert.Equal("https://example.com/list.txt", source.Url);
+        Assert.Equal("65444:501", source.Community);
+    }
+
+    [Fact]
+    public void AddCustomSource_DuplicateName_Throws()
+    {
+        var (store, conn) = NewStore();
+        using var _ = conn;
+        var peerId = store.CreatePeer(TestIp, 65001, null);
+
+        store.AddCustomSource(peerId, "list-a", "https://a.com/list.txt", null);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            store.AddCustomSource(peerId, "list-a", "https://b.com/other.txt", null));
+    }
+
+    [Fact]
+    public void AddCustomSource_SameName_DifferentPeer_OK()
+    {
+        var (store, conn) = NewStore();
+        using var _ = conn;
+        var idA = store.CreatePeer(TestIp, 65001, null);
+        var idB = store.CreatePeer("203.0.113.11", 65002, null);
+
+        store.AddCustomSource(idA, "shared-name", "https://a.com/list.txt", null);
+        store.AddCustomSource(idB, "shared-name", "https://b.com/list.txt", null);
+
+        Assert.Single(store.GetCustomSources(idA));
+        Assert.Single(store.GetCustomSources(idB));
+    }
+
+    [Fact]
+    public void DeleteCustomSource_Removes_Only_That_Source()
+    {
+        var (store, conn) = NewStore();
+        using var _ = conn;
+        var peerId = store.CreatePeer(TestIp, 65001, null);
+
+        store.AddCustomSource(peerId, "list-a", "https://a.com/list.txt", "65444:501");
+        store.AddCustomSource(peerId, "list-b", "https://b.com/list.txt", null);
+
+        var deleted = store.DeleteCustomSource(peerId, "list-a");
+        Assert.True(deleted);
+
+        var remaining = store.GetCustomSources(peerId);
+        var source = Assert.Single(remaining);
+        Assert.Equal("list-b", source.Name);
+    }
+
+    [Fact]
+    public void DeleteCustomSource_NotFound_Returns_False()
+    {
+        var (store, conn) = NewStore();
+        using var _ = conn;
+        var peerId = store.CreatePeer(TestIp, 65001, null);
+
+        Assert.False(store.DeleteCustomSource(peerId, "nonexistent"));
+    }
+
+    [Fact]
+    public void DeletePeer_Cascades_Sources()
+    {
+        var (store, conn) = NewStore();
+        using var _ = conn;
+        var peerId = store.CreatePeer(TestIp, 65001, null);
+
+        store.AddCustomSource(peerId, "list-a", "https://a.com/list.txt", null);
+        store.AddCustomSource(peerId, "list-b", "https://b.com/list.txt", null);
+
+        store.DeletePeer(peerId);
+
+        Assert.Empty(store.GetCustomSources(peerId));
+    }
+
+    [Fact]
+    public void GetCustomSources_Empty_For_NewPeer()
+    {
+        var (store, conn) = NewStore();
+        using var _ = conn;
+        var peerId = store.CreatePeer(TestIp, 65001, null);
+
+        Assert.Empty(store.GetCustomSources(peerId));
+    }
+
+    [Fact]
+    public void Community_Is_Optional_Null()
+    {
+        var (store, conn) = NewStore();
+        using var _ = conn;
+        var peerId = store.CreatePeer(TestIp, 65001, null);
+
+        store.AddCustomSource(peerId, "no-comm", "https://example.com/list.txt", null);
+
+        var source = Assert.Single(store.GetCustomSources(peerId));
+        Assert.Null(source.Community);
+    }
+}

--- a/BGPLite.Tests/PeerCustomSourceTests.cs
+++ b/BGPLite.Tests/PeerCustomSourceTests.cs
@@ -89,7 +89,7 @@ public class PeerCustomSourceTests
         var sourceA = store.AddCustomSource(peerId, "list-a", "https://a.com/list.txt", "65444:501");
         store.AddCustomSource(peerId, "list-b", "https://b.com/list.txt", null);
 
-        var deleted = store.DeleteCustomSource(sourceA.Id);
+        var deleted = store.DeleteCustomSource(peerId, sourceA.Id);
         Assert.True(deleted);
 
         var remaining = store.GetCustomSources(peerId);
@@ -104,7 +104,7 @@ public class PeerCustomSourceTests
         using var _ = conn;
         var peerId = store.CreatePeer(TestIp, 65001, null);
 
-        Assert.False(store.DeleteCustomSource("nonexistent-id"));
+        Assert.False(store.DeleteCustomSource(peerId, "nonexistent-id"));
     }
 
     [Fact]
@@ -167,11 +167,11 @@ public class PeerCustomSourceTests
         var source = store.AddCustomSource(peerId, "toggle", "https://example.com/list.txt", null);
         Assert.False(source.Active);
 
-        Assert.True(store.SetSourceActive(source.Id, true));
+        Assert.True(store.SetSourceActive(peerId, source.Id, true));
         var fetched = Assert.Single(store.GetCustomSources(peerId));
         Assert.True(fetched.Active);
 
-        Assert.True(store.SetSourceActive(source.Id, false));
+        Assert.True(store.SetSourceActive(peerId, source.Id, false));
         fetched = Assert.Single(store.GetCustomSources(peerId));
         Assert.False(fetched.Active);
     }
@@ -181,7 +181,39 @@ public class PeerCustomSourceTests
     {
         var (store, conn) = NewStore();
         using var _ = conn;
+        var peerId = store.CreatePeer(TestIp, 65001, null);
 
-        Assert.False(store.SetSourceActive("nonexistent", true));
+        Assert.False(store.SetSourceActive(peerId, "nonexistent", true));
+    }
+
+    [Fact]
+    public void DeleteCustomSource_CrossPeer_Returns_False()
+    {
+        var (store, conn) = NewStore();
+        using var _ = conn;
+        var idA = store.CreatePeer(TestIp, 65001, null);
+        var idB = store.CreatePeer("203.0.113.11", 65002, null);
+
+        var source = store.AddCustomSource(idA, "list-a", "https://a.com/list.txt", null);
+
+        // Peer B tries to delete Peer A's source — must fail (peer-scoped).
+        Assert.False(store.DeleteCustomSource(idB, source.Id));
+        Assert.Single(store.GetCustomSources(idA)); // source still exists for A
+    }
+
+    [Fact]
+    public void SetSourceActive_CrossPeer_Returns_False()
+    {
+        var (store, conn) = NewStore();
+        using var _ = conn;
+        var idA = store.CreatePeer(TestIp, 65001, null);
+        var idB = store.CreatePeer("203.0.113.11", 65002, null);
+
+        var source = store.AddCustomSource(idA, "list-a", "https://a.com/list.txt", null);
+
+        // Peer B tries to toggle Peer A's source — must fail.
+        Assert.False(store.SetSourceActive(idB, source.Id, true));
+        var fetched = Assert.Single(store.GetCustomSources(idA));
+        Assert.False(fetched.Active); // unchanged
     }
 }

--- a/BGPLite.Tests/PeerCustomSourceTests.cs
+++ b/BGPLite.Tests/PeerCustomSourceTests.cs
@@ -1,5 +1,6 @@
 using BGPLite.Api;
 using BGPLite.Api.Entities;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 
 namespace BGPLite.Tests;
@@ -39,13 +40,15 @@ public class PeerCustomSourceTests
         using var _ = conn;
         var peerId = store.CreatePeer(TestIp, 65001, null);
 
-        store.AddCustomSource(peerId, "my-list", "https://example.com/list.txt", "65444:501");
+        var source = store.AddCustomSource(peerId, "my-list", "https://example.com/list.txt", "65444:501");
 
+        Assert.NotEmpty(source.Id);
         var sources = store.GetCustomSources(peerId);
-        var source = Assert.Single(sources);
-        Assert.Equal("my-list", source.Name);
-        Assert.Equal("https://example.com/list.txt", source.Url);
-        Assert.Equal("65444:501", source.Community);
+        var fetched = Assert.Single(sources);
+        Assert.Equal(source.Id, fetched.Id);
+        Assert.Equal("my-list", fetched.Name);
+        Assert.Equal("https://example.com/list.txt", fetched.Url);
+        Assert.Equal("65444:501", fetched.Community);
     }
 
     [Fact]
@@ -77,16 +80,16 @@ public class PeerCustomSourceTests
     }
 
     [Fact]
-    public void DeleteCustomSource_Removes_Only_That_Source()
+    public void DeleteCustomSource_BySourceId_Removes_Only_That_Source()
     {
         var (store, conn) = NewStore();
         using var _ = conn;
         var peerId = store.CreatePeer(TestIp, 65001, null);
 
-        store.AddCustomSource(peerId, "list-a", "https://a.com/list.txt", "65444:501");
+        var sourceA = store.AddCustomSource(peerId, "list-a", "https://a.com/list.txt", "65444:501");
         store.AddCustomSource(peerId, "list-b", "https://b.com/list.txt", null);
 
-        var deleted = store.DeleteCustomSource(peerId, "list-a");
+        var deleted = store.DeleteCustomSource(sourceA.Id);
         Assert.True(deleted);
 
         var remaining = store.GetCustomSources(peerId);
@@ -101,7 +104,7 @@ public class PeerCustomSourceTests
         using var _ = conn;
         var peerId = store.CreatePeer(TestIp, 65001, null);
 
-        Assert.False(store.DeleteCustomSource(peerId, "nonexistent"));
+        Assert.False(store.DeleteCustomSource("nonexistent-id"));
     }
 
     [Fact]
@@ -140,5 +143,45 @@ public class PeerCustomSourceTests
 
         var source = Assert.Single(store.GetCustomSources(peerId));
         Assert.Null(source.Community);
+    }
+
+    [Fact]
+    public void NewSource_Is_Inactive_ByDefault()
+    {
+        var (store, conn) = NewStore();
+        using var _ = conn;
+        var peerId = store.CreatePeer(TestIp, 65001, null);
+
+        var source = store.AddCustomSource(peerId, "paused", "https://example.com/list.txt", null);
+
+        Assert.False(source.Active, "new source must default to inactive (user explicitly activates)");
+    }
+
+    [Fact]
+    public void SetSourceActive_Toggles_State()
+    {
+        var (store, conn) = NewStore();
+        using var _ = conn;
+        var peerId = store.CreatePeer(TestIp, 65001, null);
+
+        var source = store.AddCustomSource(peerId, "toggle", "https://example.com/list.txt", null);
+        Assert.False(source.Active);
+
+        Assert.True(store.SetSourceActive(source.Id, true));
+        var fetched = Assert.Single(store.GetCustomSources(peerId));
+        Assert.True(fetched.Active);
+
+        Assert.True(store.SetSourceActive(source.Id, false));
+        fetched = Assert.Single(store.GetCustomSources(peerId));
+        Assert.False(fetched.Active);
+    }
+
+    [Fact]
+    public void SetSourceActive_NotFound_Returns_False()
+    {
+        var (store, conn) = NewStore();
+        using var _ = conn;
+
+        Assert.False(store.SetSourceActive("nonexistent", true));
     }
 }

--- a/BGPLite.Tests/PeerCustomSourceTests.cs
+++ b/BGPLite.Tests/PeerCustomSourceTests.cs
@@ -52,31 +52,18 @@ public class PeerCustomSourceTests
     }
 
     [Fact]
-    public void AddCustomSource_DuplicateName_Throws()
+    public void AddCustomSource_SameName_SamePeer_OK()
     {
+        // Name is just a label, not a unique key — duplicates are allowed (different Ids).
         var (store, conn) = NewStore();
         using var _ = conn;
         var peerId = store.CreatePeer(TestIp, 65001, null);
 
-        store.AddCustomSource(peerId, "list-a", "https://a.com/list.txt", null);
+        var a = store.AddCustomSource(peerId, "my-list", "https://a.com/list.txt", null);
+        var b = store.AddCustomSource(peerId, "my-list", "https://b.com/other.txt", null);
 
-        Assert.Throws<InvalidOperationException>(() =>
-            store.AddCustomSource(peerId, "list-a", "https://b.com/other.txt", null));
-    }
-
-    [Fact]
-    public void AddCustomSource_SameName_DifferentPeer_OK()
-    {
-        var (store, conn) = NewStore();
-        using var _ = conn;
-        var idA = store.CreatePeer(TestIp, 65001, null);
-        var idB = store.CreatePeer("203.0.113.11", 65002, null);
-
-        store.AddCustomSource(idA, "shared-name", "https://a.com/list.txt", null);
-        store.AddCustomSource(idB, "shared-name", "https://b.com/list.txt", null);
-
-        Assert.Single(store.GetCustomSources(idA));
-        Assert.Single(store.GetCustomSources(idB));
+        Assert.NotEqual(a.Id, b.Id);
+        Assert.Equal(2, store.GetCustomSources(peerId).Count);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #146

Part of #143 (epic). Data + API layer for user-supplied URL prefix-list sources.

## What
- **Entity**: `PeerCustomSource` (PeerId, Name, Url, Community?) — mirrors PeerCustomPrefix.
- **PeerStore**: GetCustomSources, AddCustomSource (throws on dup name), DeleteCustomSource.
- **REST API**: `GET/POST /api/peers/{id}/sources` + `DELETE /api/peers/{id}/sources/{name}`.
- `GET /api/peers/{id}` response now includes `customSources`.

## Design
- Sources are **URLs stored as-is** — NOT parsed at API time. Fetched in SendAllRoutesAsync (#147).
- SSRF defense (#144, ConnectCallback) applies at fetch time.
- By **Peer ID**, not IP (unambiguous, consistent with existing `/api/peers/{id}` pattern).
- Independent REST endpoints (not in-body like CustomPrefixes) — sources have independent CRUD lifecycle.

## Verification
build 0 errors; **384 tests** (+8 PeerCustomSourceTests: add/get/delete, dup name, same name diff peer, cascade, empty, optional community); format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-peer custom source management under `/api/peers/{id}/sources` (GET list, POST add) and `/api/peers/{id}/sources/{sourceId}` (DELETE remove, PATCH toggle active).
  * Peer responses now include `customSources` (id, name, url, community, active), with source URLs validated as absolute `http/https` and active defaulting to inactive.
* **Bug Fixes**
  * Delete and active-state updates are correctly scoped to the matching peer + source id.
* **Tests**
  * Added in-memory EF Core tests covering listing, optional community, inactive default, toggling, not-found behavior, cross-peer isolation, and cascade deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->