### PR TITLE
refactor(providers): thread TimeProvider through PrefixService caches

### DIFF
--- a/BGPLite.Providers/PrefixService.cs
+++ b/BGPLite.Providers/PrefixService.cs
@@ -25,9 +25,10 @@ public sealed class PrefixService : IPrefixService
     // default does not constrain real deployments.
     private readonly int _maxCacheEntries;
     private readonly ILogger<PrefixService>? _logger;
+    private readonly TimeProvider _timeProvider;
     private readonly UserSourceCache _userSourceCache;
 
-    public PrefixService(AppConfig config, RipeStatProvider? ripeStat, IPrefixSourceService prefixSources, HttpPrefixProvider? httpProvider = null, TimeSpan? cacheTtl = null, ILogger<PrefixService>? logger = null, TimeSpan? negativeTtl = null, int? maxCacheEntries = null)
+    public PrefixService(AppConfig config, RipeStatProvider? ripeStat, IPrefixSourceService prefixSources, HttpPrefixProvider? httpProvider = null, TimeSpan? cacheTtl = null, ILogger<PrefixService>? logger = null, TimeSpan? negativeTtl = null, int? maxCacheEntries = null, TimeProvider? timeProvider = null)
     {
         _config = config;
         _ripeStat = ripeStat;
@@ -40,7 +41,8 @@ public sealed class PrefixService : IPrefixService
         // churn traffic, not normal operation.
         _maxCacheEntries = maxCacheEntries ?? 4096;
         _logger = logger;
-        _userSourceCache = new UserSourceCache(logger: logger);
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _userSourceCache = new UserSourceCache(logger: logger, timeProvider: _timeProvider);
     }
 
     /// <summary>
@@ -104,12 +106,12 @@ public sealed class PrefixService : IPrefixService
 
                 // No cached copy: remember the failure briefly so repeated calls don't hammer RIPEstat.
                 EvictIfAtCapacity(asn);
-                _cache[asn] = ([], DateTime.UtcNow, Negative: true);
+                _cache[asn] = ([], _timeProvider.GetUtcNow().UtcDateTime, Negative: true);
                 throw;
             }
 
             EvictIfAtCapacity(asn);
-            _cache[asn] = (prefixes, DateTime.UtcNow, Negative: false);
+            _cache[asn] = (prefixes, _timeProvider.GetUtcNow().UtcDateTime, Negative: false);
             return prefixes;
         }
         finally
@@ -126,7 +128,7 @@ public sealed class PrefixService : IPrefixService
         if (!_cache.TryGetValue(asn, out var entry)) return false;
 
         var ttl = entry.Negative ? _negativeTtl : _cacheTtl;
-        if (DateTime.UtcNow - entry.CachedAt < ttl)
+        if (_timeProvider.GetUtcNow().UtcDateTime - entry.CachedAt < ttl)
         {
             data = entry.Data;
             return true;
@@ -145,7 +147,7 @@ public sealed class PrefixService : IPrefixService
         if (_cache.ContainsKey(insertingKey)) return; // already present, no insert coming
 
         // Snapshot, drop expired entries first (cheapest eviction), then by oldest CachedAt.
-        var now = DateTime.UtcNow;
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
         var toEvict = new List<uint>();
         foreach (var (key, entry) in _cache)
         {
@@ -244,12 +246,12 @@ public sealed class PrefixService : IPrefixService
 
     public async Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
     {
-        if (_ruProjected is not null && DateTime.UtcNow - _ruCachedAt < _cacheTtl)
+        if (_ruProjected is not null && _timeProvider.GetUtcNow().UtcDateTime - _ruCachedAt < _cacheTtl)
             return _ruProjected;
 
         var prefixes = await _prefixSources.GetDefaultAsync(ct);
         _ruProjected = prefixes.Select(p => (p.Prefix, p.Length, 0u)).ToList();
-        _ruCachedAt = DateTime.UtcNow;
+        _ruCachedAt = _timeProvider.GetUtcNow().UtcDateTime;
         return _ruProjected;
     }
 

--- a/BGPLite.Providers/PrefixSourceService.cs
+++ b/BGPLite.Providers/PrefixSourceService.cs
@@ -17,6 +17,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
     private readonly ILogger<PrefixSourceService> _logger;
     private readonly TimeSpan _cacheTtl;
     private readonly TimeSpan _negativeTtl;
+    private readonly TimeProvider _timeProvider;
 
     // Name → (a prefix list, cached at, is negative). Negative entries (failed loads) use _negativeTtl.
     private readonly ConcurrentDictionary<string, (IReadOnlyList<(uint Prefix, byte Length)> List, DateTime CachedAt, bool Negative)> _cache = new();
@@ -28,7 +29,8 @@ public sealed class PrefixSourceService : IPrefixSourceService
         PrefixSourceProviderFactory factory,
         ILogger<PrefixSourceService> logger,
         TimeSpan? cacheTtl = null,
-        TimeSpan? negativeTtl = null)
+        TimeSpan? negativeTtl = null,
+        TimeProvider? timeProvider = null)
     {
         var duplicate = config.PrefixSources
             .GroupBy(s => s.Name)
@@ -42,6 +44,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
         _logger = logger;
         _cacheTtl = cacheTtl ?? TimeSpan.FromHours(1);
         _negativeTtl = negativeTtl ?? TimeSpan.FromSeconds(30);
+        _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
     public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name, CancellationToken ct = default)
