### PR TITLE
perf(providers): URL-keyed TTL cache for per-peer user-source fetches (#150)

### DIFF
--- a/BGPLite.Providers/PrefixService.cs
+++ b/BGPLite.Providers/PrefixService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using BGPLite.Configuration;
+using Microsoft.Extensions.Logging;
 
 namespace BGPLite.Providers;
 
@@ -11,21 +12,26 @@ public sealed class PrefixService : IPrefixService
     private readonly HttpPrefixProvider? _httpProvider;
     private readonly ConcurrentDictionary<uint, (IReadOnlyList<(uint Prefix, byte Length)> Data, DateTime CachedAt)> _cache = new();
     private readonly TimeSpan _cacheTtl;
+    private readonly UserSourceCache _userSourceCache;
 
-    public PrefixService(AppConfig config, RipeStatProvider? ripeStat, IPrefixSourceService prefixSources, HttpPrefixProvider? httpProvider = null, TimeSpan? cacheTtl = null)
+    public PrefixService(AppConfig config, RipeStatProvider? ripeStat, IPrefixSourceService prefixSources, HttpPrefixProvider? httpProvider = null, TimeSpan? cacheTtl = null, ILogger<PrefixService>? logger = null)
     {
         _config = config;
         _ripeStat = ripeStat;
         _prefixSources = prefixSources;
         _httpProvider = httpProvider;
         _cacheTtl = cacheTtl ?? TimeSpan.FromHours(1);
+        _userSourceCache = new UserSourceCache(logger: logger);
     }
 
     /// <summary>
-    /// Fetches a per-peer user-supplied URL prefix-list source (issue #147). The URL is peer-supplied
-    /// (not in <c>AppConfig.PrefixSources</c>), so it bypasses the name-keyed cache and loads directly
-    /// through the http provider — inheriting SSRF defense (#144: validated <c>ConnectCallback</c>,
-    /// no redirect-following, 10 MB cap). Returns empty when no http provider is wired.
+    /// Fetches a per-peer user-supplied URL prefix-list source (issues #147 / #150). The URL is
+    /// peer-supplied (not in <c>AppConfig.PrefixSources</c>, so the name-keyed <see cref="PrefixSourceService"/>
+    /// cache can't help); instead a URL-keyed TTL cache (<see cref="UserSourceCache"/>) dedupes fetches
+    /// across peers and serves a stale copy on transient failure. SSRF defense (#144) is inherited from
+    /// the http provider's named client. Returns empty when no http provider is wired. The <c>Active</c>
+    /// lifecycle is handled by the caller (LoadPeerRoutingView filters Active before this is reached),
+    /// so paused sources are never advertised regardless of cache state.
     /// </summary>
     public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
     {
@@ -37,7 +43,7 @@ public sealed class PrefixService : IPrefixService
             Url = url,
             Community = community
         };
-        return await _httpProvider.LoadAsync(source, ct);
+        return await _userSourceCache.GetOrLoadAsync(url, name, ct => _httpProvider.LoadAsync(source, ct), ct);
     }
 
     public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)

