### PR TITLE
feat(api): show actual advertised prefix count (post-aggregation) in API

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -525,6 +525,11 @@ public sealed class ManagementApi : IHostedService, IDisposable
             ? _store.GetCommunities(peer.Ip, peer.Asn.Value)
             : new HashSet<uint>();
 
+        // #212: actual advertised count from the live session (post-aggregation, post-dedup).
+        var advertisedCount = peer.Asn.HasValue
+            ? _sessionManager?.GetAdvertisedPrefixCount(peer.Ip, peer.Asn.Value) ?? 0
+            : 0;
+
         return new
         {
             id = peer.Id,
@@ -538,7 +543,10 @@ public sealed class ManagementApi : IHostedService, IDisposable
             customPrefixes,
             customAsns,
             communities = communities.Select(CommunityCodec.Format),
-            allRoutes = communities.Count == 0
+            allRoutes = communities.Count == 0,
+            // #212: the actual number of prefixes on the wire (after aggregation + duplicate NLRI
+            // merge). 0 = session not established or no routes sent yet.
+            advertisedPrefixCount = advertisedCount
         };
     }
 

--- a/BGPLite.Server/BgpServer.cs
+++ b/BGPLite.Server/BgpServer.cs
@@ -355,6 +355,19 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
                  .Distinct()
                  .ToList();
 
+    /// <summary>
+    /// Returns the actual advertised prefix count (post-aggregation, post-dedup) for the given
+    /// peer (Ip, Asn), or 0 if no session is established (#212).
+    /// </summary>
+    public int GetAdvertisedPrefixCount(string peerIp, uint asn)
+    {
+        if (!IPAddress.TryParse(peerIp, out var ip)) return 0;
+        return _sessions
+            .Where(kvp => kvp.Key.Address.Equals(ip) && kvp.Value.RemoteAsn == asn)
+            .Select(kvp => kvp.Value.AdvertisedPrefixCount)
+            .FirstOrDefault();
+    }
+
     public void Dispose()
     {
         Volatile.Write(ref _acceptingConnections, 0);

--- a/BGPLite.Server/BgpServer.cs
+++ b/BGPLite.Server/BgpServer.cs
@@ -363,7 +363,7 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
     {
         if (!IPAddress.TryParse(peerIp, out var ip)) return 0;
         return _sessions
-            .Where(kvp => kvp.Key.Address.Equals(ip) && kvp.Value.RemoteAsn == asn)
+            .Where(kvp => kvp.Key.Address.Equals(ip) && kvp.Value.RemoteAsn == asn && kvp.Value.IsEstablished)
             .Select(kvp => kvp.Value.AdvertisedPrefixCount)
             .FirstOrDefault();
     }

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -62,6 +62,10 @@ public sealed class BgpSession : IDisposable
     private bool _localFourByteAsn; // derived from negotiated OPEN capability (RFC 6793)
     private ushort _negotiatedHoldTime;
     private List<IpPrefix> _advertisedPrefixes = [];
+    // #212: actual count sent on the wire (after aggregation + dedup). Updated at the end of
+    // SendRoutesAsync. Read via AdvertisedPrefixCount for the management API/UI so operators see
+    // the real number their peer's router receives, not the raw pre-aggregation count.
+    private int _advertisedCount;
     private TimeSpan _keepAliveInterval;
     private long _lastReceivedTicks; // UTC ticks of last received message; drives the HoldTimer (Interlocked)
     // Debounce ROUTE_REFRESH (RFC 2918): rate-limit per-session route re-announcements to avoid
@@ -78,6 +82,8 @@ public sealed class BgpSession : IDisposable
     /// <summary>The remote ASN negotiated from the peer's OPEN (#206). Set after ValidateOpen; used by
     /// BgpServer.RefreshPeerAsync to filter sessions by (Ip, Asn) on shared IPs.</summary>
     public uint RemoteAsn => _remoteAsn;
+    /// <summary>Actual prefix count sent on the wire (post-aggregation, post-dedup). 0 = never sent.</summary>
+    public int AdvertisedPrefixCount => Volatile.Read(ref _advertisedCount);
     public bool IsEstablished => _state == BgpFsmState.Established;
 
     public async Task RefreshRoutesAsync(CancellationToken ct = default)
@@ -149,6 +155,7 @@ public sealed class BgpSession : IDisposable
 
         _logger.LogInformation("Withdrawn {Count} routes from {Peer}", count, _peer);
         _advertisedPrefixes.Clear();
+        Volatile.Write(ref _advertisedCount, 0); // #212: routes withdrawn — no longer advertised
     }
 
     public BgpSession(
@@ -680,6 +687,8 @@ public sealed class BgpSession : IDisposable
         }
 
         _logger.LogInformation("UpdateSent {Count} routes to {Peer}", sent, _peer);
+        // #212: cache the actual wire count for the API/UI.
+        Volatile.Write(ref _advertisedCount, sent);
     }
 
     /// <summary>

--- a/BGPLite.Server/ISessionManager.cs
+++ b/BGPLite.Server/ISessionManager.cs
@@ -8,4 +8,6 @@ public interface ISessionManager
     /// </summary>
     Task RefreshPeerAsync(string peerIp, uint asn);
     List<string> GetActivePeerIps();
+    /// <summary>Actual advertised prefix count (post-aggregation, post-dedup), or 0 (#212).</summary>
+    int GetAdvertisedPrefixCount(string peerIp, uint asn);
 }


### PR DESCRIPTION
Closes #212

## Problem

The API showed raw pre-aggregation prefix counts. Operators saw "12375 prefixes" but the peer's router received 2617 (after aggregation + duplicate NLRI merge). Confusing.

## Fix

Added `advertisedPrefixCount` to the peer detail API response (`GET /api/peers/{id}`, `GET /api/me`). This is the **actual** number of NLRI sent on the wire, cached from the last `SendRoutesAsync`:

```json
{
  "id": "...",
  "lists": ["aws", "cloudflare", "google", ...],
  "allRoutes": true,
  "advertisedPrefixCount": 2617
}
```

### Implementation
- `BgpSession._advertisedCount` (Volatile int) — updated at the end of `SendRoutesAsync`, reset to 0 on `WithdrawAllAsync`
- `BgpSession.AdvertisedPrefixCount` — public read-only property
- `BgpServer.GetAdvertisedPrefixCount(ip, asn)` — finds the matching session and reads its count
- `ISessionManager.GetAdvertisedPrefixCount` — interface method
- `BuildPeerDetail` — adds `advertisedPrefixCount` to the API response

### Performance
Zero per-request cost — just a volatile read from the cached session state. No re-aggregation.

## Verification

- `dotnet build BGPLite.sln` ✅
- `dotnet test BGPLite.sln` ✅ 476 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Peer details in the management API now include an `advertisedPrefixCount` field.
  * The system now reports the actual number of prefixes advertised to each peer.

* **Bug Fixes**
  * `advertisedPrefixCount` now reflects the live, post-processing count (post-aggregation and deduplication) matching what’s sent on the wire.
  * If a peer has no valid established session or ASN, the value safely returns `0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->