### PR TITLE
refactor: grouped architecture/best-practice cleanups

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -518,7 +518,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
     {
         var (body, bodyError) = await ReadBodyAsync(ctx);
         if (bodyError is not null) return bodyError;
-        var data = JsonSerializer.Deserialize<CreatePeerRequest>(body, _jsonOpts);
+        var data = JsonSerializer.Deserialize<CreatePeerRequest>(body!, _jsonOpts);
 
         if (data is null)
             return ApiResponse.Error("Invalid request body", 400);
@@ -606,7 +606,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         var (body, bodyError) = await ReadBodyAsync(ctx);
         if (bodyError is not null) return bodyError;
-        var data = JsonSerializer.Deserialize<UpdatePeerRequest>(body, _jsonOpts);
+        var data = JsonSerializer.Deserialize<UpdatePeerRequest>(body!, _jsonOpts);
 
         if (data is null)
             return ApiResponse.Error("Invalid request body", 400);
@@ -681,7 +681,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         var (body, bodyError) = await ReadBodyAsync(ctx);
         if (bodyError is not null) return bodyError;
-        var data = JsonSerializer.Deserialize<AddSourceRequest>(body, _jsonOpts);
+        var data = JsonSerializer.Deserialize<AddSourceRequest>(body!, _jsonOpts);
 
         if (data is null || string.IsNullOrWhiteSpace(data.Name) || string.IsNullOrWhiteSpace(data.Url))
             return ApiResponse.Error("Name and Url are required", 400);
@@ -715,7 +715,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         var (body, bodyError) = await ReadBodyAsync(ctx);
         if (bodyError is not null) return bodyError;
-        var data = JsonSerializer.Deserialize<PatchSourceRequest>(body, _jsonOpts);
+        var data = JsonSerializer.Deserialize<PatchSourceRequest>(body!, _jsonOpts);
 
         if (data is null || data.Active is null)
             return ApiResponse.Error("PATCH body must contain { \"active\": true/false }", 400);

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -36,7 +36,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
     private readonly string _listenAddress;  // #90: bind address — loopback by default
     private HttpListener? _listener;
     private Task? _listenTask;
-    private CancellationTokenSource _cts = new();
+    private readonly CancellationTokenSource _cts = new();
 
     public ManagementApi(
         PeerStore store,
@@ -772,7 +772,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
                 foreach (var (prefix, length, _) in fetched)
                     prefixes.Add($"{BgpConstants.UintToIPAddress(prefix)}/{length}");
             }
-            catch { }
+            catch (Exception ex) { _logger.LogWarning(ex, "CollectPeerPrefixes: ASN fetch failed"); }
         }
 
         // Country-based lists
@@ -784,7 +784,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
                 foreach (var (prefix, length, _) in ruPrefixes)
                     prefixes.Add($"{BgpConstants.UintToIPAddress(prefix)}/{length}");
             }
-            catch { }
+            catch (Exception ex) { _logger.LogWarning(ex, "CollectPeerPrefixes: RU prefix fetch failed"); }
         }
 
         return prefixes.Distinct().OrderBy(p => p).ToList();
@@ -1114,11 +1114,13 @@ public sealed class ManagementApi : IHostedService, IDisposable
         return nets;
     }
 
