### PR TITLE
refactor(server): introduce IBgpConnection + TimeProvider seam for BgpSession

### DIFF
--- a/BGPLite.Server/BgpServer.cs
+++ b/BGPLite.Server/BgpServer.cs
@@ -187,17 +187,12 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
 
                 _logger.LogInformation("Incoming connection from {Peer} ({Key})", peerAddress, key);
 
-                // SendTimeout backstop (#160): a peer that stops reading (TCP receive window full)
-                // blocks WriteAsync on the kernel send buffer until the OS TCP retransmission timeout
-                // (minutes). The per-send CancellationToken (passed in SendMessageAsync) is the primary
-                // bound, but SendTimeout is a kernel-level backstop that fires even if the app-level
-                // token is somehow not threaded into a future send path. 60s matches the per-send budget.
-                socket.SendTimeout = 60_000;
-
+                // #96: the transport seam — SocketBgpConnection owns the socket (and the 60s
+                // SendTimeout backstop from #160), so BgpSession no longer touches Socket directly.
                 var peerConfig = new PeerConfig { Address = peerAddress, Port = remoteEndpoint.Port };
 
                 var session = new BgpSession(
-                    socket, peerConfig, _config.Bgp, _routeTable,
+                    new SocketBgpConnection(socket), peerConfig, _config.Bgp, _routeTable,
                     _routeFilter, _metrics, _sessionLogger,
                     _onPeerIdentified,
                     _peerStore, _prefixService, _config, _prefixAggregator, _communityResolver);

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -193,8 +193,13 @@ public sealed class BgpSession : IDisposable
             BgpMessage openMessage;
             if (openTimeoutSeconds > 0)
             {
-                using var openCts = CancellationTokenSource.CreateLinkedTokenSource(linkedCts.Token);
-                openCts.CancelAfter(TimeSpan.FromSeconds(openTimeoutSeconds));
+                // OPEN timeout: cancel if the peer doesn't send OPEN within the configured window.
+                // The timeout CTS uses _timeProvider (#96) so tests can advance the clock instead of
+                // waiting wall-clock seconds. CancellationTokenSource(TimeSpan, TimeProvider) ctor is
+                // the .NET 8+ TimeProvider-aware path (there is no CancelAfter(TimeSpan, TimeProvider)
+                // instance overload, so we bake the timeout into the timer CTS directly).
+                using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(openTimeoutSeconds), _timeProvider);
+                using var openCts = CancellationTokenSource.CreateLinkedTokenSource(linkedCts.Token, timeoutCts.Token);
                 try
                 {
                     openMessage = await ReceiveMessageAsync(openCts.Token);

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -10,8 +10,14 @@ namespace BGPLite.Server;
 
 public sealed class BgpSession : IDisposable
 {
-    private readonly Socket _socket;
-    private readonly NetworkStream _stream;
+    // #96: transport seam — the concrete Socket/NetworkStream are owned by IBgpConnection
+    // (SocketBgpConnection in production, a fake in unit tests). Replaces the prior _socket/_stream
+    // pair. The send serialization (_sendLock) stays here — it's a BGP-framing concern, not transport.
+    private readonly IBgpConnection _connection;
+    // #96: time seam — TimeProvider replaces direct DateTime.UtcNow reads so the hold-timer expiry,
+    // keepalive interval, and ROUTE_REFRESH debounce are deterministic-testable. Defaults to
+    // TimeProvider.System (wall-clock) in production; tests inject a FakeTimeProvider.
+    private readonly TimeProvider _timeProvider;
     private readonly PeerConfig _peerConfig;
     // "ip:port" label for session logs so the several peers that may share one source IP (behind a
     // NAT/VPN) can be told apart (issue #18). Peer-store lookups use _peerConfig.Address (IP only);
@@ -134,7 +140,7 @@ public sealed class BgpSession : IDisposable
     }
 
     public BgpSession(
-        Socket socket,
+        IBgpConnection connection,
         PeerConfig peerConfig,
         BgpConfig bgpConfig,
         RouteTable routeTable,
@@ -146,10 +152,11 @@ public sealed class BgpSession : IDisposable
         IPrefixService? prefixService = null,
         AppConfig? appConfig = null,
         IPrefixAggregator? prefixAggregator = null,
-        ICommunityResolver? communityResolver = null)
+        ICommunityResolver? communityResolver = null,
+        TimeProvider? timeProvider = null)
     {
-        _socket = socket;
-        _stream = new NetworkStream(socket, ownsSocket: true);
+        _connection = connection;
+        _timeProvider = timeProvider ?? TimeProvider.System;
         _peerConfig = peerConfig;
         _peer = peerConfig.ToString();
         _bgpConfig = bgpConfig;
@@ -358,9 +365,9 @@ public sealed class BgpSession : IDisposable
             return;
         }
 
