### PR TITLE
fix(server): honor CancellationToken in StopAsync and NotifyCeaseAsync

### DIFF
--- a/BGPLite.Server/BgpServer.cs
+++ b/BGPLite.Server/BgpServer.cs
@@ -99,9 +99,14 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
             _listener.Close();
         }
 
+        // The host's shutdown token bounds how long each step blocks — a stuck peer (TCP receive
+        // window full → WriteAsync blocks on the send buffer) must not pin StopAsync past the host's
+        // grace (#161). WaitAsync propagates the cancellation as OperationCanceledException; on
+        // cancel we abandon the pending step and move on to force-disposing the sessions below.
         if (_acceptTask is not null)
         {
-            try { await _acceptTask; }
+            try { await _acceptTask.WaitAsync(cancellationToken); }
+            catch (OperationCanceledException) { /* host grace elapsed — proceed to force teardown */ }
             catch { }
         }
 
@@ -122,14 +127,20 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
         {
             var ceases = _sessions.Values
                 .Where(s => s.IsEstablished)
-                .Select(s => s.NotifyCeaseAsync())
+                .Select(s => s.NotifyCeaseAsync(cancellationToken))
                 .ToArray();
             if (ceases.Length > 0)
-                await Task.WhenAll(ceases);
+            {
+                try { await Task.WhenAll(ceases).WaitAsync(cancellationToken); }
+                catch (OperationCanceledException) { /* host grace elapsed — proceed to force teardown */ }
+                catch { }
+            }
         }
 
         _cts.Cancel();
 
+        // Always dispose the sessions even if a Cease step was cancelled above — the socket close is
+        // the ultimate signal to the peer and releases FDs/timers/tasks so the process can exit.
         foreach (var session in _sessions.Values)
         {
             session.Dispose();
@@ -139,7 +150,9 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
         _statusTimer?.Dispose();
         if (_statusTask is not null)
         {
-            try { await _statusTask; } catch { }
+            try { await _statusTask.WaitAsync(cancellationToken); }
+            catch (OperationCanceledException) { /* host grace elapsed */ }
+            catch { }
         }
     }
 

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -1241,16 +1241,19 @@ public sealed class BgpSession : IDisposable
     // Single synchronized entry point for ALL outbound BGP bytes (RFC 4271 framing requires a
     // continuous message stream; NetworkStream is not thread-safe). Callers do NOT need to
     // acquire _sendLock themselves — every send path goes through here.
