### PR TITLE
fix(providers): connect SSRF-validated hosts IPv4-first, fall through on failure (#151)

### DIFF
--- a/BGPLite.Providers/PrefixSourceUrlValidator.cs
+++ b/BGPLite.Providers/PrefixSourceUrlValidator.cs
@@ -31,6 +31,10 @@ public static class PrefixSourceUrlValidator
         IPNetwork.Parse("fe80::/10"),           // IPv6 link-local
     ];
 
+    /// <summary>Per-address connect budget so one blackholed candidate can't consume the whole
+    /// ConnectTimeout before the next resolved address is tried.</summary>
+    private static readonly TimeSpan PerAttemptConnectTimeout = TimeSpan.FromSeconds(5);
+
     /// <summary>True if the address falls in a blocked (non-public) range.</summary>
     internal static bool IsBlockedAddress(IPAddress address)
     {
@@ -80,11 +84,22 @@ public static class PrefixSourceUrlValidator
         Exception? last = null;
         foreach (var addr in OrderForConnect(addresses))
         {
+            // Bound each attempt so one blackholed address can't consume the whole connect budget
+            // before the next candidate is tried. Real cancellation (ct) still propagates.
+            using var attempt = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            attempt.CancelAfter(PerAttemptConnectTimeout);
+
             var socket = new Socket(addr.AddressFamily, SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
             try
             {
-                await socket.ConnectAsync(addr, port, ct);
+                await socket.ConnectAsync(addr, port, attempt.Token);
                 return new NetworkStream(socket, ownsSocket: true);
+            }
+            catch (OperationCanceledException) when (attempt.IsCancellationRequested && !ct.IsCancellationRequested)
+            {
+                socket.Dispose();
+                last = new TimeoutException(
+                    $"Timed out connecting to '{host}' ({addr}) after {PerAttemptConnectTimeout.TotalSeconds:0}s; trying next address.");
             }
             catch (OperationCanceledException) { socket.Dispose(); throw; }
             catch (Exception ex)

--- a/BGPLite.Providers/PrefixSourceUrlValidator.cs
+++ b/BGPLite.Providers/PrefixSourceUrlValidator.cs
@@ -42,7 +42,8 @@ public static class PrefixSourceUrlValidator
 
     /// <summary>
     /// SocketsHttpHandler.ConnectCallback: resolves DNS, validates ALL resolved IPs are public,
-    /// then connects to the first valid one. No TOCTOU (the validated IP IS the connected IP).
+    /// then connects with a matching-family socket per address (IPv4 preferred) until one succeeds.
+    /// No TOCTOU — every address is validated above and the connected IP is one of them.
     /// SocketsHttpHandler does NOT follow redirects (no 302-to-internal-IP bypass).
     /// </summary>
     public static async ValueTask<Stream> CreateValidatedConnectionAsync(
@@ -61,6 +62,9 @@ public static class PrefixSourceUrlValidator
             throw new InvalidOperationException($"DNS resolution failed for '{host}': {ex.Message}", ex);
         }
 
+        if (addresses.Length == 0)
+            throw new InvalidOperationException($"DNS returned no addresses for '{host}'.");
+
         foreach (var addr in addresses)
         {
             if (IsBlockedAddress(addr))
@@ -68,18 +72,39 @@ public static class PrefixSourceUrlValidator
                     $"SSRF blocked: '{host}' resolves to non-public address {addr}.");
         }
 
-        var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
-        try
+        // Connect with a matching-family socket per address, IPv4-first, until one succeeds. A host
+        // whose first DNS record is IPv6 used to throw SocketException (AddressFamilyNotSupported)
+        // on the hardcoded IPv4 socket (#151); and many deployments (e.g. an IPv4-only server with no
+        // IPv6 on the interface) can only route IPv4 anyway. Now each validated address gets its own
+        // socket and we fall through to the next on failure.
+        Exception? last = null;
+        foreach (var addr in OrderForConnect(addresses))
         {
-            await socket.ConnectAsync(addresses[0], port, ct);
-            return new NetworkStream(socket, ownsSocket: true);
+            var socket = new Socket(addr.AddressFamily, SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+            try
+            {
+                await socket.ConnectAsync(addr, port, ct);
+                return new NetworkStream(socket, ownsSocket: true);
+            }
+            catch (OperationCanceledException) { socket.Dispose(); throw; }
+            catch (Exception ex)
+            {
+                socket.Dispose();
+                last = ex;
+            }
         }
-        catch
-        {
-            socket.Dispose();
-            throw;
-        }
+
+        throw new InvalidOperationException(
+            $"Could not connect to '{host}' on any of {addresses.Length} resolved address(es).", last);
     }
+
+    /// <summary>
+    /// Orders resolved addresses IPv4-first (stable within each family). IPv4 is preferred because
+    /// many deployments (e.g. an IPv4-only server with no IPv6 on the interface) can only route IPv4,
+    /// so an IPv6 address returned first by DNS would be unreachable. Internal for unit testing.
+    /// </summary>
+    internal static IEnumerable<IPAddress> OrderForConnect(IPAddress[] addresses)
+        => addresses.OrderBy(a => a.AddressFamily == AddressFamily.InterNetwork ? 0 : 1);
 
     /// <summary>
     /// Validates that a URL is well-formed, uses http/https, and resolves to a public IP.

--- a/BGPLite.Tests/PrefixSourceUrlValidatorTests.cs
+++ b/BGPLite.Tests/PrefixSourceUrlValidatorTests.cs
@@ -87,4 +87,47 @@ public class PrefixSourceUrlValidatorTests
         Assert.False(isValid);
         Assert.Contains("Invalid URL", error);
     }
+
+    // --- OrderForConnect (#151): IPv4-first so an IPv4-only server (no IPv6 interface) still connects,
+    //     instead of throwing SocketException on a hardcoded IPv4 socket handed an IPv6 addresses[0]. ---
+
+    [Fact]
+    public void OrderForConnect_Prefers_IPv4_Before_IPv6()
+    {
+        var ipv6 = IPAddress.Parse("2606:2800:220:1::1");
+        var ipv4 = IPAddress.Parse("93.184.216.34");
+
+        var ordered = PrefixSourceUrlValidator.OrderForConnect([ipv6, ipv4]).ToArray();
+
+        Assert.Equal(ipv4, ordered[0]);
+        Assert.Equal(ipv6, ordered[1]);
+    }
+
+    [Fact]
+    public void OrderForConnect_Is_Stable_Within_Family()
+    {
+        var b = IPAddress.Parse("8.8.8.8");            // IPv4
+        var a = IPAddress.Parse("93.184.216.34");      // IPv4
+        var v6 = IPAddress.Parse("2606:2800:220:1::1");
+
+        // LINQ OrderBy is stable: IPv4 entries keep input order (b before a), IPv6 trails.
+        var ordered = PrefixSourceUrlValidator.OrderForConnect([b, v6, a]).ToArray();
+
+        Assert.Equal([b, a, v6], ordered);
+    }
+
+    [Fact]
+    public void OrderForConnect_IPv6_Only_Unchanged()
+    {
+        var x = IPAddress.Parse("2606:2800:220:1::1");
+        var y = IPAddress.Parse("2606:2800:220:2::2");
+
+        var ordered = PrefixSourceUrlValidator.OrderForConnect([x, y]).ToArray();
+
+        Assert.Equal([x, y], ordered);
+    }
+
+    [Fact]
+    public void OrderForConnect_Empty_Returns_Empty()
+        => Assert.Empty(PrefixSourceUrlValidator.OrderForConnect([]).ToArray());
 }


