### PR TITLE
feat(server): fetch and advertise per-peer user URL sources (#147)

### DIFF
--- a/BGPLite.Api/PeerStore.cs
+++ b/BGPLite.Api/PeerStore.cs
@@ -115,7 +115,7 @@ public sealed class PeerStore : IPeerStore
             .Include(p => p.Subscriptions)
             .Include(p => p.CustomPrefixes)
             .Include(p => p.CustomAsns)
-            .Include(p => p.CustomSources)
+            .Include(p => p.CustomSources.Where(c => c.Active))
             .FirstOrDefault(p => p.Ip == ip && p.Asn == asn);
         if (peer is null) return null;
 
@@ -131,8 +131,9 @@ public sealed class PeerStore : IPeerStore
             peer.Subscriptions.Select(s => s.AsnListName).ToList(),
             peer.CustomPrefixes.Select(c => c.Prefix + "/" + c.PrefixLength).ToList(),
             peer.CustomAsns.Select(c => c.Asn).ToList(),
-            // Only Active user sources are advertised (issue #147); paused ones never leave the DB.
-            peer.CustomSources.Where(c => c.Active)
+            // Only Active user sources are advertised (issue #147); the filtered Include above
+            // already excluded paused rows at the SQL level.
+            peer.CustomSources
                 .Select(c => new CustomSourceView(c.Name, c.Url, c.Community))
                 .ToList());
     }

--- a/BGPLite.Api/PeerStore.cs
+++ b/BGPLite.Api/PeerStore.cs
@@ -102,7 +102,7 @@ public sealed class PeerStore : IPeerStore
     /// Single-roundtrip replacement for the <c>GetPeer</c> + <c>UpdateSessionStatus</c> +
     /// <c>GetSubscriptions</c> + <c>GetCustomPrefixes</c> + <c>GetCustomAsns</c> sequence the BGP
     /// send path used to issue as FIVE separate <c>DbContext</c>s (issue #84). Loads the peer by
-    /// <c>(Ip, Asn)</c> with the three routing-relevant child collections <c>Include</c>'d in ONE
+    /// <c>(Ip, Asn)</c> with the four routing-relevant child collections <c>Include</c>'d in ONE
     /// <c>AsNoTracking</c> query (read-only intent, consistent with the other getters), then folds
     /// the "session active" status write into the SAME <c>DbContext</c> via <c>ExecuteUpdate</c> —
     /// so the whole read+update is one connection (six statements on five connections → two
@@ -115,6 +115,7 @@ public sealed class PeerStore : IPeerStore
             .Include(p => p.Subscriptions)
             .Include(p => p.CustomPrefixes)
             .Include(p => p.CustomAsns)
+            .Include(p => p.CustomSources)
             .FirstOrDefault(p => p.Ip == ip && p.Asn == asn);
         if (peer is null) return null;
 
@@ -129,7 +130,11 @@ public sealed class PeerStore : IPeerStore
             peer.Id,
             peer.Subscriptions.Select(s => s.AsnListName).ToList(),
             peer.CustomPrefixes.Select(c => c.Prefix + "/" + c.PrefixLength).ToList(),
-            peer.CustomAsns.Select(c => c.Asn).ToList());
+            peer.CustomAsns.Select(c => c.Asn).ToList(),
+            // Only Active user sources are advertised (issue #147); paused ones never leave the DB.
+            peer.CustomSources.Where(c => c.Active)
+                .Select(c => new CustomSourceView(c.Name, c.Url, c.Community))
+                .ToList());
     }
 
     public void SetDescription(string id, string description)

--- a/BGPLite.Configuration/IPrefixService.cs
+++ b/BGPLite.Configuration/IPrefixService.cs
@@ -13,5 +13,13 @@ public interface IPrefixService
     Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default);
     Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default);
     Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default);
+    /// <summary>
+    /// Fetches a per-peer user-supplied URL prefix-list source (epic #143 / issue #147). Unlike
+    /// <see cref="GetSourcePrefixesAsync"/> (named, config-keyed, cache-through), this loads an
+    /// arbitrary URL directly via the http provider — the URL is peer-supplied, not in
+    /// <c>AppConfig.PrefixSources</c>, so it is not name-resolvable and not cached. SSRF defense
+    /// (#144) is inherited from the http named client's <c>ConnectCallback</c>.
+    /// </summary>
+    Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default);
     Task WarmUpAsync(CancellationToken ct = default);
 }