-    private async Task SendMessageAsync(BgpMessage message, CancellationToken ct = default)
+    // Returns true if the message was fully written; false if the send was cancelled (e.g. the
+    // shutdown grace elapsed) or the session was disposed mid-send — callers that need accurate
+    // teardown logging (NotifyCeaseAsync) branch on this instead of assuming success.
+    private async Task<bool> SendMessageAsync(BgpMessage message, CancellationToken ct = default)
     {
         try
         {
             await _sendLock.WaitAsync(ct);
         }
-        catch (OperationCanceledException) { return; }
+        catch (OperationCanceledException) { return false; }
         catch (ObjectDisposedException)
         {
-            return;
+            return false;
         }
 
         try
@@ -1261,14 +1264,17 @@ public sealed class BgpSession : IDisposable
             {
                 var written = BgpMessageWriter.WriteMessage(message, buffer);
                 await _stream.WriteAsync(buffer.AsMemory(0, written), ct);
+                return true;
             }
             catch (OperationCanceledException)
             {
                 // Caller cancelled the send (e.g. shutdown grace expired) — best effort during teardown.
+                return false;
             }
             catch (ObjectDisposedException)
             {
                 // Session disposed mid-send — best effort during teardown.
+                return false;
             }
             finally
             {
@@ -1362,10 +1368,10 @@ public sealed class BgpSession : IDisposable
 
     private Task SendKeepaliveAsync() => SendMessageAsync(BgpKeepaliveMessage.Instance);
 
-    private Task SendNotificationAsync(byte errorCode, byte subErrorCode, CancellationToken ct = default)
+    private Task<bool> SendNotificationAsync(byte errorCode, byte subErrorCode, CancellationToken ct = default)
         => SendNotificationAsync(errorCode, subErrorCode, null, ct);
 
-    private async Task SendNotificationAsync(byte errorCode, byte subErrorCode, byte[]? data, CancellationToken ct = default)
+    private async Task<bool> SendNotificationAsync(byte errorCode, byte subErrorCode, byte[]? data, CancellationToken ct = default)
     {
         var notification = new BgpNotificationMessage
         {
@@ -1373,8 +1379,10 @@ public sealed class BgpSession : IDisposable
             SubErrorCode = subErrorCode,
             Data = data is null ? null : (byte[])data.Clone()
         };
-        await SendMessageAsync(notification, ct);
-        _logger.LogInformation("NotificationSent to {Peer}: {Error}/{SubError}", _peer, errorCode, subErrorCode);
+        var sent = await SendMessageAsync(notification, ct);
+        if (sent)
+            _logger.LogInformation("NotificationSent to {Peer}: {Error}/{SubError}", _peer, errorCode, subErrorCode);
+        return sent;
     }
 
     /// <summary>
@@ -1397,13 +1405,13 @@ public sealed class BgpSession : IDisposable
 
         try
         {
-            await SendNotificationAsync(BgpConstants.Error.Cease, BgpConstants.SubError.CeaseAdministrativeReset, ct);
-            _logger.LogInformation("Cease sent to {Peer} on shutdown", _peer);
-        }
-        catch (OperationCanceledException)
-        {
-            // Shutdown grace elapsed before the Cease send completed — best effort during teardown;
-            // the socket close below is the ultimate signal to the peer.
+            var sent = await SendNotificationAsync(BgpConstants.Error.Cease, BgpConstants.SubError.CeaseAdministrativeReset, ct);
+            if (sent)
+                _logger.LogInformation("Cease sent to {Peer} on shutdown", _peer);
+            else
+                // Cancellation (host grace elapsed) or session disposed mid-send — best effort during
+                // teardown; the socket close below is the ultimate signal to the peer.
+                _logger.LogDebug("Cease to {Peer} on shutdown did not complete (cancelled or disposed)", _peer);
         }
         catch (Exception ex)
         {

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -1241,12 +1241,13 @@ public sealed class BgpSession : IDisposable
     // Single synchronized entry point for ALL outbound BGP bytes (RFC 4271 framing requires a
     // continuous message stream; NetworkStream is not thread-safe). Callers do NOT need to
     // acquire _sendLock themselves — every send path goes through here.
-    private async Task SendMessageAsync(BgpMessage message)
+    private async Task SendMessageAsync(BgpMessage message, CancellationToken ct = default)
     {
         try
         {
-            await _sendLock.WaitAsync();
+            await _sendLock.WaitAsync(ct);
         }
+        catch (OperationCanceledException) { return; }
         catch (ObjectDisposedException)
         {
             return;
@@ -1259,7 +1260,11 @@ public sealed class BgpSession : IDisposable
             try
             {
                 var written = BgpMessageWriter.WriteMessage(message, buffer);
-                await _stream.WriteAsync(buffer.AsMemory(0, written));
+                await _stream.WriteAsync(buffer.AsMemory(0, written), ct);
+            }
+            catch (OperationCanceledException)
+            {
+                // Caller cancelled the send (e.g. shutdown grace expired) — best effort during teardown.
             }
             catch (ObjectDisposedException)
             {
@@ -1357,12 +1362,10 @@ public sealed class BgpSession : IDisposable
 
     private Task SendKeepaliveAsync() => SendMessageAsync(BgpKeepaliveMessage.Instance);
 
-    private async Task SendNotificationAsync(byte errorCode, byte subErrorCode)
-    {
-        await SendNotificationAsync(errorCode, subErrorCode, null);
-    }
+    private Task SendNotificationAsync(byte errorCode, byte subErrorCode, CancellationToken ct = default)
+        => SendNotificationAsync(errorCode, subErrorCode, null, ct);
 
-    private async Task SendNotificationAsync(byte errorCode, byte subErrorCode, byte[]? data)
+    private async Task SendNotificationAsync(byte errorCode, byte subErrorCode, byte[]? data, CancellationToken ct = default)
     {
         var notification = new BgpNotificationMessage
         {
@@ -1370,7 +1373,7 @@ public sealed class BgpSession : IDisposable
             SubErrorCode = subErrorCode,
             Data = data is null ? null : (byte[])data.Clone()
         };
-        await SendMessageAsync(notification);
+        await SendMessageAsync(notification, ct);
         _logger.LogInformation("NotificationSent to {Peer}: {Error}/{SubError}", _peer, errorCode, subErrorCode);
     }
 
@@ -1379,8 +1382,10 @@ public sealed class BgpSession : IDisposable
     /// should only invoke this on an Established session and only when Graceful Restart is disabled —
     /// a NOTIFICATION termination bypasses GR (RFC 4724 §4), so with GR on we drop the TCP connection
     /// instead to let peers retain our routes. Write/IO errors are swallowed (we are shutting down).
+    /// Accepts a <see cref="CancellationToken"/> so the host's shutdown grace can bound how long a
+    /// single Cease send blocks (a slow/stuck peer otherwise pins the send lock indefinitely).
     /// </summary>
-    public async Task NotifyCeaseAsync()
+    public async Task NotifyCeaseAsync(CancellationToken ct = default)
     {
         // Atomically claim the teardown as LocalCease BEFORE sending. If a concurrent
         // MarkSilentClose (GR-aware shutdown / session replacement) or a peer NOTIFICATION
@@ -1392,8 +1397,13 @@ public sealed class BgpSession : IDisposable
 
         try
         {
-            await SendNotificationAsync(BgpConstants.Error.Cease, BgpConstants.SubError.CeaseAdministrativeReset);
+            await SendNotificationAsync(BgpConstants.Error.Cease, BgpConstants.SubError.CeaseAdministrativeReset, ct);
             _logger.LogInformation("Cease sent to {Peer} on shutdown", _peer);
+        }
+        catch (OperationCanceledException)
+        {
+            // Shutdown grace elapsed before the Cease send completed — best effort during teardown;
+            // the socket close below is the ultimate signal to the peer.
         }
         catch (Exception ex)
         {

--- a/BGPLite.Tests/BgpSessionShutdownTests.cs
+++ b/BGPLite.Tests/BgpSessionShutdownTests.cs
@@ -653,4 +653,32 @@ public class BgpSessionShutdownTests
             got += n;
         }
     }
+
+    /// <summary>
+    /// Regression for #161: NotifyCeaseAsync must honor a CancellationToken so the host's shutdown
+    /// grace can bound how long a Cease send blocks. With an already-cancelled token the call must
+    /// return promptly instead of blocking on the socket write — the ultimate signal to the peer is
+    /// the socket close that follows, not the Cease bytes.
+    /// </summary>
+    [Fact]
+    public async Task NotifyCeaseAsync_Honors_Cancelled_Token_Returns_Promptly()
+    {
+        var (server, client) = ConnectedPair();
+        using var clientSock = client;
+        var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
+        using var session = new BgpSession(
+            server, new PeerConfig { Address = "127.0.0.1" }, bgpConfig,
+            new RouteTable(), AllowAllFilter.Instance, new BgpMetrics(), new NopLogger<BgpSession>());
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        await session.NotifyCeaseAsync(cts.Token);
+        sw.Stop();
+
+        // Must return well under a second — cancellation short-circuits the send path.
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(2),
+            $"NotifyCeaseAsync with a cancelled token took {sw.ElapsedMilliseconds}ms — token not honored");
+    }
 }


### PR DESCRIPTION
Closes #161

## Problem

`BgpServer.StopAsync(CancellationToken)` accepted a token but never used it. The three awaits (`_acceptTask`, the Cease fan-out, `_statusTask`) ignored the host's shutdown grace. Combined with the send path having no cancellation (a slow/stuck peer blocks `WriteAsync` on the kernel send buffer until the TCP retransmission timeout — minutes), a single unresponsive peer pinned `StopAsync` past the host's shutdown timeout with no escape. On `docker stop` / `systemctl stop` the process was SIGKILLed after the grace instead of unwinding cleanly.

`NotifyCeaseAsync` and `SendMessageAsync`/`SendNotificationAsync` accepted no `CancellationToken` at all, so there was no way to bound a Cease send from the caller.

## Fix

Threaded the token end-to-end on the shutdown path:

- `SendMessageAsync`, both `SendNotificationAsync` overloads, and `NotifyCeaseAsync` now accept an optional `CancellationToken` (default `default`) and pass it into `_sendLock.WaitAsync` and `WriteAsync`. `OperationCanceledException` is caught and unwinds cleanly — the socket close that follows is the ultimate signal to the peer.
- `StopAsync` wraps each of its three awaits with `.WaitAsync(cancellationToken)` and catches `OperationCanceledException` to proceed to force-disposing the sessions. The Cease is best-effort; resource release (FDs, timers, tasks) is not.

The default-argument overloads keep the 15+ existing call sites of `SendNotificationAsync`/`SendMessageAsync` unchanged — no churn in the session FSM paths.

This pairs with #160 (send-path cancellation on the session side). It does not depend on #160 to land — the default token preserves existing behavior — but together they make the entire shutdown chain cancellable.

## Verification

- `dotnet build BGPLite.sln` ✅
- `dotnet test BGPLite.sln` ✅ 413 passed (+1 new regression test)
- New test: `NotifyCeaseAsync_Honors_Cancelled_Token_Returns_Promptly` — asserts that with an already-cancelled token, `NotifyCeaseAsync` returns in under 2s instead of blocking on the socket write.
- Existing shutdown tests (16) still pass — the default-argument change is backward-compatible.

## Risk / behavior change

- **Intentional behavior change**: when the host's shutdown grace elapses mid-Cease, the Cease bytes may not reach the peer. This is strictly an improvement over the status quo (the whole process hangs and gets SIGKILLed, which also fails to send the Cease). The peer sees a TCP close either way.
- No change to the session FSM send path for normal operation (default token = `CancellationToken.None` semantics).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown behavior so shutdown cancellation is honored more explicitly during graceful teardown.
  * Cease notifications and periodic status/logging steps now respect the provided cancellation window to avoid delayed shutdown.
  * Message sending during shutdown is now cancellation-aware to reduce the risk of hangs when connections are closing.

* **Tests**
  * Added a regression test ensuring `NotifyCeaseAsync` returns promptly when cancellation is already requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->