### PR TITLE
fix(providers): reject /0 + /33+ and mask host bits in PrefixListParser

### DIFF
--- a/BGPLite.Providers/PrefixListParser.cs
+++ b/BGPLite.Providers/PrefixListParser.cs
@@ -9,11 +9,25 @@ namespace BGPLite.Providers;
 /// Blank lines and lines starting with <c>#</c> are ignored; malformed and non-IPv4
 /// lines are skipped silently (the route table only stores IPv4 <c>(uint, byte)</c> keys).
 /// </summary>
+/// <remarks>
+/// <b>Length and host-bit handling (#162).</b> Prefix length is constrained to the valid IPv4 range
+/// 1..32 — a stray <c>0.0.0.0/0</c> line would otherwise advertise the entire IPv4 space (a
+/// catastrophic route leak from a peer-supplied URL list, #147). Length 0 is rejected: a route
+/// server should not originate a default. Host bits are masked to the network address so that
+/// <c>10.0.0.5/24</c> normalizes to <c>10.0.0.0/24</c> — without this, the same network submitted
+/// with different host bits is stored as distinct rows and breaks dedup / longest-prefix-match.
+/// </remarks>
 public static class PrefixListParser
 {
     public static IReadOnlyList<(uint Prefix, byte Length)> Parse(string text)
     {
         var result = new List<(uint Prefix, byte Length)>();
+
+        // Strip a leading UTF-8 BOM (\uFEFF): string.Trim() does not remove it (it is not in the
+        // Char.IsWhiteSpace set), so without this the first line of a BOM-prefixed list is silently
+        // dropped — a common shape for files saved on Windows / some CDNs (#162).
+        if (text.Length > 0 && text[0] == '\uFEFF')
+            text = text[1..];
 
         foreach (var raw in text.Split('\n'))
         {
@@ -25,8 +39,14 @@ public static class PrefixListParser
             if (!IPAddress.TryParse(line[..slash], out var ip)) continue;
             if (!byte.TryParse(line[(slash + 1)..], out var length)) continue;
             if (ip.AddressFamily != AddressFamily.InterNetwork) continue; // IPv4 only
+            // Reject 0 (default route — a route server should not originate one) and > 32 (nonsensical
+            // IPv4 length that byte.TryParse accepted). Length 1..32 only.
+            if (length is 0 or > 32) continue;
 
-            result.Add((BgpConstants.IPAddressToUint(ip), length));
+            // Mask host bits to the network address so equivalent prefixes normalize to one key.
+            var packed = BgpConstants.IPAddressToUint(ip);
+            var masked = packed & (0xFFFFFFFFu << (32 - length));
+            result.Add((masked, length));
         }
 
         return result;

--- a/BGPLite.Tests/PrefixListParserTests.cs
+++ b/BGPLite.Tests/PrefixListParserTests.cs
@@ -54,4 +54,72 @@ public class PrefixListParserTests
         var result = PrefixListParser.Parse("10.0.0.0/8\n5.6.0.0/16");
         Assert.Equal(2, result.Count);
     }
+
+    // --- #162: length validation + host-bit masking regression coverage ---
+
+    [Fact]
+    public void RejectsDefaultRoute_Length0()
+    {
+        // A route server must not originate a default — a stray 0.0.0.0/0 in a peer-supplied
+        // URL list would otherwise advertise the entire IPv4 space (#147, #162).
+        Assert.Empty(PrefixListParser.Parse("0.0.0.0/0"));
+    }
+
+    [Theory]
+    [InlineData("1.2.3.0/33")]
+    [InlineData("1.2.3.0/250")]
+    [InlineData("1.2.3.0/255")]
+    public void RejectsOutOfRangeLength(string line)
+    {
+        // byte.TryParse accepts 0..255; only 1..32 is a valid IPv4 prefix length.
+        Assert.Empty(PrefixListParser.Parse(line));
+    }
+
+    [Fact]
+    public void RejectsDefaultRoute_KeepsValidLines()
+    {
+        var result = PrefixListParser.Parse("0.0.0.0/0\n1.2.3.0/24");
+        var single = Assert.Single(result);
+        Assert.Equal((Ip("1.2.3.0"), (byte)24), single);
+    }
+
+    [Fact]
+    public void MasksHostBits_ToNetworkAddress()
+    {
+        // 10.0.0.5/24 and 10.0.0.99/24 are the same network; both must normalize to 10.0.0.0/24
+        // so downstream dedup keys them as one route instead of two distinct rows.
+        var result = PrefixListParser.Parse("10.0.0.5/24\n10.0.0.99/24");
+        Assert.Equal(2, result.Count);
+        Assert.All(result, r => Assert.Equal((Ip("10.0.0.0"), (byte)24), r));
+    }
+
+    [Fact]
+    public void MasksHostBits_NetworkAlreadyAligned_IsIdempotent()
+    {
+        var result = PrefixListParser.Parse("10.0.0.0/24");
+        var single = Assert.Single(result);
+        Assert.Equal((Ip("10.0.0.0"), (byte)24), single);
+    }
+
+    [Fact]
+    public void MasksHostBits_BoundaryLengths()
+    {
+        // /1 masks all but the top bit; /32 (host route) masks nothing.
+        var r1 = Assert.Single(PrefixListParser.Parse("255.255.255.255/1"));
+        Assert.Equal((Ip("128.0.0.0"), (byte)1), r1);
+
+        var r32 = Assert.Single(PrefixListParser.Parse("10.0.0.5/32"));
+        Assert.Equal((Ip("10.0.0.5"), (byte)32), r32);
+    }
+
+    [Fact]
+    public void SkipsUtf8Bom_FirstLine()
+    {
+        // A UTF-8 BOM (\uFEFF) is not stripped by string.Trim() — without explicit handling the
+        // first line of a BOM-prefixed list is silently dropped (#162).
+        var bom = "\uFEFF1.2.3.0/24";
+        var result = PrefixListParser.Parse(bom);
+        var single = Assert.Single(result);
+        Assert.Equal((Ip("1.2.3.0"), (byte)24), single);
+    }
 }