--- a/BGPLite.Providers/HttpPrefixProvider.cs
+++ b/BGPLite.Providers/HttpPrefixProvider.cs
@@ -68,7 +68,9 @@ public sealed class HttpPrefixProvider(
 
         var text = Encoding.UTF8.GetString(ms.GetBuffer(), 0, (int)ms.Length);
         var prefixes = PrefixListParser.Parse(text);
-        logger.LogInformation("Source '{Name}' (http): loaded {Count} prefixes from {Url}", source.Name, prefixes.Count, url);
+        // Log only the source Name (the operator/peer-supplied identifier), never the URL — peer URLs
+        // (#147) may carry tokens in the query string that must not reach application logs.
+        logger.LogInformation("Source '{Name}' (http): loaded {Count} prefixes", source.Name, prefixes.Count);
         return prefixes;
     }
 }

--- a/BGPLite.Providers/PrefixService.cs
+++ b/BGPLite.Providers/PrefixService.cs
@@ -8,15 +8,36 @@ public sealed class PrefixService : IPrefixService
     private readonly RipeStatProvider? _ripeStat;
     private readonly IPrefixSourceService _prefixSources;
     private readonly AppConfig _config;
+    private readonly HttpPrefixProvider? _httpProvider;
     private readonly ConcurrentDictionary<uint, (IReadOnlyList<(uint Prefix, byte Length)> Data, DateTime CachedAt)> _cache = new();
     private readonly TimeSpan _cacheTtl;
 
-    public PrefixService(AppConfig config, RipeStatProvider? ripeStat, IPrefixSourceService prefixSources, TimeSpan? cacheTtl = null)
+    public PrefixService(AppConfig config, RipeStatProvider? ripeStat, IPrefixSourceService prefixSources, HttpPrefixProvider? httpProvider = null, TimeSpan? cacheTtl = null)
     {
         _config = config;
         _ripeStat = ripeStat;
         _prefixSources = prefixSources;
+        _httpProvider = httpProvider;
         _cacheTtl = cacheTtl ?? TimeSpan.FromHours(1);
+    }
+
+    /// <summary>
+    /// Fetches a per-peer user-supplied URL prefix-list source (issue #147). The URL is peer-supplied
+    /// (not in <c>AppConfig.PrefixSources</c>), so it bypasses the name-keyed cache and loads directly
+    /// through the http provider — inheriting SSRF defense (#144: validated <c>ConnectCallback</c>,
+    /// no redirect-following, 10 MB cap). Returns empty when no http provider is wired.
+    /// </summary>
+    public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
+    {
+        if (_httpProvider is null) return [];
+        var source = new PrefixSourceConfig
+        {
+            Kind = "http",
+            Name = name,
+            Url = url,
+            Community = community
+        };
+        return await _httpProvider.LoadAsync(source, ct);
     }
 
     public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)

--- a/BGPLite.Routing/ICommunityResolver.cs
+++ b/BGPLite.Routing/ICommunityResolver.cs
@@ -13,6 +13,16 @@ public enum CommunitySourceKind
     Custom,
     /// <summary>Per-peer custom AS-originated prefixes (static community <c>&lt;Asn&gt;:200</c>, overridable via config).</summary>
     CustomAsn,
+    /// <summary>
+    /// Per-peer user-supplied URL prefix-list source (epic #143 / issue #147). The community is the
+    /// source's explicit <c>Community</c> if set; otherwise it is auto-generated as
+    /// <c>&lt;LocalAsn&gt;:(500 + FNV-1a(Name) % 100)</c> — a deterministic value in the 500–599 range so
+    /// it survives restarts (receiving peers' filters stay stable). Sources sharing a <c>Name</c> share a
+    /// community by design (community tags a source CATEGORY, not a row); set <c>Community</c> explicitly
+    /// for distinct tags. With no explicit community and a 4-byte local ASN (&gt; 65535) the routes are
+    /// untagged, matching <see cref="Custom"/>/<see cref="CustomAsn"/>.
+    /// </summary>
+    UserSource,
     /// <summary>Fallback / default source when nothing else applies.</summary>
     Default
 }
@@ -21,9 +31,12 @@ public enum CommunitySourceKind
 /// Identifies where a prefix came from so a community can be resolved for it.
 /// <c>ListName</c> carries the list/source name for <see cref="CommunitySourceKind.AsnList"/>,
 /// <see cref="CommunitySourceKind.Country"/>, <see cref="CommunitySourceKind.PrefixSource"/>
-/// (and the default-source name for <see cref="CommunitySourceKind.Default"/>).
+/// (and the default-source name for <see cref="CommunitySourceKind.Default"/>), and the source name
+/// (the auto-generation hash seed) for <see cref="CommunitySourceKind.UserSource"/>.
+/// <c>Community</c> carries an explicit <c>"ASN:VALUE"</c> override for
+/// <see cref="CommunitySourceKind.UserSource"/> (null = auto-generate).
 /// </summary>