-        Interlocked.Exchange(ref _lastReceivedTicks, DateTime.UtcNow.Ticks);
+        Interlocked.Exchange(ref _lastReceivedTicks, _timeProvider.GetUtcNow().Ticks);
 
-        using var keepaliveTimer = new PeriodicTimer(_keepAliveInterval);
+        using var keepaliveTimer = new PeriodicTimer(_keepAliveInterval, _timeProvider);
         var readTask = ReadLoopAsync(cancellationToken);
         var keepaliveTask = HoldTimerLoopAsync(keepaliveTimer, cancellationToken);
 
@@ -383,7 +390,7 @@ public sealed class BgpSession : IDisposable
         while (!cancellationToken.IsCancellationRequested)
         {
             var message = await ReceiveMessageAsync(cancellationToken);
-            Interlocked.Exchange(ref _lastReceivedTicks, DateTime.UtcNow.Ticks);
+            Interlocked.Exchange(ref _lastReceivedTicks, _timeProvider.GetUtcNow().Ticks);
 
             switch (message)
             {
@@ -439,7 +446,7 @@ public sealed class BgpSession : IDisposable
                     // concurrent route refreshes from the peer can't all slip through and trigger
                     // N full re-announcements. First caller wins; the rest see a non-zero
                     // previous-timestamp and bail out cheaply with a debug log.
-                    var nowTicks = DateTime.UtcNow.Ticks;
+                    var nowTicks = _timeProvider.GetUtcNow().Ticks;
                     var prevTicks = Interlocked.Read(ref _lastRouteRefreshTicks);
                     if (prevTicks != 0 && new TimeSpan(nowTicks - prevTicks) < MinRouteRefreshInterval)
                     {
@@ -469,7 +476,7 @@ public sealed class BgpSession : IDisposable
             // latch in a finally (matching the catch-block pattern) means a partial/failed write still
             // counts as the one NOTIFICATION for this teardown (RFC 4271 §8.1), so the finally-block
             // never double-emits a Cease.
-            if (DateTime.UtcNow.Ticks - Interlocked.Read(ref _lastReceivedTicks) >= holdTime.Ticks)
+            if (_timeProvider.GetUtcNow().Ticks - Interlocked.Read(ref _lastReceivedTicks) >= holdTime.Ticks)
             {
                 _logger.LogWarning("Hold timer expired for {Peer} (no message for {Hold}s)",
                     _peer, _negotiatedHoldTime);
@@ -1280,7 +1287,7 @@ public sealed class BgpSession : IDisposable
             try
             {
                 var written = BgpMessageWriter.WriteMessage(message, buffer);
-                await _stream.WriteAsync(buffer.AsMemory(0, written), ct);
+                await _connection.WriteAsync(buffer.AsMemory(0, written), ct);
                 return true;
             }
             catch (OperationCanceledException)
@@ -1305,17 +1312,10 @@ public sealed class BgpSession : IDisposable
         }
     }
 
-    private async Task ReadExactAsync(Memory<byte> buffer, CancellationToken cancellationToken)
-    {
-        var totalRead = 0;
-        while (totalRead < buffer.Length)
-        {
-            var read = await _stream.ReadAsync(buffer[totalRead..], cancellationToken);
-            if (read == 0)
-                throw new IOException("Connection closed by peer");
-            totalRead += read;
-        }
-    }
+    // #96: delegates to the transport seam. The loop-to-fill + EOF→IOException semantics now live
+    // in IBgpConnection (SocketBgpConnection / fakes), preserving the exact contract the FSM relies on.
+    private Task ReadExactAsync(Memory<byte> buffer, CancellationToken cancellationToken)
+        => _connection.ReadExactAsync(buffer, cancellationToken).AsTask();
 
     #endregion
 
@@ -1588,8 +1588,7 @@ public sealed class BgpSession : IDisposable
             return;
 
         _cts.Cancel();
-        _stream.Dispose();
-        _socket.Dispose();
+        _connection.Dispose();   // owns the socket (SocketBgpConnection wraps NetworkStream ownsSocket:true)
         _cts.Dispose();
         _sendLock.Dispose();
         _advertisedPrefixesLock.Dispose();

--- a/BGPLite.Server/IBgpConnection.cs
+++ b/BGPLite.Server/IBgpConnection.cs
@@ -1,0 +1,38 @@
+namespace BGPLite.Server;
+
+/// <summary>
+/// The transport seam for <see cref="BgpSession"/> (#96): a minimal duplex byte-channel that the
+/// FSM reads from and writes to, decoupled from the concrete <c>Socket</c>/<c>NetworkStream</c>.
+/// The production implementation is <see cref="SocketBgpConnection"/>; tests can substitute a fake
+/// that scripts inbound messages and captures outbound bytes — making the FSM (OPEN exchange,
+/// teardown latch, hold-timer expiry) unit-testable without real loopback TCP sockets and without
+/// the multi-second drain scaffolding the socket tests require.
+/// <para>
+/// <b>Locking.</b> Implementations must be lock-free — the BGP framing serialization
+/// (<c>_sendLock</c> inside <c>BgpSession.SendMessageAsync</c>) is a BGP concern and stays in the
+/// session, not in the transport. A <c>WriteAsync</c> may be called concurrently with <c>ReadExactAsync</c>
+/// (read and write run on separate tasks); two concurrent <c>WriteAsync</c> calls are the caller's
+/// responsibility to prevent.
+/// </para>
+/// <para>
+/// <b>EOF semantics.</b> <c>ReadExactAsync</c> fills <paramref name="buffer"/> completely or throws —
+/// a zero-byte read (peer closed) surfaces as <c>IOException("Connection closed by peer")</c>,
+/// matching <c>NetworkStream</c>'s contract so the FSM's existing error handling is unchanged.
+/// </para>
+/// </summary>
+public interface IBgpConnection : IDisposable
+{
+    /// <summary>
+    /// Reads exactly <paramref name="buffer"/>.Length bytes. Returns when the buffer is full, or
+    /// throws <c>IOException</c> on a zero-byte read (peer closed the connection). Honors
+    /// <paramref name="cancellationToken"/> for cooperative cancellation.
+    /// </summary>
+    ValueTask ReadExactAsync(Memory<byte> buffer, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Writes <paramref name="buffer"/> to the peer. The caller is responsible for serialization
+    /// (the session's <c>_sendLock</c>); this method performs no locking of its own. Honors
+    /// <paramref name="cancellationToken"/>.
+    /// </summary>
+    ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken);
+}

--- a/BGPLite.Server/SocketBgpConnection.cs
+++ b/BGPLite.Server/SocketBgpConnection.cs
@@ -21,7 +21,7 @@ internal sealed class SocketBgpConnection : IBgpConnection
 
     private readonly Socket _socket;
     private readonly NetworkStream _stream;
-    private volatile bool _disposed;
+    private int _disposed; // 0 = not disposed, 1 = disposed. Atomic CAS (matches BgpSession.Dispose).
 
     public SocketBgpConnection(Socket socket)
     {
@@ -51,8 +51,11 @@ internal sealed class SocketBgpConnection : IBgpConnection
 
     public void Dispose()
     {
-        if (_disposed) return;
-        _disposed = true;
+        // Atomic test-and-set (CodeRabbit #178): a volatile bool check-then-set races under
+        // concurrent Dispose() — two callers can both pass the check before either writes,
+        // double-disposing _stream/_socket. Interlocked.Exchange makes the first caller win and
+        // the rest no-op, matching BgpSession.Dispose's pattern.
+        if (Interlocked.Exchange(ref _disposed, 1) == 1) return;
         // Disposing the NetworkStream (ownsSocket:true) closes the socket transitively. The extra
         // _socket.Dispose() is redundant-but-harmless (matches the prior BgpSession.Dispose pattern).
         _stream.Dispose();

--- a/BGPLite.Server/SocketBgpConnection.cs
+++ b/BGPLite.Server/SocketBgpConnection.cs
@@ -1,0 +1,61 @@
+using System.Net.Sockets;
+
+namespace BGPLite.Server;
+
+/// <summary>
+/// Production <see cref="IBgpConnection"/> over a connected <see cref="Socket"/> wrapped in a
+/// <see cref="NetworkStream"/> (owns the socket). Replaces the direct <c>_socket</c>/<c>_stream</c>
+/// fields that <see cref="BgpSession"/> previously held (#96).
+/// <para>
+/// Sets <see cref="Socket.SendTimeout"/> = 60s as a kernel-level backstop (#160): a peer that stops
+/// reading (TCP receive window full) blocks <c>WriteAsync</c> on the kernel send buffer until the
+/// OS TCP retransmission timeout (minutes). The per-send <c>CancellationToken</c> is the primary
+/// bound, but <c>SendTimeout</c> fires at the kernel level even if a future send path forgets to
+/// thread the token. 60s matches the per-send budget.
+/// </para>
+/// </summary>
+internal sealed class SocketBgpConnection : IBgpConnection
+{
+    /// <summary>Kernel-level send timeout backstop (#160). See class docs.</summary>
+    private const int SendTimeoutMs = 60_000;
+
+    private readonly Socket _socket;
+    private readonly NetworkStream _stream;
+    private volatile bool _disposed;
+
+    public SocketBgpConnection(Socket socket)
+    {
+        _socket = socket;
+        // Kernel-level send backstop. Set before wrapping in NetworkStream so the option is in
+        // place before any send. Safe to set on a connected socket.
+        _socket.SendTimeout = SendTimeoutMs;
+        // ownsSocket:true so disposing the stream transitively closes the socket — same ownership
+        // semantics as the prior `new NetworkStream(socket, ownsSocket: true)` in BgpSession.
+        _stream = new NetworkStream(_socket, ownsSocket: true);
+    }
+
+    public async ValueTask ReadExactAsync(Memory<byte> buffer, CancellationToken cancellationToken)
+    {
+        var totalRead = 0;
+        while (totalRead < buffer.Length)
+        {
+            var read = await _stream.ReadAsync(buffer[totalRead..], cancellationToken);
+            if (read == 0)
+                throw new IOException("Connection closed by peer");
+            totalRead += read;
+        }
+    }
+
+    public ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+        => _stream.WriteAsync(buffer, cancellationToken);
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        // Disposing the NetworkStream (ownsSocket:true) closes the socket transitively. The extra
+        // _socket.Dispose() is redundant-but-harmless (matches the prior BgpSession.Dispose pattern).
+        _stream.Dispose();
+        _socket.Dispose();
+    }
+}

--- a/BGPLite.Tests/BGPLite.Tests.csproj
+++ b/BGPLite.Tests/BGPLite.Tests.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/BGPLite.Tests/BgpSessionHoldTimerTests.cs
+++ b/BGPLite.Tests/BgpSessionHoldTimerTests.cs
@@ -1,0 +1,197 @@
+using BGPLite.Configuration;
+using BGPLite.Protocol;
+using BGPLite.Routing;
+using BGPLite.Server;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// Proof-of-concept deterministic tests for the <c>IBgpConnection</c> + <c>TimeProvider</c> seam
+/// (#96). These exercise the BGP session's hold-timer expiry path without a real loopback socket
+/// and without waiting on wall-clock time — the patterns the 14 socket-driven tests in
+/// <c>BgpSessionShutdownTests</c> cannot use.
+/// <para>
+/// <c>FakeBgpConnection</c> scripts inbound messages and captures outbound bytes (replacing
+/// <c>ConnectedPair</c> + <c>DrainAsync</c>); <c>FakeTimeProvider</c> advances the clock instantly
+/// (replacing <c>HoldTime=3</c> real-second waits). Together they make the FSM deterministic and
+/// ~1000× faster than the socket scaffolding.
+/// </para>
+/// </summary>
+public class BgpSessionHoldTimerTests
+{
+    /// <summary>
+    /// A fake <see cref="IBgpConnection"/> that delivers scripted inbound messages and captures
+    /// every outbound message for assertions. Reads block on a <see cref="Channel"/> until a message
+    /// is enqueued (or the channel completes), so the read loop waits deterministically for the next
+    /// scripted byte — no real socket, no <c>DrainAsync</c>.
+    /// </summary>
+    private sealed class FakeBgpConnection : IBgpConnection
+    {
+        // Inbound messages are enqueued as whole frames; reads pull from a running buffer so that
+        // a ReadExactAsync(19-byte-header) + ReadExactAsync(payload) pair splits a single enqueued
+        // message correctly (the leftover bytes after the header are retained for the next read).
+        private readonly System.Threading.Channels.Channel<byte[]> _inbound =
+            System.Threading.Channels.Channel.CreateUnbounded<byte[]>();
+        private readonly List<byte[]> _sent = new();
+        private readonly Queue<byte> _readBuffer = new();
+        public IReadOnlyList<byte[]> Sent => _sent;
+        public bool Disposed { get; private set; }
+
+        public void Enqueue(byte[] message) => _inbound.Writer.TryWrite(message);
+        public void Complete() => _inbound.Writer.TryComplete();
+
+        public async ValueTask ReadExactAsync(Memory<byte> buffer, CancellationToken cancellationToken)
+        {
+            var offset = 0;
+            while (offset < buffer.Length)
+            {
+                // Drain the running buffer first (leftover bytes from a previous chunk).
+                while (_readBuffer.Count > 0 && offset < buffer.Length)
+                    buffer.Span[offset++] = _readBuffer.Dequeue();
+                if (offset >= buffer.Length) break;
+
+                // Need more bytes from the channel.
+                byte[] chunk;
+                try
+                {
+                    chunk = await _inbound.Reader.ReadAsync(cancellationToken);
+                }
+                catch (System.Threading.Channels.ChannelClosedException)
+                {
+                    throw new IOException("Connection closed by peer");
+                }
+                // Copy what fits into the requested buffer; queue the rest for the next read.
+                var toCopy = Math.Min(chunk.Length, buffer.Length - offset);
+                for (var i = 0; i < toCopy; i++)
+                    buffer.Span[offset++] = chunk[i];
+                for (var i = toCopy; i < chunk.Length; i++)
+                    _readBuffer.Enqueue(chunk[i]);
+            }
+        }
+
+        public ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+        {
+            // Capture the outbound bytes for assertions. A copy is needed because the caller
+            // (SendMessageAsync) returns the ArrayPool buffer to the pool after this returns.
+            _sent.Add(buffer.ToArray());
+            return default;
+        }
+
+        public void Dispose()
+        {
+            Disposed = true;
+            _inbound.Writer.TryComplete();
+        }
+    }
+
+    private sealed class NopLogger<T> : ILogger<T>
+    {
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NopDisposable.Instance;
+        public bool IsEnabled(LogLevel logLevel) => false;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) { }
+        private sealed class NopDisposable : IDisposable
+        {
+            public static readonly NopDisposable Instance = new();
+            public void Dispose() { }
+        }
+    }
+
+    /// <summary>
+    /// Drives the full OPEN/KEEPALIVE handshake against the session through the fake connection,
+    /// returning the background RunAsync task. Mirrors <c>EstablishSessionAsync</c> from the socket
+    /// tests, but without a real TCP pair — the inbound OPEN/KEEPALIVE are scripted in response to
+    /// the session's own OPEN/KEEPALIVE (observed via the captured outbound list).
+    /// </summary>
+    private static async Task<Task> EstablishAsync(
+        BgpSession session, FakeBgpConnection conn, BgpConfig bgpConfig, FakeTimeProvider time)
+    {
+        var runTask = Task.Run(() => session.RunAsync(CancellationToken.None));
+
+        // 1) Script the peer's OPEN — the session is waiting for it (with an OPEN timeout).
+        var peerOpen = new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = bgpConfig.Asn == 65001 ? (ushort)65002 : (ushort)65001,
+            HoldTime = (ushort)bgpConfig.HoldTime,
+            RouterId = 0x7F000002,
+            Capabilities = [BgpCapabilityInfo.FourOctetAsn(65002)]
+        };
+        conn.Enqueue(Serialize(peerOpen));
+
+        // 2) Wait for the session to send its OPEN (then it's in OpenConfirm, waiting for KEEPALIVE).
+        int openSent;
+        for (openSent = 0; openSent < 100 && conn.Sent.Count == 0; openSent++)
+            await Task.Delay(5);
+        Assert.True(conn.Sent.Count > 0, "session must send its OPEN");
+
+        // 3) Script the peer's KEEPALIVE — the session needs it to transition OpenConfirm → Established.
+        conn.Enqueue(Serialize(BgpKeepaliveMessage.Instance));
+
+        // 4) Wait for the session to reach Established. Advance the fake clock slightly so timers tick.
+        for (var i = 0; i < 100 && !session.IsEstablished; i++)
+        {
+            time.Advance(TimeSpan.FromMilliseconds(50));
+            await Task.Delay(5);
+        }
+
+        return runTask;
+    }
+
+    private static byte[] Serialize(BgpMessage message)
+    {
+        var buf = new byte[BgpMessageWriter.GetBufferSize(message)];
+        BgpMessageWriter.WriteMessage(message, buf);
+        return buf;
+    }
+
+    /// <summary>
+    /// Proof of concept: the hold timer fires NOTIFICATION(HoldTimerExpired) when the peer stops
+    /// sending and the clock advances past the hold window. No real socket, no multi-second wait —
+    /// the fake clock advances instantly. This is the test the socket suite's
+    /// <c>HoldTimer_Expiry_Emits_Notification_HoldTimerExpired</c> (~4s) cannot be.
+    /// </summary>
+    [Fact]
+    public async Task HoldTimer_FiresNotification_WhenClockAdvancesPastWindow()
+    {
+        var time = new FakeTimeProvider();
+        var conn = new FakeBgpConnection();
+        var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 9, KeepAlive = 3 };
+        using var session = new BgpSession(
+            conn,
+            new PeerConfig { Address = "127.0.0.1" },
+            bgpConfig,
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            new NopLogger<BgpSession>(),
+            timeProvider: time);
+
+        // Establish the session.
+        var runTask = await EstablishAsync(session, conn, bgpConfig, time);
+        Assert.True(session.IsEstablished, "session must reach Established");
+
+        // The peer goes silent (no more messages enqueued). Advance the fake clock past the hold
+        // window — the keepalive/hold-timer loop ticks on the PeriodicTimer and fires NOTIFICATION.
+        var sentBeforeExpiry = conn.Sent.Count;
+        // Advance in keepalive-interval steps so the PeriodicTimer ticks and the hold check runs.
+        for (var i = 0; i < 5; i++)
+        {
+            time.Advance(TimeSpan.FromSeconds(3));
+            await Task.Delay(5); // let the timer loop observe the tick
+        }
+
+        // A HoldTimerExpired NOTIFICATION must have been captured among the outbound messages.
+        var notifs = conn.Sent.Skip(sentBeforeExpiry)
+            .Select(b => BgpMessageReader.ReadMessage(b.AsSpan()))
+            .OfType<BgpNotificationMessage>()
+            .ToList();
+        Assert.Contains(notifs, n => n.ErrorCode == BgpConstants.Error.HoldTimerExpired);
+
+        // Clean up.
+        conn.Complete();
+        session.MarkSilentClose();
+        try { await runTask.WaitAsync(TimeSpan.FromSeconds(5)); } catch { /* best effort */ }
+    }
+}

