### PR TITLE
fix(providers): send per-source headers/timeout per-request, not via client mutation

### DIFF
--- a/BGPLite.Providers/HttpPrefixProvider.cs
+++ b/BGPLite.Providers/HttpPrefixProvider.cs
@@ -31,46 +31,69 @@ public sealed class HttpPrefixProvider(
         if (string.IsNullOrWhiteSpace(source.Url))
             throw new InvalidOperationException($"Prefix source '{source.Name}': Kind=http requires a Url.");
 
-        var url = source.Url;
         var http = httpFactory.CreateClient(ClientName);
+
+        // Per-source timeout: link the caller's token with a CancelAfter so a slow peer URL can't pin
+        // the fetch past its configured budget. We do NOT mutate http.Timeout (#155 regression): the
+        // named client is pooled by IHttpClientFactory, and mutating it leaks the per-source timeout
+        // onto the next caller that reuses the same client within the handler-lifetime window.
+        CancellationTokenSource? timeoutCts = null;
+        CancellationToken linkedToken;
         if (source.Timeout is int seconds && seconds > 0)
-            http.Timeout = TimeSpan.FromSeconds(seconds);
-        if (source.Headers is { Count: > 0 } headers)
-            foreach (var (key, value) in headers)
-            {
-                if (key.Equals("User-Agent", StringComparison.OrdinalIgnoreCase))
-                    http.DefaultRequestHeaders.Remove(key);
-                if (!http.DefaultRequestHeaders.TryAddWithoutValidation(key, value))
-                    logger.LogWarning("Source '{Name}': could not add request header '{Header}'.", source.Name, key);
-            }
-
-        // Stream-read with size cap (#144): ResponseHeadersRead gets headers first (fast Content-Length
-        // check), then stream the body with a hard cap to prevent OOM. SSRF validation is at the
-        // handler level (SocketsHttpHandler.ConnectCallback in Program.cs) — no pre-resolve here.
-        using var response = await http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct);
-        response.EnsureSuccessStatusCode();
-
-        if (response.Content.Headers.ContentLength is long contentLength && contentLength > MaxResponseBytes)
-            throw new InvalidOperationException(
-                $"Prefix source '{source.Name}': response too large ({contentLength} bytes, max {MaxResponseBytes}).");
-
-        using var stream = await response.Content.ReadAsStreamAsync(ct);
-        using var ms = new MemoryStream();
-        var buffer = new byte[8192];
-        int read;
-        while ((read = await stream.ReadAsync(buffer, ct)) > 0)
         {
-            ms.Write(buffer, 0, read);
-            if (ms.Length > MaxResponseBytes)
-                throw new InvalidOperationException(
-                    $"Prefix source '{source.Name}': response exceeded {MaxResponseBytes} bytes during stream.");
+            timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            timeoutCts.CancelAfter(TimeSpan.FromSeconds(seconds));
+            linkedToken = timeoutCts.Token;
+        }
+        else
+        {
+            linkedToken = ct;
         }
 
-        var text = Encoding.UTF8.GetString(ms.GetBuffer(), 0, (int)ms.Length);
-        var prefixes = PrefixListParser.Parse(text);
-        // Log only the source Name (the operator/peer-supplied identifier), never the URL — peer URLs
-        // (#147) may carry tokens in the query string that must not reach application logs.
-        logger.LogInformation("Source '{Name}' (http): loaded {Count} prefixes", source.Name, prefixes.Count);
-        return prefixes;
+        // Per-source headers go on the REQUEST message, never on http.DefaultRequestHeaders (#155):
+        // the named client is pooled and shared, so mutating its default headers leaks source A's
+        // Authorization / X-API-Key onto source B's next request. Per-message headers merge with the
+        // client's configured defaults (User-Agent: BGPLite/1.0) and override per-source.
+        using var request = new HttpRequestMessage(HttpMethod.Get, source.Url);
+        if (source.Headers is { Count: > 0 } headers)
+            foreach (var (key, value) in headers)
+                if (!request.Headers.TryAddWithoutValidation(key, value))
+                    logger.LogWarning("Source '{Name}': could not add request header '{Header}'.", source.Name, key);
+
+        try
+        {
+            // Stream-read with size cap (#144): ResponseHeadersRead gets headers first (fast Content-Length
+            // check), then stream the body with a hard cap to prevent OOM. SSRF validation is at the
+            // handler level (SocketsHttpHandler.ConnectCallback in Program.cs) — no pre-resolve here.
+            using var response = await http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, linkedToken);
+            response.EnsureSuccessStatusCode();
+
+            if (response.Content.Headers.ContentLength is long contentLength && contentLength > MaxResponseBytes)
+                throw new InvalidOperationException(
+                    $"Prefix source '{source.Name}': response too large ({contentLength} bytes, max {MaxResponseBytes}).");
+
+            using var stream = await response.Content.ReadAsStreamAsync(linkedToken);
+            using var ms = new MemoryStream();
+            var buffer = new byte[8192];
+            int read;
+            while ((read = await stream.ReadAsync(buffer, linkedToken)) > 0)
+            {
+                ms.Write(buffer, 0, read);
+                if (ms.Length > MaxResponseBytes)
+                    throw new InvalidOperationException(
+                        $"Prefix source '{source.Name}': response exceeded {MaxResponseBytes} bytes during stream.");
+            }
+
+            var text = Encoding.UTF8.GetString(ms.GetBuffer(), 0, (int)ms.Length);
+            var prefixes = PrefixListParser.Parse(text);
+            // Log only the source Name (the operator/peer-supplied identifier), never the URL — peer URLs
+            // (#147) may carry tokens in the query string that must not reach application logs.
+            logger.LogInformation("Source '{Name}' (http): loaded {Count} prefixes", source.Name, prefixes.Count);
+            return prefixes;
+        }
+        finally
+        {
+            timeoutCts?.Dispose();
+        }
     }
 }

