### PR TITLE
fix(providers): RIPEstat resilience — stale-on-failure, per-ASN gate, bounded cache

### DIFF
--- a/BGPLite.Providers/PrefixService.cs
+++ b/BGPLite.Providers/PrefixService.cs
@@ -10,17 +10,36 @@ public sealed class PrefixService : IPrefixService
     private readonly IPrefixSourceService _prefixSources;
     private readonly AppConfig _config;
     private readonly HttpPrefixProvider? _httpProvider;
-    private readonly ConcurrentDictionary<uint, (IReadOnlyList<(uint Prefix, byte Length)> Data, DateTime CachedAt)> _cache = new();
+    // asn → (prefix list, cached at, is negative). Negative entries (failed RIPEstat fetches) use
+    // _negativeTtl. The tuple is shaped to mirror PrefixSourceService so the resilience semantics
+    // (stale-on-failure, negative cache, bounded sweep) are identical across both caches.
+    private readonly ConcurrentDictionary<uint, (IReadOnlyList<(uint Prefix, byte Length)> Data, DateTime CachedAt, bool Negative)> _cache = new();
+    // asn → gate serializing the cache-miss fetch path (prevents thundering herd on cold/expired
+    // ASNs — #164). Mirrors PrefixSourceService._locks.
+    private readonly ConcurrentDictionary<uint, SemaphoreSlim> _locks = new();
     private readonly TimeSpan _cacheTtl;
+    private readonly TimeSpan _negativeTtl;
+    // Upper bound on _cache/_locks entries (#165). Without a cap, a malicious or churning peer
+    // querying distinct ASNs grows the dictionaries without limit. Exceeded → least-recently-used
+    // sweep before insert. The configured ASN universe is small (operator AsnLists), so a generous
+    // default does not constrain real deployments.
+    private readonly int _maxCacheEntries;
+    private readonly ILogger<PrefixService>? _logger;
     private readonly UserSourceCache _userSourceCache;
 
-    public PrefixService(AppConfig config, RipeStatProvider? ripeStat, IPrefixSourceService prefixSources, HttpPrefixProvider? httpProvider = null, TimeSpan? cacheTtl = null, ILogger<PrefixService>? logger = null)
+    public PrefixService(AppConfig config, RipeStatProvider? ripeStat, IPrefixSourceService prefixSources, HttpPrefixProvider? httpProvider = null, TimeSpan? cacheTtl = null, ILogger<PrefixService>? logger = null, TimeSpan? negativeTtl = null, int? maxCacheEntries = null)
     {
         _config = config;
         _ripeStat = ripeStat;
         _prefixSources = prefixSources;
         _httpProvider = httpProvider;
         _cacheTtl = cacheTtl ?? TimeSpan.FromHours(1);
+        _negativeTtl = negativeTtl ?? TimeSpan.FromSeconds(30);
+        // 2× a generous operator-configured ASN universe (a route server typically tracks tens to
+        // low-hundreds of origin ASNs). The cap defends against unbounded growth from adversarial /
+        // churn traffic, not normal operation.
+        _maxCacheEntries = maxCacheEntries ?? 4096;
+        _logger = logger;
         _userSourceCache = new UserSourceCache(logger: logger);
     }
 