### PR DESCRIPTION
Closes #162

## Problem

`PrefixListParser.Parse` validated the prefix length only as a `byte`, so:
- `0.0.0.0/0` was accepted → a single line in a peer-supplied URL list advertised **the entire IPv4 space** to all peers (route leak, #147 surface).
- `33..255` were silently stored (nonsensical IPv4 lengths).
- Host bits were never masked → `10.0.0.5/24` stored verbatim instead of `10.0.0.0/24`, producing duplicate/overlapping routes and breaking dedup / longest-prefix-match.

The API-layer `ParseCustomPrefix` (#123) was hardened with a `0..32` range check, but the **providers-layer parser** (feeds `HttpPrefixProvider` peer-URL fetches and `FilePrefixProvider`) was not.

Also: a leading UTF-8 BOM (`\uFEFF`) is not stripped by `string.Trim()`, so the first line of a BOM-prefixed list was silently dropped.

## Fix

`BGPLite.Providers/PrefixListParser.cs`:
- Length constrained to **1..32** (length 0 = default route rejected — a route server should not originate one).
- Host bits masked to the network address: `packed & (0xFFFFFFFFu << (32 - length))`.
- Strip a leading UTF-8 BOM before splitting.

## Verification

- `dotnet build BGPLite.sln` ✅
- `dotnet test BGPLite.sln` ✅ 421 passed (was 413, +8 new regression tests)
- New tests in `PrefixListParserTests`: `RejectsDefaultRoute_Length0`, `RejectsOutOfRangeLength` (Theory: /33, /250, /255), `RejectsDefaultRoute_KeepsValidLines`, `MasksHostBits_ToNetworkAddress`, `MasksHostBits_NetworkAlreadyAligned_IsIdempotent`, `MasksHostBits_BoundaryLengths` (/1 and /32), `SkipsUtf8Bom_FirstLine`.

## Risk / behavior change

- **Intentional behavior change**: `/0` is now rejected at the providers layer. Operators previously relying on a `/0` line in `nets.txt` to advertise a default will lose that default (they should originate it via BGP config, not a CIDR list). Flagged for the release notes.
- Host-bit masking may collapse previously-distinct rows that differed only in host bits — strictly a correctness improvement (they were always the same network).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of prefix lists so invalid IPv4 prefix lengths are ignored.
  * Normalized IPv4 prefixes to their network address, preventing duplicate entries caused by host bits.
  * Added support for UTF-8 BOM-prefixed files so the first line is parsed correctly.

* **Tests**
  * Expanded test coverage for invalid lengths, canonical prefix handling, boundary cases, and BOM-related parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->