-public sealed record CommunitySource(CommunitySourceKind Kind, string? ListName = null);
+public sealed record CommunitySource(CommunitySourceKind Kind, string? ListName = null, string? Community = null);
 
 /// <summary>
 /// Resolves the BGP community/communities to attach to prefixes that came from a given source.

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -588,8 +588,10 @@ public sealed class BgpSession : IDisposable
                 var customPrefixes = peer.CustomPrefixes;
                 var customAsns = peer.CustomAsns;
 
-                // Unconfigured peer — send RU defaults
-                if (subscriptionIds.Count == 0 && customPrefixes.Count == 0 && customAsns.Count == 0)
+                // Unconfigured peer — send RU defaults. A peer whose only configuration is active
+                // user URL sources (issue #147) is NOT unconfigured — it must not fall through to RU.
+                if (subscriptionIds.Count == 0 && customPrefixes.Count == 0 && customAsns.Count == 0
+                    && peer.UserSources.Count == 0)
                 {
                     _logger.LogInformation("Unconfigured peer {Peer}, sending RU defaults", _peer);
                     try
@@ -725,6 +727,16 @@ public sealed class BgpSession : IDisposable
                     {
                         _logger.LogError(ex, "Failed to fetch custom AS prefixes for {Peer}", _peer);
                     }
+                }
+
+                // Per-peer user URL sources (#143/#147): each Active source is fetched through the
+                // prefix service (http provider → SSRF defense #144) and stamped with its resolved
+                // UserSource community. One failing URL does not drop the peer's other sources
+                // (per-source try/catch, like the CustomAsns block above); OCE propagates (#114).
+                foreach (var source in peer.UserSources)
+                {
+                    await AddUserSourceRoutesAsync(
+                        routes, source, nextHop, _prefixService!, _communityResolver, _logger, _peer, _cts.Token);
                 }
 
                 _logger.LogInformation("Sending {Count} total routes to {Peer}", routes.Count, _peer);
@@ -1036,6 +1048,41 @@ public sealed class BgpSession : IDisposable
         routes.GroupBy(r => (r.Communities, r.LargeCommunities), CommunitySetPairComparer.Instance)
               .Select(g => g.ToList())
               .ToList();
+
+    /// <summary>
+    /// Fetches one per-peer user URL source (issue #147) and appends its prefixes to
+    /// <paramref name="routes"/>, stamped with the resolved <see cref="CommunitySourceKind.UserSource"/>
+    /// community. Fetched through <paramref name="prefixService"/> (http provider → SSRF defense #144).
+    /// One failing URL only logs and continues — it must not drop the peer's other sources (per-source
+    /// try/catch, like the CustomAsns block); <see cref="OperationCanceledException"/> is NOT caught
+    /// (session cancellation must propagate, #114). Internal so the per-source fetch-and-stamp is
+    /// unit-testable without a live session.
+    /// </summary>
+    internal static async Task AddUserSourceRoutesAsync(
+        List<Route> routes,
+        CustomSourceView source,
+        uint nextHop,
+        IPrefixService prefixService,
+        ICommunityResolver communityResolver,
+        ILogger logger,
+        string peerLabel,
+        CancellationToken ct)
+    {
+        try
+        {
+            var comms = communityResolver.Resolve(
+                new CommunitySource(CommunitySourceKind.UserSource, source.Name, source.Community));
+            var prefixes = await prefixService.GetUserSourcePrefixesAsync(source.Name, source.Url, source.Community, ct);
+            foreach (var (prefix, length) in prefixes)
+                routes.Add(MakeRoute(prefix, length, nextHop, null, comms));
+            logger.LogInformation("Peer {Peer} user-source {Source} -> {Count} prefixes",
+                peerLabel, source.Name, prefixes.Count);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogError(ex, "Failed to fetch user-source {Source} for {Peer}", source.Name, peerLabel);
+        }
+    }
 
     /// <summary>
     /// Builds a <see cref="Route"/> carrying the given regular and large community sets.

--- a/BGPLite.Server/ConfigCommunityResolver.cs
+++ b/BGPLite.Server/ConfigCommunityResolver.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using BGPLite.Configuration;
 using BGPLite.Protocol;
 using BGPLite.Routing;
@@ -23,11 +24,14 @@ public sealed class ConfigCommunityResolver : ICommunityResolver
     // Static communities for the per-peer custom categories, resolved once in the ctor.
     private readonly uint[] _customPrefixComms;
     private readonly uint[] _customAsnComms;
