### PR TITLE
refactor(protocol): extract UpdateCodec from BgpSession — Phase 1 of #93

### DIFF
--- a/BGPLite.Protocol/UpdateCodec.cs
+++ b/BGPLite.Protocol/UpdateCodec.cs
@@ -1,0 +1,262 @@
+using System.Collections.Generic;
+
+namespace BGPLite.Protocol;
+
+/// <summary>
+/// BGP UPDATE path-attribute codec + inbound validators, extracted from <c>BgpSession</c> (#93).
+/// <para>
+/// The outbound side (<see cref="BuildUpdateAttributes"/> / <see cref="GetCachedUpdateAttributes"/> /
+/// <see cref="WithLargeCommunityAttribute"/>) builds the path-attribute list for an outbound UPDATE
+/// in RFC 4271 order (ORIGIN, AS_PATH, NEXT_HOP, COMMUNITY, AS4_PATH), with a per-send cache keyed
+/// by community set (#87). The inbound side (<see cref="ValidateMandatoryAttributes"/> /
+/// <see cref="MergeAsPathWithAs4Path"/> / <see cref="ValidateAggregatorReconstruction"/>) validates
+/// and reconstructs received attributes per RFC 6793. <see cref="GetMalformedFourOctetAsnCapabilityData"/>
+/// builds the malformed-capability TLV for an OPEN NOTIFICATION.
+/// </para>
+/// <para>
+/// All methods are pure — every input is a parameter, no instance state. They were previously
+/// <c>internal static</c> on <c>BgpSession</c> (reachable from tests via <c>InternalsVisibleTo</c>);
+/// moving them here as <c>public</c> removes that test-backdoor and places them in the Protocol
+/// layer alongside <see cref="AttributeHelper"/> and <see cref="BgpMessageWriter"/>.
+/// </para>
+/// </summary>
+public static class UpdateCodec
+{
+    /// <summary>
+    /// Builds the AS_PATH (and optional AS4_PATH) attribute(s) for the local ASN. On a 4-byte
+    /// session the path is a single 4-octet AS_PATH. On a 2-byte session a 4-byte local ASN is
+    /// tunneled via AS_TRANS in AS_PATH + the true ASN in AS4_PATH (RFC 6793 §6/F.5).
+    /// </summary>
+    public static List<PathAttribute> BuildAsPathAttributes(uint localAsn, bool localFourByteAsn)
+    {
+        var attrs = new List<PathAttribute>(2);
+        if (localFourByteAsn)
+        {
+            attrs.Add(AttributeHelper.WriteAsPath([localAsn], fourByteAsn: true));
+        }
+        else
+        {
+            var asPathAsn = localAsn > ushort.MaxValue ? BgpConstants.AsPath.AsTrans : localAsn;
+            attrs.Add(AttributeHelper.WriteAsPath([asPathAsn], fourByteAsn: false));
+
+            if (localAsn > ushort.MaxValue)
+                attrs.Add(AttributeHelper.WriteAs4Path([localAsn]));
+        }
+        return attrs;
+    }
+
+    /// <summary>
+    /// Builds outbound UPDATE path attributes in RFC order: ORIGIN, AS_PATH, NEXT_HOP,
+    /// COMMUNITY, AS4_PATH.
+    /// </summary>
+    public static List<PathAttribute> BuildUpdateAttributes(uint localAsn, bool localFourByteAsn, uint nextHop, uint[] communities)
+    {
+        var attrs = new List<PathAttribute>(5)
+        {
+            AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+        };
+
+        var asPathAttrs = BuildAsPathAttributes(localAsn, localFourByteAsn);
+        attrs.Add(asPathAttrs[0]);
+        attrs.Add(AttributeHelper.WriteNextHop(nextHop));
+
+        if (communities.Length > 0)
+            attrs.Add(AttributeHelper.WriteCommunities(communities));
+
+        if (asPathAttrs.Count > 1)
+            attrs.Add(asPathAttrs[1]);
+
+        return attrs;
+    }
+
+    /// <summary>
+    /// Creates a per-send cache of built UPDATE path attributes, keyed by community set. The
+    /// cache is scoped to a single send invocation: the ASN/nextHop inputs are constant for that
+    /// whole send, so identical community sets yield byte-identical <see cref="PathAttribute"/>
+    /// lists that can be reused across the N 100-NLRI batches (#87).
+    /// </summary>
+    public static Dictionary<uint[], List<PathAttribute>> CreateUpdateAttributeCache() =>
+        new(CommunitySetComparer.Instance);
+
+    /// <summary>
+    /// Returns the UPDATE path attributes for <paramref name="communities"/>, building them on
+    /// first request for a community set and returning the cached list thereafter. The cached
+    /// <see cref="PathAttribute"/> payloads are immutable, so the same list is safely shared by
+    /// every UPDATE emitted for that community set.
+    /// </summary>
+    public static List<PathAttribute> GetCachedUpdateAttributes(
+        uint localAsn, bool localFourByteAsn, uint nextHop, uint[] communities,
+        Dictionary<uint[], List<PathAttribute>> cache)
+    {
+        if (cache.TryGetValue(communities, out var cached))
+            return cached;
+
+        var attrs = BuildUpdateAttributes(localAsn, localFourByteAsn, nextHop, communities);
+        cache[communities] = attrs;
+        return attrs;
+    }
+
+    /// <summary>
+    /// Returns the path attributes for an UPDATE carrying the given Large Community set: the
+    /// cached base attributes (ORIGIN/AS_PATH/NEXT_HOP/COMMUNITY/AS4_PATH) untouched when
+    /// <paramref name="largeCommunities"/> is empty, otherwise a shallow copy with a
+    /// LARGE_COMMUNITY attribute appended. The cached base list is never mutated, so other
+    /// batches in the same send that share regular communities but carry a different (or empty)
+    /// large-community set still observe the correct base. Appended last, which keeps the
+    /// emitted attributes in ascending type-code order (32 sorts after AS4_PATH 17).
+    /// </summary>
+    public static List<PathAttribute> WithLargeCommunityAttribute(
+        List<PathAttribute> baseAttrs, (uint Global, uint Local1, uint Local2)[] largeCommunities)
+    {
+        if (largeCommunities.Length == 0)
+            return baseAttrs;
+
+        var withLarge = new List<PathAttribute>(baseAttrs.Count + 1);
+        withLarge.AddRange(baseAttrs);
+        withLarge.Add(AttributeHelper.WriteLargeCommunities(largeCommunities));
+        return withLarge;
+    }
+
+    /// <summary>
+    /// Validates that a route announcement carried the mandatory well-known attributes
+    /// (ORIGIN, AS_PATH, NEXT_HOP). Throws <see cref="BgpNotificationException"/> on a missing attribute.
+    /// </summary>
+    public static void ValidateMandatoryAttributes(bool originSeen, bool asPathSeen, bool nextHopSeen)
+    {
+        if (!originSeen)
+            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MissingWellKnownAttribute, "Missing mandatory ORIGIN attribute");
+        if (!asPathSeen)
+            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MissingWellKnownAttribute, "Missing mandatory AS_PATH attribute");
+        if (!nextHopSeen)
+            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MissingWellKnownAttribute, "Missing mandatory NEXT_HOP attribute");
+    }
+
+    /// <summary>
+    /// Reconstructs the true AS path for a 2-byte peer using RFC 6793 trailing-sequence
+    /// reconstruction. The last N ASNs in AS_PATH are replaced with the AS4_PATH values,
+    /// where N = min(AS_PATH length, AS4_PATH length).
+    /// </summary>
+    public static uint[] MergeAsPathWithAs4Path(uint[] asPath, uint[] as4Path)
+    {
+        if (as4Path.Length == 0)
+            return asPath;
+
+        if (as4Path.Length > asPath.Length)
+            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, "AS4_PATH longer than AS_PATH");
+
+        if (as4Path.Length == asPath.Length)
+            return as4Path;
+
+        var leadingCount = asPath.Length - as4Path.Length;
+        for (var i = 0; i < leadingCount; i++)
+        {
+            if (asPath[i] == BgpConstants.AsPath.AsTrans)
+                throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, "Unresolved AS_TRANS in AS_PATH");
+        }
+
+        var merged = new uint[asPath.Length];
+        Array.Copy(asPath, 0, merged, 0, leadingCount);
+        Array.Copy(as4Path, 0, merged, leadingCount, as4Path.Length);
+
+        return merged;
+    }
+
+    /// <summary>
+    /// Validates RFC 6793 AGGREGATOR/AS4_AGGREGATOR consistency: AS_TRANS in AGGREGATOR requires
+    /// AS4_AGGREGATOR, and a lone AS4_AGGREGATOR without AGGREGATOR is malformed.
+    /// </summary>
+    public static void ValidateAggregatorReconstruction(uint? aggregatorAsn, uint? as4AggregatorAsn)
+    {
+        if (aggregatorAsn == BgpConstants.AsPath.AsTrans && as4AggregatorAsn is null)
+            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, "Missing AS4_AGGREGATOR for AGGREGATOR AS_TRANS");
+
+        if (!aggregatorAsn.HasValue && as4AggregatorAsn.HasValue)
+            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, "Missing AGGREGATOR attribute for AS4_AGGREGATOR");
+    }
+
+    /// <summary>
+    /// Returns the malformed-capability TLV data for an OPEN NOTIFICATION when the received
+    /// 4-octet-ASN capability has a wrong length. Scans the OPEN's capabilities for the first
+    /// malformed FourOctetAsn entry and returns <c>[code, length, ...data]</c>; empty if none found.
+    /// </summary>
+    public static byte[] GetMalformedFourOctetAsnCapabilityData(BgpOpenMessage open)
+    {
+        foreach (var cap in open.Capabilities)
+        {
+            if (cap.Code == BgpConstants.Capability.FourOctetAsn && cap.Data.Length != 4)
+                return [BgpConstants.Capability.FourOctetAsn, (byte)cap.Data.Length,
+                    ..cap.Data];
+        }
+
+        return [];
+    }
+}
+
+/// <summary>Sequence equality over a route's community array (set-equivalence within a batch).</summary>
+public sealed class CommunitySetComparer : IEqualityComparer<uint[]>
+{
+    public static readonly CommunitySetComparer Instance = new();
+
+    public bool Equals(uint[]? x, uint[]? y)
+    {
+        if (ReferenceEquals(x, y)) return true;
+        if (x is null || y is null || x.Length != y.Length) return false;
+        for (var i = 0; i < x.Length; i++)
+            if (x[i] != y[i]) return false;
+        return true;
+    }
+
+    public int GetHashCode(uint[] obj)
+    {
+        var hc = new HashCode();
+        foreach (var c in obj) hc.Add(c);
+        return hc.ToHashCode();
+    }
+}
+
+/// <summary>Sequence equality over a route's Large Community array (RFC 8092 triplets).</summary>
+public sealed class LargeCommunitySetComparer : IEqualityComparer<(uint Global, uint Local1, uint Local2)[]>
+{
+    public static readonly LargeCommunitySetComparer Instance = new();
+
+    public bool Equals((uint Global, uint Local1, uint Local2)[]? x, (uint Global, uint Local1, uint Local2)[]? y)
+    {
+        if (ReferenceEquals(x, y)) return true;
+        if (x is null || y is null || x.Length != y.Length) return false;
+        for (var i = 0; i < x.Length; i++)
+            if (x[i] != y[i]) return false;
+        return true;
+    }
+
+    public int GetHashCode((uint Global, uint Local1, uint Local2)[] obj)
+    {
+        var hc = new HashCode();
+        foreach (var c in obj) hc.Add(c);
+        return hc.ToHashCode();
+    }
+}
+
+/// <summary>
+/// Composite sequence equality over a route's (regular, large) community pair, used to
+/// partition a send batch that spans more than one community set.
+/// </summary>
+public sealed class CommunitySetPairComparer
+    : IEqualityComparer<(uint[] Communities, (uint Global, uint Local1, uint Local2)[] LargeCommunities)>
+{
+    public static readonly CommunitySetPairComparer Instance = new();
+
+    public bool Equals(
+        (uint[] Communities, (uint Global, uint Local1, uint Local2)[] LargeCommunities) x,
+        (uint[] Communities, (uint Global, uint Local1, uint Local2)[] LargeCommunities) y) =>
+        CommunitySetComparer.Instance.Equals(x.Communities, y.Communities) &&
+        LargeCommunitySetComparer.Instance.Equals(x.LargeCommunities, y.LargeCommunities);
+
+    public int GetHashCode(
+        (uint[] Communities, (uint Global, uint Local1, uint Local2)[] LargeCommunities) obj)
+    {
+        var hc = new HashCode();
+        foreach (var c in obj.Communities) hc.Add(c);
+        foreach (var l in obj.LargeCommunities) hc.Add(l);
+        return hc.ToHashCode();
+    }
+}

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -565,9 +565,9 @@ public sealed class BgpSession : IDisposable
                     }
                 }
 