--- a/BGPLite.Tests/HttpPrefixProviderTests.cs
+++ b/BGPLite.Tests/HttpPrefixProviderTests.cs
@@ -47,17 +47,18 @@ public class HttpPrefixProviderTests
         }
     }
 
-    /// <summary>Records the URL + Authorization header of every incoming request (thread-safe).</summary>
+    /// <summary>Records the URL, Authorization, X-API-Key headers + the per-request state of every
+    /// incoming request (thread-safe). Used to assert per-source headers land on the REQUEST message
+    /// and never mutate the shared client's DefaultRequestHeaders (#155).</summary>
     private sealed class RecordingHandler : HttpMessageHandler
     {
-        public ConcurrentQueue<(string Url, string? Auth)> Seen { get; } = new();
+        public ConcurrentQueue<HttpRequestMessage> Seen { get; } = new();
         public string? LastUserAgent { get; private set; }
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
         {
-            var auth = request.Headers.Authorization is { } h ? $"{h.Scheme} {h.Parameter}" : null;
             LastUserAgent = request.Headers.UserAgent.ToString();
-            Seen.Enqueue((request.RequestUri!.ToString(), auth));
+            Seen.Enqueue(request);
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent("1.2.3.0/24\n")
@@ -93,22 +94,29 @@ public class HttpPrefixProviderTests
     }
 
     [Fact]
-    public async Task AppliesPerSourceTimeout()
+    public async Task AppliesPerSourceTimeout_DoesNotMutateSharedClient()
     {
+        // #155: per-source timeout must NOT mutate http.Timeout (the named client is pooled). A slow
+        // source that times out must do so via a linked CTS, leaving the client's Timeout untouched
+        // for the next caller.
         var factory = new StubFactory(new StubHandler(HttpStatusCode.OK, "1.2.3.0/24\n"));
         var provider = new HttpPrefixProvider(factory, NullLogger<HttpPrefixProvider>.Instance);
 
         await provider.LoadAsync(new PrefixSourceConfig { Name = "t", Kind = "http", Url = "https://example.com/x.txt", Timeout = 7 });
 
         Assert.NotNull(factory.LastClient);
-        Assert.Equal(TimeSpan.FromSeconds(7), factory.LastClient!.Timeout);
+        // The client's own Timeout is the default (100s) — NOT mutated to 7s by LoadAsync.
+        Assert.Equal(TimeSpan.FromSeconds(100), factory.LastClient!.Timeout);
     }
 
     [Fact]
-    public async Task AppliesPerSourceHeaders()
+    public async Task AppliesPerSourceHeaders_OnRequestMessage()
     {
-        var factory = new StubFactory(new StubHandler(HttpStatusCode.OK, "1.2.3.0/24\n"));
-        var provider = new HttpPrefixProvider(factory, NullLogger<HttpPrefixProvider>.Instance);
+        // #155: per-source headers must land on the REQUEST message, never on
+        // http.DefaultRequestHeaders (the named client is pooled — mutating it leaks credentials
+        // across sources). RecordingHandler captures the actual request that reached the handler.
+        var handler = new RecordingHandler();
+        var provider = new HttpPrefixProvider(new StubFactory(handler), NullLogger<HttpPrefixProvider>.Instance);
 
         await provider.LoadAsync(new PrefixSourceConfig
         {
@@ -118,9 +126,31 @@ public class HttpPrefixProviderTests
             Headers = new() { ["Authorization"] = "Bearer secret", ["X-API-Key"] = "k" }
         });
 
-        var headers = factory.LastClient!.DefaultRequestHeaders;
-        Assert.Equal("Bearer secret", headers.GetValues("Authorization").First());
-        Assert.Equal("k", headers.GetValues("X-API-Key").First());
+        var request = Assert.Single(handler.Seen);
+        Assert.Equal("Bearer secret", request.Headers.GetValues("Authorization").First());
+        Assert.Equal("k", request.Headers.GetValues("X-API-Key").First());
+    }
+
+    [Fact]
+    public async Task PerSourceHeaders_DoNotLeakOntoNextRequest()
+    {
+        // #155 regression: source A's Authorization must NOT appear on source B's request when they
+        // reuse the same named client. The prior code mutated DefaultRequestHeaders, so source A's
+        // credentials bled onto source B.
+        var handler = new RecordingHandler();
+        var provider = new HttpPrefixProvider(new StubFactory(handler), NullLogger<HttpPrefixProvider>.Instance);
+
+        var srcA = new PrefixSourceConfig { Name = "a", Kind = "http", Url = "https://a.example/x.txt", Headers = new() { ["Authorization"] = "Bearer AAA" } };
+        var srcB = new PrefixSourceConfig { Name = "b", Kind = "http", Url = "https://b.example/x.txt" };
+
+        await provider.LoadAsync(srcA);
+        await provider.LoadAsync(srcB);
+
+        var requests = handler.Seen.ToList();
+        Assert.Equal(2, requests.Count);
+        Assert.Equal("Bearer AAA", requests[0].Headers.GetValues("Authorization").First());
+        // Source B must carry NO Authorization header — A's credentials did not leak.
+        Assert.False(requests[1].Headers.Contains("Authorization"));
     }
 
     [Fact]
@@ -138,8 +168,8 @@ public class HttpPrefixProviderTests
 
         var seen = handler.Seen.ToList();
         Assert.Equal(40, seen.Count);
-        Assert.All(seen.Where(x => x.Url.Contains("a.example")), x => Assert.Equal("Bearer AAA", x.Auth));
-        Assert.All(seen.Where(x => x.Url.Contains("b.example")), x => Assert.Equal("Bearer BBB", x.Auth));
+        Assert.All(seen.Where(r => r.RequestUri!.ToString().Contains("a.example")), r => Assert.Equal("Bearer AAA", r.Headers.GetValues("Authorization").First()));
+        Assert.All(seen.Where(r => r.RequestUri!.ToString().Contains("b.example")), r => Assert.Equal("Bearer BBB", r.Headers.GetValues("Authorization").First()));
     }
 
     [Fact]


