### PR TITLE
fix(api): cap request body size — defend against OOM DoS

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -314,6 +314,50 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
     #endregion
 
+    #region Request body reader
+
+    /// <summary>
+    /// Reads the request body with a hard size cap (#156): rejects bodies larger than
+    /// <see cref="AppConfig.MaxRequestBodyBytes"/> with <c>413 Payload Too Large</c> BEFORE
+    /// deserialization. <c>HttpListener</c> has no default body limit, so without this a single
+    /// client could stream gigabytes into the process. The cap also covers chunked-transfer bodies
+    /// (no Content-Length) via the read-loop's running byte count.
+    /// </summary>
+    private async Task<(string? Body, ApiResponse? Error)> ReadBodyAsync(HttpListenerContext ctx)
+    {
+        var maxBytes = _config.MaxRequestBodyBytes;
+
+        // Fast path: Content-Length present and already over the cap → reject without reading.
+        if (ctx.Request.ContentLength64 > maxBytes)
+            return (null, ApiResponse.Error(
+                $"Request body too large ({ctx.Request.ContentLength64} bytes, max {maxBytes}).", 413));
+
+        return await ReadBoundedBodyAsync(ctx.Request.InputStream, maxBytes);
+    }
+
+    /// <summary>
+    /// Pure body reader with a hard byte cap — extracted for unit testing (#156). Returns
+    /// <c>(null, 413-error)</c> when the stream yields more than <paramref name="maxBytes"/> bytes,
+    /// otherwise the full body decoded as UTF-8. Covers both sized and chunked/streaming bodies.
+    /// </summary>
+    internal static async Task<(string? Body, ApiResponse? Error)> ReadBoundedBodyAsync(Stream input, long maxBytes)
+    {
+        using var ms = new MemoryStream();
+        var buffer = new byte[8192];
+        int read;
+        while ((read = await input.ReadAsync(buffer, 0, buffer.Length)) > 0)
+        {
+            ms.Write(buffer, 0, read);
+            if (ms.Length > maxBytes)
+                return (null, ApiResponse.Error(
+                    $"Request body too large (over {maxBytes} bytes).", 413));
+        }
+
+        return (Encoding.UTF8.GetString(ms.GetBuffer(), 0, (int)ms.Length), null);
+    }
+
+    #endregion
+
     #region GET /api/server
 
     private ApiResponse HandleGetServer()