--- a/BGPLite.Providers/UserSourceCache.cs
+++ b/BGPLite.Providers/UserSourceCache.cs
@@ -1,0 +1,110 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace BGPLite.Providers;
+
+/// <summary>
+/// URL-keyed in-memory TTL cache for per-peer user-supplied prefix-list sources (issue #150, epic #143).
+/// Mirrors <see cref="PrefixSourceService"/>'s cache shape: separate positive/negative TTL, per-key
+/// serialization (no thundering herd on a cold/expired key), and stale-on-failure serving so a peer's
+/// routes stay stable through transient fetch errors. Keyed by URL (not source name) so peers that
+/// subscribe to the same list share a single fetch.
+/// </summary>
+/// <remarks>
+/// <b>Layering / Active-state contract.</b> This cache knows nothing about a source's <c>Active</c>
+/// flag or peer ownership — it is a pure URL → prefix-list memo. The Active/pause lifecycle is owned
+/// by the caller: <c>PeerStore.LoadPeerRoutingView</c> filters <c>Where(c =&gt; c.Active)</c> before the
+/// send path ever reaches this cache, so a <b>paused source contributes no prefixes regardless of what
+/// is cached</b>. Because the cache is shared across peers (URL-keyed), pausing or deleting a source in
+/// one peer does NOT evict the entry here — another peer with the same URL may still need it; orphaned
+/// entries (no active subscriber) simply expire via TTL. The cache sits above the fetcher and is
+/// transparent to the #144 SSRF defense, which lives in <see cref="HttpPrefixProvider"/>'s named client.
+/// <see cref="OperationCanceledException"/> always propagates (#114) and is never cached as negative.
+/// </remarks>
+internal sealed class UserSourceCache
+{
+    private readonly TimeSpan _positiveTtl;
+    private readonly TimeSpan _negativeTtl;
+    private readonly ILogger? _logger;
+
+    // url → (list, cached at, is negative). Negative entries (failed loads) use _negativeTtl.
+    private readonly ConcurrentDictionary<string, (IReadOnlyList<(uint Prefix, byte Length)> List, DateTime CachedAt, bool Negative)> _cache = new();
+    // url → gate serializing the cache-miss fetch path (prevents thundering herd on cold/expired keys).
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new();
+
+    public UserSourceCache(TimeSpan? positiveTtl = null, TimeSpan? negativeTtl = null, ILogger? logger = null)
+    {
+        _positiveTtl = positiveTtl ?? TimeSpan.FromHours(1);
+        _negativeTtl = negativeTtl ?? TimeSpan.FromSeconds(30);
+        _logger = logger;
+    }
+
+    /// <param name="url">Cache key (the source URL — dedupes across peers).</param>
+    /// <param name="logLabel">Safe identifier (the source <c>Name</c>) for log lines — the URL itself is
+    /// never logged, since peer URLs may carry query-string tokens (#149).</param>
+    /// <param name="loadAsync">The fetcher ( HttpPrefixProvider.LoadAsync closed over the source config).</param>
+    public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetOrLoadAsync(
+        string url,
+        string logLabel,
+        Func<CancellationToken, Task<IReadOnlyList<(uint Prefix, byte Length)>>> loadAsync,
+        CancellationToken ct)
+    {
+        if (TryGetFresh(url, out var fresh))
+            return fresh;
+
+        // Serialize per-key so concurrent callers (e.g. several peers refreshing the same URL) share
+        // a single fetch — no thundering herd.
+        var gate = _locks.GetOrAdd(url, _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync(ct);
+        try
+        {
+            if (TryGetFresh(url, out var rechecked))
+                return rechecked;
+
+            IReadOnlyList<(uint Prefix, byte Length)> prefixes;
+            try
+            {
+                prefixes = await loadAsync(ct);
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                // Serve the last good copy if we have one (regardless of its age).
+                if (_cache.TryGetValue(url, out var stale) && !stale.Negative)
+                {
+                    _logger?.LogWarning(ex, "User-source '{Name}' load failed; serving cached copy ({Count} prefixes).",
+                        logLabel, stale.List.Count);
+                    return stale.List;
+                }
+
+                // Otherwise remember the failure briefly so repeated calls don't hammer the fetcher.
+                _cache[url] = ([], DateTime.UtcNow, Negative: true);
+                _logger?.LogWarning(ex, "User-source '{Name}' load failed (no cached copy); negative-cached for {Seconds}s.",
+                    logLabel, (int)_negativeTtl.TotalSeconds);
+                throw;
+            }
+
+            _cache[url] = (prefixes, DateTime.UtcNow, Negative: false);
+            return prefixes;
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    private bool TryGetFresh(string url, out IReadOnlyList<(uint Prefix, byte Length)> list)
+    {
+        list = null!;
+        if (!_cache.TryGetValue(url, out var entry)) return false;
+
+        var ttl = entry.Negative ? _negativeTtl : _positiveTtl;
+        if (DateTime.UtcNow - entry.CachedAt < ttl)
+        {
+            list = entry.List;
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/BGPLite.Tests/UserSourceCacheTests.cs
+++ b/BGPLite.Tests/UserSourceCacheTests.cs
@@ -45,6 +45,36 @@ public class UserSourceCacheTests
     }
 
     [Fact]
+    public async Task Concurrent_Same_Url_Fetched_Once_Gate_Serializes()
+    {
+        // Exercises the per-URL SemaphoreSlim (the actual thundering-herd defense): many concurrent
+        // callers for the same URL share a single fetch. A blocking fetcher holds all racers in-flight
+        // until released, so this can't pass by accident via sequential cache reuse.
+        var cache = new UserSourceCache();
+        var hold = new TaskCompletionSource();
+        int calls = 0;
+        Task<IReadOnlyList<(uint Prefix, byte Length)>> Load(CancellationToken ct)
+        {
+            Interlocked.Increment(ref calls);
+            return HoldAndReturn();
+        }
+        async Task<IReadOnlyList<(uint Prefix, byte Length)>> HoldAndReturn()
+        {
+            await hold.Task;          // keep the in-flight fetch blocked until all racers are queued
+            return P((0u, 0));
+        }
+
+        var tasks = Enumerable.Range(0, 16)
+            .Select(_ => cache.GetOrLoadAsync("https://example.com/l", "src", Load, CancellationToken.None))
+            .ToArray();
+        hold.SetResult();             // release the single fetch
+        var results = await Task.WhenAll(tasks);
+
+        Assert.Equal(1, calls);       // exactly one fetch despite 16 concurrent callers
+        Assert.All(results, r => Assert.Single(r));
+    }
+
+    [Fact]
     public async Task Different_Urls_Fetched_Separately()
     {
         var cache = new UserSourceCache();

--- a/BGPLite.Tests/UserSourceCacheTests.cs
+++ b/BGPLite.Tests/UserSourceCacheTests.cs
@@ -1,0 +1,139 @@
+using BGPLite.Providers;
+using Xunit;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// Unit coverage for <see cref="UserSourceCache"/> (#150) — the URL-keyed TTL cache for per-peer
+/// user-supplied prefix-list sources. Exercises the cache directly with a fake fetch delegate, so no
+/// <c>HttpPrefixProvider</c>/HTTP layer is involved. Mirrors the shape of <c>PrefixSourceService</c>'s
+/// cache: positive/negative TTL, per-key serialization, stale-on-failure, OCE propagation (#114).
+/// </summary>
+public class UserSourceCacheTests
+{
+    private static IReadOnlyList<(uint Prefix, byte Length)> P(params (uint, byte)[] xs) =>
+        xs.Select(x => (x.Item1, x.Item2)).ToList();
+
+    /// <summary>A controllable fetcher: counts calls, returns a canned list or throws.</summary>
+    private sealed class Fetcher
+    {
+        public int Calls;
+        public Func<IReadOnlyList<(uint Prefix, byte Length)>>? OnSuccess;
+        public Exception? Throw;
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> Invoke(CancellationToken ct)
+        {
+            Calls++;
+            if (Throw is OperationCanceledException oce) throw oce;
+            if (Throw is not null) throw Throw;
+            return Task.FromResult(OnSuccess?.Invoke() ?? []);
+        }
+    }
+
+    [Fact]
+    public async Task Same_Url_Dedupes_Across_Calls_FetcherInvokedOnce()
+    {
+        // The point of URL-keying (#150): two calls for the same URL — e.g. two peers refreshing the
+        // same popular list — share one fetch.
+        var cache = new UserSourceCache();
+        var f = new Fetcher { OnSuccess = () => P((0xC0A80000u, (byte)24)) };
+
+        var a = await cache.GetOrLoadAsync("https://example.com/l", "src", f.Invoke, CancellationToken.None);
+        var b = await cache.GetOrLoadAsync("https://example.com/l", "src", f.Invoke, CancellationToken.None);
+
+        Assert.Equal(1, f.Calls);
+        Assert.Same(a, b);
+    }
+
+    [Fact]
+    public async Task Different_Urls_Fetched_Separately()
+    {
+        var cache = new UserSourceCache();
+        var f = new Fetcher { OnSuccess = () => [] };
+
+        await cache.GetOrLoadAsync("https://example.com/a", "a", f.Invoke, default);
+        await cache.GetOrLoadAsync("https://example.com/b", "b", f.Invoke, default);
+
+        Assert.Equal(2, f.Calls);
+    }
+
+    [Fact]
+    public async Task Stale_On_Failure_Serves_Last_Good_Copy()
+    {
+        // Stale-serving only triggers on a refetch that fails — so let the positive entry expire first,
+        // then make the refetch throw. The (now-expired) last good copy is served regardless of age.
+        var cache = new UserSourceCache(positiveTtl: TimeSpan.FromMilliseconds(80));
+        var f = new Fetcher { OnSuccess = () => P((0u, 0)) };
+        await cache.GetOrLoadAsync("https://example.com/l", "src", f.Invoke, default); // prime positive
+        await Task.Delay(120);                                                        // let it expire
+
+        f.OnSuccess = null;
+        f.Throw = new InvalidOperationException("boom");
+        var served = await cache.GetOrLoadAsync("https://example.com/l", "src", f.Invoke, default); // refetch fails → stale
+
+        Assert.Equal(2, f.Calls);      // attempted refetch, failed, served stale
+        Assert.Single(served);         // the primed prefix survived the transient failure
+    }
+
+    [Fact]
+    public async Task Cold_Failure_Propagates_And_Negative_Caches()
+    {
+        var cache = new UserSourceCache();
+        var f = new Fetcher { Throw = new InvalidOperationException("boom") };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => cache.GetOrLoadAsync("https://example.com/l", "src", f.Invoke, default));
+
+        // Second call within the negative TTL returns [] WITHOUT invoking the fetcher — repeated
+        // failures don't hammer the upstream.
+        var served = await cache.GetOrLoadAsync("https://example.com/l", "src", f.Invoke, default);
+        Assert.Equal(1, f.Calls);
+        Assert.Empty(served);
+    }
+
+    [Fact]
+    public async Task OperationCanceled_Propagates_And_Is_Not_Negative_Cached()
+    {
+        // #114: cancellation must propagate and must not be recorded as a negative entry.
+        var cache = new UserSourceCache();
+        var f = new Fetcher { Throw = new OperationCanceledException() };
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => cache.GetOrLoadAsync("https://example.com/l", "src", f.Invoke, default));
+        Assert.Equal(1, f.Calls);
+
+        // No negative cache → the next call reaches the fetcher again.
+        f.Throw = null;
+        f.OnSuccess = () => P((1u, 1));
+        var served = await cache.GetOrLoadAsync("https://example.com/l", "src", f.Invoke, default);
+        Assert.Equal(2, f.Calls);
+        Assert.Single(served);
+    }
+
+    [Fact]
+    public async Task Positive_Ttl_Expiry_Triggers_Refetch()
+    {
+        var cache = new UserSourceCache(positiveTtl: TimeSpan.FromMilliseconds(80));
+        var f = new Fetcher { OnSuccess = () => P((1u, 1)) };
+
+        await cache.GetOrLoadAsync("https://example.com/l", "src", f.Invoke, default);
+        await Task.Delay(120);
+        await cache.GetOrLoadAsync("https://example.com/l", "src", f.Invoke, default);
+
+        Assert.Equal(2, f.Calls);
+    }
+
+    [Fact]
+    public async Task Negative_Ttl_Expiry_Triggers_Refetch()
+    {
+        var cache = new UserSourceCache(negativeTtl: TimeSpan.FromMilliseconds(80));
+        var f = new Fetcher { Throw = new InvalidOperationException("boom") };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => cache.GetOrLoadAsync("https://example.com/l", "src", f.Invoke, default));
+        await Task.Delay(120);
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => cache.GetOrLoadAsync("https://example.com/l", "src", f.Invoke, default));
+
+        Assert.Equal(2, f.Calls); // negative entry expired → refetched
+    }
+}

--- a/BGPLite/Program.cs
+++ b/BGPLite/Program.cs
@@ -122,7 +122,7 @@ builder.Services.AddSingleton<IPrefixService>(sp =>
 {
     var ripe = sp.GetRequiredService<RipeStatProvider>();
     var sources = sp.GetRequiredService<IPrefixSourceService>();
-    return new PrefixService(config, ripe, sources, sp.GetRequiredService<HttpPrefixProvider>());
+    return new PrefixService(config, ripe, sources, sp.GetRequiredService<HttpPrefixProvider>(), logger: sp.GetRequiredService<ILogger<PrefixService>>());
 });
 
 BgpServer? bgpServer = null;


### PR DESCRIPTION
## What

Closes #150 — follow-up to #147 (epic #143). Adds a URL-keyed in-memory TTL cache for per-peer user-supplied prefix-list sources, so they're no longer cold-fetched on every `SendAllRoutesAsync` refresh for every peer.

## Why

After #147, each active user source was re-fetched on every refresh, per peer. The existing `PrefixSourceService` cache couldn't help — it's keyed by **operator** `PrefixSources.Name` and peer URLs aren't in `AppConfig.PrefixSources`. With N peers × M active sources × refresh interval, that was N×M cold HTTP fetches per refresh. `HttpPrefixProvider` is stateless by design, so the cache belongs one layer up.

## How

New `UserSourceCache` (`internal`, `BGPLite.Providers`), mirroring `PrefixSourceService`'s proven shape:
- **URL-keyed** `ConcurrentDictionary` + per-key `SemaphoreSlim` → no thundering herd on a cold/expired key.
- **Positive TTL 1h, negative TTL 30s** (injectable for tests).
- **Stale-on-failure**: a transient fetch error serves the last good copy, so a peer's routes stay stable; a cold failure (no cached copy) records a short-lived negative entry so repeated calls don't hammer the upstream.
- **OCE propagates** (#114) and is never recorded as negative.
- **Logs by source `Name`** (the safe identifier), **never the URL** — peer URLs may carry query-string tokens (#149 redaction preserved).

`PrefixService.GetUserSourcePrefixesAsync` now goes through the cache. SSRF defense (#144) is inherited — the cache sits above `HttpPrefixProvider`, transparent to it. No `BgpSession` change (the seam is unchanged).

### Why URL-keyed (shared across peers)

Keying by URL — not by `(peer, source)` or source name — means peers that subscribe to the **same list share one fetch**. This is the common case (e.g. several peers on the same popular blocklist) and it's the main memory/traffic win.

### Paused / disabled sources (explicit)

The cache knows nothing about a source's `Active` flag — by design. The pause lifecycle is handled **above** the cache:
- `LoadPeerRoutingView` applies `Where(c => c.Active)` (`PeerStore.cs`) before the send path reaches the cache, so a **paused source contributes no prefixes regardless of cache state** — it's "filtered in advance", not evicted.
- Because the cache is shared (URL-keyed), pausing or deleting a source in one peer does **not** evict the entry — another peer may still need the same URL. Orphaned entries (no active subscriber left) simply expire via TTL.

So: disable = "not considered during prefix formation" (immediate, next refresh); the shared entry stays for any other subscriber and ages out otherwise. No cross-layer invalidation coupling needed.

## Verification

- `dotnet build` — 0 errors.
- `dotnet test` — **407/407** (7 new in `UserSourceCacheTests`: same-URL dedup, distinct-URL separation, stale-on-failure, cold-failure negative-cache, OCE propagation + not-negative-cached, positive/negative TTL expiry).
- `dotnet format` — clean.
- Operator `PrefixSources` path unchanged (still uses `PrefixSourceService`'s name-keyed cache).

## Follow-ups

- **#151** (IPv4-only `Socket` in `PrefixSourceUrlValidator`) remains open — separate concern.

Refs: #150, #147, #143.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved per-URL caching and de-duplication for user-provided prefix-list sources, reducing repeated remote fetches.
  * Added controlled retry behavior with TTLs to keep prefix data fresh without unnecessary reloads.
* **Bug Fixes**
  * If an update fails, the last known good prefix list is served instead of breaking responses.
  * Cancellations now propagate correctly and do not poison the cache; failures are briefly negative-cached.
* **Tests**
  * Expanded test coverage for TTL, concurrency, failure, cancellation, and per-URL isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->