### PR TITLE
fix(api): trigger peer refresh on source add/delete/toggle

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -707,7 +707,8 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
     private async Task<ApiResponse> HandleAddSource(string peerId, HttpListenerContext ctx)
     {
-        if (_store.GetDbPeerById(peerId) is null)
+        var peer = _store.GetDbPeerById(peerId);
+        if (peer is null)
             return ApiResponse.Error("Peer not found", 404);
 
         var (body, bodyError) = await ReadBodyAsync(ctx);
@@ -722,6 +723,10 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         var source = _store.AddCustomSource(peerId, data.Name, data.Url, data.Community);
 
+        // Trigger refresh so the peer receives the new source's prefixes immediately —
+        // same pattern as CreatePeer/UpdatePeer (lines 586/679).
+        _ = _sessionManager.RefreshPeerAsync(peer.Ip);
+
         _logger.LogInformation("Added source '{Name}' ({Url}) to peer {PeerId}",
             SanitizeForLog(data.Name), SanitizeForLog(data.Url), SanitizeForLog(peerId));
         return ApiResponse.Ok(new { id = source.Id, name = source.Name, url = source.Url, community = source.Community, active = source.Active });
@@ -729,11 +734,15 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
     private ApiResponse HandleDeleteSource(string peerId, string sourceId)
     {
-        if (_store.GetDbPeerById(peerId) is null)
+        var peer = _store.GetDbPeerById(peerId);
+        if (peer is null)
             return ApiResponse.Error("Peer not found", 404);
 
         if (!_store.DeleteCustomSource(peerId, sourceId))
             return ApiResponse.Error($"Source '{sourceId}' not found", 404);
+
+        // Trigger refresh so the source's prefixes are withdrawn immediately.
+        _ = _sessionManager.RefreshPeerAsync(peer.Ip);
 
         _logger.LogInformation("Deleted source {SourceId} from peer {PeerId}", SanitizeForLog(sourceId), SanitizeForLog(peerId));
         return ApiResponse.Ok(new { id = sourceId, deleted = true });
@@ -741,7 +750,8 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
     private async Task<ApiResponse> HandlePatchSource(string peerId, string sourceId, HttpListenerContext ctx)
     {
-        if (_store.GetDbPeerById(peerId) is null)
+        var peer = _store.GetDbPeerById(peerId);
+        if (peer is null)
             return ApiResponse.Error("Peer not found", 404);
 
         var (body, bodyError) = await ReadBodyAsync(ctx);
@@ -753,6 +763,9 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         if (!_store.SetSourceActive(peerId, sourceId, data.Active.Value))
             return ApiResponse.Error($"Source '{sourceId}' not found", 404);
+
+        // Trigger refresh so toggling active/inactive takes effect immediately.
+        _ = _sessionManager.RefreshPeerAsync(peer.Ip);
 
         _logger.LogInformation("Source {SourceId} active={Active}", SanitizeForLog(sourceId), data.Active.Value);
         return ApiResponse.Ok(new { id = sourceId, active = data.Active.Value });


### PR DESCRIPTION
Closes #197

## Problem

Adding, deleting, or toggling a per-peer user URL source (`POST/DELETE/PATCH /api/peers/{id}/sources`) did not trigger a route refresh. The peer's advertised routes stayed stale until a separate manual refresh.

`HandleCreatePeer` and `HandleUpdatePeer` already call `RefreshPeerAsync` after mutating peer config — the three source handlers were missing the same pattern.

## Fix

Added `_ = _sessionManager.RefreshPeerAsync(peer.Ip)` after each source mutation:
- `HandleAddSource` — new source → peer receives its prefixes immediately
- `HandleDeleteSource` — deleted source → prefixes withdrawn immediately
- `HandlePatchSource` — active/inactive toggle → refresh takes effect immediately

Also changed `_store.GetDbPeerById(peerId) is null` to capture the peer variable so `peer.Ip` is available for the refresh call.

## Verification

- `dotnet build BGPLite.sln` ✅
- `dotnet test BGPLite.sln` ✅ 476 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Changes to peer source settings now take effect immediately after adding, updating, or removing a source.
  * Improved synchronization so connected peers receive updated routing information sooner after source changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->