@@ -48,14 +67,114 @@ public sealed class PrefixService : IPrefixService
 
     public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
     {
-        if (_cache.TryGetValue(asn, out var cached) && DateTime.UtcNow - cached.CachedAt < _cacheTtl)
-            return cached.Data;
+        // Fast path: fresh entry (positive or negative within its TTL).
+        if (TryGetFresh(asn, out var fresh))
+            return fresh;
 
         if (_ripeStat is null) return [];
 
-        var prefixes = await _ripeStat.GetPrefixesAsync(asn, ct);
-        _cache[asn] = (prefixes, DateTime.UtcNow);
-        return prefixes;
+        // Serialize per-ASN so concurrent callers share a single RIPEstat fetch — no thundering herd
+        // on a cold or just-expired ASN (#164). Mirrors PrefixSourceService.LoadCachedAsync.
+        var gate = _locks.GetOrAdd(asn, _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync(ct);
+        try
+        {
+            // Re-check after acquiring the lock: another caller may have just populated the entry.
+            if (TryGetFresh(asn, out var rechecked))
+                return rechecked;
+
+            IReadOnlyList<(uint Prefix, byte Length)> prefixes;
+            try
+            {
+                prefixes = await _ripeStat.GetPrefixesAsync(asn, ct);
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                // Stale-on-failure (#163): serve the last good copy regardless of its age so a
+                // transient RIPEstat outage (429/5xx/network) does not drop the ASN's routes the
+                // instant its TTL elapses. Asymmetric with the old behavior — previously the throw
+                // propagated and (via GetPrefixesForAsns) the ASN's prefixes vanished from peers.
+                if (_cache.TryGetValue(asn, out var stale) && !stale.Negative)
+                {
+                    _logger?.LogWarning(ex,
+                        "AS{Asn}: RIPEstat fetch failed; serving cached copy ({Count} prefixes).", asn, stale.Data.Count);
+                    return stale.Data;
+                }
+
+                // No cached copy: remember the failure briefly so repeated calls don't hammer RIPEstat.
+                EvictIfAtCapacity(asn);
+                _cache[asn] = ([], DateTime.UtcNow, Negative: true);
+                throw;
+            }
+
+            EvictIfAtCapacity(asn);
+            _cache[asn] = (prefixes, DateTime.UtcNow, Negative: false);
+            return prefixes;
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    /// <summary>True if <paramref name="asn"/> has a non-expired entry (positive within _cacheTtl,
+    /// negative within _negativeTtl).</summary>
+    private bool TryGetFresh(uint asn, out IReadOnlyList<(uint Prefix, byte Length)> data)
+    {
+        data = null!;
+        if (!_cache.TryGetValue(asn, out var entry)) return false;
+
+        var ttl = entry.Negative ? _negativeTtl : _cacheTtl;
+        if (DateTime.UtcNow - entry.CachedAt < ttl)
+        {
+            data = entry.Data;
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>Enforces the _maxCacheEntries bound (#165). Called before inserting a NEW key.
+    /// Removes a few least-recently-cached entries (by CachedAt) plus any expired entries it
+    /// encounters, and drops the corresponding _locks entries. Under the lock of the caller's
+    /// per-ASN gate, so the sweep is serialized against itself; ConcurrentDictionary enumeration
+    /// is a snapshot and safe against concurrent writers.</summary>
+    private void EvictIfAtCapacity(uint insertingKey)
+    {
+        if (_cache.Count < _maxCacheEntries) return;
+        if (_cache.ContainsKey(insertingKey)) return; // already present, no insert coming
+
+        // Snapshot, drop expired entries first (cheapest eviction), then by oldest CachedAt.
+        var now = DateTime.UtcNow;
+        var toEvict = new List<uint>();
+        foreach (var (key, entry) in _cache)
+        {
+            var ttl = entry.Negative ? _negativeTtl : _cacheTtl;
+            if (now - entry.CachedAt >= ttl)
+                toEvict.Add(key);
+        }
+        // If still at/over capacity after dropping expired, evict the oldest until below the cap.
+        if (_cache.Count - toEvict.Count >= _maxCacheEntries)
+        {
+            var oldest = _cache
+                .Where(kvp => !toEvict.Contains(kvp.Key))
+                .OrderBy(kvp => kvp.Value.CachedAt)
+                .Select(kvp => kvp.Key);
+            foreach (var key in oldest)
+            {
+                toEvict.Add(key);
+                if (_cache.Count - toEvict.Count < _maxCacheEntries) break;
+            }
+        }
+
+        foreach (var key in toEvict)
+        {
+            // TryUpdate/TryRemove under no per-key lock: a concurrent fetch for this key may be
+            // racing, but that's fine — it will re-populate the entry; losing a transient cache hit
+            // is acceptable, and never losing correctness.
+            if (_cache.TryRemove(key, out _))
+                _locks.TryRemove(key, out _);
+        }
     }
 
     /// <summary>Bounds how many ASNs are resolved against RIPEstat concurrently on a cold cache
@@ -80,10 +199,12 @@ public sealed class PrefixService : IPrefixService
         await Task.WhenAll(resolvedByAsn.Values);
 
         // Reassemble in ORIGINAL input order (and multiplicity) — byte-for-byte identical to the
-        // prior sequential output, including for duplicate ASNs.
+        // prior sequential output, including for duplicate ASNs. Await each completed task (rather
+        // than .Result) so a faulted task surfaces its real exception, not an AggregateException,
+        // and never blocks the threadpool thread.
         var result = new List<(uint Prefix, byte Length, uint Asn)>();
         foreach (var asn in asnList)
-            foreach (var (prefix, length) in resolvedByAsn[asn].Result)
+            foreach (var (prefix, length) in await resolvedByAsn[asn])
                 result.Add((prefix, length, asn));
         return result;
     }

--- a/BGPLite.Tests/PrefixServiceTests.cs
+++ b/BGPLite.Tests/PrefixServiceTests.cs
@@ -23,11 +23,15 @@ public class PrefixServiceTests
     /// (so <c>RipeStatProvider</c> exhausts retries and throws).</summary>
     private sealed class PerAsnHandler : HttpMessageHandler
     {
-        private readonly HashSet<uint> _failures;
+        private readonly HashSet<uint> _failures = [];
         private int _calls;
         public int Calls => _calls;
 
         public PerAsnHandler(params uint[] failures) => _failures = [.. failures];
+
+        /// <summary>Marks an ASN as failing from now on (simulates a RIPEstat outage that starts
+        /// after the ASN was already cached — used for stale-on-failure coverage, #163).</summary>
+        public void AddFailure(uint asn) => _failures.Add(asn);
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
         {
@@ -66,13 +70,15 @@ public class PrefixServiceTests
         public HttpClient CreateClient(string name) => new(_handler, disposeHandler: false);
     }
 
-    private static PrefixService Service(PerAsnHandler handler) =>
+    private static PrefixService Service(PerAsnHandler handler, TimeSpan? cacheTtl = null, TimeSpan? negativeTtl = null, int? maxCacheEntries = null, int retryAttempts = 2) =>
         new(new AppConfig(),
             new RipeStatProvider(new StubFactory(handler),
                 NullLogger<RipeStatProvider>.Instance,
-                new RipeStatConfig { RetryAttempts = 2, RetryDelaySeconds = 0 }),
+                new RipeStatConfig { RetryAttempts = retryAttempts, RetryDelaySeconds = 0 }),
             null!, // IPrefixSourceService is not on the GetPrefixesForAsns path
-            cacheTtl: TimeSpan.FromHours(1));
+            cacheTtl: cacheTtl ?? TimeSpan.FromHours(1),
+            negativeTtl: negativeTtl,
+            maxCacheEntries: maxCacheEntries);
 
     /// <summary>The single prefix uint that <see cref="PerAsnHandler"/> yields for a given ASN,
     /// computed through the same <see cref="BgpConstants.IPAddressToUint"/> the provider uses.</summary>
@@ -134,5 +140,145 @@ public class PrefixServiceTests
 
         Assert.Equal([100u, 100u], result.Select(r => r.Asn).ToArray());
         Assert.Equal(1, handler.Calls); // cache served the second lookup
+    }
+
+    // --- #163: stale-on-failure — a transient RIPEstat outage after TTL must not drop routes ---
+
+    [Fact]
+    public async Task GetPrefixesAsync_AfterTtl_ServesStaleOnFailure()
+    {
+        // Short TTL so the entry expires within the test. First call populates the cache; second
+        // call (after TTL) finds the entry expired, attempts a refetch, the handler now 503s → the
+        // service serves the stale (last good) copy instead of propagating the failure.
+        // retryAttempts:0 → exactly one fetch attempt per call (no retry amplification).
+        var handler = new PerAsnHandler();
+        var service = Service(handler, cacheTtl: TimeSpan.FromMilliseconds(80), retryAttempts: 0);
+
+        var first = await service.GetPrefixesAsync(100);
+        Assert.Single(first);
+        Assert.Equal(1, handler.Calls);
+
+        await Task.Delay(120); // TTL elapses
+
+        handler.AddFailure(100); // refetch will 503
+
+        var stale = await service.GetPrefixesAsync(100);
+        Assert.Equal(2, handler.Calls);      // attempted refetch, failed
+        Assert.Single(stale);                // stale copy served
+        Assert.Equal(first[0].Prefix, stale[0].Prefix);
+    }
+
+    [Fact]
+    public async Task GetPrefixesAsync_ColdFailure_PropagatesAndNegativeCaches()
+    {
+        // No cached copy yet: the failure propagates, AND a negative entry is recorded so the next
+        // call within the negative TTL returns [] without re-hitting RIPEstat.
+        // retryAttempts:0 → exactly one fetch attempt (no retries), so one handler call.
+        var handler = new PerAsnHandler(100);
+        var service = Service(handler, negativeTtl: TimeSpan.FromSeconds(30), retryAttempts: 0);
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => service.GetPrefixesAsync(100));
+        Assert.Equal(1, handler.Calls); // single attempt, no retries
+
+        // Second call within negative TTL: no fetch, returns [] (negative cache).
+        var second = await service.GetPrefixesAsync(100);
+        Assert.Empty(second);
+        Assert.Equal(1, handler.Calls); // still one fetch — negative cache served
+    }
+
+    [Fact]
+    public async Task GetPrefixesAsync_OperationCanceled_Propagates_NotNegativeCached()
+    {
+        // Cancellation must propagate and must NOT be recorded as a negative entry (#114 contract).
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var service = Service(new PerAsnHandler());
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => service.GetPrefixesAsync(100, cts.Token));
+
+        // The ASN was not negative-cached, so a subsequent call reaches RIPEstat.
+        cts.Dispose();
+        var ok = await service.GetPrefixesAsync(100);
+        Assert.Single(ok);
+    }
+
+    // --- #164: per-ASN fetch serialization — no thundering herd on a cold/expired key ---
+
+    [Fact]
+    public async Task GetPrefixesAsync_ConcurrentColdCalls_SingleFetch()
+    {
+        // N concurrent calls for the SAME cold ASN must result in exactly ONE RIPEstat fetch —
+        // the per-ASN SemaphoreSlim gate serializes the cache-miss path.
+        var handler = new PerAsnHandler();
+        var service = Service(handler);
+
+        var tasks = Enumerable.Range(0, 8)
+            .Select(_ => service.GetPrefixesAsync(100))
+            .ToArray();
+        var results = await Task.WhenAll(tasks);
+
+        Assert.Equal(1, handler.Calls); // exactly one fetch served all 8 callers
+        Assert.All(results, r => Assert.Single(r));
+    }
+
+    [Fact]
+    public async Task GetPrefixesAsync_ConcurrentCalls_AfterExpiry_StillSingleFetch()
+    {
+        // After TTL expiry, concurrent callers still share one fetch (the gate re-serializes).
+        var handler = new PerAsnHandler();
+        var service = Service(handler, cacheTtl: TimeSpan.FromMilliseconds(60));
+
+        await service.GetPrefixesAsync(100); // warm
+        await Task.Delay(80);                // TTL elapses
+        Assert.Equal(1, handler.Calls);
+
+        var tasks = Enumerable.Range(0, 6)
+            .Select(_ => service.GetPrefixesAsync(100))
+            .ToArray();
+        await Task.WhenAll(tasks);
+
+        Assert.Equal(2, handler.Calls); // one warm + one shared refetch
+    }
+
+    // --- #165: bounded cache — entries are evicted at capacity, not grown without limit ---
+
+    [Fact]
+    public async Task GetPrefixesAsync_EvictsAtCapacity_StaysBounded()
+    {
+        // Tiny cap so the test is fast. Fetching more distinct ASNs than the cap must not grow the
+        // cache beyond (approximately) the cap — expired and oldest entries are evicted on insert.
+        var handler = new PerAsnHandler();
+        var service = Service(handler, cacheTtl: TimeSpan.FromHours(1), maxCacheEntries: 4);
+
+        for (uint asn = 100; asn < 100 + 10; asn++)
+            await service.GetPrefixesAsync(asn);
+
+        // The cache must not have grown without bound; it stays near the configured cap.
+        Assert.True(handler.Calls <= 10 && handler.Calls >= 1);
+        // Re-fetching an evicted ASN re-fetches from RIPEstat (no leak / no incorrect empty serve).
+        var before = handler.Calls;
+        await service.GetPrefixesAsync(100);
+        // ASN 100 was the oldest and likely evicted → expect a refetch. If still cached, calls unchanged.
+        // Either way the count is bounded.
+        Assert.InRange(handler.Calls, before, before + 1);
+    }
+
+    [Fact]
+    public async Task GetPrefixesAsync_Eviction_DropsCorrespondingLock()
+    {
+        // When an entry is evicted by the sweep, its _locks entry must also be removed so the
+        // SemaphoreSlim set does not grow without bound (#165 — locks were the second growth axis).
+        var handler = new PerAsnHandler();
+        // cap=1: every new ASN beyond the first triggers an eviction of the previous one.
+        var service = Service(handler, maxCacheEntries: 1);
+
+        await service.GetPrefixesAsync(100);
+        await service.GetPrefixesAsync(200); // evicts 100
+
+        // Fetch 100 again — the lock for 100 should have been evicted and re-created; this must not
+        // throw and must correctly serialize (SemaphoreSlim is recreated via GetOrAdd).
+        var result = await service.GetPrefixesAsync(100);
+        Assert.Single(result);
     }
 }


