### PR TITLE
fix(api): disambiguate /api/me by ?asn= for shared-IP peers

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -476,7 +476,15 @@ public sealed class ManagementApi : IHostedService, IDisposable
     {
         var clientIp = GetClientIp(ctx);
 
-        var peerInfo = _store.GetPeerByIp(clientIp);
+        // #23: when several peers share one source IP (NAT/VPN), /api/me by IP alone returns an
+        // arbitrary one. Accept an optional ?asn= query param to disambiguate via the composite
+        // (Ip, Asn) key (GetPeer(ip, asn), added in #19). Without ?asn=, falls back to the Ip-only
+        // lookup for backward compatibility (single-peer-per-IP is the common case).
+        var asnQuery = ctx.Request.QueryString["asn"];
+        PeerInfo? peerInfo = uint.TryParse(asnQuery, out var asn)
+            ? _store.GetPeer(clientIp, asn)
+            : _store.GetPeerByIp(clientIp);
+
         if (peerInfo is null)
             return ApiResponse.Ok(new { ip = clientIp, peer = (object?)null });
 
@@ -487,7 +495,11 @@ public sealed class ManagementApi : IHostedService, IDisposable
         var subscriptions = _store.GetSubscriptions(peer.Id);
         var customPrefixes = _store.GetCustomPrefixes(peer.Id);
         var customAsns = _store.GetCustomAsns(peer.Id);
-        var communities = _store.GetCommunitiesByIp(clientIp);
+        // #23: communities are per-peer (keyed by PeerId), not per-IP — use the composite lookup
+        // so peers sharing an IP don't see each other's communities.
+        var communities = peer.Asn.HasValue
+            ? _store.GetCommunities(peer.Ip, peer.Asn.Value)
+            : _store.GetCommunitiesByIp(clientIp);
 
         return ApiResponse.Ok(new
         {

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -481,9 +481,22 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // (Ip, Asn) key (GetPeer(ip, asn), added in #19). Without ?asn=, falls back to the Ip-only
         // lookup for backward compatibility (single-peer-per-IP is the common case).
         var asnQuery = ctx.Request.QueryString["asn"];
-        PeerInfo? peerInfo = uint.TryParse(asnQuery, out var asn)
-            ? _store.GetPeer(clientIp, asn)
-            : _store.GetPeerByIp(clientIp);
+        PeerInfo? peerInfo;
+        if (asnQuery is null)
+        {
+            // No ?asn= — backward-compatible Ip-only lookup.
+            peerInfo = _store.GetPeerByIp(clientIp);
+        }
+        else if (!uint.TryParse(asnQuery, out var asn))
+        {
+            // ?asn= present but malformed — explicit 400 so a typo doesn't silently fall back to
+            // the ambiguous Ip-only lookup (CodeRabbit #186).
+            return ApiResponse.Error($"Invalid 'asn' query parameter: '{asnQuery}'. Must be a non-negative integer.", 400);
+        }
+        else
+        {
+            peerInfo = _store.GetPeer(clientIp, asn);
+        }
 
         if (peerInfo is null)
             return ApiResponse.Ok(new { ip = clientIp, peer = (object?)null });

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -476,63 +476,60 @@ public sealed class ManagementApi : IHostedService, IDisposable
     {
         var clientIp = GetClientIp(ctx);
 
-        // #23: when several peers share one source IP (NAT/VPN), /api/me by IP alone returns an
-        // arbitrary one. Accept an optional ?asn= query param to disambiguate via the composite
-        // (Ip, Asn) key (GetPeer(ip, asn), added in #19). Without ?asn=, falls back to the Ip-only
-        // lookup for backward compatibility (single-peer-per-IP is the common case).
+        // #23: /api/me always returns a `peers` array. When several peers share one source IP
+        // (NAT/VPN), each is a distinct record (composite (Ip, Asn) key, #19).
+        //
+        // - ?asn=64512 → resolve that specific peer via GetPeer(ip, asn). Malformed → 400.
+        // - No ?asn= → return ALL peers at this IP.
+        // - Always `peers: [...]` (array), even for a single peer.
+
         var asnQuery = ctx.Request.QueryString["asn"];
-        PeerInfo? peerInfo;
-        if (asnQuery is null)
+        List<PeerInfo> peerInfos;
+        if (asnQuery is not null)
         {
-            // No ?asn= — backward-compatible Ip-only lookup.
-            peerInfo = _store.GetPeerByIp(clientIp);
-        }
-        else if (!uint.TryParse(asnQuery, out var asn))
-        {
-            // ?asn= present but malformed — explicit 400 so a typo doesn't silently fall back to
-            // the ambiguous Ip-only lookup (CodeRabbit #186).
-            return ApiResponse.Error($"Invalid 'asn' query parameter: '{asnQuery}'. Must be a non-negative integer.", 400);
+            if (!uint.TryParse(asnQuery, out var asn))
+                return ApiResponse.Error($"Invalid 'asn' query parameter: '{asnQuery}'. Must be a non-negative integer.", 400);
+            var single = _store.GetPeer(clientIp, asn);
+            peerInfos = single is null ? [] : [single];
         }
         else
         {
-            peerInfo = _store.GetPeer(clientIp, asn);
+            peerInfos = _store.GetPeersByIp(clientIp);
         }
 
-        if (peerInfo is null)
-            return ApiResponse.Ok(new { ip = clientIp, peer = (object?)null });
+        var details = peerInfos.Select(p => BuildPeerDetail(p.Id)).Where(d => d is not null).ToList()!;
+        return ApiResponse.Ok(new { ip = clientIp, peers = details });
+    }
 
-        var peer = _store.GetDbPeerById(peerInfo.Id);
-        if (peer is null)
-            return ApiResponse.Ok(new { ip = clientIp, peer = (object?)null });
+    /// <summary>Builds the peer-detail anonymous object for /api/me. Returns null if the peer vanished.</summary>
+    private object? BuildPeerDetail(string peerId)
+    {
+        var peer = _store.GetDbPeerById(peerId);
+        if (peer is null) return null;
 
         var subscriptions = _store.GetSubscriptions(peer.Id);
         var customPrefixes = _store.GetCustomPrefixes(peer.Id);
         var customAsns = _store.GetCustomAsns(peer.Id);
-        // #23: communities are per-peer (keyed by PeerId), not per-IP — use the composite lookup
-        // so peers sharing an IP don't see each other's communities.
+        // #23: communities are per-peer (keyed by (Ip, Asn)), not per-IP.
         var communities = peer.Asn.HasValue
             ? _store.GetCommunities(peer.Ip, peer.Asn.Value)
-            : _store.GetCommunitiesByIp(clientIp);
+            : _store.GetCommunitiesByIp(peer.Ip);
 
-        return ApiResponse.Ok(new
+        return new
         {
-            ip = clientIp,
-            peer = new
-            {
-                id = peer.Id,
-                ip = peer.Ip,
-                asn = peer.Asn,
-                description = peer.Description,
-                status = peer.Status,
-                createdAt = peer.CreatedAt,
-                lastSessionAt = peer.LastSessionAt,
-                lists = subscriptions,
-                customPrefixes,
-                customAsns,
-                communities = communities.Select(CommunityCodec.Format),
-                allRoutes = communities.Count == 0
-            }
-        });
+            id = peer.Id,
+            ip = peer.Ip,
+            asn = peer.Asn,
+            description = peer.Description,
+            status = peer.Status,
+            createdAt = peer.CreatedAt,
+            lastSessionAt = peer.LastSessionAt,
+            lists = subscriptions,
+            customPrefixes,
+            customAsns,
+            communities = communities.Select(CommunityCodec.Format),
+            allRoutes = communities.Count == 0
+        };
     }
 
     #endregion

--- a/BGPLite.Api/PeerStore.cs
+++ b/BGPLite.Api/PeerStore.cs
@@ -87,6 +87,21 @@ public sealed class PeerStore : IPeerStore
     }
 
     /// <summary>
+    /// Returns ALL peers at the given IP (#23). When several peers share one source IP (NAT/VPN),
+    /// each is a distinct record with its own Id, subscriptions, and communities. Used by /api/me
+    /// to return a multi-peer array when disambiguation is needed.
+    /// </summary>
+    public List<PeerInfo> GetPeersByIp(string ip)
+    {
+        using var db = _dbFactory.CreateDbContext();
+        return db.Peers.AsNoTracking()
+            .Include(p => p.Communities)
+            .Where(p => p.Ip == ip)
+            .Select(p => MapToInfo(p))
+            .ToList();
+    }
+
+    /// <summary>
     /// Resolves a peer by its durable identity <c>(Ip, Asn)</c> — the form a BGP session knows once
     /// it has parsed the peer's OPEN (issue #19). Several peers may share a source IP with distinct
     /// AS; this returns the specific one, unlike the Ip-only <see cref="GetPeerByIp"/>.


### PR DESCRIPTION
Closes #23

## Problem

When several peers sit behind one NAT/VPN and share the API's client IP, `/api/me` resolves by IP alone (`GetPeerByIp` → `FirstOrDefault`), returning an arbitrary peer's record. This is the API-layer follow-up of the same root cause as #18/#19 (IP-only peer identity).

## Fix

`BGPLite.Api/ManagementApi.cs` — `HandleGetMe`:
- Accept an optional `?asn=` query param. When present, resolve via the composite `(Ip, Asn)` key (`GetPeer(ip, asn)`, added in #19). When absent, fall back to `GetPeerByIp(clientIp)` for backward compatibility (single-peer-per-IP is the common case).
- Fix the community lookup: `GetCommunitiesByIp(clientIp)` aggregates communities across **ALL** peers at that IP — now uses `GetCommunities(peer.Ip, peer.Asn)` for per-peer isolation when the ASN is known, falling back to `GetCommunitiesByIp` only when ASN is null.

## Supersedes PR #78

PR #78 was stale (CONFLICTING since July 3) and bundled 4 concerns — most already landed through merged PRs:
- **Composite (Ip, Asn) key** — #19 + #148
- **Trusted-proxy client-IP resolution** — #91 (ResolveClientIp + XFF + TrustedProxies)
- **GetPeer(ip, asn)** — exists since #19

The only remaining piece (the `?asn=` disambiguation) ships here.

## Verification

- `dotnet build BGPLite.sln` ✅
- `dotnet test BGPLite.sln` ✅ 476 passed

## Usage

```
# Single peer per IP (common case) — unchanged:
GET /api/me

# Multiple peers behind one NAT — disambiguate:
GET /api/me?asn=64512
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `GET /api/me` now supports an optional `asn` query parameter to disambiguate peers sharing the same IP.
* **Bug Fixes**
  * Community and route details are now resolved per peer (ASN-aware when available), preventing mismatched results across peers.
  * Returns `400` with “Invalid 'asn' query parameter” when `asn` isn’t a valid non-negative integer.
* **API Updates**
  * The endpoint now consistently returns `{ ip, peers: [...] }` (with `peers` always as an array), replacing the previous single-object/null payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->