### PR TITLE
fix(server): refresh only the matching (Ip, Asn) session on shared IPs

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -610,7 +610,9 @@ public sealed class ManagementApi : IHostedService, IDisposable
         var customPrefixes = _store.GetCustomPrefixes(peer.Id);
         var customAsns = _store.GetCustomAsns(peer.Id);
         var customSources = _store.GetCustomSources(peer.Id);
-        var communities = _store.GetCommunitiesByIp(peer.Ip);
+        var communities = peer.Asn.HasValue
+            ? _store.GetCommunities(peer.Ip, peer.Asn.Value)
+            : new HashSet<uint>();
 
         return ApiResponse.Ok(new
         {
@@ -726,7 +728,8 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         // Trigger refresh so the peer receives the new source's prefixes immediately —
         // same pattern as CreatePeer/UpdatePeer. Pass ASN so shared-IP peers aren't refreshed (#200).
-        _ = _sessionManager.RefreshPeerAsync(peer.Ip, peer.Asn ?? 0);
+        if (_sessionManager is not null)
+            _ = _sessionManager.RefreshPeerAsync(peer.Ip, peer.Asn ?? 0);
 
         _logger.LogInformation("Added source '{Name}' ({Url}) to peer {PeerId}",
             SanitizeForLog(data.Name), SanitizeForLog(data.Url), SanitizeForLog(peerId));
@@ -743,7 +746,8 @@ public sealed class ManagementApi : IHostedService, IDisposable
             return ApiResponse.Error($"Source '{sourceId}' not found", 404);
 
         // Trigger refresh so the source's prefixes are withdrawn immediately (#200: ASN-scoped).
-        _ = _sessionManager.RefreshPeerAsync(peer.Ip, peer.Asn ?? 0);
+        if (_sessionManager is not null)
+            _ = _sessionManager.RefreshPeerAsync(peer.Ip, peer.Asn ?? 0);
 
         _logger.LogInformation("Deleted source {SourceId} from peer {PeerId}", SanitizeForLog(sourceId), SanitizeForLog(peerId));
         return ApiResponse.Ok(new { id = sourceId, deleted = true });
@@ -766,7 +770,8 @@ public sealed class ManagementApi : IHostedService, IDisposable
             return ApiResponse.Error($"Source '{sourceId}' not found", 404);
 
         // Trigger refresh so toggling active/inactive takes effect immediately (#200: ASN-scoped).
-        _ = _sessionManager.RefreshPeerAsync(peer.Ip, peer.Asn ?? 0);
+        if (_sessionManager is not null)
+            _ = _sessionManager.RefreshPeerAsync(peer.Ip, peer.Asn ?? 0);
 
         _logger.LogInformation("Source {SourceId} active={Active}", SanitizeForLog(sourceId), data.Active.Value);
         return ApiResponse.Ok(new { id = sourceId, active = data.Active.Value });

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -519,10 +519,11 @@ public sealed class ManagementApi : IHostedService, IDisposable
         var subscriptions = _store.GetSubscriptions(peer.Id);
         var customPrefixes = _store.GetCustomPrefixes(peer.Id);
         var customAsns = _store.GetCustomAsns(peer.Id);
-        // #23: communities are per-peer (keyed by (Ip, Asn)), not per-IP.
+        // #200: communities are per-peer (keyed by (Ip, Asn)), not per-IP.
+        // peer.Asn is always set for established BGP peers; fallback to empty for safety.
         var communities = peer.Asn.HasValue
             ? _store.GetCommunities(peer.Ip, peer.Asn.Value)
-            : _store.GetCommunitiesByIp(peer.Ip);
+            : new HashSet<uint>();
 
         return new
         {
@@ -583,7 +584,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
             data.Ip, data.Asn, id, asnLists.Count, customPrefixes.Count, data.CustomAsns?.Count ?? 0);
 
         if (_sessionManager is not null)
-            _ = _sessionManager.RefreshPeerAsync(data.Ip);
+            _ = _sessionManager.RefreshPeerAsync(data.Ip, data.Asn);
 
         return ApiResponse.Ok(new
         {
@@ -676,7 +677,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         _logger.LogInformation("Updated peer {Id}", SanitizeForLog(peerId));
 
         if (_sessionManager is not null)
-            _ = _sessionManager.RefreshPeerAsync(peer.Ip);
+            _ = _sessionManager.RefreshPeerAsync(peer.Ip, peer.Asn ?? 0);
 
         return HandleGetPeer(peerId);
     }
@@ -724,8 +725,8 @@ public sealed class ManagementApi : IHostedService, IDisposable
         var source = _store.AddCustomSource(peerId, data.Name, data.Url, data.Community);
 
         // Trigger refresh so the peer receives the new source's prefixes immediately —
-        // same pattern as CreatePeer/UpdatePeer (lines 586/679).
-        _ = _sessionManager.RefreshPeerAsync(peer.Ip);
+        // same pattern as CreatePeer/UpdatePeer. Pass ASN so shared-IP peers aren't refreshed (#200).
+        _ = _sessionManager.RefreshPeerAsync(peer.Ip, peer.Asn ?? 0);
 
         _logger.LogInformation("Added source '{Name}' ({Url}) to peer {PeerId}",
             SanitizeForLog(data.Name), SanitizeForLog(data.Url), SanitizeForLog(peerId));
@@ -741,8 +742,8 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (!_store.DeleteCustomSource(peerId, sourceId))
             return ApiResponse.Error($"Source '{sourceId}' not found", 404);
 
-        // Trigger refresh so the source's prefixes are withdrawn immediately.
-        _ = _sessionManager.RefreshPeerAsync(peer.Ip);
+        // Trigger refresh so the source's prefixes are withdrawn immediately (#200: ASN-scoped).
+        _ = _sessionManager.RefreshPeerAsync(peer.Ip, peer.Asn ?? 0);
 
         _logger.LogInformation("Deleted source {SourceId} from peer {PeerId}", SanitizeForLog(sourceId), SanitizeForLog(peerId));
         return ApiResponse.Ok(new { id = sourceId, deleted = true });
@@ -764,8 +765,8 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (!_store.SetSourceActive(peerId, sourceId, data.Active.Value))
             return ApiResponse.Error($"Source '{sourceId}' not found", 404);
 
-        // Trigger refresh so toggling active/inactive takes effect immediately.
-        _ = _sessionManager.RefreshPeerAsync(peer.Ip);
+        // Trigger refresh so toggling active/inactive takes effect immediately (#200: ASN-scoped).
+        _ = _sessionManager.RefreshPeerAsync(peer.Ip, peer.Asn ?? 0);
 
         _logger.LogInformation("Source {SourceId} active={Active}", SanitizeForLog(sourceId), data.Active.Value);
         return ApiResponse.Ok(new { id = sourceId, active = data.Active.Value });

--- a/BGPLite.Server/BgpServer.cs
+++ b/BGPLite.Server/BgpServer.cs
@@ -315,10 +315,10 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
         }
     }
 
-    public async Task RefreshPeerAsync(string peerIp)
+    public async Task RefreshPeerAsync(string peerIp, uint asn)
     {
-        // Several peers may share one source IP (distinct source ports — keyed by SessionKey, see
-        // issue #18), so refresh every established session for that IP rather than a single slot.
+        // #200: filter by BOTH IP and ASN so a refresh for one peer on a shared IP (NAT/VPN)
+        // does not refresh sibling sessions with a different ASN.
         if (!IPAddress.TryParse(peerIp, out var ip))
         {
             _logger.LogWarning("RefreshPeer: invalid IP {Ip}", peerIp);
@@ -326,14 +326,14 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
         }
 
         var sessions = _sessions
-            .Where(kvp => kvp.Key.Address.Equals(ip))
+            .Where(kvp => kvp.Key.Address.Equals(ip) && kvp.Value.Peer.RemoteAsn == asn)
             .Select(kvp => kvp.Value)
             .ToList();
 
         if (sessions.Count == 0)
         {
-            _logger.LogWarning("RefreshPeer: no session for {Ip} (active: [{Peers}])",
-                peerIp, string.Join(", ", _sessions.Keys));
+            _logger.LogWarning("RefreshPeer: no session for {Ip} AS{Asn} (active: [{Peers}])",
+                peerIp, asn, string.Join(", ", _sessions.Keys));
             return;
         }
 

--- a/BGPLite.Server/ISessionManager.cs
+++ b/BGPLite.Server/ISessionManager.cs
@@ -2,6 +2,10 @@ namespace BGPLite.Server;
 
 public interface ISessionManager
 {
-    Task RefreshPeerAsync(string peerIp);
+    /// <summary>
+    /// Refreshes the route set for the peer identified by (ip, asn). When several peers share one
+    /// source IP (NAT/VPN), only the session matching BOTH fields is refreshed (#200).
+    /// </summary>
+    Task RefreshPeerAsync(string peerIp, uint asn);
     List<string> GetActivePeerIps();
 }


### PR DESCRIPTION
Closes #200

## Problem

`RefreshPeerAsync(string peerIp)` filtered sessions by **IP only**. When several peers share one source IP (NAT/VPN, distinct ASN — composite key from #19), a refresh for one peer refreshed **ALL** siblings on that IP.

**Confirmed in production:** two peers on one IP — a refresh for AS65001 also refreshed AS64999, causing unnecessary route re-advertisement.

## Fix

### `ISessionManager` + `BgpServer`
- Signature: `RefreshPeerAsync(string peerIp)` → `RefreshPeerAsync(string peerIp, uint asn)`
- Filter: `kvp.Key.Address.Equals(ip)` → `kvp.Key.Address.Equals(ip) && kvp.Value.Peer.RemoteAsn == asn`

### ManagementApi — all 5 callers pass ASN
- `HandleCreatePeer`: `data.Asn` (uint, always set from the request body)
- `HandleUpdatePeer` / `HandleAddSource` / `HandleDeleteSource` / `HandlePatchSource`: `peer.Asn ?? 0`
  - ASN 0 never matches a real BGP session (RFC 4271 §4.2: ASN 0 is reserved), so a peer with null ASN is a safe no-op refresh.

### Cleanup: GetCommunitiesByIp → GetCommunities(ip, asn)
Both remaining `GetCommunitiesByIp(peer.Ip)` fallbacks in `HandleGetMe` / `BuildPeerDetail` replaced with `GetCommunities(peer.Ip, peer.Asn.Value)` or empty set when ASN is null. Communities are per-peer, not per-IP.

## Verification

- `dotnet build BGPLite.sln` ✅
- `dotnet test BGPLite.sln` ✅ 476 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Peer details now show community information only when an ASN is available, preventing incorrect results for ASN-less peers.
  * Session refresh after peer or source mutations is now scoped by both peer IP and ASN, reducing unnecessary/incorrect refreshes for peers that share an IP.
  * Refresh-related logging is clearer when no matching session is found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->