@@ -139,11 +142,11 @@ public sealed class PrefixSourceService : IPrefixSourceService
                 }
 
                 // Otherwise remember the failure briefly, so repeated calls don't hammer the provider.
-                _cache[source.Name] = ([], DateTime.UtcNow, Negative: true);
+                _cache[source.Name] = ([], _timeProvider.GetUtcNow().UtcDateTime, Negative: true);
                 throw;
             }
 
-            _cache[source.Name] = (prefixes, DateTime.UtcNow, Negative: false);
+            _cache[source.Name] = (prefixes, _timeProvider.GetUtcNow().UtcDateTime, Negative: false);
             return prefixes;
         }
         finally
@@ -158,7 +161,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
         if (!_cache.TryGetValue(name, out var entry)) return false;
 
         var ttl = entry.Negative ? _negativeTtl : _cacheTtl;
-        if (DateTime.UtcNow - entry.CachedAt < ttl)
+        if (_timeProvider.GetUtcNow().UtcDateTime - entry.CachedAt < ttl)
         {
             list = entry.List;
             return true;

--- a/BGPLite.Providers/UserSourceCache.cs
+++ b/BGPLite.Providers/UserSourceCache.cs
@@ -26,17 +26,19 @@ internal sealed class UserSourceCache
     private readonly TimeSpan _positiveTtl;
     private readonly TimeSpan _negativeTtl;
     private readonly ILogger? _logger;
+    private readonly TimeProvider _timeProvider;
 
     // url → (list, cached at, is negative). Negative entries (failed loads) use _negativeTtl.
     private readonly ConcurrentDictionary<string, (IReadOnlyList<(uint Prefix, byte Length)> List, DateTime CachedAt, bool Negative)> _cache = new();
     // url → gate serializing the cache-miss fetch path (prevents thundering herd on cold/expired keys).
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new();
 
-    public UserSourceCache(TimeSpan? positiveTtl = null, TimeSpan? negativeTtl = null, ILogger? logger = null)
+    public UserSourceCache(TimeSpan? positiveTtl = null, TimeSpan? negativeTtl = null, ILogger? logger = null, TimeProvider? timeProvider = null)
     {
         _positiveTtl = positiveTtl ?? TimeSpan.FromHours(1);
         _negativeTtl = negativeTtl ?? TimeSpan.FromSeconds(30);
         _logger = logger;
+        _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
     /// <param name="url">Cache key (the source URL — dedupes across peers).</param>
@@ -78,13 +80,13 @@ internal sealed class UserSourceCache
                 }
 
                 // Otherwise remember the failure briefly so repeated calls don't hammer the fetcher.
-                _cache[url] = ([], DateTime.UtcNow, Negative: true);
+                _cache[url] = ([], _timeProvider.GetUtcNow().UtcDateTime, Negative: true);
                 _logger?.LogWarning(ex, "User-source '{Name}' load failed (no cached copy); negative-cached for {Seconds}s.",
                     logLabel, (int)_negativeTtl.TotalSeconds);
                 throw;
             }
 
-            _cache[url] = (prefixes, DateTime.UtcNow, Negative: false);
+            _cache[url] = (prefixes, _timeProvider.GetUtcNow().UtcDateTime, Negative: false);
             return prefixes;
         }
         finally
@@ -99,7 +101,7 @@ internal sealed class UserSourceCache
         if (!_cache.TryGetValue(url, out var entry)) return false;
 
         var ttl = entry.Negative ? _negativeTtl : _positiveTtl;
-        if (DateTime.UtcNow - entry.CachedAt < ttl)
+        if (_timeProvider.GetUtcNow().UtcDateTime - entry.CachedAt < ttl)
         {
             list = entry.List;
             return true;


### PR DESCRIPTION
Closes #103

## Problem

All 12 `DateTime.UtcNow` sites in the Providers layer (PrefixService 6, PrefixSourceService 3, UserSourceCache 3) hard-coded the wall clock into the TTL/stale-on-failure logic. BgpSession was already migrated to `TimeProvider` in #96; this completes the migration so the entire time-sensitive surface is testable deterministically.

## Fix

Each class gains a `TimeProvider? timeProvider = null` ctor param (default → `TimeProvider.System`):

- **`PrefixService`** — 6 sites: cache store (`CachedAt`), TTL comparison, eviction sweep `now`, RU-projection cache. Threads its `TimeProvider` into `UserSourceCache`.
- **`PrefixSourceService`** — 3 sites: cache store, TTL comparison.
- **`UserSourceCache`** — 3 sites: cache store, TTL comparison.

All `DateTime.UtcNow` → `_timeProvider.GetUtcNow().UtcDateTime`. No behavior change in production (`TimeProvider.System` returns wall-clock UTC). Existing DI registrations and test constructors use the default (`null` → System), so no caller changes needed.

## Verification

- `dotnet build BGPLite.sln` ✅
- `dotnet test BGPLite.sln` ✅ 476 passed (all existing tests use default TimeProvider.System — no change)

## What this enables

Tests can now inject `FakeTimeProvider` to advance the clock instantly for:
- TTL expiry → refetch (currently needs real `Task.Delay`)
- Stale-on-failure serving (needs real time to expire then real time to fail)
- Negative-cache expiry
- Eviction sweep ordering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache freshness and expiration handling for prefix and user source data.
  * Made time-based cache behavior more consistent, which can help prevent stale results and unexpected cache misses.
  * Improved handling of failed loads so temporary negative cache entries expire more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->