+    // Local ASN, captured for UserSource auto-generation (<Asn>:5XX).
+    private readonly uint _asn;
 
     public ConfigCommunityResolver(AppConfig config, BgpConfig bgpConfig, ILogger<ConfigCommunityResolver>? logger = null)
     {
         _config = config;
         _logger = logger;
+        _asn = bgpConfig.Asn;
         _customPrefixComms = ResolveStaticCommunity(config.CustomPrefixCommunity, bgpConfig.Asn, 100, nameof(config.CustomPrefixCommunity));
         _customAsnComms = ResolveStaticCommunity(config.CustomAsnCommunity, bgpConfig.Asn, 200, nameof(config.CustomAsnCommunity));
     }
@@ -39,10 +43,35 @@ public sealed class ConfigCommunityResolver : ICommunityResolver
         CommunitySourceKind.PrefixSource => ParseOrDefault(FindPrefixSourceCommunity(source.ListName ?? _config.DefaultPrefixSource)),
         CommunitySourceKind.Custom => _customPrefixComms,
         CommunitySourceKind.CustomAsn => _customAsnComms,
+        // User-supplied URL source (#143/#147): explicit Community overrides; otherwise auto-gen from
+        // the reserved 500-599 range via a deterministic FNV-1a hash of the source name (stable across
+        // restarts). Reuses ResolveStaticCommunity so an invalid explicit value falls back to the
+        // auto-gen default and asn>0xFFFF yields Empty — identical semantics to Custom/CustomAsn.
+        CommunitySourceKind.UserSource => ResolveStaticCommunity(
+            source.Community, _asn, 500 + (int)(StableHash(source.ListName ?? "") % 100), "user-source community"),
         _ => Empty, // Default
     };
 
     private uint[] ParseOrDefault(string? raw) => string.IsNullOrWhiteSpace(raw) ? Empty : ParseCached(raw!);
+
+    /// <summary>
+    /// Deterministic 32-bit FNV-1a hash over the UTF-8 bytes of <paramref name="s"/>. Required because
+    /// <see cref="string.GetHashCode()"/> is randomized per-process, which would make auto-generated
+    /// user-source communities drift across restarts and silently break receiving peers' filters.
+    /// </summary>
+    private static uint StableHash(string s)
+    {
+        unchecked
+        {
+            uint hash = 2166136261u;
+            foreach (var b in Encoding.UTF8.GetBytes(s))
+            {
+                hash ^= b;
+                hash *= 16777619u;
+            }
+            return hash;
+        }
+    }
 
     private string? FindAsnListCommunity(string? name) =>
         name is null ? null : _config.RipeStat?.AsnLists.FirstOrDefault(l => l.Name == name)?.Community;

--- a/BGPLite.Server/IPeerStore.cs
+++ b/BGPLite.Server/IPeerStore.cs
@@ -20,13 +20,13 @@ public interface IPeerStore
 
     /// <summary>
     /// Loads a peer by its durable identity <c>(Ip, Asn)</c> together with the routing-relevant
-    /// child data (<see cref="Subscriptions"/>, <see cref="CustomPrefixes"/>, <see cref="CustomAsns"/>)
-    /// in a SINGLE query, and folds the "session active" status update (Status="active",
-    /// LastSessionAt=now) into the SAME DbContext — so the BGP send path does one read+write
-    /// roundtrip instead of the five separate <c>GetPeer</c>/<c>UpdateSessionStatus</c>/
-    /// <c>GetSubscriptions</c>/<c>GetCustomPrefixes</c>/<c>GetCustomAsns</c> calls it used to make
-    /// (issue #84). Returns <c>null</c> when the peer is unknown (the caller then auto-registers).
-    /// The collection shapes match the standalone getters exactly (no behavior change).
+    /// child data (<see cref="PeerRoutingView.Subscriptions"/>, <see cref="PeerRoutingView.CustomPrefixes"/>,
+    /// <see cref="PeerRoutingView.CustomAsns"/>, <see cref="PeerRoutingView.UserSources"/>) in a SINGLE query,
+    /// and folds the "session active" status update (Status="active", LastSessionAt=now) into the SAME
+    /// DbContext — so the BGP send path does one read+write roundtrip instead of separate
+    /// <c>GetPeer</c>/<c>UpdateSessionStatus</c>/<c>GetSubscriptions</c>/<c>GetCustomPrefixes</c>/
+    /// <c>GetCustomAsns</c> calls (issue #84). Returns <c>null</c> when the peer is unknown (the caller
+    /// then auto-registers). The collection shapes match the standalone getters exactly (no behavior change).
     /// </summary>
     PeerRoutingView? LoadPeerRoutingView(string ip, uint asn);
 }