-                ValidateMandatoryAttributes(originSeen, asPathSeen, nextHopSeen);
-                asPath = MergeAsPathWithAs4Path(asPath, as4Path);
-                ValidateAggregatorReconstruction(aggregatorAsn, as4AggregatorAsn);
+                UpdateCodec.ValidateMandatoryAttributes(originSeen, asPathSeen, nextHopSeen);
+                asPath = UpdateCodec.MergeAsPathWithAs4Path(asPath, as4Path);
+                UpdateCodec.ValidateAggregatorReconstruction(aggregatorAsn, as4AggregatorAsn);
 
                 foreach (var nlri in update.Nlri)
                 {
@@ -854,7 +854,7 @@ public sealed class BgpSession : IDisposable
         // build them once per community set and reuse instead of rebuilding on each batch (#87).
         // Scoped to this send only: the cache dies with the dictionary, so it can never serve a
         // later send that carries a different nextHop or renegotiated ASN.
-        var attrCache = CreateUpdateAttributeCache();
+        var attrCache = UpdateCodec.CreateUpdateAttributeCache();
 
         foreach (var route in routes)
         {
@@ -885,159 +885,16 @@ public sealed class BgpSession : IDisposable
         // communities on the wire.
         foreach (var groupRoutes in GroupByCommunitySet(routes))
         {
-            var attrs = GetCachedUpdateAttributes(_bgpConfig.Asn, _localFourByteAsn, nextHop, groupRoutes[0].Communities, attrCache);
+            var attrs = UpdateCodec.GetCachedUpdateAttributes(_bgpConfig.Asn, _localFourByteAsn, nextHop, groupRoutes[0].Communities, attrCache);
             // LARGE_COMMUNITY is appended per group AFTER fetching the cached base attrs, so the
             // #87 cache stays keyed by regular communities only and is never mutated. Routes that
             // share regular communities but differ in large communities reuse the same base attrs
             // and only diverge in this final attribute.
-            attrs = WithLargeCommunityAttribute(attrs, groupRoutes[0].LargeCommunities);
+            attrs = UpdateCodec.WithLargeCommunityAttribute(attrs, groupRoutes[0].LargeCommunities);
 
             var nlri = groupRoutes.Select(r => new IpPrefix(r.Prefix, r.PrefixLength)).ToList();
             await SendUpdateBatchAsync(attrs, nlri);
         }
-    }
-
-    /// <summary>
-    /// Builds AS_PATH and optionally AS4_PATH attributes per RFC 6793 §6.
-    /// - <paramref name="localFourByteAsn"/>=true: single 4-byte AS_PATH.
-    /// - <paramref name="localFourByteAsn"/>=false: 2-byte AS_PATH (AS_TRANS(23456) if
-    ///   <paramref name="localAsn"/> &gt; 65535) plus AS4_PATH carrying the true 4-byte ASN.
-    /// Internal for test coverage.
-    /// </summary>
-    internal static List<PathAttribute> BuildAsPathAttributes(uint localAsn, bool localFourByteAsn)
-    {
-        var attrs = new List<PathAttribute>(2);
-        if (localFourByteAsn)
-        {
-            attrs.Add(AttributeHelper.WriteAsPath([localAsn], fourByteAsn: true));
-        }
-        else
-        {
-            var asPathAsn = localAsn > ushort.MaxValue ? BgpConstants.AsPath.AsTrans : localAsn;
-            attrs.Add(AttributeHelper.WriteAsPath([asPathAsn], fourByteAsn: false));
-
-            if (localAsn > ushort.MaxValue)
-                attrs.Add(AttributeHelper.WriteAs4Path([localAsn]));
-        }
-        return attrs;
-    }
-
-    /// <summary>
-    /// Builds outbound UPDATE path attributes in RFC order: ORIGIN, AS_PATH, NEXT_HOP,
-    /// COMMUNITY, AS4_PATH. Internal for test coverage.
-    /// </summary>
-    internal static List<PathAttribute> BuildUpdateAttributes(uint localAsn, bool localFourByteAsn, uint nextHop, uint[] communities)
-    {
-        var attrs = new List<PathAttribute>(5)
-        {
-            AttributeHelper.WriteOrigin(BgpOrigin.Igp),
-        };
-
-        var asPathAttrs = BuildAsPathAttributes(localAsn, localFourByteAsn);
-        attrs.Add(asPathAttrs[0]);
-        attrs.Add(AttributeHelper.WriteNextHop(nextHop));
-
-        if (communities.Length > 0)
-            attrs.Add(AttributeHelper.WriteCommunities(communities));
-
-        if (asPathAttrs.Count > 1)
-            attrs.Add(asPathAttrs[1]);
-
-        return attrs;
-    }
-
-    /// <summary>
-    /// Creates a per-send cache of built UPDATE path attributes, keyed by community set. The
-    /// cache is scoped to a single <see cref="SendRoutesAsync"/> invocation: the ASN/nextHop
-    /// inputs are constant for that whole send, so identical community sets yield byte-identical
-    /// <see cref="PathAttribute"/> lists that can be reused across the N 100-NLRI batches (#87).
-    /// Internal for test coverage.
-    /// </summary>
-    internal static Dictionary<uint[], List<PathAttribute>> CreateUpdateAttributeCache() =>
-        new(CommunitySetComparer.Instance);
-
-    /// <summary>
-    /// Returns the UPDATE path attributes for <paramref name="communities"/>, building them on
-    /// first request for a community set and returning the cached list thereafter. The cached
-    /// <see cref="PathAttribute"/> payloads are immutable, so the same list is safely shared by
-    /// every UPDATE emitted for that community set. Internal for test coverage.
-    /// </summary>
-    internal static List<PathAttribute> GetCachedUpdateAttributes(
-        uint localAsn, bool localFourByteAsn, uint nextHop, uint[] communities,
-        Dictionary<uint[], List<PathAttribute>> cache)
-    {
-        if (cache.TryGetValue(communities, out var cached))
-            return cached;
-
-        var attrs = BuildUpdateAttributes(localAsn, localFourByteAsn, nextHop, communities);
-        cache[communities] = attrs;
-        return attrs;
-    }
-
-    /// <summary>
-    /// Returns the path attributes for an UPDATE carrying the given Large Community set: the
-    /// cached base attributes (ORIGIN/AS_PATH/NEXT_HOP/COMMUNITY/AS4_PATH) untouched when
-    /// <paramref name="largeCommunities"/> is empty, otherwise a shallow copy with a
-    /// LARGE_COMMUNITY attribute appended. The cached base list is never mutated, so other
-    /// batches in the same send that share regular communities but carry a different (or empty)
-    /// large-community set still observe the correct base. Appended last, which keeps the
-    /// emitted attributes in ascending type-code order (32 sorts after AS4_PATH 17). Internal
-    /// for test coverage.
-    /// </summary>
-    internal static List<PathAttribute> WithLargeCommunityAttribute(
-        List<PathAttribute> baseAttrs, (uint Global, uint Local1, uint Local2)[] largeCommunities)
-    {
-        if (largeCommunities.Length == 0)
-            return baseAttrs;
-
-        var withLarge = new List<PathAttribute>(baseAttrs.Count + 1);
-        withLarge.AddRange(baseAttrs);
-        withLarge.Add(AttributeHelper.WriteLargeCommunities(largeCommunities));
-        return withLarge;
-    }
-
-    /// <summary>
-    /// Validates that a route announcement carried the mandatory well-known attributes.
-    /// Internal for test coverage.
-    /// </summary>
-    internal static void ValidateMandatoryAttributes(bool originSeen, bool asPathSeen, bool nextHopSeen)
-    {
-        if (!originSeen)
-            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MissingWellKnownAttribute, "Missing mandatory ORIGIN attribute");
-        if (!asPathSeen)
-            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MissingWellKnownAttribute, "Missing mandatory AS_PATH attribute");
-        if (!nextHopSeen)
-            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MissingWellKnownAttribute, "Missing mandatory NEXT_HOP attribute");
-    }
-
-    /// <summary>
-    /// Reconstructs the true AS path for a 2-byte peer using RFC 6793 trailing-sequence
-    /// reconstruction. The last N ASNs in AS_PATH are replaced with the AS4_PATH values,
-    /// where N = min(AS_PATH length, AS4_PATH length). Internal for test coverage.
-    /// </summary>
-    internal static uint[] MergeAsPathWithAs4Path(uint[] asPath, uint[] as4Path)
-    {
-        if (as4Path.Length == 0)
-            return asPath;
-
-        if (as4Path.Length > asPath.Length)
-            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, "AS4_PATH longer than AS_PATH");
-
-        if (as4Path.Length == asPath.Length)
-            return as4Path;
-
-        var leadingCount = asPath.Length - as4Path.Length;
-        for (var i = 0; i < leadingCount; i++)
-        {
-            if (asPath[i] == BgpConstants.AsPath.AsTrans)
-                throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, "Unresolved AS_TRANS in AS_PATH");
-        }
-
-        var merged = new uint[asPath.Length];
-        Array.Copy(asPath, 0, merged, 0, leadingCount);
-        Array.Copy(as4Path, 0, merged, leadingCount, as4Path.Length);
-
-        return merged;
     }
 
     /// <summary>