### PR DESCRIPTION
Closes #155

## Problem

`HttpPrefixProvider.LoadAsync` mutated the pooled `HttpClient` returned by `IHttpClientFactory.CreateClient(ClientName)` on every load:

- `http.Timeout = TimeSpan.FromSeconds(seconds)` overwrote the client's timeout.
- `http.DefaultRequestHeaders.TryAddWithoutValidation(key, value)` mutated the client's default headers (Authorization, X-API-Key, custom tokens).

`IHttpClientFactory.CreateClient("http")` returns a pooled `HttpClient` whose `DefaultRequestHeaders` are shared across callers within a handler-lifetime window. Per-source credentials leaked across concurrently-fetched sources; per-source timeout was observed by the next source on the same client; concurrent `LoadAsync` calls raced on `DefaultRequestHeaders`.

The prior tests (`AppliesPerSourceTimeout`, `AppliesPerSourceHeaders`) actually **codified the bug** — they asserted that `factory.LastClient.Timeout` / `DefaultRequestHeaders` had been mutated.

## Fix

`BGPLite.Providers/HttpPrefixProvider.cs`:
- **Per-source timeout**: applied via a linked `CancellationTokenSource.CancelAfter`, leaving `http.Timeout` at its configured default (100s). `http.Timeout` is never mutated.
- **Per-source headers**: placed on a per-request `HttpRequestMessage` and sent via `http.SendAsync`. They merge with the client's configured defaults (`User-Agent: BGPLite/1.0` from `Program.cs` DI registration) and override per-source, but never mutate the shared client.
- The `User-Agent` special-case removal (`if (key.Equals("User-Agent")) Remove(...)`) is no longer needed — per-message headers naturally override client defaults for the same header.

## Verification

- `dotnet build BGPLite.sln` ✅
- `dotnet test BGPLite.sln` ✅ 430 passed (+1 new test, 2 updated to assert on the request message instead of the mutated client)
- Updated: `AppliesPerSourceTimeout_DoesNotMutateSharedClient` (asserts `http.Timeout` stays at 100s default), `AppliesPerSourceHeaders_OnRequestMessage` (asserts headers on the request that reached the handler).
- New: `PerSourceHeaders_DoNotLeakOntoNextRequest` — fetches source A with `Authorization: Bearer AAA`, then source B with no headers; asserts source B's request carries NO Authorization header.
- Existing `ParallelRequests_DoNotShareHeaders` (40 concurrent) still passes.

## Risk / behavior change

- **Intentional behavior change**: a per-source timeout that previously raised `http.Timeout`'s `TaskCanceledException` on the client now raises it via the linked CTS. The exception type is the same (`TaskCanceledException` / `OperationCanceledException`); callers already catch these. No contract change.
- Per-source `User-Agent` override still works (verified by `PerSourceUserAgent_OverridesDefault`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Per-request timeouts and headers now apply to each outgoing HTTP request without affecting other requests.
  * Improved handling of authorization and API key headers so they no longer leak across shared HTTP client usage.
  * Maintained response size limits and streaming behavior while making request cancellation more reliable.

* **Tests**
  * Strengthened coverage for per-source timeout and header behavior, including parallel request cases and header isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->