### PR TITLE
fix(api): map 0.0.0.0 to + wildcard for HttpListener on Linux

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -142,7 +142,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // - IPv6 literals (e.g. "::1") must be bracketed: http://[::1]:5001/ (CodeRabbit #181).
         // - IPv4 ("127.0.0.1") and hostnames ("localhost") go through as-is.
         string host;
-        if (_listenAddress == "0.0.0.0")
+        if (_listenAddress is "0.0.0.0" or "::")
             host = "+";
         else if (_listenAddress.Contains(':'))
             host = $"[{_listenAddress}]";

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -136,9 +136,18 @@ public sealed class ManagementApi : IHostedService, IDisposable
     public Task StartAsync(CancellationToken cancellationToken)
     {
         _listener = new HttpListener();
-        // IPv6 literals (e.g. "::1") must be bracketed in a URI: http://[::1]:5001/, not http://::1:5001/.
-        // IPv4 and hostnames ("127.0.0.1", "localhost", "0.0.0.0") go through as-is (CodeRabbit #181).
-        var host = _listenAddress.Contains(':') ? $"[{_listenAddress}]" : _listenAddress;
+        // HttpListener prefix normalization:
+        // - "0.0.0.0" must be mapped to "+" — HttpListener on Linux does NOT accept 0.0.0.0
+        //   (throws HttpListenerException "The request is not supported"), only the "+" wildcard (#195).
+        // - IPv6 literals (e.g. "::1") must be bracketed: http://[::1]:5001/ (CodeRabbit #181).
+        // - IPv4 ("127.0.0.1") and hostnames ("localhost") go through as-is.
+        string host;
+        if (_listenAddress == "0.0.0.0")
+            host = "+";
+        else if (_listenAddress.Contains(':'))
+            host = $"[{_listenAddress}]";
+        else
+            host = _listenAddress;
         _listener.Prefixes.Add($"http://{host}:{_port}/");
         _listener.Start();
 


### PR DESCRIPTION
Closes #195

## Problem

`ApiListen: "0.0.0.0"` — the documented way to expose the API in Docker bridge mode — crashes at startup:

```
System.Net.HttpListenerException (50): The request is not supported.
   at System.Net.HttpListener.Start()
```

`HttpListener` on Linux does NOT accept `0.0.0.0` as a prefix host — only `+` (the wildcard). The pre-#91 code used `http://+:{port}/`; the #90 loopback-bind refactor introduced explicit address handling but did not map `0.0.0.0` → `+`.

**Production-down** for Docker bridge-mode deployments.

## Fix

Map `0.0.0.0` → `+` when building the HttpListener prefix. IPv6 literals (`::1`) are bracketed. Other addresses (`127.0.0.1`, `localhost`) pass through as-is.

## Verification

- `dotnet build BGPLite.sln` ✅
- `dotnet test BGPLite.sln` ✅ 476 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved management service startup by normalizing HTTP listener host handling.
  * `0.0.0.0` and `::` are now treated as wildcard bindings, while IPv6 literals (e.g., `::1`) are formatted correctly for use with the listener.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->