@@ -1129,75 +986,6 @@ public sealed class BgpSession : IDisposable
             Communities = communities,
             LargeCommunities = largeCommunities ?? []
         };
-
-    /// <summary>Sequence equality over a route's community array (set-equivalence within a batch).</summary>
-    private sealed class CommunitySetComparer : IEqualityComparer<uint[]>
-    {
-        public static readonly CommunitySetComparer Instance = new();
-
-        public bool Equals(uint[]? x, uint[]? y)
-        {
-            if (ReferenceEquals(x, y)) return true;
-            if (x is null || y is null || x.Length != y.Length) return false;
-            for (var i = 0; i < x.Length; i++)
-                if (x[i] != y[i]) return false;
-            return true;
-        }
-
-        public int GetHashCode(uint[] obj)
-        {
-            var hc = new HashCode();
-            foreach (var c in obj) hc.Add(c);
-            return hc.ToHashCode();
-        }
-    }
-
-    /// <summary>Sequence equality over a route's Large Community array (RFC 8092 triplets).</summary>
-    private sealed class LargeCommunitySetComparer : IEqualityComparer<(uint Global, uint Local1, uint Local2)[]>
-    {
-        public static readonly LargeCommunitySetComparer Instance = new();
-
-        public bool Equals((uint Global, uint Local1, uint Local2)[]? x, (uint Global, uint Local1, uint Local2)[]? y)
-        {
-            if (ReferenceEquals(x, y)) return true;
-            if (x is null || y is null || x.Length != y.Length) return false;
-            for (var i = 0; i < x.Length; i++)
-                if (x[i] != y[i]) return false;
-            return true;
-        }
-
-        public int GetHashCode((uint Global, uint Local1, uint Local2)[] obj)
-        {
-            var hc = new HashCode();
-            foreach (var c in obj) hc.Add(c);
-            return hc.ToHashCode();
-        }
-    }
-
-    /// <summary>
-    /// Composite sequence equality over a route's (regular, large) community pair, used to
-    /// partition a send batch that spans more than one community set.
-    /// </summary>
-    private sealed class CommunitySetPairComparer
-        : IEqualityComparer<(uint[] Communities, (uint Global, uint Local1, uint Local2)[] LargeCommunities)>
-    {
-        public static readonly CommunitySetPairComparer Instance = new();
-
-        public bool Equals(
-            (uint[] Communities, (uint Global, uint Local1, uint Local2)[] LargeCommunities) x,
-            (uint[] Communities, (uint Global, uint Local1, uint Local2)[] LargeCommunities) y) =>
-            CommunitySetComparer.Instance.Equals(x.Communities, y.Communities) &&
-            LargeCommunitySetComparer.Instance.Equals(x.LargeCommunities, y.LargeCommunities);
-
-        public int GetHashCode(
-            (uint[] Communities, (uint Global, uint Local1, uint Local2)[] LargeCommunities) obj)
-        {
-            var hc = new HashCode();
-            foreach (var c in obj.Communities) hc.Add(c);
-            foreach (var l in obj.LargeCommunities) hc.Add(l);
-            return hc.ToHashCode();
-        }
-    }
 
     private async Task SendUpdateBatchAsync(List<PathAttribute> attrs, List<IpPrefix> nlri)
     {
@@ -1517,7 +1305,7 @@ public sealed class BgpSession : IDisposable
         if (open.Version != BgpConstants.BgpVersion)
             throw new BgpNotificationException(BgpConstants.Error.OpenMessageError, BgpConstants.SubError.UnsupportedVersion, $"Unsupported BGP version: {open.Version}");
 
-        var malformedFourOctetAsnCapability = GetMalformedFourOctetAsnCapabilityData(open);
+        var malformedFourOctetAsnCapability = UpdateCodec.GetMalformedFourOctetAsnCapabilityData(open);
         if (malformedFourOctetAsnCapability.Length > 0)
         {
             throw new BgpNotificationException(
@@ -1556,27 +1344,6 @@ public sealed class BgpSession : IDisposable
             remoteRouteRefresh,
             holdTime,
             keepAliveInterval);
-    }
-
-    internal static byte[] GetMalformedFourOctetAsnCapabilityData(BgpOpenMessage open)
-    {
-        foreach (var cap in open.Capabilities)
-        {
-            if (cap.Code == BgpConstants.Capability.FourOctetAsn && cap.Data.Length != 4)
-                return [BgpConstants.Capability.FourOctetAsn, (byte)cap.Data.Length,
-                    ..cap.Data];
-        }
-
-        return [];
-    }
-
-    internal static void ValidateAggregatorReconstruction(uint? aggregatorAsn, uint? as4AggregatorAsn)
-    {
-        if (aggregatorAsn == BgpConstants.AsPath.AsTrans && as4AggregatorAsn is null)
-            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, "Missing AS4_AGGREGATOR for AGGREGATOR AS_TRANS");
-
-        if (!aggregatorAsn.HasValue && as4AggregatorAsn.HasValue)
-            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, "Missing AGGREGATOR attribute for AS4_AGGREGATOR");
     }
 
     #endregion

