### PR TITLE
fix(server): expose RemoteAsn on BgpSession for ASN-scoped refresh

### DIFF
--- a/BGPLite.Server/BgpServer.cs
+++ b/BGPLite.Server/BgpServer.cs
@@ -326,7 +326,7 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
         }
 
         var sessions = _sessions
-            .Where(kvp => kvp.Key.Address.Equals(ip) && kvp.Value.Peer.RemoteAsn == asn)
+            .Where(kvp => kvp.Key.Address.Equals(ip) && kvp.Value.RemoteAsn == asn)
             .Select(kvp => kvp.Value)
             .ToList();
 

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -75,6 +75,9 @@ public sealed class BgpSession : IDisposable
 
     public BgpFsmState State => _state;
     public PeerConfig Peer => _peerConfig;
+    /// <summary>The remote ASN negotiated from the peer's OPEN (#206). Set after ValidateOpen; used by
+    /// BgpServer.RefreshPeerAsync to filter sessions by (Ip, Asn) on shared IPs.</summary>
+    public uint RemoteAsn => _remoteAsn;
     public bool IsEstablished => _state == BgpFsmState.Established;
 
     public async Task RefreshRoutesAsync(CancellationToken ct = default)


### PR DESCRIPTION
Closes #206

## Problem

`RefreshPeerAsync(ip, asn)` (added in #200/PR #201) filters sessions by `session.Peer.RemoteAsn == asn`. But `PeerConfig.RemoteAsn` is **never set** — it stays `null` from construction in `BgpServer.AcceptLoopAsync`. The negotiated ASN lives in `BgpSession._remoteAsn` (set by `ValidateOpen`), but was not exposed publicly.

So `session.Peer.RemoteAsn == asn` is always `null == 65001` → **false** → refresh never finds the session. **API-triggered refreshes don't fire** — peers keep stale route sets.

**Confirmed in production:** `RefreshPeer: no session for 170.168.100.165 AS65001` — the session IS active but RemoteAsn was null so the filter failed.

## Fix

- Added `public uint RemoteAsn => _remoteAsn;` on BgpSession (mirrors `State`/`IsEstablished`).
- Changed `BgpServer.RefreshPeerAsync` filter from `Peer.RemoteAsn` to `RemoteAsn`.

## Verification

- `dotnet build BGPLite.sln` ✅
- `dotnet test BGPLite.sln` ✅ 476 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved peer refresh handling so sessions are matched more reliably in shared-IP scenarios.
  * Refresh now correctly targets the intended established sessions before reloading routes.

* **Documentation**
  * Added clearer public API documentation for a session property used during peer matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->