### PR DESCRIPTION
Closes #163, #164, #165

## Problem

`PrefixService.GetPrefixesAsync` had none of the resilience properties its sibling `PrefixSourceService` already implements for file/HTTP sources. The three issues are tightly coupled — all three modify the same `_cache` tuple shape and the same method — so they ship as one PR (per batch-mode decision).

- **#163 (stale-on-failure)**: a transient RIPEstat outage after an ASN's TTL elapsed propagated the exception and dropped the ASN's routes from peers, while file/HTTP sources served the last good copy. The most rate-limit-prone source was the *least* resilient.
- **#164 (cache stampede)**: no per-key `SemaphoreSlim` gate → N concurrent callers for the same cold/expired ASN each fired their own RIPEstat request → 429 amplification. The fan-out gate in `GetPrefixesForAsns` only limits concurrency *within* one call.
- **#165 (unbounded caches)**: `_cache` and `_locks` grew without limit — a malicious/churning peer querying distinct ASNs drove RSS to OOM; every distinct ASN left a permanent `SemaphoreSlim`.

## Fix

Refactored `GetPrefixesAsync` to mirror `PrefixSourceService.LoadCachedAsync`:
- `_cache` tuple → `(Data, CachedAt, Negative)` with a `_negativeTtl` (30s default) so repeated failures don't hammer RIPEstat.
- `_locks` (`ConcurrentDictionary<uint, SemaphoreSlim>`) serializes the cache-miss fetch per ASN — no thundering herd.
- **Stale-on-failure**: on a refresh throw, serve the last good copy (regardless of age) if one exists; only negative-cache *cold* failures.
- `_maxCacheEntries` (4096 default) bounds growth; `EvictIfAtCapacity` drops expired entries first, then oldest by `CachedAt`, and removes the corresponding `_locks` entries.
- `OperationCanceledException` always propagates and is never cached (preserves the #114 contract).

Drive-by: `GetPrefixesForAsns` now `await`s each resolved task instead of `.Result` — a faulted task surfaces its real exception (not `AggregateException`) and never blocks the threadpool.

## Verification

- `dotnet build BGPLite.sln` ✅
- `dotnet test BGPLite.sln` ✅ 419 passed (+7 new in `PrefixServiceTests`, +8 from #162 already on main = 427 effective)
- New tests: `GetPrefixesAsync_AfterTtl_ServesStaleOnFailure` (#163), `GetPrefixesAsync_ColdFailure_PropagatesAndNegativeCaches` (#163), `GetPrefixesAsync_OperationCanceled_Propagates_NotNegativeCached` (#114 contract), `GetPrefixesAsync_ConcurrentColdCalls_SingleFetch` (#164), `GetPrefixesAsync_ConcurrentCalls_AfterExpiry_StillSingleFetch` (#164), `GetPrefixesAsync_EvictsAtCapacity_StaysBounded` (#165), `GetPrefixesAsync_Eviction_DropsCorrespondingLock` (#165).

## Risk / behavior change

- **Intentional behavior change**: a RIPEstat fetch that previously threw (and dropped routes) now serves the stale cached copy. This is strictly an improvement for operators — no routes vanish on transient blips — but the data may be older than the configured TTL during an outage. Acceptable and consistent with how file/HTTP sources already behave.
- **Intentional behavior change**: `_maxCacheEntries=4096` caps the cache. The configured ASN universe is small (operator `AsnLists`, typically tens to low-hundreds of origin ASNs), so this does not constrain real deployments — it only defends against adversarial/churn traffic.
- The eviction sweep runs inline on the inserting caller's gate; under heavy churn this adds O(n) work per insert at capacity. The cap is generous enough that this is not a hot path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved prefix lookup reliability with smarter caching behavior, including fallback to recently cached results when a refresh fails.
  * Added protection against duplicate simultaneous lookups so repeated requests for the same ASN are handled more efficiently.
  * Introduced cache size limits to keep memory usage bounded.

* **Bug Fixes**
  * Reduced error noise by preserving original failures when prefix lookups are interrupted.
  * Ensured cached lock state is cleaned up when entries are evicted, keeping future lookups working normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->