@@ -43,13 +43,22 @@ public class PeerInfo
 }
 
 /// <summary>
+/// A per-peer user-supplied URL prefix-list source (epic #143 / issue #147), projected from
+/// <c>PeerCustomSource</c>. Only <c>Active</c> sources appear here — paused sources never leave the DB.
+/// <c>Community</c> is the raw user-supplied <c>"ASN:VALUE"</c> override, or null for auto-generation.
+/// </summary>
+public sealed record CustomSourceView(string Name, string Url, string? Community);
+
+/// <summary>
 /// The slice of peer data the BGP send path consumes, loaded in one query for issue #84.
 /// Field shapes are identical to the standalone getters so the caller behavior is unchanged:
 /// <c>Subscriptions</c> = <c>GetSubscriptions</c>, <c>CustomPrefixes</c> = <c>"prefix/length"</c>
-/// strings like <c>GetCustomPrefixes</c>, <c>CustomAsns</c> = <c>GetCustomAsns</c>.
+/// strings like <c>GetCustomPrefixes</c>, <c>CustomAsns</c> = <c>GetCustomAsns</c>. <c>UserSources</c>
+/// (issue #147) holds only the peer's active URL sources, fetched and advertised per-peer.
 /// </summary>
 public sealed record PeerRoutingView(
     string PeerId,
     List<string> Subscriptions,
     List<string> CustomPrefixes,
-    List<uint> CustomAsns);
+    List<uint> CustomAsns,
+    List<CustomSourceView> UserSources);