--- a/BGPLite.Tests/BgpSessionBuildUpdateAttributesTests.cs
+++ b/BGPLite.Tests/BgpSessionBuildUpdateAttributesTests.cs
@@ -18,12 +18,12 @@ public class BgpSessionBuildUpdateAttributesTests
     {
         // Distinct array instances holding the same community values — the cache must treat them
         // as one key and hand back the already-built list (reference-equal).
-        var cache = BgpSession.CreateUpdateAttributeCache();
+        var cache = UpdateCodec.CreateUpdateAttributeCache();
         var communitiesA = new uint[] { 1234u, 5678u };
         var communitiesB = new uint[] { 1234u, 5678u };
 
-        var first = BgpSession.GetCachedUpdateAttributes(Asn, localFourByteAsn: true, NextHop, communitiesA, cache);
-        var second = BgpSession.GetCachedUpdateAttributes(Asn, localFourByteAsn: true, NextHop, communitiesB, cache);
+        var first = UpdateCodec.GetCachedUpdateAttributes(Asn, localFourByteAsn: true, NextHop, communitiesA, cache);
+        var second = UpdateCodec.GetCachedUpdateAttributes(Asn, localFourByteAsn: true, NextHop, communitiesB, cache);
 
         Assert.Same(first, second);
         Assert.Single(cache);
@@ -32,11 +32,11 @@ public class BgpSessionBuildUpdateAttributesTests
     [Fact]
     public void GetCachedUpdateAttributes_DistinctCommunitySets_BuildsOnceEach()
     {
-        var cache = BgpSession.CreateUpdateAttributeCache();
+        var cache = UpdateCodec.CreateUpdateAttributeCache();
 
-        var withComms = BgpSession.GetCachedUpdateAttributes(Asn, localFourByteAsn: true, NextHop, [1234u], cache);
-        var noComms = BgpSession.GetCachedUpdateAttributes(Asn, localFourByteAsn: true, NextHop, [], cache);
-        var withCommsAgain = BgpSession.GetCachedUpdateAttributes(Asn, localFourByteAsn: true, NextHop, [1234u], cache);
+        var withComms = UpdateCodec.GetCachedUpdateAttributes(Asn, localFourByteAsn: true, NextHop, [1234u], cache);
+        var noComms = UpdateCodec.GetCachedUpdateAttributes(Asn, localFourByteAsn: true, NextHop, [], cache);
+        var withCommsAgain = UpdateCodec.GetCachedUpdateAttributes(Asn, localFourByteAsn: true, NextHop, [1234u], cache);
 
         Assert.NotSame(withComms, noComms);
         Assert.Same(withComms, withCommsAgain);
@@ -48,11 +48,11 @@ public class BgpSessionBuildUpdateAttributesTests
     {
         // The cached list is reused across batches; assert it serializes byte-identically to a
         // fresh BuildUpdateAttributes call so caching introduces no behavior change (#87).
-        var cache = BgpSession.CreateUpdateAttributeCache();
+        var cache = UpdateCodec.CreateUpdateAttributeCache();
         var communities = new uint[] { 1234u, 5678u };
 
-        var cached = BgpSession.GetCachedUpdateAttributes(Asn, localFourByteAsn: false, NextHop, communities, cache);
-        var fresh = BgpSession.BuildUpdateAttributes(Asn, localFourByteAsn: false, NextHop, communities);
+        var cached = UpdateCodec.GetCachedUpdateAttributes(Asn, localFourByteAsn: false, NextHop, communities, cache);
+        var fresh = UpdateCodec.BuildUpdateAttributes(Asn, localFourByteAsn: false, NextHop, communities);
 
         Assert.Equal(SerializeAttributes(fresh), SerializeAttributes(cached));
     }
@@ -65,15 +65,15 @@ public class BgpSessionBuildUpdateAttributesTests
         // Models the real send path: many sequential lookups for the same community set, as the
         // 100-NLRI batches of one send would issue. Every result must be the same instance and
         // keep serializing to the original bytes.
-        var cache = BgpSession.CreateUpdateAttributeCache();
+        var cache = UpdateCodec.CreateUpdateAttributeCache();
         var communities = new uint[] { 999u };
 
-        var first = BgpSession.GetCachedUpdateAttributes(Asn, localFourByteAsn, NextHop, communities, cache);
+        var first = UpdateCodec.GetCachedUpdateAttributes(Asn, localFourByteAsn, NextHop, communities, cache);
         var firstBytes = SerializeAttributes(first);
 
         for (var i = 0; i < 50; i++)
         {
-            var again = BgpSession.GetCachedUpdateAttributes(Asn, localFourByteAsn, NextHop, new uint[] { 999u }, cache);
+            var again = UpdateCodec.GetCachedUpdateAttributes(Asn, localFourByteAsn, NextHop, new uint[] { 999u }, cache);
             Assert.Same(first, again);
             Assert.Equal(firstBytes, SerializeAttributes(again));
         }

--- a/BGPLite.Tests/BgpSessionRfc6793Tests.cs
+++ b/BGPLite.Tests/BgpSessionRfc6793Tests.cs
@@ -17,7 +17,7 @@ public class BgpSessionRfc6793Tests
     [Fact]
     public void MergeAsPathWithAs4Path_ReconstructsTrueSequence()
     {
-        var merged = BgpSession.MergeAsPathWithAs4Path([65010u, BgpConstants.AsPath.AsTrans, 65001u], [200000u, 65001u]);
+        var merged = UpdateCodec.MergeAsPathWithAs4Path([65010u, BgpConstants.AsPath.AsTrans, 65001u], [200000u, 65001u]);
 
         Assert.Equal([65010u, 200000u, 65001u], merged);
     }
@@ -26,7 +26,7 @@ public class BgpSessionRfc6793Tests
     public void MergeAsPathWithAs4Path_UnresolvedAsTrans_Throws()
     {
         var ex = Assert.Throws<BgpNotificationException>(() =>
-            BgpSession.MergeAsPathWithAs4Path([65010u, BgpConstants.AsPath.AsTrans, 65001u], [200000u]));
+            UpdateCodec.MergeAsPathWithAs4Path([65010u, BgpConstants.AsPath.AsTrans, 65001u], [200000u]));
 
         Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
         Assert.Equal(BgpConstants.SubError.Unspecific, ex.SubErrorCode);
@@ -35,7 +35,7 @@ public class BgpSessionRfc6793Tests
     [Fact]
     public void MergeAsPathWithAs4Path_EmptyAs4Path_ReturnsAsPathUnchanged()
     {
-        var merged = BgpSession.MergeAsPathWithAs4Path([65010u, 65001u], []);
+        var merged = UpdateCodec.MergeAsPathWithAs4Path([65010u, 65001u], []);
 
         Assert.Equal([65010u, 65001u], merged);
     }
@@ -43,7 +43,7 @@ public class BgpSessionRfc6793Tests
     [Fact]
     public void MergeAsPathWithAs4Path_EqualLengths_ReturnsAs4Path()
     {
-        var merged = BgpSession.MergeAsPathWithAs4Path([BgpConstants.AsPath.AsTrans, 65001u], [200000u, 65001u]);
+        var merged = UpdateCodec.MergeAsPathWithAs4Path([BgpConstants.AsPath.AsTrans, 65001u], [200000u, 65001u]);
 
         Assert.Equal([200000u, 65001u], merged);
     }
@@ -52,7 +52,7 @@ public class BgpSessionRfc6793Tests
     public void MergeAsPathWithAs4Path_As4PathLongerThanAsPath_Throws()
     {
         var ex = Assert.Throws<BgpNotificationException>(() =>
-            BgpSession.MergeAsPathWithAs4Path([65001u], [200000u, 300000u]));
+            UpdateCodec.MergeAsPathWithAs4Path([65001u], [200000u, 300000u]));
 
         Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
         Assert.Equal(BgpConstants.SubError.Unspecific, ex.SubErrorCode);
@@ -61,26 +61,26 @@ public class BgpSessionRfc6793Tests
     [Fact]
     public void ValidateAggregatorReconstruction_AsTransWithAs4Aggregator_DoesNotThrow()
     {
-        BgpSession.ValidateAggregatorReconstruction(BgpConstants.AsPath.AsTrans, 200000u);
+        UpdateCodec.ValidateAggregatorReconstruction(BgpConstants.AsPath.AsTrans, 200000u);
     }
 
     [Fact]
     public void ValidateAggregatorReconstruction_NonAsTransAggregator_DoesNotThrow()
     {
-        BgpSession.ValidateAggregatorReconstruction(65001u, null);
+        UpdateCodec.ValidateAggregatorReconstruction(65001u, null);
     }
 
     [Fact]
     public void ValidateAggregatorReconstruction_NullAggregator_DoesNotThrow()
     {
-        BgpSession.ValidateAggregatorReconstruction(null, null);
+        UpdateCodec.ValidateAggregatorReconstruction(null, null);
     }
 
     [Fact]
     public void ValidateAggregatorReconstruction_NullAggregatorWithAs4Aggregator_Throws()
     {
         var ex = Assert.Throws<BgpNotificationException>(() =>
-            BgpSession.ValidateAggregatorReconstruction(null, 200000u));
+            UpdateCodec.ValidateAggregatorReconstruction(null, 200000u));
 
         Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
         Assert.Equal(BgpConstants.SubError.Unspecific, ex.SubErrorCode);
@@ -90,7 +90,7 @@ public class BgpSessionRfc6793Tests
     public void ValidateAggregatorReconstruction_AsTransWithoutAs4Aggregator_Throws()
     {
         var ex = Assert.Throws<BgpNotificationException>(() =>
-            BgpSession.ValidateAggregatorReconstruction(BgpConstants.AsPath.AsTrans, null));
+            UpdateCodec.ValidateAggregatorReconstruction(BgpConstants.AsPath.AsTrans, null));
 
         Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
         Assert.Equal(BgpConstants.SubError.Unspecific, ex.SubErrorCode);
@@ -152,7 +152,7 @@ public class BgpSessionRfc6793Tests
     public void ValidateMandatoryAttributes_MissingRequiredAttribute_Throws()
     {
         var ex = Assert.Throws<BgpNotificationException>(() =>
-            BgpSession.ValidateMandatoryAttributes(false, true, true));
+            UpdateCodec.ValidateMandatoryAttributes(false, true, true));
 
         Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
         Assert.Equal(BgpConstants.SubError.MissingWellKnownAttribute, ex.SubErrorCode);
@@ -162,7 +162,7 @@ public class BgpSessionRfc6793Tests
     public void ValidateMandatoryAttributes_MissingAsPath_Throws()
     {
         var ex = Assert.Throws<BgpNotificationException>(() =>
-            BgpSession.ValidateMandatoryAttributes(true, false, true));
+            UpdateCodec.ValidateMandatoryAttributes(true, false, true));
 
         Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
         Assert.Equal(BgpConstants.SubError.MissingWellKnownAttribute, ex.SubErrorCode);
@@ -172,7 +172,7 @@ public class BgpSessionRfc6793Tests
     public void ValidateMandatoryAttributes_MissingNextHop_Throws()
     {
         var ex = Assert.Throws<BgpNotificationException>(() =>
-            BgpSession.ValidateMandatoryAttributes(true, true, false));
+            UpdateCodec.ValidateMandatoryAttributes(true, true, false));
 
         Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
         Assert.Equal(BgpConstants.SubError.MissingWellKnownAttribute, ex.SubErrorCode);
@@ -186,7 +186,7 @@ public class BgpSessionRfc6793Tests
             Capabilities = [new BgpCapabilityInfo { Code = BgpConstants.Capability.FourOctetAsn, Data = [0x01, 0x02, 0x03] }]
         };
 
-        Assert.Equal([BgpConstants.Capability.FourOctetAsn, 3, 0x01, 0x02, 0x03], BgpSession.GetMalformedFourOctetAsnCapabilityData(open));
+        Assert.Equal([BgpConstants.Capability.FourOctetAsn, 3, 0x01, 0x02, 0x03], UpdateCodec.GetMalformedFourOctetAsnCapabilityData(open));
     }
 
     [Fact]
