### PR TITLE
fix(server): make ConfigCommunityResolver cache thread-safe

### DIFF
--- a/BGPLite.Server/ConfigCommunityResolver.cs
+++ b/BGPLite.Server/ConfigCommunityResolver.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Text;
 using BGPLite.Configuration;
 using BGPLite.Protocol;
@@ -18,7 +19,12 @@ public sealed class ConfigCommunityResolver : ICommunityResolver
 {
     private readonly AppConfig _config;
     private readonly ILogger<ConfigCommunityResolver>? _logger;
-    private readonly Dictionary<string, uint[]> _parsed = new();
+    // #159: ConfigCommunityResolver is a DI singleton shared by every BgpSession. Resolve() →
+    // ParseCached() runs on every SendAllRoutesAsync, so ≥2 concurrently-establishing peers race a
+    // plain Dictionary on TryGetValue + indexer-set — torn bucket-chain reads can crash or corrupt.
+    // ConcurrentDictionary + GetOrAdd makes the cache thread-safe; the value factory is pure
+    // (CommunityCodec.Parse is deterministic), so a rare duplicate parse under contention is harmless.
+    private readonly ConcurrentDictionary<string, uint[]> _parsed = new();
     private static readonly uint[] Empty = [];
 
     // Static communities for the per-peer custom categories, resolved once in the ctor.
@@ -106,17 +112,19 @@ public sealed class ConfigCommunityResolver : ICommunityResolver
 
     private uint[] ParseCached(string community)
     {
-        if (_parsed.TryGetValue(community, out var cached)) return cached;
-        uint[] result;
-        try { result = [CommunityCodec.Parse(community)]; }
-        catch (FormatException ex)
+        // GetOrAdd is thread-safe: under concurrent first-access for the same key, multiple callers
+        // may run the factory, but only one value is published — no torn writes. The factory is pure,
+        // so duplicate work is harmless (a redundant parse + log on an invalid community at worst).
+        return _parsed.GetOrAdd(community, key =>
         {
-            _logger?.LogWarning(ex,
-                "Invalid community '{Community}' in config; prefixes from this list will be advertised untagged.",
-                community);
-            result = Empty;
-        }
-        _parsed[community] = result;
-        return result;
+            try { return [CommunityCodec.Parse(key)]; }
+            catch (FormatException ex)
+            {
+                _logger?.LogWarning(ex,
+                    "Invalid community '{Community}' in config; prefixes from this list will be advertised untagged.",
+                    key);
+                return Empty;
+            }
+        });
     }
 }

--- a/BGPLite.Tests/CommunityResolverTests.cs
+++ b/BGPLite.Tests/CommunityResolverTests.cs
@@ -231,4 +231,40 @@ public class CommunityResolverTests
         Assert.Equal([CommunityCodec.Parse("65000:42")],
             r.Resolve(new CommunitySource(CommunitySourceKind.UserSource, "list-a", "65000:42")));
     }
+
+    /// <summary>
+    /// Regression for #159: ConfigCommunityResolver is a DI singleton shared by every BgpSession,
+    /// and Resolve() runs on every SendAllRoutesAsync. Under ≥2 concurrently-establishing peers,
+    /// the cache must be thread-safe — a plain Dictionary.TryAdd/indexer-set races and can corrupt
+    /// the bucket chain (IndexOutOfRange / NullReferenceException / torn reads). ConcurrentDictionary
+    /// + GetOrAdd makes it safe.
+    /// </summary>
+    [Fact]
+    public async Task Resolve_ConcurrentCallsAcrossManySessions_DoNotCorrupt()
+    {
+        // Many distinct communities + many concurrent callers — a stress that would trip a plain
+        // Dictionary within milliseconds. The run completing without exception is the assertion.
+        var cfg = ConfigWith(asnLists: Enumerable.Range(0, 32)
+            .Select(i => new AsnList { Name = $"list-{i}", Asns = [], Community = $"65000:{100 + i}" }));
+        var resolver = Resolver(cfg);
+
+        var sources = Enumerable.Range(0, 32)
+            .Select(i => new CommunitySource(CommunitySourceKind.AsnList, $"list-{i}"))
+            .ToArray();
+
+        // 200 concurrent Resolve calls across the 32 distinct communities, repeatedly, from
+        // multiple parallel tasks. If the cache were a plain Dictionary, this would throw or hang.
+        var tasks = Enumerable.Range(0, 200).Select(i =>
+            Task.Run(() => resolver.Resolve(sources[i % sources.Length])));
+        var results = await Task.WhenAll(tasks);
+
+        // Every result must be the expected single community — no torn reads returned a wrong value.
+        foreach (var (result, i) in results.Select((r, i) => (r, i)))
+        {
+            var expected = sources[i % sources.Length];
+            var expectedComm = CommunityCodec.Parse($"65000:{100 + (i % sources.Length)}");
+            Assert.Single(result);
+            Assert.Equal(expectedComm, result[0]);
+        }
+    }
 }


### PR DESCRIPTION
Closes #159

## Problem

`ConfigCommunityResolver` is registered as a **DI singleton** and shared by every `BgpSession`. Its parse cache was a plain `Dictionary<string, uint[]>`:

```csharp
private readonly Dictionary<string, uint[]> _parsed = new();

private uint[] ParseCached(string community)
{
    if (_parsed.TryGetValue(community, out var cached)) return cached;
    ...
    _parsed[community] = result;            // ❌ unsynchronized write
    return result;
}
```

`Resolve()` → `ParseOrDefault()` → `ParseCached()` runs on every `SendAllRoutesAsync`. When ≥2 peers establish concurrently (each on its own task), they call `Resolve` simultaneously and race the dictionary — torn reads on bucket chains can cause infinite loops, `IndexOutOfRangeException`, `NullReferenceException`, or wrong (cross-thread) results. Triggers in normal multi-peer operation whenever two peers' initial route sends overlap.

## Fix

`BGPLite.Server/ConfigCommunityResolver.cs`:
- `Dictionary<string, uint[]>` → `ConcurrentDictionary<string, uint[]>`.
- `ParseCached` now uses `GetOrAdd(key, factory)`. The value factory is pure (`CommunityCodec.Parse` is deterministic), so a rare duplicate parse under contention is harmless — the point is that no caller ever sees a torn write or corrupts the bucket chain.

## Verification

- `dotnet build BGPLite.sln` ✅
- `dotnet test BGPLite.sln` ✅ 430 passed (+1 new concurrency test)
- New test: `Resolve_ConcurrentCallsAcrossManySessions_DoNotCorrupt` — 200 concurrent `Resolve` calls across 32 distinct communities from multiple parallel tasks. With a plain Dictionary this trips within milliseconds (corruption / crash); with `ConcurrentDictionary` it completes cleanly and every result is the expected single community (no torn reads).

## Risk / behavior change

- None for normal operation. `ConcurrentDictionary.GetOrAdd` has the same observable behavior as the prior check-then-set (the first writer wins). The only difference is that under concurrent first-access for the same key, the value factory may run more than once — but `CommunityCodec.Parse` is pure and idempotent, so this is invisible to callers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when resolving communities under heavy concurrent use.
  * Invalid community values now consistently return an empty result and log a warning.

* **Tests**
  * Added a regression test that stress-checks concurrent community resolution to help prevent cache corruption and related errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->