@@ -423,8 +467,8 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
     private async Task<ApiResponse> HandleCreatePeer(HttpListenerContext ctx)
     {
-        using var reader = new StreamReader(ctx.Request.InputStream, Encoding.UTF8);
-        var body = await reader.ReadToEndAsync();
+        var (body, bodyError) = await ReadBodyAsync(ctx);
+        if (bodyError is not null) return bodyError;
         var data = JsonSerializer.Deserialize<CreatePeerRequest>(body, _jsonOpts);
 
         if (data is null)
@@ -511,8 +555,8 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (peer is null)
             return ApiResponse.Error("Peer not found", 404);
 
-        using var reader = new StreamReader(ctx.Request.InputStream, Encoding.UTF8);
-        var body = await reader.ReadToEndAsync();
+        var (body, bodyError) = await ReadBodyAsync(ctx);
+        if (bodyError is not null) return bodyError;
         var data = JsonSerializer.Deserialize<UpdatePeerRequest>(body, _jsonOpts);
 
         if (data is null)
@@ -586,8 +630,8 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (_store.GetDbPeerById(peerId) is null)
             return ApiResponse.Error("Peer not found", 404);
 
-        using var reader = new StreamReader(ctx.Request.InputStream, Encoding.UTF8);
-        var body = await reader.ReadToEndAsync();
+        var (body, bodyError) = await ReadBodyAsync(ctx);
+        if (bodyError is not null) return bodyError;
         var data = JsonSerializer.Deserialize<AddSourceRequest>(body, _jsonOpts);
 
         if (data is null || string.IsNullOrWhiteSpace(data.Name) || string.IsNullOrWhiteSpace(data.Url))
@@ -620,8 +664,8 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (_store.GetDbPeerById(peerId) is null)
             return ApiResponse.Error("Peer not found", 404);
 
-        using var reader = new StreamReader(ctx.Request.InputStream, Encoding.UTF8);
-        var body = await reader.ReadToEndAsync();
+        var (body, bodyError) = await ReadBodyAsync(ctx);
+        if (bodyError is not null) return bodyError;
         var data = JsonSerializer.Deserialize<PatchSourceRequest>(body, _jsonOpts);
 
         if (data is null || data.Active is null)
@@ -1086,7 +1130,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
     private record AddSourceRequest(string Name, string Url, string? Community);
     private record PatchSourceRequest([property: JsonPropertyName("active")] bool? Active);
 
-    private record ApiResponse(object? Body, int StatusCode = 200)
+    internal record ApiResponse(object? Body, int StatusCode = 200)
     {
         public static ApiResponse Ok(object data) => new(data);
         public static ApiResponse Error(string message, int code) => new(new { error = message }, code);

--- a/BGPLite.Configuration/AppConfig.cs
+++ b/BGPLite.Configuration/AppConfig.cs
@@ -86,6 +86,15 @@ public sealed class AppConfig
             throw new InvalidOperationException(
                 $"Invalid configuration: ApiPort must be between 1 and 65535 (got {ApiPort}).");
 
+        // MaxRequestBodyBytes is a security boundary (#156 DoS cap); reject nonsensical values at
+        // startup so a bad YAML cannot break all mutating API requests (<= 0) or weaken the cap to
+        // nothing (impractically large). 1 KiB lower bound leaves room for a minimal peer payload;
+        // 64 MiB upper bound is far beyond any legitimate peer-config write.
+        if (MaxRequestBodyBytes is < 1024 or > 64 * 1024 * 1024)
+            throw new InvalidOperationException(
+                $"Invalid configuration: MaxRequestBodyBytes must be between 1024 and 67108864 bytes " +
+                $"(got {MaxRequestBodyBytes}).");
+
         for (var i = 0; i < Peers.Count; i++)
         {
             var peer = Peers[i];

--- a/BGPLite.Configuration/AppConfig.cs
+++ b/BGPLite.Configuration/AppConfig.cs
@@ -49,6 +49,16 @@ public sealed class AppConfig
     public ApiRateLimitConfig? ApiRateLimit { get; init; }
 
     /// <summary>
+    /// Maximum request body size in bytes accepted by the management API on POST/PUT/PATCH routes
+    /// (#156). Bodies larger than this are rejected with <c>413 Payload Too Large</c> before
+    /// deserialization, defending against memory-exhaustion DoS (<c>HttpListener</c> has no default
+    /// body cap). 1 MiB comfortably fits any realistic peer-config payload (hundreds of CIDRs /
+    /// ASNs); raise it only if an operator legitimately needs larger writes. Defaults to 1 MiB.
+    /// </summary>
+    [YamlMember(Alias = "MaxRequestBodyBytes")]
+    public long MaxRequestBodyBytes { get; init; } = 1024 * 1024;
+
+    /// <summary>
     /// Origins allowed to make cross-origin (CORS) requests to the management API (#99), e.g.
     /// <c>["https://operator.example.com", "https://bgp.example.net"]</c>. A request's
     /// <c>Origin</c> header is echoed back as <c>Access-Control-Allow-Origin</c> only when it

--- a/BGPLite.Tests/ConfigValidationTests.cs
+++ b/BGPLite.Tests/ConfigValidationTests.cs
@@ -98,6 +98,27 @@ public class ConfigValidationTests
     }
 
     [Theory]
+    [InlineData(0)]            // nonsensical — rejects every body
+    [InlineData(-1)]
+    [InlineData(512)]          // below the 1 KiB floor — too small for a minimal peer payload
+    [InlineData(64 * 1024 * 1024 + 1)]  // above the 64 MiB ceiling — weakens the DoS cap to nothing
+    public void Validate_RejectsBadMaxRequestBodyBytes(long bytes)
+    {
+        var config = new AppConfig { Bgp = Bgp(), MaxRequestBodyBytes = bytes };
+
+        var ex = Assert.Throws<InvalidOperationException>(() => config.Validate());
+        Assert.Contains("MaxRequestBodyBytes", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_AcceptsDefaultMaxRequestBodyBytes()
+    {
+        // The default (1 MiB) must pass validation — guards against an accidentally-too-tight range.
+        var config = new AppConfig { Bgp = Bgp() };
+        config.Validate();
+    }
+
+    [Theory]
     [InlineData("not-an-ip")]
     [InlineData("::1")]
     public void Validate_RejectsBadPeerAddress(string address)

--- a/BGPLite.Tests/RequestBodyLimitsTests.cs
+++ b/BGPLite.Tests/RequestBodyLimitsTests.cs
@@ -1,0 +1,107 @@
+using System.Text;
+using BGPLite.Api;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// Regression coverage for #156: the management-API request body is capped at
+/// <c>AppConfig.MaxRequestBodyBytes</c> so a single client cannot stream gigabytes into the
+/// process (HttpListener has no default body cap). Tests the pure
+/// <see cref="ManagementApi.ReadBoundedBodyAsync"/> helper directly.
+/// </summary>
+public class RequestBodyLimitsTests
+{
+    [Fact]
+    public async Task UnderCap_BodyReturned()
+    {
+        using var input = new MemoryStream(Encoding.UTF8.GetBytes("{\"ip\":\"1.2.3.4\"}"));
+        var (body, error) = await ManagementApi.ReadBoundedBodyAsync(input, maxBytes: 1024);
+
+        Assert.Null(error);
+        Assert.Equal("{\"ip\":\"1.2.3.4\"}", body);
+    }
+
+    [Fact]
+    public async Task ExactlyAtCap_BodyReturned()
+    {
+        // A body of exactly maxBytes fits — the cap is inclusive.
+        var payload = "{\"x\":1}"; // 7 bytes
+        using var input = new MemoryStream(Encoding.UTF8.GetBytes(payload));
+        var (body, error) = await ManagementApi.ReadBoundedBodyAsync(input, maxBytes: payload.Length);
+
+        Assert.Null(error);
+        Assert.Equal(payload, body);
+    }
+
+    [Fact]
+    public async Task OverCap_Returns413_NoFullBufferMaterialized()
+    {
+        // A body well over the cap must be rejected with 413 without materializing the full payload
+        // (the read loop aborts as soon as the running count exceeds the cap).
+        var huge = new string('x', 10 * 1024 * 1024); // 10 MiB
+        using var input = new MemoryStream(Encoding.UTF8.GetBytes(huge));
+        var (body, error) = await ManagementApi.ReadBoundedBodyAsync(input, maxBytes: 1024);
+
+        Assert.Null(body);
+        Assert.NotNull(error);
+        Assert.Equal(413, error!.StatusCode);
+        // ApiResponse.Body wraps the message in { error = "..." }; assert the status code is enough.
+    }
+
+    [Fact]
+    public async Task StreamingBody_OverCapMidStream_Returns413()
+    {
+        // Chunked/streaming body (no Content-Length on this Stream) that crosses the cap partway
+        // through is still rejected — the read loop checks the running count on every chunk.
+        var chunk = Encoding.UTF8.GetBytes(new string('x', 600));
+        using var input = new ChunkedStream(chunk, repeat: 10); // 6000 bytes total, cap 1024
+        var (body, error) = await ManagementApi.ReadBoundedBodyAsync(input, maxBytes: 1024);
+
+        Assert.Null(body);
+        Assert.NotNull(error);
+        Assert.Equal(413, error!.StatusCode);
+    }
+
+    [Fact]
+    public async Task EmptyBody_ReturnsEmptyString()
+    {
+        using var input = new MemoryStream();
+        var (body, error) = await ManagementApi.ReadBoundedBodyAsync(input, maxBytes: 1024);
+
+        Assert.Null(error);
+        Assert.Equal("", body);
+    }
+
+    /// <summary>A stream that repeats a fixed chunk N times, simulating a streaming/chunked body.</summary>
+    private sealed class ChunkedStream : Stream
+    {
+        private readonly byte[] _chunk;
+        private readonly int _repeat;
+        private int _emitted;
+
+        public ChunkedStream(byte[] chunk, int repeat)
+        {
+            _chunk = chunk;
+            _repeat = repeat;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => _chunk.Length * _repeat;
+        public override long Position { get => _emitted; set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (_emitted >= _chunk.Length * _repeat) return 0;
+            // Emit one chunk per Read call so the read loop sees the cap crossed mid-stream.
+            var n = Math.Min(_chunk.Length, count);
+            Array.Copy(_chunk, 0, buffer, offset, n);
+            _emitted += n;
+            return n;
+        }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
Closes #156

## Problem

Every POST/PUT/PATCH handler in `ManagementApi` read the request body with an unbounded `StreamReader.ReadToEndAsync`:

```csharp
using var reader = new StreamReader(ctx.Request.InputStream, Encoding.UTF8);
var body = await reader.ReadToEndAsync();     // no ContentLength64 check, no cap
```

`HttpListener` has no default body cap, so a single client could stream gigabytes into the process before deserialization even ran (memory-exhaustion DoS). The compound risk: even a small JSON body could declare millions of `CustomPrefixes` / `CustomAsns` / `Sources` per peer, which then get persisted and re-loaded on every peer refresh. Compounds with #90 (no auth): anyone reachable can drive the process to OOM.

## Fix

`BGPLite.Configuration/AppConfig.cs`:
- New `MaxRequestBodyBytes` (default 1 MiB) — comfortably fits any realistic peer-config payload (hundreds of CIDRs / ASNs).

`BGPLite.Api/ManagementApi.cs`:
- New `ReadBodyAsync(ctx)` — fast-path rejects oversized `ContentLength64` with `413`, then reads the stream with a running byte count so chunked/streaming bodies (no Content-Length, or a lying Content-Length) are also bounded.
- The four body-reading handlers (`HandleCreatePeer`, `HandleUpdatePeer`, `HandleAddSource`, `HandlePatchSource`) now go through `ReadBodyAsync` and early-return its `413` error before deserialization.
- Pure read logic extracted to `internal static ReadBoundedBodyAsync(Stream, maxBytes)` for direct unit testing; `ApiResponse` made `internal` (was `private`) so the test can assert on the status code.

## Verification

- `dotnet build BGPLite.sln` ✅
- `dotnet test BGPLite.sln` ✅ 434 passed (+5 new in `RequestBodyLimitsTests`)
- New tests: `UnderCap_BodyReturned`, `ExactlyAtCap_BodyReturned` (cap is inclusive), `OverCap_Returns413_NoFullBufferMaterialized` (10 MiB body, 1 KiB cap → 413, read loop aborts early), `StreamingBody_OverCapMidStream_Returns413` (chunked-stream body crosses cap mid-read), `EmptyBody_ReturnsEmptyString`.

## Risk / behavior change

- **Intentional behavior change**: requests with a body larger than `MaxRequestBodyBytes` (default 1 MiB) now get `413` instead of being accepted. 1 MiB is generous for peer config; operators with legitimately larger writes can raise it in YAML. No silent regression for normal usage.
- Per-collection count limits (e.g. max 10 000 custom prefixes) are **not** added in this PR — the issue mentioned them, but they are a separate concern and a 1 MiB body cap already bounds the practical abuse (a 1 MiB JSON body can hold ~50k short CIDR strings, which is large but not catastrophic). Follow-up if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable maximum request body size for management API requests (default 1 MiB).

* **Bug Fixes**
  * Oversized request bodies are now rejected early with `413 Payload Too Large`, before JSON processing.
  * Size limiting applies consistently across peer and source create/update/patch endpoints, including streamed/chunked uploads.

* **Tests**
  * Added request body limit tests covering accept/reject, boundary, empty, and mid-stream cap enforcement.
  * Added configuration validation tests for valid/invalid maximum-size values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->