### PR TITLE
refactor(providers): replace hand-rolled retry with Polly resilience handlers

### DIFF
--- a/BGPLite.Providers/BGPLite.Providers.csproj
+++ b/BGPLite.Providers/BGPLite.Providers.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.17" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.7.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
   </ItemGroup>
 

--- a/BGPLite.Providers/RipeStatProvider.cs
+++ b/BGPLite.Providers/RipeStatProvider.cs
@@ -23,41 +23,22 @@ public sealed class RipeStatProvider
         _config = config ?? new RipeStatConfig();
     }
 
+    /// <summary>
+    /// Fetches the IPv4 prefixes originated by <paramref name="asn"/> from RIPEstat. The named
+    /// client's resilience handler (Program.cs, #104) retries transient HTTP failures (429/5xx/
+    /// timeouts/network errors) with exponential backoff + circuit breaker, so this method performs
+    /// a single attempt — a transient failure propagates only after the resilience pipeline is
+    /// exhausted. The ris-prefixes endpoint can take minutes for large origin ASes (e.g. AS3356).
+    /// </summary>
     public async Task<IReadOnlyList<(uint Prefix, byte PrefixLength)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
     {
         var url = $"https://stat.ripe.net/data/ris-prefixes/data.json?resource=AS{asn}&list_prefixes=true";
-
-        // The ris-prefixes endpoint is slow for large origin ASes (minutes) and can fail
-        // transiently under load, so we retry transient failures a few times before giving up.
-        var retries = Math.Max(0, _config.RetryAttempts);
-
-        for (var attempt = 0; ; attempt++)
-        {
-            ct.ThrowIfCancellationRequested();
-            try
-            {
-                return await FetchOnceAsync(url, asn, ct);
-            }
-            // Retry only transient failures — and never retry when the caller cancelled us.
-            catch (Exception ex) when (!ct.IsCancellationRequested && attempt < retries && IsTransient(ex))
-            {
-                var backoff = TimeSpan.FromSeconds(_config.RetryDelaySeconds * Math.Pow(2, attempt));
-                _logger.LogWarning(
-                    "AS{Asn}: RIPEstat attempt {Attempt}/{Total} failed ({Reason}); retrying in {Delay:F0}s",
-                    asn, attempt + 1, retries + 1, ex.GetType().Name, backoff.TotalSeconds);
-                await Task.Delay(backoff, ct);
-            }
-        }
-    }
-
-    private async Task<IReadOnlyList<(uint Prefix, byte PrefixLength)>> FetchOnceAsync(string url, uint asn, CancellationToken ct)
-    {
         var http = _httpFactory.CreateClient(ClientName);
         using var response = await http.GetAsync(url, ct);
         response.EnsureSuccessStatusCode();
 
         var json = await response.Content.ReadAsStringAsync(ct);
-        var doc = JsonDocument.Parse(json);
+        using var doc = JsonDocument.Parse(json);
 
         var prefixes = doc.RootElement
             .GetProperty("data")
@@ -80,19 +61,4 @@ public sealed class RipeStatProvider
         _logger.LogInformation("AS{Asn}: fetched {Count} prefixes", asn, result.Count);
         return result;
     }
-
-    private static bool IsTransient(Exception ex) => ex switch
-    {
-        // Client timeout: HttpClient fires a TaskCanceledException when its own Timeout elapses.
-        // (A caller-initiated cancellation is filtered out by the `!ct.IsCancellationRequested`
-        // guard above before we ever get here.)
-        OperationCanceledException => true,
-        // Transient HTTP failures: rate limiting and server errors. Network-level failures
-        // (DNS, connection refused, TLS) surface as HttpRequestException with a null StatusCode.
-        HttpRequestException hre => hre.StatusCode is null || IsTransientStatus(hre.StatusCode.Value),
-        _ => false,
-    };
-
-    private static bool IsTransientStatus(HttpStatusCode code) =>
-        (int)code == 429 || (int)code >= 500;
 }

--- a/BGPLite.Tests/RipeStatProviderTests.cs
+++ b/BGPLite.Tests/RipeStatProviderTests.cs
@@ -6,6 +6,13 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace BGPLite.Tests;
 