--- a/BGPLite.Tests/BgpSessionUserSourceTests.cs
+++ b/BGPLite.Tests/BgpSessionUserSourceTests.cs
@@ -1,0 +1,119 @@
+using BGPLite.Configuration;
+using BGPLite.Protocol;
+using BGPLite.Routing;
+using BGPLite.Server;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// Unit coverage for the per-peer user-source send path added in #147 (epic #143). Exercises
+/// <see cref="BgpSession.AddUserSourceRoutesAsync"/> directly with fakes — no live BgpSession/socket —
+/// mirroring the static-helper convention used by the other BgpSession tests.
+/// </summary>
+public class BgpSessionUserSourceTests
+{
+    private static readonly uint[] Comms = [CommunityCodec.Parse("65000:42")];
+
+    /// <summary>Captures the resolved <see cref="CommunitySource"/> and returns a fixed community set.</summary>
+    private sealed class StubResolver : ICommunityResolver
+    {
+        public CommunitySource? Last { get; private set; }
+        public uint[] Resolve(CommunitySource source)
+        {
+            Last = source;
+            return Comms;
+        }
+    }
+
+    /// <summary>A minimal <see cref="IPrefixService"/> that only implements the user-source path.</summary>
+    private sealed class StubPrefixService : IPrefixService
+    {
+        public IReadOnlyList<(uint Prefix, byte Length)> Result { get; set; } = [];
+        public Exception? Throw { get; set; }
+        public (string Name, string Url, string? Community)? Last { get; private set; }
+
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(
+            string name, string url, string? community, CancellationToken ct = default)
+        {
+            Last = (name, url, community);
+            if (Throw is not null) throw Throw;
+            return Task.FromResult(Result);
+        }
+
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
+            => Task.FromResult(new List<(uint Prefix, byte Length, uint Asn)>());
+        public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
+        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
+            => Task.FromResult(new List<(uint Prefix, byte Length, uint Asn)>());
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task Success_AddsRoutesWithResolvedCommunity()
+    {
+        var svc = new StubPrefixService { Result = [(0xC0A80000u, (byte)24)] };
+        var resolver = new StubResolver();
+        var routes = new List<Route>();
+
+        await BgpSession.AddUserSourceRoutesAsync(
+            routes, new CustomSourceView("msft", "https://example.com/x.txt", "65000:42"),
+            0x01020304u, svc, resolver, NullLogger.Instance, "peer", CancellationToken.None);
+
+        var route = Assert.Single(routes);
+        Assert.Equal(0xC0A80000u, route.Prefix);
+        Assert.Equal((byte)24, route.PrefixLength);
+        Assert.Equal(0x01020304u, route.NextHop);
+        Assert.Empty(route.AsPath);                  // URL lists have no per-prefix origin AS (like CustomPrefixes)
+        Assert.Equal(Comms, route.Communities);
+        // The resolver saw a UserSource kind, and the prefix service got the source's name/url/community.
+        Assert.Equal(CommunitySourceKind.UserSource, resolver.Last!.Kind);
+        Assert.Equal(("msft", "https://example.com/x.txt", "65000:42"), svc.Last);
+    }
+
+    [Fact]
+    public async Task ProviderThrows_OtherSourceUnaffected()
+    {
+        // Per-source try/catch: one failing URL must not drop another source's prefixes.
+        var routes = new List<Route>();
+        var throwSvc = new StubPrefixService { Throw = new InvalidOperationException("boom") };
+        var okSvc = new StubPrefixService { Result = [(0x0A000000u, (byte)8)] };
+
+        await BgpSession.AddUserSourceRoutesAsync(
+            routes, new CustomSourceView("bad", "https://x/b", null), 1, throwSvc, new StubResolver(), NullLogger.Instance, "peer", CancellationToken.None);
+        await BgpSession.AddUserSourceRoutesAsync(
+            routes, new CustomSourceView("good", "https://x/g", null), 1, okSvc, new StubResolver(), NullLogger.Instance, "peer", CancellationToken.None);
+
+        Assert.Single(routes);                       // only the second source's prefix made it
+    }
+
+    [Fact]
+    public async Task OperationCanceled_Propagates()
+    {
+        // Regression for #114: cancellation must NOT be swallowed by the per-source catch.
+        var svc = new StubPrefixService { Throw = new OperationCanceledException() };
+        var routes = new List<Route>();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => BgpSession.AddUserSourceRoutesAsync(
+            routes, new CustomSourceView("c", "https://x/c", null), 1, svc, new StubResolver(),
+            NullLogger.Instance, "peer", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ProviderReturnsEmpty_AddsNoRoutes()
+    {
+        var svc = new StubPrefixService { Result = [] };
+        var routes = new List<Route>();
+
+        await BgpSession.AddUserSourceRoutesAsync(
+            routes, new CustomSourceView("empty", "https://x/e", null), 1, svc, new StubResolver(),
+            NullLogger.Instance, "peer", CancellationToken.None);
+
+        Assert.Empty(routes);
+    }
+}

--- a/BGPLite.Tests/CommunityResolverTests.cs
+++ b/BGPLite.Tests/CommunityResolverTests.cs
@@ -157,4 +157,78 @@ public class CommunityResolverTests
         var r = new ConfigCommunityResolver(new AppConfig(), new BgpConfig { Asn = 200000 }, null);
         Assert.Empty(r.Resolve(new CommunitySource(CommunitySourceKind.Custom)));
     }
+
+    // --- UserSource (#143 / #147) — auto-gen from a reserved 5XX range, override via Community ---
+
+    [Fact]
+    public void Resolve_UserSource_ExplicitCommunity_Wins()
+    {
+        var r = new ConfigCommunityResolver(new AppConfig(), new BgpConfig { Asn = 65444 }, null);
+        Assert.Equal([CommunityCodec.Parse("65000:42")],
+            r.Resolve(new CommunitySource(CommunitySourceKind.UserSource, "my-list", "65000:42")));
+    }
+
+    [Fact]
+    public void Resolve_UserSource_ExplicitInvalid_FallsBackToAutoGen()
+    {
+        // Mirrors Custom/CustomAsn: an invalid explicit override logs and uses the auto-gen default
+        // (NOT empty) so a typo doesn't silently untag the source's prefixes.
+        var r = new ConfigCommunityResolver(new AppConfig(), new BgpConfig { Asn = 65444 }, null);
+        var auto = r.Resolve(new CommunitySource(CommunitySourceKind.UserSource, "my-list"));
+        var fallback = r.Resolve(new CommunitySource(CommunitySourceKind.UserSource, "my-list", "not-a-community"));
+        Assert.Equal(auto, fallback);
+        Assert.NotEmpty(fallback);
+    }
+
+    [Fact]
+    public void Resolve_UserSource_AutoGen_DeterministicAcrossInstances()
+    {
+        // Auto-gen must be stable across resolver instances (and thus across restarts) —
+        // string.GetHashCode() is randomized per-process and would fail this on the next launch.
+        var r1 = new ConfigCommunityResolver(new AppConfig(), new BgpConfig { Asn = 65444 }, null);
+        var r2 = new ConfigCommunityResolver(new AppConfig(), new BgpConfig { Asn = 65444 }, null);
+        Assert.Equal(
+            r1.Resolve(new CommunitySource(CommunitySourceKind.UserSource, "list-a")),
+            r2.Resolve(new CommunitySource(CommunitySourceKind.UserSource, "list-a")));
+    }
+
+    [Fact]
+    public void Resolve_UserSource_AutoGen_KnownExpected()
+    {
+        // Locks the formula: <LocalAsn>:(500 + Fnv1a(Name) % 100), value range 500-599. Inlining
+        // FNV-1a means any future accidental switch to string.GetHashCode() fails this test.
+        static uint Fnv1a(string s)
+        {
+            unchecked
+            {
+                uint hash = 2166136261u;
+                foreach (var b in System.Text.Encoding.UTF8.GetBytes(s))
+                {
+                    hash ^= b;
+                    hash *= 16777619u;
+                }
+                return hash;
+            }
+        }
+        var expected = (65444u << 16) | (500u + Fnv1a("my-list") % 100);
+        var r = new ConfigCommunityResolver(new AppConfig(), new BgpConfig { Asn = 65444 }, null);
+        Assert.Equal([expected], r.Resolve(new CommunitySource(CommunitySourceKind.UserSource, "my-list")));
+    }
+
+    [Fact]
+    public void Resolve_UserSource_FourByteAsn_AutoGen_Empty()
+    {
+        var r = new ConfigCommunityResolver(new AppConfig(), new BgpConfig { Asn = 200000 }, null);
+        Assert.Empty(r.Resolve(new CommunitySource(CommunitySourceKind.UserSource, "list-a")));
+    }
+
+    [Fact]
+    public void Resolve_UserSource_FourByteAsn_ExplicitCommunity_StillResolves()
+    {
+        // An explicit community parses even with a 4-byte local ASN — the asn>0xFFFF guard only
+        // blocks auto-generation, mirroring Custom/CustomAsn override behavior.
+        var r = new ConfigCommunityResolver(new AppConfig(), new BgpConfig { Asn = 200000 }, null);
+        Assert.Equal([CommunityCodec.Parse("65000:42")],
+            r.Resolve(new CommunitySource(CommunitySourceKind.UserSource, "list-a", "65000:42")));
+    }
 }

--- a/BGPLite.Tests/PeerStoreKeyingTests.cs
+++ b/BGPLite.Tests/PeerStoreKeyingTests.cs
@@ -161,6 +161,42 @@ public class PeerStoreKeyingTests
     }
 
     [Fact]