-    private static async Task WriteResponse(HttpListenerContext ctx, ApiResponse response)
+    private async Task WriteResponse(HttpListenerContext ctx, ApiResponse response)
     {
         ctx.Response.StatusCode = response.StatusCode;
         ctx.Response.ContentType = "application/json";
-        var json = JsonSerializer.Serialize(response.Body);
+        // Pass the cached JsonSerializerOptions (#105 aot/perf) — without it, Serialize falls back to
+        // default per-call options (reflection + no caching), a perf regression on every response.
+        var json = JsonSerializer.Serialize(response.Body, _jsonOpts);
         var bytes = Encoding.UTF8.GetBytes(json);
         await ctx.Response.OutputStream.WriteAsync(bytes);
         ctx.Response.Close();

--- a/BGPLite.Protocol/BgpMessageReader.cs
+++ b/BGPLite.Protocol/BgpMessageReader.cs
@@ -41,12 +41,10 @@ public static class BgpMessageReader
 
     private static void ValidateMarker(ReadOnlySpan<byte> marker)
     {
-        var expected = BgpConstants.Marker;
-        for (var i = 0; i < BgpConstants.MarkerSize; i++)
-        {
-            if (marker[i] != expected[i])
-                throw new BgpParseException("Invalid BGP marker");
-        }
+        // #105: SequenceEqual over ReadOnlySpan<byte> replaces the hand-rolled byte-by-byte loop —
+        // idiomatic, vectorizable by the JIT, and the same semantics.
+        if (!marker.SequenceEqual(BgpConstants.Marker))
+            throw new BgpParseException("Invalid BGP marker");
     }
 
     #region OPEN

--- a/BGPLite.Protocol/BgpMessageWriter.cs
+++ b/BGPLite.Protocol/BgpMessageWriter.cs
@@ -13,7 +13,7 @@ public static class BgpMessageWriter
             BgpUpdateMessage update => WriteUpdate(update, buffer),
             BgpNotificationMessage notification => WriteNotification(notification, buffer),
             BgpRouteRefreshMessage refresh => WriteRouteRefresh(refresh, buffer),
-            _ => throw new ArgumentException($"Unknown message type: {message.Type}")
+            _ => throw new NotSupportedException($"Unknown BGP message type: {message.Type}")
         };
     }
 
@@ -26,7 +26,7 @@ public static class BgpMessageWriter
             BgpUpdateMessage update => BgpConstants.MessageHeaderSize + GetUpdatePayloadSize(update),
             BgpNotificationMessage n => BgpConstants.MessageHeaderSize + 2 + (n.Data?.Length ?? 0),
             BgpRouteRefreshMessage => BgpConstants.MessageHeaderSize + 4,
-            _ => throw new ArgumentException($"Unknown message type: {message.Type}")
+            _ => throw new NotSupportedException($"Unknown BGP message type: {message.Type}")
         };
     }
 

--- a/BGPLite.Server/BgpServer.cs
+++ b/BGPLite.Server/BgpServer.cs
@@ -360,6 +360,7 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
         Volatile.Write(ref _acceptingConnections, 0);
         _listener?.Close();
         _cts.Cancel();
+        _cts.Dispose();  // #105: dispose the CTS (StopAsync's graceful path doesn't reach here)
         foreach (var session in _sessions.Values)
             session.Dispose();
     }

--- a/BGPLite.Server/RouteAssembler.cs
+++ b/BGPLite.Server/RouteAssembler.cs
@@ -151,8 +151,9 @@ internal sealed class RouteAssembler
 
                 // Prefix-source subscriptions: subscribed names that match a configured PrefixSource.
                 var resolvedAsRipe = subscribedLists.Select(l => l.Name).ToHashSet();
+                var prefixSources = _appConfig.PrefixSources;  // safe: we're inside the _appConfig is not null guard
                 var sourceNames = subscriptionIds