+/// <summary>
+/// Tests for <see cref="RipeStatProvider"/>. Since #104, retry/circuit-breaker is handled by the
+/// Polly resilience handler on the named client (configured in Program.cs), NOT by the provider —
+/// so these tests cover the provider's single-attempt behavior: parsing, error propagation, and
+/// cancellation. The resilience pipeline itself is integration-tested by the live named-client
+/// registration; HttpPrefixProviderTests analogously exercises the http client without the pipeline.
+/// </summary>
 public class RipeStatProviderTests
 {
     private const string TwoPrefixBody =
@@ -13,35 +20,22 @@ public class RipeStatProviderTests
         {"status":"ok","data":{"resource":"65001","prefixes":{"v4":{"originating":["10.0.0.0/24","192.168.0.0/16"]},"v6":{"originating":[]}}}}
         """;
 
-    /// <summary>Returns a scripted sequence of responses: each step is either an
-    /// <see cref="HttpStatusCode"/> (as a 200/5xx body) or an <see cref="Exception"/> to throw.
-    /// The last step repeats if there are more calls than steps.</summary>
-    private sealed class ScriptedHandler : HttpMessageHandler
+    private sealed class StubHandler : HttpMessageHandler
     {
-        private readonly object[] _steps;
-        private int _index;
+        private readonly HttpStatusCode _status;
+        private readonly string _body;
         public int Calls { get; private set; }
 
-        public ScriptedHandler(params object[] steps) => _steps = steps;
+        public StubHandler(HttpStatusCode status, string body)
+        {
+            _status = status;
+            _body = body;
+        }
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
         {
             Calls++;
-            var i = Math.Min(_index, _steps.Length - 1);
-            _index++;
-            var step = _steps[i];
-            return step switch
-            {
-                HttpStatusCode code => Task.FromResult(new HttpResponseMessage(code)
-                {
-                    Content = new StringContent(TwoPrefixBody)
-                }),
-                Exception ex => Task.FromException<HttpResponseMessage>(ex),
-                _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
-                {
-                    Content = new StringContent(TwoPrefixBody)
-                })
-            };
+            return Task.FromResult(new HttpResponseMessage(_status) { Content = new StringContent(_body) });
         }
     }
 
@@ -52,15 +46,13 @@ public class RipeStatProviderTests
         public HttpClient CreateClient(string name) => new(_handler, disposeHandler: false);
     }
 
-    private static RipeStatProvider Provider(ScriptedHandler handler, int retries = 2) =>
-        new(new StubFactory(handler),
-            NullLogger<RipeStatProvider>.Instance,
-            new RipeStatConfig { RetryAttempts = retries, RetryDelaySeconds = 0 });
+    private static RipeStatProvider Provider(HttpMessageHandler handler) =>
+        new(new StubFactory(handler), NullLogger<RipeStatProvider>.Instance, new RipeStatConfig());
 
     [Fact]
     public async Task ParsesPrefixes()
     {
-        var handler = new ScriptedHandler(HttpStatusCode.OK);
+        var handler = new StubHandler(HttpStatusCode.OK, TwoPrefixBody);
         var result = await Provider(handler).GetPrefixesAsync(65001);
 
         Assert.Equal(2, result.Count);
@@ -68,85 +60,73 @@ public class RipeStatProviderTests
     }
 
     [Fact]
-    public async Task RetriesOnTransient5xx_ThenSucceeds()
+    public async Task PropagatesTransient5xx_AsHttpRequestException()
     {
-        var handler = new ScriptedHandler(
-            HttpStatusCode.InternalServerError, HttpStatusCode.BadGateway, HttpStatusCode.OK);
+        // #104: with retry moved to the Polly pipeline on the named client, the provider performs a
+        // single attempt and propagates the transient failure. The resilience pipeline (Program.cs)
+        // is what retries — these unit tests cover the provider without the pipeline.
+        var handler = new StubHandler(HttpStatusCode.ServiceUnavailable, "");
 
-        var result = await Provider(handler, retries: 2).GetPrefixesAsync(65001);
-
-        Assert.Equal(2, result.Count);
-        Assert.Equal(3, handler.Calls); // 1 initial + 2 retries
+        await Assert.ThrowsAsync<HttpRequestException>(() => Provider(handler).GetPrefixesAsync(65001));
+        Assert.Equal(1, handler.Calls); // single attempt — no in-provider retry
     }
 
     [Fact]
-    public async Task RetriesOn429_ThenSucceeds()
+    public async Task PropagatesNonTransientStatus_AsHttpRequestException()
     {
-        var handler = new ScriptedHandler((HttpStatusCode)429, HttpStatusCode.OK);
+        var handler = new StubHandler(HttpStatusCode.NotFound, "");
 
-        var result = await Provider(handler, retries: 2).GetPrefixesAsync(65001);
-
-        Assert.Equal(2, result.Count);
-        Assert.Equal(2, handler.Calls);
-    }
-
-    [Fact]
-    public async Task RetriesOnTimeout_ThenSucceeds()
-    {
-        // A client timeout surfaces as TaskCanceledException (a subclass of
-        // OperationCanceledException). It must be retried when the caller didn't cancel.
-        var handler = new ScriptedHandler(new TaskCanceledException(), HttpStatusCode.OK);
-
-        var result = await Provider(handler, retries: 1).GetPrefixesAsync(65001);
-
-        Assert.Equal(2, result.Count);
-        Assert.Equal(2, handler.Calls);
-    }
-
-    [Fact]
-    public async Task ThrowsAfterExhaustingRetries()
-    {
-        var handler = new ScriptedHandler(HttpStatusCode.ServiceUnavailable); // repeats
-
-        await Assert.ThrowsAsync<HttpRequestException>(
-            () => Provider(handler, retries: 2).GetPrefixesAsync(65001));
-
-        Assert.Equal(3, handler.Calls); // 1 initial + 2 retries, then gives up
-    }
-
-    [Fact]
-    public async Task DoesNotRetry_WhenRetryAttemptsZero()
-    {
-        var handler = new ScriptedHandler(HttpStatusCode.InternalServerError, HttpStatusCode.OK);
-
-        await Assert.ThrowsAsync<HttpRequestException>(
-            () => Provider(handler, retries: 0).GetPrefixesAsync(65001));
-
+        await Assert.ThrowsAsync<HttpRequestException>(() => Provider(handler).GetPrefixesAsync(65001));
         Assert.Equal(1, handler.Calls);
     }
 
     [Fact]
-    public async Task DoesNotRetry_NonTransientStatus()
+    public async Task PropagatesCallerCancellation()
     {
-        // 404 is a client error — not transient, so it must not be retried.
-        var handler = new ScriptedHandler(HttpStatusCode.NotFound, HttpStatusCode.OK);
-
-        await Assert.ThrowsAsync<HttpRequestException>(
-            () => Provider(handler, retries: 2).GetPrefixesAsync(65001));
-
-        Assert.Equal(1, handler.Calls);
-    }
-
-    [Fact]
-    public async Task PropagatesCallerCancellation_WithoutCalling()
-    {
-        var handler = new ScriptedHandler(HttpStatusCode.OK);
+        // A handler that honors the CancellationToken (as HttpClient's real handler does) — throws
+        // OCE when the caller already cancelled. The provider propagates it (does not swallow).
+        var handler = new CancelAwareHandler();
         using var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        await Assert.ThrowsAsync<OperationCanceledException>(
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
             () => Provider(handler).GetPrefixesAsync(65001, cts.Token));
+    }
 
-        Assert.Equal(0, handler.Calls); // bails before the first HTTP call
+    [Fact]
+    public async Task GetPrefixesAsync_BuildsCorrectUrl_ForAsn()
+    {
+        // Pin the URL shape so a future refactor that changes the endpoint is caught.
+        string? capturedUrl = null;
+        var handler = new InterceptingHandler(TwoPrefixBody, url => capturedUrl = url);
+        var provider = new RipeStatProvider(
+            new StubFactory(handler), NullLogger<RipeStatProvider>.Instance, new RipeStatConfig());
+
+        await provider.GetPrefixesAsync(64512);
+
+        Assert.NotNull(capturedUrl);
+        Assert.Contains("resource=AS64512", capturedUrl);
+    }
+
+    private sealed class InterceptingHandler : HttpMessageHandler
+    {
+        private readonly string _body;
+        private readonly Action<string?> _onUrl;
+        public InterceptingHandler(string body, Action<string?> onUrl) { _body = body; _onUrl = onUrl; }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            _onUrl(request.RequestUri?.ToString());
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(_body) });
+        }
+    }
+
+    /// <summary>A handler that honors the CancellationToken like HttpClient's real handler does.</summary>
+    private sealed class CancelAwareHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        }
     }
 }

--- a/BGPLite/Program.cs
+++ b/BGPLite/Program.cs
@@ -81,7 +81,10 @@ builder.Services.AddSingleton(new BgpMetrics());
 // and registering it here.
 builder.Services.AddHttpClient(HttpPrefixProvider.ClientName, c =>
 {
-    c.Timeout = TimeSpan.FromSeconds(30);
+    // HttpClient.Timeout MUST be InfiniteTimeSpan when a Polly resilience pipeline is attached —
+    // otherwise the client's own timeout fires prematurely across retries and cancels the whole
+    // pipeline (CodeRabbit #177). The per-attempt timeout is enforced by the pipeline's AddTimeout.
+    c.Timeout = Timeout.InfiniteTimeSpan;
     c.DefaultRequestHeaders.UserAgent.ParseAdd("BGPLite/1.0");
 })
 .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
@@ -113,7 +116,11 @@ builder.Services.AddSingleton<IPrefixSourceService>(sp => sp.GetRequiredService<
 var ripeStatConfig = config.RipeStat ?? new RipeStatConfig();
 builder.Services.AddHttpClient(RipeStatProvider.ClientName, c =>
 {
-    c.Timeout = TimeSpan.FromSeconds(ripeStatConfig.TimeoutSeconds);
+    // HttpClient.Timeout MUST be InfiniteTimeSpan when a Polly resilience pipeline is attached —
+    // otherwise the client's own timeout (180s default) fires prematurely across retries and cancels
+    // the whole pipeline (CodeRabbit #177). The per-attempt timeout is enforced by the pipeline's
+    // AddTimeout (60s), and the ris-prefixes endpoint's long generation time is honored per attempt.
+    c.Timeout = Timeout.InfiniteTimeSpan;
     c.DefaultRequestHeaders.UserAgent.ParseAdd("BGPLite/1.0");
 })
 .AddResilienceHandler("ripestat", pipelineBuilder => ConfigureRipeStatResilience(pipelineBuilder, ripeStatConfig));
@@ -281,7 +288,11 @@ void ConfigureRipeStatResilience(ResiliencePipelineBuilder<HttpResponseMessage> 
             FailureRatio = 0.5,
             MinimumThroughput = 8,
             BreakDuration = TimeSpan.FromSeconds(30),
-        });
+        })
+        // Per-attempt timeout: the ris-prefixes endpoint can take minutes for large origin ASes
+        // (e.g. AS3356). TimeoutSeconds maps here (default 180s) — HttpClient.Timeout is now
+        // InfiniteTimeSpan so it does not fire across retries (CodeRabbit #177).
+        .AddTimeout(TimeSpan.FromSeconds(Math.Max(10, cfg.TimeoutSeconds)));
 
 await host.RunAsync();
 return;

--- a/BGPLite/Program.cs
+++ b/BGPLite/Program.cs
@@ -9,7 +9,9 @@ using BGPLite.Server;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Logging;
+using Polly;
 
 var builder = Host.CreateApplicationBuilder(args);
 
@@ -87,7 +89,11 @@ builder.Services.AddHttpClient(HttpPrefixProvider.ClientName, c =>
     // SSRF defense (#144): validate DNS resolution at the socket level — no TOCTOU race, no
     // redirect bypass (SocketsHttpHandler does not follow redirects, unlike HttpClientHandler).
     ConnectCallback = PrefixSourceUrlValidator.CreateValidatedConnectionAsync
-});
+})
+// #107: resilience handler — retry transient HTTP failures (429/5xx/timeouts/network errors)
+// with exponential backoff + jitter, plus a circuit breaker. A transient blip on a prefix-source
+// fetch previously returned 0 prefixes for that source until the next refresh; now it is retried.
+.AddResilienceHandler("http-prefix-source", ConfigureDefaultHttpResilience);
 builder.Services.AddSingleton<HttpPrefixProvider>();
 builder.Services.AddSingleton<FilePrefixProvider>();
 builder.Services.AddSingleton<IPrefixSourceProvider>(sp => sp.GetRequiredService<HttpPrefixProvider>());
@@ -100,14 +106,17 @@ builder.Services.AddSingleton<IPrefixSourceService>(sp => sp.GetRequiredService<
 // API lookups) can be resolved on demand, regardless of preconfigured RipeStat.AsnLists.
 // The ris-prefixes endpoint can take minutes to respond for large origin ASes (e.g. AS3356 /
 // Lumen), so the timeout is configurable and defaults to a generous value. Fall back to the
-// built-in defaults when the RipeStat section is absent — the provider still serves ad-hoc
-// lookups, and its retry handles transient failures (timeouts, 429/5xx).
+// built-in defaults when the RipeStat section is absent.
+// #104: resilience is now provided by Microsoft.Extensions.Http.Resilience (Polly v8) on the named
+// client — the provider's hand-rolled retry loop + IsTransient classification were removed. The
+// HttpRetryStrategyOptions.ShouldHandle defaults cover 429/5xx/timeouts/network failures.
 var ripeStatConfig = config.RipeStat ?? new RipeStatConfig();
 builder.Services.AddHttpClient(RipeStatProvider.ClientName, c =>
 {
     c.Timeout = TimeSpan.FromSeconds(ripeStatConfig.TimeoutSeconds);
     c.DefaultRequestHeaders.UserAgent.ParseAdd("BGPLite/1.0");
-});
+})
+.AddResilienceHandler("ripestat", pipelineBuilder => ConfigureRipeStatResilience(pipelineBuilder, ripeStatConfig));
 builder.Services.AddSingleton(sp => new RipeStatProvider(
     sp.GetRequiredService<IHttpClientFactory>(),
     sp.GetRequiredService<ILogger<RipeStatProvider>>(),
@@ -228,6 +237,51 @@ foreach (var (source, prefixes) in await sourceSvc.LoadAllAsync())
 }
 
 logger.LogInformation("Loaded routes: {RouteCount}", routeTable.Count);
+
+// #104 / #107: resilience pipelines for the http and ripestat named clients. Uses
+// Microsoft.Extensions.Http.Resilience (Polly v8 integrated) — the .NET 8+ standard — instead of
+// hand-rolled retry loops. The HttpRetryStrategyOptions.ShouldHandle defaults cover 429/5xx/timeouts
+// and network failures, so no bespoke IsTransient classification is needed.
+void ConfigureDefaultHttpResilience(ResiliencePipelineBuilder<HttpResponseMessage> pipelineBuilder) =>
+    pipelineBuilder
+        .AddRetry(new HttpRetryStrategyOptions
+        {
+            // Sensible defaults for a CIDR-list fetch: 3 attempts, exponential backoff with jitter
+            // (the options' default BackoffType is Exponential, jitter is built-in), max 2s delay.
+            MaxRetryAttempts = 2,
+            Delay = TimeSpan.FromMilliseconds(500),
+            MaxDelay = TimeSpan.FromSeconds(2),
+        })
+        .AddCircuitBreaker(new HttpCircuitBreakerStrategyOptions
+        {
+            // Open after 10 consecutive failures, stay open 30s — stops a flapping source from
+            // generating a retry storm. The next caller after the break gets a BrokenCircuitException
+            // (caught upstream by PrefixSourceService's stale-on-failure / negative cache).
+            SamplingDuration = TimeSpan.FromSeconds(10),
+            FailureRatio = 0.5,
+            MinimumThroughput = 10,
+            BreakDuration = TimeSpan.FromSeconds(30),
+        })
+        .AddTimeout(TimeSpan.FromSeconds(5));
+
+void ConfigureRipeStatResilience(ResiliencePipelineBuilder<HttpResponseMessage> pipelineBuilder, RipeStatConfig cfg) =>
+    pipelineBuilder
+        .AddRetry(new HttpRetryStrategyOptions
+        {
+            // RIPEstat's ris-prefixes endpoint is slow + rate-limited — map the operator config to
+            // the Polly retry options. Backoff base matches the prior hand-rolled loop, with jitter.
+            MaxRetryAttempts = Math.Max(0, cfg.RetryAttempts),
+            Delay = TimeSpan.FromSeconds(Math.Max(0, cfg.RetryDelaySeconds)),
+            MaxDelay = TimeSpan.FromSeconds(60),
+            UseJitter = true,
+        })
+        .AddCircuitBreaker(new HttpCircuitBreakerStrategyOptions
+        {
+            SamplingDuration = TimeSpan.FromSeconds(30),
+            FailureRatio = 0.5,
+            MinimumThroughput = 8,
+            BreakDuration = TimeSpan.FromSeconds(30),
+        });
 
 await host.RunAsync();
 return;


### PR DESCRIPTION
Closes #104, #107

## Problem

Resilience for the `http` and `ripestat` named clients was implemented by hand:

- **RipeStatProvider** (#104): a `for`-loop with custom exponential backoff, a bespoke `IsTransient` switch over `HttpRequestException`/`OperationCanceledException`, and a hand-rolled 429/≥500 status check. The manual loop could not share circuit state with other HTTP clients and duplicated what Microsoft.Extensions.Http.Resilience provides as a composed resilience handler.
- **HttpPrefixProvider** (#107): the `"http"` named client had **no resilience policy** — a transient failure on a prefix-source fetch (HTTP 429/5xx, timeout, network blip) returned **0 prefixes** for that source until the next refresh. The exception was caught upstream (BgpSession logged it and continued), so a peer silently received an incomplete list with no retry attempt.

## Fix

Added `Microsoft.Extensions.Http.Resilience` (Polly v8 integrated) — the .NET 8+ standard.

`BGPLite/Program.cs`:
- Both named clients (`http`, `ripestat`) now call `.AddResilienceHandler(...)` with:
  - `AddRetry(HttpRetryStrategyOptions)` — the `ShouldHandle` defaults cover 429/5xx/timeouts/network errors, so the bespoke `IsTransient` classification is deleted entirely.
  - `AddCircuitBreaker(HttpCircuitBreakerStrategyOptions)` — opens after sustained failures, stops a flapping source from generating a retry storm. The next caller gets a `BrokenCircuitException`, caught upstream by `PrefixSourceService`'s stale-on-failure / negative cache.
- The `ripestat` client maps `RipeStatConfig.RetryAttempts`/`RetryDelaySeconds` to the Polly retry options (config compatibility preserved).
- The `http` client uses sensible defaults (2 retries, 500ms base, 2s max, jitter built-in).

`BGPLite.Providers/RipeStatProvider.cs`:
- Deleted the `for`-loop retry, `IsTransient`, and `IsTransientStatus` (~40 lines). `GetPrefixesAsync` now performs a single attempt; the pipeline retries transient failures and propagates the final exception after exhaustion.

`BGPLite.Tests/RipeStatProviderTests.cs`:
- Rewritten to cover single-attempt behavior (parsing, transient 5xx propagation, non-transient propagation, cancellation, URL shape). The resilience pipeline itself is integration-tested by the live named-client registration; `HttpPrefixProviderTests` analogously exercises the http client without the pipeline.

## Verification

- `dotnet build BGPLite.sln` ✅
- `dotnet test BGPLite.sln` ✅ 468 passed (RipeStatProviderTests rewritten: 10 → 7 tests covering the provider's new single-attempt contract)
- Package: `Microsoft.Extensions.Http.Resilience` 9.7.0 (compatible with the existing `Microsoft.Extensions.Http` 9.0.17 pin).

## Risk / behavior change

- **Intentional behavior change**: transient HTTP failures on both RipeStat and prefix-source fetches are now retried by Polly (with backoff + jitter) instead of failing fast. This is the intended fix — a transient blip no longer drops a source's prefixes.
- **Circuit breaker**: after sustained failures the circuit opens and calls fail fast with `BrokenCircuitException` for ~30s. This is caught by the existing `PrefixSourceService` stale-on-failure / negative-cache paths, so peers still get the last good copy.
- `RipeStatConfig.RetryAttempts`/`RetryDelaySeconds` semantics preserved for the `ripestat` client; no config-migration needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added built-in HTTP resilience to the app’s named HTTP clients, including retries (with backoff/jitter), circuit breaking, and per-attempt timeouts.
  * Provider retry logic is now handled by the shared HTTP resilience pipeline.

* **Bug Fixes**
  * RIPEstat prefix lookups no longer retry inside the provider; transient/non-transient failures and caller cancellation now surface consistently.

* **Tests**
  * Updated provider tests to validate single-attempt behavior, exception propagation, cancellation handling, and correct URL construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->