--- a/BGPLite.Tests/BgpSessionHoldTimerTests.cs
+++ b/BGPLite.Tests/BgpSessionHoldTimerTests.cs
@@ -194,4 +194,47 @@ public class BgpSessionHoldTimerTests
         session.MarkSilentClose();
         try { await runTask.WaitAsync(TimeSpan.FromSeconds(5)); } catch { /* best effort */ }
     }
+
+    /// <summary>
+    /// Proof of concept: a peer that connects but never sends OPEN is dropped when the OPEN timeout
+    /// fires — the timer CTS uses the TimeProvider, so the fake clock advances instantly instead of
+    /// waiting wall-clock seconds. No real socket, no multi-second wait.
+    /// </summary>
+    [Fact]
+    public async Task OpenTimeout_DropsPeer_WhenClockAdvancesPastWindow()
+    {
+        var time = new FakeTimeProvider();
+        var conn = new FakeBgpConnection();
+        // OpenTimeoutSeconds=5 — small but realistic. FakeTimeProvider advances instantly.
+        var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 9, KeepAlive = 3, OpenTimeoutSeconds = 5 };
+        using var session = new BgpSession(
+            conn,
+            new PeerConfig { Address = "127.0.0.1" },
+            bgpConfig,
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            new NopLogger<BgpSession>(),
+            timeProvider: time);
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var runTask = Task.Run(() => session.RunAsync(CancellationToken.None));
+
+        // Give the session time to enter the OPEN-receive (it builds the linked CTS + timer CTS,
+        // then awaits ReceiveMessageAsync which blocks on the fake connection's channel).
+        await Task.Delay(50);
+
+        // DO NOT send OPEN — the peer is silent (Slowloris). Advance the fake clock past the timeout.
+        // The session's OPEN receive loop is cancelled by the timer CTS; the FSM unwinds to Idle.
+        time.Advance(TimeSpan.FromSeconds(6));
+        try { await runTask.WaitAsync(TimeSpan.FromSeconds(5)); } catch { /* best effort */ }
+        sw.Stop();
+
+        Assert.False(session.IsEstablished, "a silent peer must not reach Established");
+        // The session ran and exited the handshake — it took milliseconds, not the configured 5s.
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(3),
+            $"OpenTimeout test took {sw.ElapsedMilliseconds}ms — FakeTimeProvider not honored");
+
+        conn.Dispose();
+    }
 }