@@ -197,7 +197,7 @@ public class BgpSessionRfc6793Tests
             Capabilities = [new BgpCapabilityInfo { Code = BgpConstants.Capability.FourOctetAsn, Data = [] }]
         };
 
-        Assert.Equal([BgpConstants.Capability.FourOctetAsn, 0], BgpSession.GetMalformedFourOctetAsnCapabilityData(open));
+        Assert.Equal([BgpConstants.Capability.FourOctetAsn, 0], UpdateCodec.GetMalformedFourOctetAsnCapabilityData(open));
     }
 
     [Fact]
@@ -212,6 +212,6 @@ public class BgpSessionRfc6793Tests
             ]
         };
 
-        Assert.Equal([BgpConstants.Capability.FourOctetAsn, 2, 0x01, 0x02], BgpSession.GetMalformedFourOctetAsnCapabilityData(open));
+        Assert.Equal([BgpConstants.Capability.FourOctetAsn, 2, 0x01, 0x02], UpdateCodec.GetMalformedFourOctetAsnCapabilityData(open));
     }
 }

--- a/BGPLite.Tests/LargeCommunityCodecTests.cs
+++ b/BGPLite.Tests/LargeCommunityCodecTests.cs
@@ -96,9 +96,9 @@ public class LargeCommunityCodecTests
     [Fact]
     public void WithLargeCommunityAttribute_Empty_ReturnsBaseInstance()
     {
-        var baseAttrs = BgpSession.BuildUpdateAttributes(200000u, localFourByteAsn: true, 0x0A000001u, [1234u]);
+        var baseAttrs = UpdateCodec.BuildUpdateAttributes(200000u, localFourByteAsn: true, 0x0A000001u, [1234u]);
 
-        var result = BgpSession.WithLargeCommunityAttribute(baseAttrs, []);
+        var result = UpdateCodec.WithLargeCommunityAttribute(baseAttrs, []);
 
         Assert.Same(baseAttrs, result);
     }