+    public void LoadPeerRoutingView_UserSources_Only_Active_Loaded()
+    {
+        // Issue #147: paused (Active=false) sources never leave the DB — only Active ones are
+        // advertised. AddCustomSource defaults Active=false; SetSourceActive toggles.
+        var (store, connection) = NewStore();
+        using var conn = connection;
+
+        var id = store.CreatePeer(SharedIp, 64512, "sources peer");
+        var active = store.AddCustomSource(id, "on", "https://example.com/on.txt", null);
+        store.AddCustomSource(id, "off", "https://example.com/off.txt", "65000:9");
+        Assert.True(store.SetSourceActive(id, active.Id, true));
+
+        var view = store.LoadPeerRoutingView(SharedIp, 64512);
+        Assert.NotNull(view);
+        var src = Assert.Single(view!.UserSources);   // the inactive "off" source is excluded
+        Assert.Equal("on", src.Name);
+        Assert.Equal("https://example.com/on.txt", src.Url);
+        Assert.Null(src.Community);
+    }
+
+    [Fact]
+    public void LoadPeerRoutingView_UserSources_All_Inactive_Empty()
+    {
+        var (store, connection) = NewStore();
+        using var conn = connection;
+
+        var id = store.CreatePeer(SharedIp, 64512, "all-inactive");
+        store.AddCustomSource(id, "a", "https://example.com/a.txt", null);
+        store.AddCustomSource(id, "b", "https://example.com/b.txt", "65000:1");
+
+        var view = store.LoadPeerRoutingView(SharedIp, 64512);
+        Assert.NotNull(view);
+        Assert.Empty(view!.UserSources);
+    }
+
+    [Fact]
     public void CreatePeer_Is_Idempotent_On_IpAsn()
     {
         var (store, connection) = NewStore();

--- a/BGPLite/Program.cs
+++ b/BGPLite/Program.cs
@@ -122,7 +122,7 @@ builder.Services.AddSingleton<IPrefixService>(sp =>
 {
     var ripe = sp.GetRequiredService<RipeStatProvider>();
     var sources = sp.GetRequiredService<IPrefixSourceService>();
-    return new PrefixService(config, ripe, sources);
+    return new PrefixService(config, ripe, sources, sp.GetRequiredService<HttpPrefixProvider>());
 });
 
 BgpServer? bgpServer = null;


### PR DESCRIPTION
## What

Closes #147 — second half of epic #143. Peers can now supply their own URL CIDR-list sources (added via #146's REST API) and have them fetched and advertised **to that peer only** — alongside operator `PrefixSources`, per-peer `CustomPrefixes` and `CustomAsns`. Completes the #143 epic.

Per-peer isolation is guaranteed by the send path (the sources come from the peer's own row in `LoadPeerRoutingView`), never by community uniqueness.

## How

- **Send path** (`BgpSession.SendAllRoutesAsync`): after the CustomAsns block, each active user source is fetched through the prefix service and stamped with its resolved `UserSource` community. `asPath = null` (URL lists carry no origin AS, matching `CustomPrefixes`). Per-source `try/catch` (one bad URL does not drop the peer's other sources); `OperationCanceledException` propagates (#114).
- **Community (Design B — through the resolver):** new `CommunitySourceKind.UserSource` + a 3rd `CommunitySource.Community` field (default `null`, non-breaking). `ConfigCommunityResolver` resolves it by **reusing `ResolveStaticCommunity`** with `defaultValue = 500 + FNV-1a(name) % 100` (reserved 500–599 range). Explicit `source.Community` overrides; an invalid one falls back to auto-gen; `asn>0xFFFF` with no explicit → empty (identical semantics to `Custom`/`CustomAsn`). **FNV-1a, not `string.GetHashCode`** — the latter is randomized per-process and would drift communities across restarts, silently breaking receiving peers' filters.
- **Single round-trip (#84) preserved:** `LoadPeerRoutingView` folds a 4th `Include(CustomSources)` into its one query and projects **only `Active`** sources into a new `PeerRoutingView.UserSources` field. No extra `DbContext`.
- **Prefix-service seam:** `IPrefixService.GetUserSourcePrefixesAsync` loads a peer-supplied URL directly via `HttpPrefixProvider` (bypassing the name-keyed cache, which only knows operator `PrefixSources`). The send path already depended on `IPrefixService`, so **no new ctor param or project reference** was needed.
- **Gate fix:** the "unconfigured peer → RU defaults" branch now also requires `UserSources` to be empty, so a peer whose only config is active user sources no longer falls through to RU.

SSRF is already defended by #144 (`ConnectCallback` validates DNS with no TOCTOU, `SocketsHttpHandler` does not follow redirects → no 302→internal bypass, 10 MB cap). Inherited for free by reusing `HttpPrefixProvider`. #90 (API auth) remains open but is not an SSRF blocker for this fetch path.

## ⚠️ Deviations from the issue snippet (it did not compile as written)

The snippet in #147 referenced symbols that don't exist; this PR implements the intent correctly:
- `_httpPrefixProvider` field/ctor → **`IPrefixService` seam** (cleaner; no Server→Providers ref).
- `ParseCommunity(...)` → **`CommunityCodec` via the resolver**.
- `CommunitySourceKind.UserSource` → **added** (enum + resolver arm + FNV-1a auto-gen).
- `_peerStore.GetCustomSources(peer.Id)` → **folded into `LoadPeerRoutingView`** (preserves #84) + `peer.Id` → `peer.PeerId`.
- **`Active` filter added** (the snippet fetched all sources; that defeats the `Active` flag — paused sources must not be advertised).

## Verification

- `dotnet build BGPLite.sln` — 0 errors.
- `dotnet test` — **400/400 passed** (6 new: UserSource resolver arm ×6 incl. FNV-1a determinism + 4-byte-ASN; send-path helper ×4 incl. OCE propagation + per-source isolation; `LoadPeerRoutingView` Active filter ×2).
- `dotnet format` — clean.
- RFC 1997: auto-gen = `(asn<<16)|value`, asn ≤ 0xFFFF, value in 500–599.
- Per-peer isolation + single round-trip confirmed by inspection.

## Follow-ups (separate issues, not in this PR)

1. URL-keyed in-process cache for per-peer user sources — currently re-fetched every refresh (no dedup; the `PrefixSourceService` cache is keyed by operator-`PrefixSources` name).
2. IPv4-only `Socket` in `PrefixSourceUrlValidator.CreateValidatedConnectionAsync` (#144) — IPv6-first hosts throw `SocketException`; this PR's broader URL surface exercises it more.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-peer user-supplied prefix sources (via URL) alongside existing subscription/custom lists.
  * User source route communities are now generated deterministically or can be explicitly overridden per source.
* **Bug Fixes**
  * Peers configured only with user-supplied sources no longer incorrectly fall back to default routes.
  * Route generation continues even if one user source fails, and only active user sources are advertised.
* **Tests**
  * Added unit tests covering user-source route sending, deterministic community resolution, and active/inactive filtering (plus cancellation propagation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->