### PR TITLE
security(api): bind management API to loopback by default

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -136,12 +136,16 @@ public sealed class ManagementApi : IHostedService, IDisposable
     public Task StartAsync(CancellationToken cancellationToken)
     {
         _listener = new HttpListener();
-        _listener.Prefixes.Add($"http://{_listenAddress}:{_port}/");
+        // IPv6 literals (e.g. "::1") must be bracketed in a URI: http://[::1]:5001/, not http://::1:5001/.
+        // IPv4 and hostnames ("127.0.0.1", "localhost", "0.0.0.0") go through as-is (CodeRabbit #181).
+        var host = _listenAddress.Contains(':') ? $"[{_listenAddress}]" : _listenAddress;
+        _listener.Prefixes.Add($"http://{host}:{_port}/");
         _listener.Start();
 
         _logger.LogInformation("Management API listening on http://{Address}:{Port}/", _listenAddress, _port);
         // Warn if the operator explicitly exposed the API without a trusted-proxy gate (#90).
-        if (_listenAddress is not "127.0.0.1" and not "localhost")
+        // Both IPv4 and IPv6 loopback are recognized as secure.
+        if (_listenAddress is not "127.0.0.1" and not "localhost" and not "::1")
         {
             _logger.LogWarning(
                 "Management API is bound to {Address} (non-loopback) — ensure an authenticated reverse " +

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -33,6 +33,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
     private readonly ISessionManager? _sessionManager;
     private readonly ILogger<ManagementApi> _logger;
     private readonly int _port;
+    private readonly string _listenAddress;  // #90: bind address — loopback by default
     private HttpListener? _listener;
     private Task? _listenTask;
     private CancellationTokenSource _cts = new();
@@ -56,6 +57,9 @@ public sealed class ManagementApi : IHostedService, IDisposable
         _sessionManager = sessionManager;
         _logger = logger;
         _port = config.ApiPort;
+        // #90: secure-by-default — bind to loopback unless the operator explicitly sets ApiListen.
+        // The previous "http://+:port" exposed the unauthenticated control plane on every interface.
+        _listenAddress = string.IsNullOrWhiteSpace(config.ApiListen) ? "127.0.0.1" : config.ApiListen!;
         _trustedProxyNetworks = ParseTrustedProxies(config.TrustedProxies);
         // Opt-in (#116): no rate limiting unless an ApiRateLimit section is configured, so the live
         // service's behavior is unchanged until the operator enables it.
@@ -132,10 +136,18 @@ public sealed class ManagementApi : IHostedService, IDisposable
     public Task StartAsync(CancellationToken cancellationToken)
     {
         _listener = new HttpListener();
-        _listener.Prefixes.Add($"http://+:{_port}/");
+        _listener.Prefixes.Add($"http://{_listenAddress}:{_port}/");
         _listener.Start();
 
-        _logger.LogInformation("Management API listening on http://+:{Port}/", _port);
+        _logger.LogInformation("Management API listening on http://{Address}:{Port}/", _listenAddress, _port);
+        // Warn if the operator explicitly exposed the API without a trusted-proxy gate (#90).
+        if (_listenAddress is not "127.0.0.1" and not "localhost")
+        {
+            _logger.LogWarning(
+                "Management API is bound to {Address} (non-loopback) — ensure an authenticated reverse " +
+                "proxy (Caddy/nginx with TLS + auth) is in front, or the unauthenticated control plane " +
+                "is reachable from the network", _listenAddress);
+        }
         _listenTask = ListenAsync(_cts.Token);
         return Task.CompletedTask;
     }

--- a/BGPLite.Configuration/AppConfig.cs
+++ b/BGPLite.Configuration/AppConfig.cs
@@ -15,6 +15,16 @@ public sealed class AppConfig
     [YamlMember(Alias = "ApiPort")]
     public int ApiPort { get; init; } = 5001;
 
+    /// <summary>
+    /// The IP address the management API binds to (#90). Default <c>null</c> → loopback
+    /// (<c>127.0.0.1</c>) — the API is reachable ONLY from the same host, so an operator who wants
+    /// to expose it MUST put an authenticated reverse proxy (Caddy/nginx with TLS + auth) in front
+    /// and set this to <c>"0.0.0.0"</c> (or a specific interface). This is secure-by-default: the
+    /// previous <c>http://+:port</c> bind exposed the unauthenticated control plane on every interface.
+    /// </summary>
+    [YamlMember(Alias = "ApiListen")]
+    public string? ApiListen { get; init; }
+
     [YamlMember(Alias = "RipeStat")]
     public RipeStatConfig? RipeStat { get; init; }
 

--- a/BGPLite.Tests/ConfigValidationTests.cs
+++ b/BGPLite.Tests/ConfigValidationTests.cs
@@ -110,6 +110,30 @@ public class ConfigValidationTests
         Assert.Contains("MaxRequestBodyBytes", ex.Message);
     }
 
+    // --- #90: ApiListen — secure-by-default loopback bind ---
+
+    [Fact]
+    public void ApiListen_DefaultsToNull_Loopback()
+    {
+        // Default (unset) → null → ManagementApi binds to 127.0.0.1 (secure-by-default).
+        var config = new AppConfig { Bgp = Bgp() };
+        Assert.Null(config.ApiListen);
+    }
+
+    [Theory]
+    [InlineData("127.0.0.1")]
+    [InlineData("0.0.0.0")]
+    [InlineData("localhost")]
+    [InlineData("::1")]
+    public void Validate_AcceptsAnyApiListen(string listen)
+    {
+        // ApiListen is a free-form bind address — any valid string is accepted (HttpListener will
+        // fail at runtime if it can't bind). Validate does not restrict it; the secure-by-default
+        // is the null → loopback mapping, not a validation constraint.
+        var config = new AppConfig { Bgp = Bgp(), ApiListen = listen };
+        config.Validate();
+    }
+
     [Fact]
     public void Validate_AcceptsDefaultMaxRequestBodyBytes()
     {

--- a/appsettings.Example.yml
+++ b/appsettings.Example.yml
@@ -64,6 +64,13 @@ DefaultPrefixSource: ru
 # CustomPrefixCommunity: "65444:100"
 # CustomAsnCommunity: "65444:200"
 
+# Management API — bind address (#90). Secure-by-default: loopback only.
+# The API is an unauthenticated control plane (create/delete peers, read routes, ...).
+# Leave this unset (default 127.0.0.1) and put an authenticated reverse proxy (Caddy/nginx
+# with TLS + auth) in front. Set to "0.0.0.0" ONLY if you have auth at the proxy layer —
+# the app logs a warning on startup when bound to a non-loopback address.
+# ApiListen: "127.0.0.1"   # default: loopback. Set "0.0.0.0" to expose (auth required!).
+
 # Management API — client-IP resolution behind a reverse proxy (#91).
 # X-Forwarded-For / X-Real-IP are honored ONLY when the immediate TCP peer is one of these trusted
 # CIDRs; otherwise the direct RemoteEndPoint is used and any client-supplied forwarding header is

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,11 @@
 # (simplest for peering). If you prefer bridge networking, drop `network_mode: host`,
 # map `ports: ["179:179","5000:5000"]`, and add `cap_add: [NET_BIND_SERVICE]`
 # (port 179 < 1024) or run a reverse-proxy/port-remapper.
+#
+# SECURITY (#90): the management API binds to 127.0.0.1 by default (loopback only).
+# With `network_mode: host`, it is reachable only from the same host — put an authenticated
+# reverse proxy (Caddy/nginx with TLS + auth) in front. To expose it directly, set
+# `ApiListen: "0.0.0.0"` in appsettings.yml — but you MUST provide auth at the proxy layer.
 services:
   bgplite:
     image: ghcr.io/ruhex/bgplite:latest


### PR DESCRIPTION
Closes #90

## Problem

The management API is an unauthenticated control plane — anyone who could reach TCP {ApiPort} could POST /api/peers (register arbitrary peer → route leak), DELETE peers, read /api/routes, etc. The previous `http://+:port` bind exposed it on **every interface by default**. For a route-server this is remote-takeover-grade.

## Fix

**Secure-by-default:** the API now binds to `127.0.0.1` (loopback) unless the operator explicitly sets `ApiListen` in config.

`BGPLite.Configuration/AppConfig.cs`:
- New `ApiListen` field (nullable string, default `null` → loopback `127.0.0.1`).

`BGPLite.Api/ManagementApi.cs`:
- `StartAsync`: `http://+:{port}` → `http://{listenAddress}:{port}/` where `listenAddress = ApiListen ?? "127.0.0.1"`.
- Logs a warning on startup when bound to a non-loopback address, prompting the operator to verify auth.

`appsettings.Example.yml` + `docker-compose.yml`:
- Documented the security model: leave unset for loopback (default), set `"0.0.0.0"` to expose — **requires** authenticated reverse proxy.

## Intended deployment topology

```
Internet → Caddy (TLS + auth) → localhost:5001 (BGPLite API, loopback only)
                               → :179 (BGPLite BGP, must be exposed for peering)
```

The operator puts auth at the proxy layer (Caddy basic-auth, client-cert, or IP allowlist). The app itself stays on loopback and is never directly reachable from the network.

## Verification

- `dotnet build BGPLite.sln` ✅
- `dotnet test BGPLite.sln` ✅ 476 passed (+5 new ApiListen config tests)

## Risk / behavior change

- **Intentional behavior change**: the API now listens on loopback by default. Operators who relied on direct access to `+:5001` from the network MUST add `ApiListen: "0.0.0.0"` to their config AND ensure auth at the proxy layer. This is the security fix.
- **For existing prod** (Caddy `reverse_proxy localhost:5001`): **no change needed** — the loopback bind is compatible with Caddy forwarding to localhost.
- The warning log on non-loopback bind is informational, not a startup failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Management API bind address is now configurable, defaulting securely to `127.0.0.1` when unset.
  * Adds additional warnings and clearer startup logs when the API is bound to a non-loopback interface.

* **Documentation**
  * Updated example configuration and deployment guidance to emphasize secure-by-default loopback binding and recommend using an authenticated reverse proxy.

* **Tests**
  * Added validation coverage for `ApiListen`, including default/unset behavior and acceptance of arbitrary provided values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->