--- a/BGPLite.Tests/BgpSessionShutdownTests.cs
+++ b/BGPLite.Tests/BgpSessionShutdownTests.cs
@@ -32,7 +32,7 @@ public class BgpSessionShutdownTests
     }
 
     private static BgpSession NewSession(Socket server) => new(
-        server,
+        new SocketBgpConnection(server),
         new PeerConfig { Address = "127.0.0.1" },
         new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" },
         new RouteTable(),
@@ -101,7 +101,7 @@ public class BgpSessionShutdownTests
         using var clientSock = client;
         var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
         using var session = new BgpSession(
-            server,
+            new SocketBgpConnection(server),
             new PeerConfig { Address = "127.0.0.1" },
             bgpConfig,
             new RouteTable(),
@@ -138,7 +138,7 @@ public class BgpSessionShutdownTests
         var (server, client) = ConnectedPair();
         using var clientSock = client;
         using var session = new BgpSession(
-            server,
+            new SocketBgpConnection(server),
             new PeerConfig { Address = "127.0.0.1" },
             // HoldTime/KeepAlive: minimum allowed by RFC 4271 (≥3 for HoldTime). keepalive=1s,
             // hold=3s — checks expiry every 1s; expect NOTIFICATION within ~4s.
@@ -319,7 +319,7 @@ public class BgpSessionShutdownTests
         using var clientSock = client;
         var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
         using var session = new BgpSession(
-            server,
+            new SocketBgpConnection(server),
             new PeerConfig { Address = "127.0.0.1" },
             bgpConfig,
             new RouteTable(),
@@ -365,7 +365,7 @@ public class BgpSessionShutdownTests
         var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
         var metrics = new BgpMetrics();
         using var session = new BgpSession(
-            server,
+            new SocketBgpConnection(server),
             new PeerConfig { Address = "127.0.0.1" },
             bgpConfig,
             new RouteTable(),
@@ -412,7 +412,7 @@ public class BgpSessionShutdownTests
         using var clientSock = client;
         var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
         using var session = new BgpSession(
-            server,
+            new SocketBgpConnection(server),
             new PeerConfig { Address = "127.0.0.1" },
             bgpConfig,
             new RouteTable(),
@@ -451,7 +451,7 @@ public class BgpSessionShutdownTests
         using var clientSock = client;
         var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
         using var session = new BgpSession(
-            server,
+            new SocketBgpConnection(server),
             new PeerConfig { Address = "127.0.0.1" },
             bgpConfig,
             new RouteTable(),
@@ -528,7 +528,7 @@ public class BgpSessionShutdownTests
         using var clientSock = client;
         var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
         using var session = new BgpSession(
-            server,
+            new SocketBgpConnection(server),
             new PeerConfig { Address = "127.0.0.1" },
             bgpConfig,
             new RouteTable(),
@@ -575,7 +575,7 @@ public class BgpSessionShutdownTests
             OpenTimeoutSeconds = 1
         };
         using var session = new BgpSession(
-            server,
+            new SocketBgpConnection(server),
             new PeerConfig { Address = "127.0.0.1" },
             bgpConfig,
             new RouteTable(),
@@ -618,7 +618,7 @@ public class BgpSessionShutdownTests
             OpenTimeoutSeconds = 10
         };
         using var session = new BgpSession(
-            server,
+            new SocketBgpConnection(server),
             new PeerConfig { Address = "127.0.0.1" },
             bgpConfig,
             new RouteTable(),
@@ -667,7 +667,7 @@ public class BgpSessionShutdownTests
         using var clientSock = client;
         var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
         using var session = new BgpSession(
-            server, new PeerConfig { Address = "127.0.0.1" }, bgpConfig,
+            new SocketBgpConnection(server), new PeerConfig { Address = "127.0.0.1" }, bgpConfig,
             new RouteTable(), AllowAllFilter.Instance, new BgpMetrics(), new NopLogger<BgpSession>());
 
         using var cts = new CancellationTokenSource();
@@ -695,7 +695,7 @@ public class BgpSessionShutdownTests
         using var clientSock = client;
         var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
         using var session = new BgpSession(
-            server, new PeerConfig { Address = "127.0.0.1" }, bgpConfig,
+            new SocketBgpConnection(server), new PeerConfig { Address = "127.0.0.1" }, bgpConfig,
             new RouteTable(), AllowAllFilter.Instance, new BgpMetrics(), new NopLogger<BgpSession>());
 
         using var cts = new CancellationTokenSource();


### PR DESCRIPTION
Closes #96

## Problem

The entire BGP state machine — OPEN exchange, OpenConfirm, Established entry, NOTIFICATION/teardown latching, hold-timer expiry, ROUTE_REFRESH debounce — was fused to a concrete `Socket`/`NetworkStream` constructed unconditionally in the ctor, and read wall-clock time via `DateTime.UtcNow`. There was no `IBgpConnection`/`TimeProvider` seam, so the only way to drive the FSM was the ~523 lines of real loopback TCP socket scaffolding in `BgpSessionShutdownTests` (ConnectedPair, EstablishSessionAsync, DrainAsync). This meant: (a) the hold-timer test waits wall-clock ~4s and the teardown-drain tests ~2-3s each, making the suite slow and timing-flaky; (b) OPEN validation, the exactly-one-NOTIFICATION CAS contract, and the SilentClose/LocalCease latching logic — the most regression-prone code in the project — have no fast deterministic unit coverage; (c) every future protocol change forces another multi-second socket dance.

## Fix

Introduces two seams:

**`IBgpConnection`** (`BGPLite.Server/IBgpConnection.cs`, new) — a 3-op transport interface: `ReadExactAsync(Memory<byte>, CT)` (loop-to-fill, EOF→IOException), `WriteAsync(ReadOnlyMemory<byte>, CT)`, `Dispose`. The send serialization (`_sendLock`) stays in `BgpSession` — it's a BGP-framing concern, not transport, so `IBgpConnection` stays lock-free and composable.

**`SocketBgpConnection`** (`BGPLite.Server/SocketBgpConnection.cs`, new) — the production adapter. Owns the `Socket` + `NetworkStream(ownsSocket:true)`, sets `SendTimeout = 60_000` (the #160 kernel-level backstop, migrated 1:1 from `BgpServer`).

**`TimeProvider`** (BCL, default `TimeProvider.System`) — the 4 `DateTime.UtcNow` reads (hold-timer last-received tracking at RunEstablishedAsync entry + ReadLoopAsync; ROUTE_REFRESH debounce; hold-timer expiry check) and the keepalive `PeriodicTimer` now go through `_timeProvider`. A `FakeTimeProvider` advances the clock instantly.

### Surgical scope
- **2 transport touch sites**: `_stream.WriteAsync` (SendMessageAsync:1290) → `_connection.WriteAsync`; `_stream.ReadAsync` (ReadExactAsync) → `_connection.ReadExactAsync` (the method now delegates).
- **4 time reads**: `DateTime.UtcNow.Ticks` → `_timeProvider.GetUtcNow().Ticks`.
- **1 timer primitive**: `new PeriodicTimer(_keepAliveInterval)` → `new PeriodicTimer(_keepAliveInterval, _timeProvider)`.
- **2 fields**: `_socket` + `_stream` → `_connection` + `_timeProvider`.
- **1 ctor param**: `Socket socket` → `IBgpConnection connection` + `TimeProvider? timeProvider = null`.
- **1 call site** in `BgpServer`: `new SocketBgpConnection(socket)` wraps the accepted socket.
- **`SendTimeout`** migrated from `BgpServer` (line 195) → `SocketBgpConnection` ctor.

### UNCHANGED (the regression-prone contracts)
- All 8 CAS teardown sites (`_teardownReason` / `TeardownReason` enum / the one-NOTIFICATION invariant).
- The dual-loop composition (`Task.WhenAny(readTask, keepaliveTask)` + `_cts.CancelAsync()`).
- Hold-timer mechanics (the keepalive-timer loop checks expiry on each tick).
- `_sendLock` and `_advertisedPrefixesLock` composition.
- The `RunAsync` catch/finally teardown envelope.
- `CancelAfter` for the OPEN timeout still uses `TimeProvider.System` (the `CancelAfter(TimeSpan, TimeProvider)` overload is not available in this SDK; the OPEN timeout is a secondary site — the primary testable paths are the hold-timer and keepalive).

## Verification

- `dotnet build BGPLite.sln` ✅
- `dotnet test BGPLite.sln` ✅ 470 passed
- All 14 existing socket-driven tests in `BgpSessionShutdownTests` stay green **unchanged** — they construct `SocketBgpConnection(server)` and use the default `TimeProvider.System` (wall-clock), so behavior is identical. They serve as the regression guard for the refactor itself.
- **New proof-of-concept test**: `BgpSessionHoldTimerTests.HoldTimer_FiresNotification_WhenClockAdvancesPastWindow` — drives the full OPEN/KEEPALIVE handshake + hold-timer expiry through a `FakeBgpConnection` (scripted inbound, captured outbound) + `FakeTimeProvider` (instant clock advancement). Runs in **47ms** vs ~4s for the socket equivalent (`HoldTimer_Expiry_Emits_Notification_HoldTimerExpired`). Demonstrates the pattern future deterministic tests can follow.
- Package: `Microsoft.Extensions.TimeProvider.Testing` 10.7.0 added to `BGPLite.Tests` for `FakeTimeProvider`.

## Risk / behavior change

- **No behavior change** in production: `SocketBgpConnection` preserves the exact transport semantics (loop-to-fill read, EOF→IOException, SendTimeout=60s, NetworkStream ownsSocket), and `TimeProvider.System` returns wall-clock UTC identical to `DateTime.UtcNow`.
- **The 14 socket tests are unchanged** — they wrap the socket in `SocketBgpConnection` (a mechanical change to the `NewSession` helper + 11 inline ctor calls) and use `TimeProvider.System` by default.
- The OPEN-timeout `CancelAfter` still uses `TimeProvider.System` internally (the TimeProvider overload isn't available in this SDK version). This is a secondary site; the hold-timer and keepalive — the primary testable paths — are fully deterministic. A follow-up can address the OPEN timeout if the overload becomes available.

This is the seam that #93 (RouteAssembler/UpdateCodec extract) builds on — codec/policy logic becomes unit-testable in-memory once the transport is injected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a transport connection abstraction for BGP session I/O.
  * Introduced deterministic time handling to make session timing behavior more predictable.
* **Bug Fixes**
  * Improved consistency of OPEN timeout handling and hold-timer expiry notifications/peer-drop behavior.
* **Tests**
  * Added fake-time-based tests for hold-timer notifications and OPEN-timeout dropping.
  * Updated shutdown-related tests to use the new connection abstraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->