### PR DESCRIPTION
## What

Closes #151 — fixes the SSRF `ConnectCallback` so it no longer throws on hosts whose first DNS record is IPv6, and actually connects on IPv4-only service hosts.

## Bug

`PrefixSourceUrlValidator.CreateValidatedConnectionAsync` (#144) hardcoded an IPv4 socket but connected to `addresses[0]`:
```csharp
var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
await socket.ConnectAsync(addresses[0], port, ct);   // addresses[0] may be IPv6
```
DNS often returns IPv6 first on dual-stack hosts → `SocketException (AddressFamilyNotSupported)` → the fetch fails. This particularly hurts **service hosts with no IPv6 on the interface** (a common deployment): such a host can't route IPv6 at all, so even a correct IPv6 socket would fail — IPv4 is the only usable path. Surfaced wider by #147 (peers' user-supplied URLs hit arbitrary public hosts).

## Fix

After validating **every** resolved address against the SSRF blocklist (unchanged), **try each address with a matching-family socket, IPv4-first, until one connects**:
```csharp
foreach (var addr in OrderForConnect(addresses))   // IPv4 first, stable within family
{
    var socket = new Socket(addr.AddressFamily, Stream, Tcp);
    try { await socket.ConnectAsync(addr, port, ct); return new NetworkStream(socket, true); }
    catch (OperationCanceledException) { socket.Dispose(); throw; }
    catch (Exception ex) { socket.Dispose(); last = ex; }
}
throw new InvalidOperationException($"Could not connect to '{host}' ...", last);
```
- **IPv4-only server**: IPv4 address connects, IPv6 (if any) is never tried. ✓
- **Dual-stack**: IPv4-first connects for IPv4-capable hosts; IPv6-only hosts fall through to the IPv6 attempt. ✓
- **IPv6-only destination on an IPv4-only box**: all attempts fail → clean `InvalidOperationException` with diagnostics (not a raw `SocketException` on the wrong family). ✓

`OrderForConnect` is extracted as `internal static` (IPv4-first, stable) for unit testing.

## Security (preserved)

- **All** addresses validated against the blocklist **before** any connect — no per-IP bypass.
- The connected IP is one of the validated set — **no TOCTOU**.
- `SocketsHttpHandler` still doesn't follow redirects — **no 302→internal bypass**.
- OCE propagates (#114).

## Verification

- `dotnet build` — 0 errors.
- `dotnet test` — **412/412** (4 new `OrderForConnect` tests: IPv4-before-IPv6, stable-within-family, IPv6-only, empty). The connect loop itself isn't unit-testable (loopback is SSRF-blocked by design); it's verified on the production IPv4-only host.
- `dotnet format` — clean.

Refs: #151, #144, #147.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validated URL connection flow by validating all resolved IPs before attempting connections.
  * Added per-address connection time budgeting so each candidate address is attempted independently.
  * Updated connection ordering to prefer IPv4 before IPv6 while keeping stable order within each family and failing clearly when none connect.
* **Documentation**
  * Refreshed SSRF-defense guidance for the validated connection process.
* **Tests**
  * Added unit tests for IPv4/IPv6 preference, stable ordering within families, and empty input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->