-                    .Where(n => !resolvedAsRipe.Contains(n) && _appConfig!.PrefixSources.Any(s => s.Name == n))
+                    .Where(n => !resolvedAsRipe.Contains(n) && prefixSources.Any(s => s.Name == n))
                     .ToList();
                 foreach (var name in sourceNames)
                 {

--- a/BGPLite.Server/RouteAssembler.cs
+++ b/BGPLite.Server/RouteAssembler.cs
@@ -67,7 +67,12 @@ internal sealed class RouteAssembler
 
         if (_peerStore is not null && _prefixService is not null && _appConfig is not null)
         {
-            var peer = _peerStore.LoadPeerRoutingView(peerIp, remoteAsn);
+            // Capture non-null locals so the compiler tracks the null-guard through the nested
+            // branches without null-forgiving operators (#105 nullable).
+            var peerStore = _peerStore;
+            var prefixService = _prefixService;
+            var appConfig = _appConfig;
+            var peer = peerStore.LoadPeerRoutingView(peerIp, remoteAsn);
             if (peer is not null)
             {
                 var subscriptionIds = peer.Subscriptions;
@@ -82,7 +87,7 @@ internal sealed class RouteAssembler
                     _logger.LogInformation("Unconfigured peer {Peer}, sending RU defaults", _peer);
                     try
                     {
-                        var ruPrefixes = await _prefixService.GetRuPrefixesAsync(ct);
+                        var ruPrefixes = await prefixService.GetRuPrefixesAsync(ct);
                         foreach (var (prefix, length, _) in ruPrefixes)
                             routes.Add(MakeRoute(prefix, length, nextHop, null, defaultComms));
                         _logger.LogInformation("Sent {Count} RU prefixes to unconfigured peer {Peer}",
@@ -98,7 +103,7 @@ internal sealed class RouteAssembler
 
                 _logger.LogInformation("Peer {Peer} subscriptions: [{Subs}]", _peer, string.Join(", ", subscriptionIds));
 
-                var subscribedLists = _appConfig?.RipeStat?.AsnLists
+                var subscribedLists = appConfig.RipeStat?.AsnLists
                     .Where(l => subscriptionIds.Contains(l.Name))
                     .ToList() ?? [];
 
@@ -117,7 +122,7 @@ internal sealed class RouteAssembler
                         {
                             var comms = _communityResolver.Resolve(
                                 new CommunitySource(CommunitySourceKind.AsnList, list.Name));
-                            var prefixes = await _prefixService.GetPrefixesForAsns(list.Asns, ct);
+                            var prefixes = await prefixService.GetPrefixesForAsns(list.Asns, ct);
                             foreach (var (prefix, length, asn) in prefixes)
                                 routes.Add(MakeRoute(prefix, length, nextHop, [asn], comms));
                         }
@@ -138,7 +143,7 @@ internal sealed class RouteAssembler
                     {
                         var comms = _communityResolver.Resolve(
                             new CommunitySource(CommunitySourceKind.Country, countryLists[0].Name));
-                        var ruPrefixes = await _prefixService.GetRuPrefixesAsync(ct);
+                        var ruPrefixes = await prefixService.GetRuPrefixesAsync(ct);
                         foreach (var (prefix, length, _) in ruPrefixes)
                             routes.Add(MakeRoute(prefix, length, nextHop, null, comms));
                         _logger.LogInformation("Fetched {Count} RU prefixes for {Peer}", ruPrefixes.Count, _peer);
@@ -151,7 +156,7 @@ internal sealed class RouteAssembler
 
                 // Prefix-source subscriptions: subscribed names that match a configured PrefixSource.
                 var resolvedAsRipe = subscribedLists.Select(l => l.Name).ToHashSet();
-                var prefixSources = _appConfig.PrefixSources;  // safe: we're inside the _appConfig is not null guard
+                var prefixSources = appConfig.PrefixSources;  // safe: we're inside the _appConfig is not null guard
                 var sourceNames = subscriptionIds
                     .Where(n => !resolvedAsRipe.Contains(n) && prefixSources.Any(s => s.Name == n))
                     .ToList();
@@ -160,7 +165,7 @@ internal sealed class RouteAssembler
                     try
                     {
                         var comms = _communityResolver.Resolve(new CommunitySource(CommunitySourceKind.PrefixSource, name));
-                        var srcPrefixes = await _prefixService.GetSourcePrefixesAsync(name, ct);
+                        var srcPrefixes = await prefixService.GetSourcePrefixesAsync(name, ct);
                         foreach (var (prefix, length) in srcPrefixes)
                             routes.Add(MakeRoute(prefix, length, nextHop, null, comms));
                         _logger.LogInformation("Fetched {Count} prefixes from source '{Source}' for {Peer}",
@@ -192,7 +197,7 @@ internal sealed class RouteAssembler
                     try
                     {
                         var customAsnComms = _communityResolver.Resolve(new CommunitySource(CommunitySourceKind.CustomAsn));
-                        var asnPrefixes = await _prefixService.GetPrefixesForAsns(customAsns, ct);
+                        var asnPrefixes = await prefixService.GetPrefixesForAsns(customAsns, ct);
                         foreach (var (prefix, length, asn) in asnPrefixes)
                             routes.Add(MakeRoute(prefix, length, nextHop, [asn], customAsnComms));
                         _logger.LogInformation("Peer {Peer} custom AS: {Asns} -> {Count} prefixes",
@@ -208,7 +213,7 @@ internal sealed class RouteAssembler
                 foreach (var source in peer.UserSources)
                 {
                     await AddUserSourceRoutesAsync(
-                        routes, source, nextHop, _prefixService!, _communityResolver, _logger, _peer, ct);
+                        routes, source, nextHop, prefixService, _communityResolver, _logger, _peer, ct);
                 }
 
                 _logger.LogInformation("Sending {Count} total routes to {Peer}", routes.Count, _peer);
@@ -219,7 +224,7 @@ internal sealed class RouteAssembler
                     _logger.LogInformation("Peer {Peer} resolved 0 prefixes, falling back to RU defaults", _peer);
                     try
                     {
-                        var ruPrefixes = await _prefixService.GetRuPrefixesAsync(ct);
+                        var ruPrefixes = await prefixService.GetRuPrefixesAsync(ct);
                         foreach (var (prefix, length, _) in ruPrefixes)
                             routes.Add(MakeRoute(prefix, length, nextHop, null, defaultComms));
                     }
@@ -235,11 +240,11 @@ internal sealed class RouteAssembler
             {
                 // Unknown peer — auto-register and send default RU list.
                 _logger.LogInformation("Unknown peer {Ip}, auto-registering with RU defaults", _peer);
-                _peerStore.CreatePeer(peerIp, remoteAsn, null);
+                peerStore.CreatePeer(peerIp, remoteAsn, null);
 
                 try
                 {
-                    var ruPrefixes = await _prefixService.GetRuPrefixesAsync(ct);
+                    var ruPrefixes = await prefixService.GetRuPrefixesAsync(ct);
                     foreach (var (prefix, length, _) in ruPrefixes)
                         routes.Add(MakeRoute(prefix, length, nextHop, null, defaultComms));
                     _logger.LogInformation("Fetched {Count} RU prefixes for unknown peer {Peer}",


### PR DESCRIPTION
Closes #105

## Problem

Issue #105 is a grouped backlog of 66 architecture/best-practice findings from the 2026-07-03 audit. Many were already addressed by this session's work (Polly resilience, exception disclosure, TimeProvider migration, codec/RouteAssembler extract, send-path cancellation, body-size cap, loopback bind). This PR ships the remaining **7 low-risk quick wins** that are isolated and behavior-preserving.

## Fix

1. **JSON** (`ManagementApi.cs`): `WriteResponse` now passes the cached `_jsonOpts` to `JsonSerializer.Serialize` — was falling back to default per-call options (perf regression, no caching, reflection-based).
2. **Marker comparison** (`BgpMessageReader.cs`): `ValidateMarker` loop → `ReadOnlySpan.SequenceEqual` (idiomatic, JIT-vectorizable).
3. **Exception type** (`BgpMessageWriter.cs`): `ArgumentException` → `NotSupportedException` + "BGP" prefix on the exhaustive-switch throw (correct type for unreachable arms).
4. **readonly CTS** (`ManagementApi.cs`): `_cts` → `readonly` (matches surrounding pattern).
5. **CTS leak** (`BgpServer.cs`): `Dispose()` now disposes `_cts` (was leaking on the non-StopAsync path).
6. **null-forgiving** (`RouteAssembler.cs`): `_appConfig!.PrefixSources` → captured local (drops `!` inside an already-null-guarded branch).
7. **Silent catches** (`ManagementApi.cs`): `CollectPeerPrefixes` bare `catch { }` → `catch with LogWarning` (2 sites — ASN fetch + RU prefix fetch were silently swallowing).

## Verification

- `dotnet build BGPLite.sln` ✅
- `dotnet test BGPLite.sln` ✅ 476 passed

## What's NOT in this PR (remaining backlog items, larger scope)

- ImmutableArray for Route.Communities/AsPath (high collections) — touches many call sites
- JsonSerializerContext for AOT — needs all DTOs annotated
- System.Diagnostics.Metrics — needs new package + instrumentation
- record conversions for config DTOs — wide churn
- Keyed DI services — DI restructuring
- EF Core migrations — schema migration strategy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics for prefix lookup failures by logging warnings instead of silently swallowing errors.
  * Strengthened BGP marker validation to correctly reject invalid input.
  * Improved error reporting for unsupported/unhandled BGP message types.
  * Made peer/source endpoint request-body deserialization more robust and consistent.
  * Enhanced server shutdown cleanup by disposing its cancellation token source.

* **Refactor**
  * Streamlined response serialization using cached JSON options.
  * Improved nullable correctness in outbound route assembly without changing routing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->