### PR TITLE
perf: remaining hot-path allocation reductions

### DIFF
--- a/BGPLite.Providers/PrefixSourceService.cs
+++ b/BGPLite.Providers/PrefixSourceService.cs
@@ -18,6 +18,8 @@ public sealed class PrefixSourceService : IPrefixSourceService
     private readonly TimeSpan _cacheTtl;
     private readonly TimeSpan _negativeTtl;
     private readonly TimeProvider _timeProvider;
+    // #85: pre-built name→source lookup (replaces per-call FirstOrDefault linear scan).
+    private readonly Dictionary<string, PrefixSourceConfig> _sourcesByName;
 
     // Name → (a prefix list, cached at, is negative). Negative entries (failed loads) use _negativeTtl.
     private readonly ConcurrentDictionary<string, (IReadOnlyList<(uint Prefix, byte Length)> List, DateTime CachedAt, bool Negative)> _cache = new();
@@ -45,12 +47,13 @@ public sealed class PrefixSourceService : IPrefixSourceService
         _cacheTtl = cacheTtl ?? TimeSpan.FromHours(1);
         _negativeTtl = negativeTtl ?? TimeSpan.FromSeconds(30);
         _timeProvider = timeProvider ?? TimeProvider.System;
+        // #85: pre-build a name→source lookup (the ctor already iterates for duplicate detection).
+        _sourcesByName = config.PrefixSources.ToDictionary(s => s.Name);
     }
 
     public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name, CancellationToken ct = default)
     {
-        var source = _config.PrefixSources.FirstOrDefault(s => s.Name == name);
-        if (source is null)
+        if (!_sourcesByName.TryGetValue(name, out var source))
         {
             _logger.LogWarning("Prefix source '{Name}' not found in configuration.", name);
             return [];
@@ -71,8 +74,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
         if (string.IsNullOrWhiteSpace(defaultName))
             return [];
 
-        var source = _config.PrefixSources.FirstOrDefault(s => s.Name == defaultName);
-        if (source is null)
+        if (!_sourcesByName.TryGetValue(defaultName, out var source))
         {
             _logger.LogWarning("DefaultPrefixSource '{Name}' does not match any configured source.", defaultName);
             return [];

--- a/BGPLite.Routing/RouteTable.cs
+++ b/BGPLite.Routing/RouteTable.cs
@@ -10,11 +10,15 @@ public sealed class RouteTable
 
     public bool AddOrUpdate(Route route)
     {
-        var added = false;
-        _routes.AddOrUpdate(route.Key,
-            _ => { added = true; return route; },
-            (_, _) => route);
-        return added;
+        // #85: avoid ConcurrentDictionary.AddOrUpdate's closure allocations (two delegate lambdas
+        // per call). The try-pattern is allocation-free and equivalent: TryAdd for the new-key
+        // case, indexer for the update case.
+        if (!_routes.TryAdd(route.Key, route))
+        {
+            _routes[route.Key] = route;
+            return false;
+        }
+        return true;
     }
 
     public bool Remove(uint prefix, byte length) =>

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -126,9 +126,14 @@ public sealed class BgpSession : IDisposable
         if (count == 0) return;
 
         const int maxPerUpdate = 100;
+        // #85: reuse a single batch list instead of GetRange (which allocates a new List per batch).
+        var batch = new List<IpPrefix>(Math.Min(maxPerUpdate, count));
         for (var i = 0; i < count; i += maxPerUpdate)
         {
-            var batch = _advertisedPrefixes.GetRange(i, Math.Min(maxPerUpdate, count - i));
+            batch.Clear();
+            var end = Math.Min(i + maxPerUpdate, count);
+            for (var j = i; j < end; j++)
+                batch.Add(_advertisedPrefixes[j]);
             var update = new BgpUpdateMessage
             {
                 WithdrawnRoutes = batch,
@@ -591,7 +596,10 @@ public sealed class BgpSession : IDisposable
                     if (_routeFilter.AcceptIncoming(route, filterPeerConfig))
                     {
                         _routeTable.AddOrUpdate(route);
-                        _logger.LogDebug("Route added: {Prefix} via {NextHop}", nlri, BgpConstants.UintToIPAddress(nextHop));
+                        // #85: guard the UintToIPAddress allocation behind IsEnabled — LogDebug
+                        // evaluates the arg eagerly even when Debug is filtered out.
+                        if (_logger.IsEnabled(LogLevel.Debug))
+                            _logger.LogDebug("Route added: {Prefix} via {NextHop}", nlri, BgpConstants.UintToIPAddress(nextHop));
                     }
                 }
             }

--- a/BGPLite.Server/ConfigCommunityResolver.cs
+++ b/BGPLite.Server/ConfigCommunityResolver.cs
@@ -32,6 +32,9 @@ public sealed class ConfigCommunityResolver : ICommunityResolver
     private readonly uint[] _customAsnComms;
     // Local ASN, captured for UserSource auto-generation (<Asn>:5XX).
     private readonly uint _asn;
+    // #85: pre-built name→community lookups (replaces per-Resolve linear FirstOrDefault scans).
+    private readonly Dictionary<string, string?> _asnListCommunities;
+    private readonly Dictionary<string, string?> _prefixSourceCommunities;
 
     public ConfigCommunityResolver(AppConfig config, BgpConfig bgpConfig, ILogger<ConfigCommunityResolver>? logger = null)
     {
@@ -40,6 +43,11 @@ public sealed class ConfigCommunityResolver : ICommunityResolver
         _asn = bgpConfig.Asn;
         _customPrefixComms = ResolveStaticCommunity(config.CustomPrefixCommunity, bgpConfig.Asn, 100, nameof(config.CustomPrefixCommunity));
         _customAsnComms = ResolveStaticCommunity(config.CustomAsnCommunity, bgpConfig.Asn, 200, nameof(config.CustomAsnCommunity));
+        // Build name→community dictionaries once in the ctor (the config is immutable).
+        _asnListCommunities = (config.RipeStat?.AsnLists ?? [])
+            .ToDictionary(l => l.Name, l => l.Community);
+        _prefixSourceCommunities = config.PrefixSources
+            .ToDictionary(s => s.Name, s => s.Community);
     }
 
     public uint[] Resolve(CommunitySource source) => source.Kind switch
@@ -80,10 +88,10 @@ public sealed class ConfigCommunityResolver : ICommunityResolver
     }
 
     private string? FindAsnListCommunity(string? name) =>
-        name is null ? null : _config.RipeStat?.AsnLists.FirstOrDefault(l => l.Name == name)?.Community;
+        name is null ? null : _asnListCommunities.TryGetValue(name, out var c) ? c : null;
 
     private string? FindPrefixSourceCommunity(string? name) =>
-        name is null ? null : _config.PrefixSources.FirstOrDefault(s => s.Name == name)?.Community;
+        name is null ? null : _prefixSourceCommunities.TryGetValue(name, out var c) ? c : null;
 
     /// <summary>
     /// Static category community: the config override if set and valid, otherwise the hardcoded

--- a/BGPLite.Server/ConfigCommunityResolver.cs
+++ b/BGPLite.Server/ConfigCommunityResolver.cs
@@ -44,8 +44,11 @@ public sealed class ConfigCommunityResolver : ICommunityResolver
         _customPrefixComms = ResolveStaticCommunity(config.CustomPrefixCommunity, bgpConfig.Asn, 100, nameof(config.CustomPrefixCommunity));
         _customAsnComms = ResolveStaticCommunity(config.CustomAsnCommunity, bgpConfig.Asn, 200, nameof(config.CustomAsnCommunity));
         // Build name→community dictionaries once in the ctor (the config is immutable).
+        // PrefixSources duplicate names are rejected by PrefixSourceService's ctor; AsnLists have
+        // no such check, so use ToDictionary with a last-wins resolver to avoid a throw on dups.
         _asnListCommunities = (config.RipeStat?.AsnLists ?? [])
-            .ToDictionary(l => l.Name, l => l.Community);
+            .GroupBy(l => l.Name)
+            .ToDictionary(g => g.Key, g => g.Last().Community);
         _prefixSourceCommunities = config.PrefixSources
             .ToDictionary(s => s.Name, s => s.Community);
     }

--- a/BGPLite.Server/RouteAssembler.cs
+++ b/BGPLite.Server/RouteAssembler.cs
@@ -123,8 +123,11 @@ internal sealed class RouteAssembler
                             var comms = _communityResolver.Resolve(
                                 new CommunitySource(CommunitySourceKind.AsnList, list.Name));
                             var prefixes = await prefixService.GetPrefixesForAsns(list.Asns, ct);
-                            foreach (var (prefix, length, asn) in prefixes)
-                                routes.Add(MakeRoute(prefix, length, nextHop, [asn], comms));
+                            foreach (var (prefix, length, _) in prefixes)
+                                // #85: AsPath is overwritten by the local ASN in the outbound codec
+                                // (BuildUpdateAttributes), so the per-prefix asn value is never used
+                                // on the wire — pass null instead of allocating [asn] per prefix.
+                                routes.Add(MakeRoute(prefix, length, nextHop, null, comms));
                         }
                         catch (Exception ex)
                         {
@@ -198,8 +201,8 @@ internal sealed class RouteAssembler
                     {
                         var customAsnComms = _communityResolver.Resolve(new CommunitySource(CommunitySourceKind.CustomAsn));
                         var asnPrefixes = await prefixService.GetPrefixesForAsns(customAsns, ct);
-                        foreach (var (prefix, length, asn) in asnPrefixes)
-                            routes.Add(MakeRoute(prefix, length, nextHop, [asn], customAsnComms));
+                        foreach (var (prefix, length, _) in asnPrefixes)
+                            routes.Add(MakeRoute(prefix, length, nextHop, null, customAsnComms));
                         _logger.LogInformation("Peer {Peer} custom AS: {Asns} -> {Count} prefixes",
                             _peer, string.Join(",", customAsns), asnPrefixes.Count);
                     }


### PR DESCRIPTION
Closes #85

## Problem

Issue #85 is a grouped perf backlog (31 findings) from the 2026-07-03 audit. Most were already fixed by this session's earlier work: AsNoTracking (#112), sync-over-async (#113), CancellationToken propagation (#114), SQLite WAL+busy_timeout (#111), parallel WarmUp (#130), GroupBy partition (#82/#184). This PR ships the **6 remaining quick wins**.

## Fix

1. **RouteAssembler** — drop per-prefix `[asn]` allocation. AsPath is overwritten by the local ASN in the outbound codec (`UpdateCodec.BuildUpdateAttributes`), so the per-prefix value is never used on the wire. Pass `null` instead (2 sites: ASN-list + custom-AS loops).
2. **BgpSession** — guard `LogDebug("Route added")` behind `IsEnabled(Debug)`. The `UintToIPAddress(nextHop)` arg was evaluated eagerly even when Debug is filtered out — a `new IPAddress` + 4-byte array allocation per inbound route.
3. **RouteTable.AddOrUpdate** — replace `ConcurrentDictionary.AddOrUpdate` (two closure lambdas per call) with the allocation-free `TryAdd` + indexer pattern.
4. **BgpSession.WithdrawAllAsync** — replace `GetRange` (new `List<IpPrefix>` per batch) with a reusable batch list + `Clear`.
5. **ConfigCommunityResolver** — pre-build `Dictionary<string, string?>` lookups for AsnLists and PrefixSources in the ctor. Replaces per-`Resolve` `FirstOrDefault` linear scans (Resolve is called 7+ times per `SendAllRoutesAsync`).
6. **PrefixSourceService** — pre-build `Dictionary<string, PrefixSourceConfig>` in the ctor. Replaces per-call `FirstOrDefault` in `GetAsync` and `GetDefaultAsync`.

## Verification

- `dotnet build BGPLite.sln` ✅
- `dotnet test BGPLite.sln` ✅ 476 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved prefix and community resolution by caching configuration lookups.
  * Reduced allocation overhead when adding or updating routes.
* **Bug Fixes**
  * Route withdrawals now reuse buffers more efficiently, lowering memory churn during large updates.
  * Debug logging no longer performs extra work unless debug mode is enabled.
  * Generated route updates no longer include per-prefix ASN path details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->