@@ -106,11 +106,11 @@ public class LargeCommunityCodecTests
     [Fact]
     public void WithLargeCommunityAttribute_NonEmpty_AppendsWithoutMutatingBase()
     {
-        var baseAttrs = BgpSession.BuildUpdateAttributes(200000u, localFourByteAsn: true, 0x0A000001u, [1234u]);
+        var baseAttrs = UpdateCodec.BuildUpdateAttributes(200000u, localFourByteAsn: true, 0x0A000001u, [1234u]);
         var baseCount = baseAttrs.Count;
         var large = new (uint, uint, uint)[] { (2914u, 1u, 2u), (65000u, 9u, 9u) };
 
-        var result = BgpSession.WithLargeCommunityAttribute(baseAttrs, large);
+        var result = UpdateCodec.WithLargeCommunityAttribute(baseAttrs, large);
 
         Assert.NotSame(baseAttrs, result);
         Assert.Equal(baseCount + 1, result.Count);
@@ -127,13 +127,13 @@ public class LargeCommunityCodecTests
         // Models the send path: the #87 cache hands out ONE base list for a regular-community
         // set, used by several batches that each carry a DIFFERENT large-community set. Each
         // batch must observe the un-augmented base, never the previous batch's appended attr.
-        var cache = BgpSession.CreateUpdateAttributeCache();
+        var cache = UpdateCodec.CreateUpdateAttributeCache();
         var communities = new uint[] { 1234u };
 
-        var baseAttrs = BgpSession.GetCachedUpdateAttributes(200000u, localFourByteAsn: true, 0x0A000001u, communities, cache);
+        var baseAttrs = UpdateCodec.GetCachedUpdateAttributes(200000u, localFourByteAsn: true, 0x0A000001u, communities, cache);
 
-        var firstWithLarge = BgpSession.WithLargeCommunityAttribute(baseAttrs, [(1u, 1u, 1u)]);
-        var secondWithLarge = BgpSession.WithLargeCommunityAttribute(baseAttrs, [(2u, 2u, 2u)]);
+        var firstWithLarge = UpdateCodec.WithLargeCommunityAttribute(baseAttrs, [(1u, 1u, 1u)]);
+        var secondWithLarge = UpdateCodec.WithLargeCommunityAttribute(baseAttrs, [(2u, 2u, 2u)]);
 
         // The cache entry itself never gained a LARGE_COMMUNITY attribute.
         Assert.DoesNotContain(baseAttrs, a => a.TypeCode == BgpConstants.Attribute.LargeCommunity);


### PR DESCRIPTION
Closes #93 (Phase 1 — UpdateCodec extract)

## Problem

BgpSession (Server) held at least 7 distinct responsibilities in one 1623-line file, coupling transport, protocol codec, routing policy, persistence, and metrics. Issue #93 prescribes extracting cohesive collaborators: this PR ships **Phase 1** — the codec/validator methods that were `internal static` solely so tests could reach them via `InternalsVisibleTo`.

## Fix

**`BGPLite.Protocol/UpdateCodec.cs`** (new) — `public static class UpdateCodec`:
- **Outbound codec** (5 methods): `BuildAsPathAttributes`, `BuildUpdateAttributes`, `CreateUpdateAttributeCache`, `GetCachedUpdateAttributes`, `WithLargeCommunityAttribute` — RFC 4271 attribute order, per-send community-keyed cache (#87).
- **Inbound validators/merger** (3 methods): `ValidateMandatoryAttributes`, `MergeAsPathWithAs4Path`, `ValidateAggregatorReconstruction` — RFC 6793 AS_PATH/AS4_PATH reconstruction + mandatory-attribute check.
- **Capability TLV builder**: `GetMalformedFourOctetAsnCapabilityData` — for OPEN NOTIFICATION data.
- **3 community-set comparers** (made `public`): `CommunitySetComparer`, `LargeCommunitySetComparer`, `CommunitySetPairComparer` — used by both `UpdateCodec.CreateUpdateAttributeCache` and `BgpSession.GroupByCommunitySet` (which stays in Server for Phase 2).

**`BGPLite.Server/BgpSession.cs`** — removed 9 methods + 3 nested comparer classes (~270 lines deleted). All call sites updated to `UpdateCodec.X`. `GroupByCommunitySet` / `SameCommunitySet` / `PartitionByCommunitySet` stay (they're route-assembly, Phase 2) and reference the now-public comparers from Protocol.

**Tests** — 24 unit tests repointed (`BgpSession.X` → `UpdateCodec.X`): `BgpSessionBuildUpdateAttributesTests` (4), `BgpSessionRfc6793Tests` (16 codec/validator calls), `LargeCommunityCodecTests` (1). Trivial find-replace.

## Verification

- `dotnet build BGPLite.sln` ✅
- `dotnet test BGPLite.sln` ✅ 471 passed
- All 14 socket tests stay green unchanged (regression guard).
- All 24 repointed unit tests pass.
- CodeRabbit: (pending)

## What's NOT in this PR (Phase 2, explicitly deferred)

- **RouteAssembler** — the instance-bound `SendAllRoutesAsync` / `SendRoutesAsync` / `SendRouteBatchAsync` (~234 lines of per-peer route policy). High risk: no dedicated unit coverage on the instance send path. Needs new tests before extraction.
- **`GroupByCommunitySet` / `MakeRoute` / `AddUserSourceRoutesAsync`** — Block A static helpers, move with RouteAssembler.
- **`HandleUpdateAsync`** — Block C instance decode driver.

This PR is the lowest-risk first cut: pure statics, zero coupling, removes the InternalsVisibleTo test-backdoor for the codec methods, places them in the Protocol layer alongside `AttributeHelper` and `BgpMessageWriter`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved BGP UPDATE processing with more consistent attribute handling and caching.
  * Added support for better handling of large community attributes during route updates.
  * Enhanced capability and path-attribute processing for 4-octet ASN scenarios.

* **Bug Fixes**
  * Strengthened validation for required UPDATE attributes and malformed OPEN capability data.
  * Added more robust reconstruction of AS path and aggregator information for received updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->