### PR TITLE
feat(providers): auto-refresh with ETag/conditional requests + periodic push

### DIFF
--- a/BGPLite.Configuration/AppConfig.cs
+++ b/BGPLite.Configuration/AppConfig.cs
@@ -81,6 +81,14 @@ public sealed class AppConfig
     public List<string>? CorsAllowedOrigins { get; init; }
 
     /// <summary>
+    /// Periodic auto-refresh (#214): a background timer checks all prefix sources for changes using
+    /// conditional requests (ETag/Last-Modified → 304). Only changed sources trigger peer refreshes.
+    /// Null/absent (default) = disabled — sources are only refreshed on peer connect/ROUTE_REFRESH.
+    /// </summary>
+    [YamlMember(Alias = "AutoRefresh")]
+    public AutoRefreshConfig? AutoRefresh { get; init; }
+
+    /// <summary>
     /// Validates the whole configuration, throwing <see cref="InvalidOperationException"/> with a
     /// clear message on the first violation (fail-loud). Called from Program.cs right after the YAML
     /// is loaded and before the host is built, so invalid config (bad ASN, RouterId=0.0.0.0,

--- a/BGPLite.Configuration/AutoRefreshConfig.cs
+++ b/BGPLite.Configuration/AutoRefreshConfig.cs
@@ -1,0 +1,32 @@
+using YamlDotNet.Serialization;
+
+namespace BGPLite.Configuration;
+
+/// <summary>
+/// Periodic auto-refresh configuration (#214). When enabled, a background timer periodically
+/// checks all prefix sources for changes using conditional requests (ETag / Last-Modified → 304
+/// Not Modified when unchanged). Only sources whose data actually changed trigger peer route
+/// refreshes — no unnecessary BGP churn.
+/// </summary>
+public sealed class AutoRefreshConfig
+{
+    /// <summary>Master switch. When false (default), no background timer runs.</summary>
+    [YamlMember(Alias = "Enabled")]
+    public bool Enabled { get; init; }
+
+    /// <summary>How often to check sources that support ETag/Last-Modified (304 = ~1 KB per check).
+    /// Default 10 minutes — 304 checks are cheap.</summary>
+    [YamlMember(Alias = "IntervalSeconds")]
+    public int IntervalSeconds { get; init; } = 600;
+
+    /// <summary>How often to check sources WITHOUT ETag support (e.g. RIPEstat). These require a
+    /// full re-fetch + hash comparison, so a longer interval (default 1 hour) reduces load.</summary>
+    [YamlMember(Alias = "NoEtagIntervalSeconds")]
+    public int NoEtagIntervalSeconds { get; init; } = 3600;
+
+    /// <summary>Max random delay (ms) between individual source checks within one cycle. Prevents
+    /// burst of conditional requests to the same host (GitHub rate limits: 60 req/min unauthenticated).
+    /// Default 2000ms.</summary>
+    [YamlMember(Alias = "MaxJitterMs")]
+    public int MaxJitterMs { get; init; } = 2000;
+}

--- a/BGPLite.Configuration/AutoRefreshConfig.cs
+++ b/BGPLite.Configuration/AutoRefreshConfig.cs
@@ -19,10 +19,12 @@ public sealed class AutoRefreshConfig
     [YamlMember(Alias = "IntervalSeconds")]
     public int IntervalSeconds { get; init; } = 600;
 
-    /// <summary>How often to check sources WITHOUT ETag support (e.g. RIPEstat). These require a
-    /// full re-fetch + hash comparison, so a longer interval (default 1 hour) reduces load.</summary>
+    /// <summary>How often to check sources WITHOUT ETag support (e.g. RIPEstat ASN lookups).
+    /// These require a full re-fetch + hash comparison. RIPEstat prefix data changes rarely
+    /// (prefixes are added/withdrawn gradually), so a long interval reduces unnecessary load.
+    /// Default 7 days (604800 seconds).</summary>
     [YamlMember(Alias = "NoEtagIntervalSeconds")]
-    public int NoEtagIntervalSeconds { get; init; } = 3600;
+    public int NoEtagIntervalSeconds { get; init; } = 604800;
 
     /// <summary>Max random delay (ms) between individual source checks within one cycle. Prevents
     /// burst of conditional requests to the same host (GitHub rate limits: 60 req/min unauthenticated).

--- a/BGPLite.Providers/AsnPrefixProvider.cs
+++ b/BGPLite.Providers/AsnPrefixProvider.cs
@@ -8,6 +8,9 @@ namespace BGPLite.Providers;
 /// Requires <see cref="PrefixSourceConfig.Asn"/>. Shares the RIPEstat client, retry, and per-ASN
 /// caching of <see cref="RipeStatProvider"/>/PrefixService, so adding it as a <c>Kind: asn</c>
 /// source under <c>PrefixSources</c> does not multiply RIPEstat traffic.
+/// <para>RIPEstat does not support ETag / Last-Modified — the <paramref name="etag"/> and
+/// <paramref name="lastModified"/> parameters are ignored. Content-change detection for auto-refresh
+/// (#214) is handled by hash comparison in <see cref="PrefixSourceService"/> (the cache layer).</para>
 /// </summary>
 public sealed class AsnPrefixProvider : IPrefixSourceProvider
 {
@@ -22,7 +25,11 @@ public sealed class AsnPrefixProvider : IPrefixSourceProvider
 
     public string Kind => "asn";
 
-    public async Task<IReadOnlyList<(uint Prefix, byte Length)>> LoadAsync(PrefixSourceConfig source, CancellationToken ct = default)
+    public async Task<SourceLoadResult> LoadAsync(
+        PrefixSourceConfig source,
+        string? etag = null,
+        DateTimeOffset? lastModified = null,
+        CancellationToken ct = default)
     {
         if (!source.Asn.HasValue)
             throw new InvalidOperationException($"Prefix source '{source.Name}': Kind=asn requires an Asn.");
@@ -31,6 +38,6 @@ public sealed class AsnPrefixProvider : IPrefixSourceProvider
         _logger.LogInformation(
             "Source '{Name}' (asn AS{Asn}): loaded {Count} prefixes via RIPEstat",
             source.Name, source.Asn.Value, prefixes.Count);
-        return prefixes.Select(p => (Prefix: p.Prefix, Length: p.PrefixLength)).ToList();
+        return SourceLoadResult.Ok(prefixes.Select(p => (Prefix: p.Prefix, Length: p.PrefixLength)).ToList());
     }
 }

--- a/BGPLite.Providers/AsnPrefixProvider.cs
+++ b/BGPLite.Providers/AsnPrefixProvider.cs
@@ -25,6 +25,13 @@ public sealed class AsnPrefixProvider : IPrefixSourceProvider
 
     public string Kind => "asn";
 
+    /// <summary>
+    /// RIPEstat does not support ETag/Last-Modified (#214) — every check re-fetches the full prefix
+    /// list and relies on content-hash comparison. Returns false so the auto-refresh timer polls these
+    /// sources at the longer <c>NoEtagIntervalSeconds</c> to avoid hammering RIPEstat.
+    /// </summary>
+    public bool SupportsConditionalRequests => false;
+
     public async Task<SourceLoadResult> LoadAsync(
         PrefixSourceConfig source,
         string? etag = null,

--- a/BGPLite.Providers/FilePrefixProvider.cs
+++ b/BGPLite.Providers/FilePrefixProvider.cs
@@ -10,6 +10,9 @@ public sealed class FilePrefixProvider(ILogger<FilePrefixProvider> logger) : IPr
 {
     public string Kind => "file";
 
+    /// <summary>File mtime comparison is a zero-cost conditional check (#214).</summary>
+    public bool SupportsConditionalRequests => true;
+
     public Task<SourceLoadResult> LoadAsync(
         PrefixSourceConfig source,
         string? etag = null,

--- a/BGPLite.Providers/FilePrefixProvider.cs
+++ b/BGPLite.Providers/FilePrefixProvider.cs
@@ -3,12 +3,18 @@ using Microsoft.Extensions.Logging;
 
 namespace BGPLite.Providers;
 
-/// <summary>Loads prefixes from a local CIDR file (Kind = <c>"file"</c>).</summary>
+/// <summary>Loads prefixes from a local CIDR file (Kind = <c>"file"</c>).
+/// Conditional reload (#214): when <paramref name="lastModified"/> matches the file's
+/// <c>LastWriteTimeUtc</c>, returns <see cref="SourceLoadResult.NotModified"/> = true (no re-parse).</summary>
 public sealed class FilePrefixProvider(ILogger<FilePrefixProvider> logger) : IPrefixSourceProvider
 {
     public string Kind => "file";
 
-    public Task<IReadOnlyList<(uint Prefix, byte Length)>> LoadAsync(PrefixSourceConfig source, CancellationToken ct = default)
+    public Task<SourceLoadResult> LoadAsync(
+        PrefixSourceConfig source,
+        string? etag = null,
+        DateTimeOffset? lastModified = null,
+        CancellationToken ct = default)
     {
         var path = source.Path;
         if (string.IsNullOrWhiteSpace(path))
@@ -21,8 +27,16 @@ public sealed class FilePrefixProvider(ILogger<FilePrefixProvider> logger) : IPr
         if (!File.Exists(fullPath))
             throw new FileNotFoundException($"Prefix file not found for source '{source.Name}': {fullPath}", fullPath);
 
+        // #214: conditional check — if the file hasn't been modified since the last load, skip re-parsing.
+        var fileMtime = new DateTimeOffset(File.GetLastWriteTimeUtc(fullPath), TimeSpan.Zero);
+        if (lastModified is not null && fileMtime == lastModified)
+        {
+            logger.LogDebug("Source '{Name}' (file): unchanged (mtime match)", source.Name);
+            return Task.FromResult(SourceLoadResult.NotModifiedResult(lastModified: fileMtime));
+        }
+
         var prefixes = PrefixListParser.Parse(File.ReadAllText(fullPath));
         logger.LogInformation("Source '{Name}' (file): loaded {Count} prefixes from {Path}", source.Name, prefixes.Count, fullPath);
-        return Task.FromResult(prefixes);
+        return Task.FromResult(SourceLoadResult.Ok(prefixes, lastModified: fileMtime));
     }
 }

--- a/BGPLite.Providers/HttpPrefixProvider.cs
+++ b/BGPLite.Providers/HttpPrefixProvider.cs
@@ -31,6 +31,9 @@ public sealed class HttpPrefixProvider(
 
     public string Kind => "http";
 
+    /// <summary>HTTP conditional requests (If-None-Match / If-Modified-Since → 304) are supported (#214).</summary>
+    public bool SupportsConditionalRequests => true;
+
     public async Task<SourceLoadResult> LoadAsync(
         PrefixSourceConfig source,
         string? etag = null,

--- a/BGPLite.Providers/HttpPrefixProvider.cs
+++ b/BGPLite.Providers/HttpPrefixProvider.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Net.Http.Headers;
 using System.Text;
 using BGPLite.Configuration;
 using Microsoft.Extensions.Http;
@@ -13,6 +15,9 @@ namespace BGPLite.Providers;
 /// <para>SSRF defense (#144): the named-client's <c>SocketsHttpHandler.ConnectCallback</c> validates
 /// every connection's DNS resolution at the socket level — no TOCTOU race, no redirect bypass.
 /// Response body is capped at <see cref="MaxResponseBytes"/> to prevent OOM.</para>
+/// <para>Conditional requests (#214): when <paramref name="etag"/> / <paramref name="lastModified"/>
+/// are provided from a prior load, sends <c>If-None-Match</c> / <c>If-Modified-Since</c>. A 304
+/// response skips the body download entirely (~1 KB headers-only round-trip).</para>
 /// </summary>
 public sealed class HttpPrefixProvider(
     IHttpClientFactory httpFactory,
@@ -26,7 +31,11 @@ public sealed class HttpPrefixProvider(
 
     public string Kind => "http";
 
-    public async Task<IReadOnlyList<(uint Prefix, byte Length)>> LoadAsync(PrefixSourceConfig source, CancellationToken ct = default)
+    public async Task<SourceLoadResult> LoadAsync(
+        PrefixSourceConfig source,
+        string? etag = null,
+        DateTimeOffset? lastModified = null,
+        CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(source.Url))
             throw new InvalidOperationException($"Prefix source '{source.Name}': Kind=http requires a Url.");
@@ -60,13 +69,36 @@ public sealed class HttpPrefixProvider(
                 if (!request.Headers.TryAddWithoutValidation(key, value))
                     logger.LogWarning("Source '{Name}': could not add request header '{Header}'.", source.Name, key);
 
+        // #214: conditional request — send validators from the prior load. GitHub raw, CDNs, and
+        // most HTTP servers support ETag / Last-Modified and reply 304 Not Modified (no body) when
+        // the content hasn't changed, making the periodic check ~1 KB instead of a full re-download.
+        if (etag is not null)
+            request.Headers.IfNoneMatch.Add(new EntityTagHeaderValue(etag));
+        if (lastModified is not null)
+            request.Headers.IfModifiedSince = lastModified;
+
         try
         {
             // Stream-read with size cap (#144): ResponseHeadersRead gets headers first (fast Content-Length
             // check), then stream the body with a hard cap to prevent OOM. SSRF validation is at the
             // handler level (SocketsHttpHandler.ConnectCallback in Program.cs) — no pre-resolve here.
             using var response = await http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, linkedToken);
+
+            // #214: 304 Not Modified — server confirms data unchanged. No body to parse. Extract any
+            // updated validators the server may have returned (some servers refresh ETag on 304).
+            if (response.StatusCode == HttpStatusCode.NotModified)
+            {
+                logger.LogDebug("Source '{Name}' (http): 304 Not Modified", source.Name);
+                var updatedEtag = response.Headers.ETag?.Tag;
+                var updatedLm = response.Content.Headers.LastModified;
+                return SourceLoadResult.NotModifiedResult(updatedEtag ?? etag, updatedLm ?? lastModified);
+            }
+
             response.EnsureSuccessStatusCode();
+
+            // Extract validators from the 200 response for next time (#214).
+            var newEtag = response.Headers.ETag?.Tag;
+            var newLm = response.Content.Headers.LastModified;
 
             if (response.Content.Headers.ContentLength is long contentLength && contentLength > MaxResponseBytes)
                 throw new InvalidOperationException(
@@ -89,7 +121,7 @@ public sealed class HttpPrefixProvider(
             // Log only the source Name (the operator/peer-supplied identifier), never the URL — peer URLs
             // (#147) may carry tokens in the query string that must not reach application logs.
             logger.LogInformation("Source '{Name}' (http): loaded {Count} prefixes", source.Name, prefixes.Count);
-            return prefixes;
+            return SourceLoadResult.Ok(prefixes, newEtag, newLm);
         }
         finally
         {

--- a/BGPLite.Providers/IPrefixSourceProvider.cs
+++ b/BGPLite.Providers/IPrefixSourceProvider.cs
@@ -13,6 +13,15 @@ public interface IPrefixSourceProvider
     /// <summary>Discriminator matched against <see cref="PrefixSourceConfig.Kind"/>.</summary>
     string Kind { get; }
 
-    /// <summary>Fetch and parse the CIDR list described by <paramref name="source"/>.</summary>
-    Task<IReadOnlyList<(uint Prefix, byte Length)>> LoadAsync(PrefixSourceConfig source, CancellationToken ct = default);
+    /// <summary>
+    /// Fetch and parse the CIDR list described by <paramref name="source"/>. When
+    /// <paramref name="etag"/> / <paramref name="lastModified"/> are provided (from a prior load),
+    /// the provider SHOULD send a conditional request (If-None-Match / If-Modified-Since) and
+    /// return <see cref="SourceLoadResult.NotModified"/> = true on a 304 (#214).
+    /// </summary>
+    Task<SourceLoadResult> LoadAsync(
+        PrefixSourceConfig source,
+        string? etag = null,
+        DateTimeOffset? lastModified = null,
+        CancellationToken ct = default);
 }

--- a/BGPLite.Providers/IPrefixSourceProvider.cs
+++ b/BGPLite.Providers/IPrefixSourceProvider.cs
@@ -14,6 +14,15 @@ public interface IPrefixSourceProvider
     string Kind { get; }
 
     /// <summary>
+    /// Whether this provider honors conditional requests (#214): when true, <see cref="LoadAsync"/>
+    /// sends <c>If-None-Match</c> / <c>If-Modified-Since</c> (or an equivalent zero-cost check like a
+    /// file mtime) and may return <see cref="SourceLoadResult.NotModified"/> = true. The auto-refresh
+    /// timer uses this to pick the poll interval — sources supporting conditional requests are polled
+    /// at <c>IntervalSeconds</c> (304s are cheap), others at the longer <c>NoEtagIntervalSeconds</c>.
+    /// </summary>
+    bool SupportsConditionalRequests { get; }
+
+    /// <summary>
     /// Fetch and parse the CIDR list described by <paramref name="source"/>. When
     /// <paramref name="etag"/> / <paramref name="lastModified"/> are provided (from a prior load),
     /// the provider SHOULD send a conditional request (If-None-Match / If-Modified-Since) and

--- a/BGPLite.Providers/IPrefixSourceService.cs
+++ b/BGPLite.Providers/IPrefixSourceService.cs
@@ -20,4 +20,10 @@ public interface IPrefixSourceService
 
     /// <summary>Prime the in-memory cache for all sources.</summary>
     Task WarmUpAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// #214: Force-refresh all sources (bypass TTL), returning the names of sources whose content
+    /// actually changed. Used by the auto-refresh timer for selective peer refresh.
+    /// </summary>
+    Task<HashSet<string>> RefreshAllAsync(CancellationToken ct = default);
 }

--- a/BGPLite.Providers/IPrefixSourceService.cs
+++ b/BGPLite.Providers/IPrefixSourceService.cs
@@ -22,8 +22,14 @@ public interface IPrefixSourceService
     Task WarmUpAsync(CancellationToken ct = default);
 
     /// <summary>
-    /// #214: Force-refresh all sources (bypass TTL), returning the names of sources whose content
-    /// actually changed. Used by the auto-refresh timer for selective peer refresh.
+    /// #214: Force-refresh a single source (bypass TTL), returning whether the content actually
+    /// changed. Used by the auto-refresh timer, which polls each source on its own jittered interval.
     /// </summary>
-    Task<HashSet<string>> RefreshAllAsync(CancellationToken ct = default);
+    Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default);
+
+    /// <summary>
+    /// #214: Whether the source supports conditional requests (ETag/Last-Modified). Drives the poll
+    /// interval selection in the auto-refresh timer.
+    /// </summary>
+    bool SourceSupportsConditional(string sourceName);
 }

--- a/BGPLite.Providers/PrefixService.cs
+++ b/BGPLite.Providers/PrefixService.cs
@@ -64,7 +64,11 @@ public sealed class PrefixService : IPrefixService
             Url = url,
             Community = community
         };
-        return await _userSourceCache.GetOrLoadAsync(url, name, ct => _httpProvider.LoadAsync(source, ct), ct);
+        return await _userSourceCache.GetOrLoadAsync(url, name, async ct =>
+        {
+            var result = await _httpProvider.LoadAsync(source, ct: ct);
+            return result.Prefixes;
+        }, ct);
     }
 
     public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)

--- a/BGPLite.Providers/PrefixSourceService.cs
+++ b/BGPLite.Providers/PrefixSourceService.cs
@@ -240,8 +240,12 @@ public sealed class PrefixSourceService : IPrefixSourceService
             // Compute Changed atomically with the cache write: compare the freshly loaded list with the
             // list that was in the cache before this load (captured above as `stale`, re-read here to
             // be safe under the gate — only this task holds the gate, so `stale` is still authoritative).
+            // Order-INDEPENDENT comparison: RIPEstat (and some HTTP sources) may return the same prefix
+            // set in a different order between requests — a SequenceEqual there would report a phantom
+            // change and trigger an unnecessary BGP re-announcement (#214: "no unnecessary BGP churn",
+            // AsnPrefixProvider docs describe the design as content-based, not positional).
             var previousList = (stale is not null && !stale.Negative) ? stale.List : null;
-            changed = previousList is null || !previousList.SequenceEqual(result.Prefixes);
+            changed = previousList is null || !SamePrefixes(previousList, result.Prefixes);
             _cache[source.Name] = new CacheEntry(result.Prefixes, now, false, result.ETag, result.LastModified);
             loaded = result.Prefixes;
         }
@@ -262,6 +266,27 @@ public sealed class PrefixSourceService : IPrefixSourceService
         }
 
         return (loaded, changed);
+    }
+
+    /// <summary>
+    /// Order-independent prefix-list equality (#214): two lists represent the same route set if they
+    /// contain the same (Prefix, Length) tuples regardless of order. RIPEstat and some HTTP sources
+    /// do not guarantee a stable ordering across requests — a positional SequenceEqual there would
+    /// report a phantom change and trigger an unnecessary BGP re-announcement. Sorting both lists
+    /// (O(n log n)) keeps duplicates significant (a repeated prefix stays a difference) and avoids
+    /// the HashSet allocation path on the common unchanged case via the fast count/SequenceEqual
+    /// shortcut when the source already returned a sorted list.
+    /// </summary>
+    private static bool SamePrefixes(IReadOnlyList<(uint Prefix, byte Length)> a, IReadOnlyList<(uint Prefix, byte Length)> b)
+    {
+        if (a.Count != b.Count) return false;
+        // Fast path: if both happen to be in the same order (common — file sources, cached HTTP),
+        // SequenceEqual is O(n) with no allocation.
+        if (a.SequenceEqual(b)) return true;
+        // Slow path: order differs — compare as sorted sequences.
+        var sa = a.OrderBy(x => x.Prefix).ThenBy(x => x.Length).ToArray();
+        var sb = b.OrderBy(x => x.Prefix).ThenBy(x => x.Length).ToArray();
+        return sa.SequenceEqual(sb);
     }
 
     private bool TryGetFresh(string name, out IReadOnlyList<(uint Prefix, byte Length)> list)

--- a/BGPLite.Providers/PrefixSourceService.cs
+++ b/BGPLite.Providers/PrefixSourceService.cs
@@ -9,6 +9,7 @@ namespace BGPLite.Providers;
 /// keeping results in an in-memory TTL cache. Per-source failures fall back to a stale cached
 /// copy (if any) or a short-lived negative entry, never breaking startup. The source named by
 /// <see cref="AppConfig.DefaultPrefixSource"/> is exposed as the RU/default set.
+/// <para>#214: stores ETag/Last-Modified per source for conditional re-fetches (304 Not Modified).</para>
 /// </summary>
 public sealed class PrefixSourceService : IPrefixSourceService
 {
@@ -21,8 +22,9 @@ public sealed class PrefixSourceService : IPrefixSourceService
     // #85: pre-built name→source lookup (replaces per-call FirstOrDefault linear scan).
     private readonly Dictionary<string, PrefixSourceConfig> _sourcesByName;
 
-    // Name → (a prefix list, cached at, is negative). Negative entries (failed loads) use _negativeTtl.
-    private readonly ConcurrentDictionary<string, (IReadOnlyList<(uint Prefix, byte Length)> List, DateTime CachedAt, bool Negative)> _cache = new();
+    // Name → (prefix list, cached at, is negative, ETag, LastModified). Negative entries use _negativeTtl.
+    // #214: ETag/LastModified enable conditional re-fetches (If-None-Match / If-Modified-Since → 304).
+    private readonly ConcurrentDictionary<string, CacheEntry> _cache = new();
     // Name → gate serializing the cache-miss fetch path (prevents thundering-herd on cold/expired keys).
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new();
 
@@ -47,7 +49,6 @@ public sealed class PrefixSourceService : IPrefixSourceService
         _cacheTtl = cacheTtl ?? TimeSpan.FromHours(1);
         _negativeTtl = negativeTtl ?? TimeSpan.FromSeconds(30);
         _timeProvider = timeProvider ?? TimeProvider.System;
-        // #85: pre-build a name→source lookup (the ctor already iterates for duplicate detection).
         _sourcesByName = config.PrefixSources.ToDictionary(s => s.Name);
     }
 
@@ -113,43 +114,95 @@ public sealed class PrefixSourceService : IPrefixSourceService
             Console.WriteLine($"  WarmUp: source '{source.Name}' — {prefixes.Count} prefixes");
     }
 
-    private async Task<IReadOnlyList<(uint Prefix, byte Length)>> LoadCachedAsync(PrefixSourceConfig source, CancellationToken ct)
+    /// <summary>
+    /// #214: Force-refresh all configured sources, bypassing the TTL. Used by the auto-refresh timer.
+    /// Returns the set of source names whose content actually changed (for selective peer refresh).
+    /// </summary>
+    public async Task<HashSet<string>> RefreshAllAsync(CancellationToken ct = default)
     {
-        if (TryGetFresh(source.Name, out var fresh))
+        var changed = new HashSet<string>();
+        foreach (var source in _config.PrefixSources)
+        {
+            try
+            {
+                var before = _cache.TryGetValue(source.Name, out var entry) ? entry : null;
+                await LoadCachedAsync(source, ct, forceRefresh: true);
+                if (_cache.TryGetValue(source.Name, out var after) && after.List is not null)
+                {
+                    if (before is null || before.List is null || !before.List.SequenceEqual(after.List))
+                        changed.Add(source.Name);
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(ex, "Auto-refresh: failed to reload source '{Name}'.", source.Name);
+            }
+        }
+        return changed;
+    }
+
+    private async Task<IReadOnlyList<(uint Prefix, byte Length)>> LoadCachedAsync(PrefixSourceConfig source, CancellationToken ct, bool forceRefresh = false)
+    {
+        if (!forceRefresh && TryGetFresh(source.Name, out var fresh))
             return fresh;
 
-        // Serialize per-key so concurrent callers share a single fetch (no thundering herd).
         var gate = _locks.GetOrAdd(source.Name, _ => new SemaphoreSlim(1, 1));
         await gate.WaitAsync(ct);
         try
         {
-            if (TryGetFresh(source.Name, out var rechecked))
+            if (!forceRefresh && TryGetFresh(source.Name, out var rechecked))
                 return rechecked;
 
-            IReadOnlyList<(uint Prefix, byte Length)> prefixes;
+            // #214: read stale validators for conditional request.
+            string? etag = null;
+            DateTimeOffset? lastModified = null;
+            if (_cache.TryGetValue(source.Name, out var stale) && !stale.Negative)
+            {
+                etag = stale.ETag;
+                lastModified = stale.LastModified;
+            }
+
+            SourceLoadResult result;
             try
             {
                 var provider = _factory.Get(source.Kind);
-                prefixes = await provider.LoadAsync(source, ct);
+                result = await provider.LoadAsync(source, etag, lastModified, ct);
             }
             catch (OperationCanceledException) { throw; }
             catch
             {
-                // Serve the last good copy if we have one (regardless of its age).
-                if (_cache.TryGetValue(source.Name, out var stale) && !stale.Negative)
+                if (_cache.TryGetValue(source.Name, out var staleCopy) && !staleCopy.Negative)
                 {
                     _logger.LogWarning("Source '{Name}' load failed; serving cached copy ({Count} prefixes).",
-                        source.Name, stale.List.Count);
-                    return stale.List;
+                        source.Name, staleCopy.List.Count);
+                    return staleCopy.List;
                 }
-
-                // Otherwise remember the failure briefly, so repeated calls don't hammer the provider.
-                _cache[source.Name] = ([], _timeProvider.GetUtcNow().UtcDateTime, Negative: true);
+                _cache[source.Name] = new CacheEntry([], _timeProvider.GetUtcNow().UtcDateTime, true);
                 throw;
             }
 
-            _cache[source.Name] = (prefixes, _timeProvider.GetUtcNow().UtcDateTime, Negative: false);
-            return prefixes;
+            // #214: 304 Not Modified — keep existing data, just refresh the timestamp + validators.
+            if (result.NotModified)
+            {
+                if (_cache.TryGetValue(source.Name, out var existing) && !existing.Negative)
+                {
+                    _cache[source.Name] = existing with
+                    {
+                        CachedAt = _timeProvider.GetUtcNow().UtcDateTime,
+                        ETag = result.ETag ?? existing.ETag,
+                        LastModified = result.LastModified ?? existing.LastModified
+                    };
+                    return existing.List;
+                }
+                // No prior data (first load got 304?) — treat as empty.
+                _cache[source.Name] = new CacheEntry([], _timeProvider.GetUtcNow().UtcDateTime, false,
+                    result.ETag, result.LastModified);
+                return [];
+            }
+
+            var now = _timeProvider.GetUtcNow().UtcDateTime;
+            _cache[source.Name] = new CacheEntry(result.Prefixes, now, false, result.ETag, result.LastModified);
+            return result.Prefixes;
         }
         finally
         {
@@ -168,7 +221,14 @@ public sealed class PrefixSourceService : IPrefixSourceService
             list = entry.List;
             return true;
         }
-
         return false;
     }
+
+    /// <summary>#214: Cache entry with ETag/Last-Modified for conditional re-fetches.</summary>
+    private sealed record CacheEntry(
+        IReadOnlyList<(uint Prefix, byte Length)> List,
+        DateTime CachedAt,
+        bool Negative,
+        string? ETag = null,
+        DateTimeOffset? LastModified = null);
 }

--- a/BGPLite.Providers/PrefixSourceService.cs
+++ b/BGPLite.Providers/PrefixSourceService.cs
@@ -19,6 +19,12 @@ public sealed class PrefixSourceService : IPrefixSourceService
     private readonly TimeSpan _cacheTtl;
     private readonly TimeSpan _negativeTtl;
     private readonly TimeProvider _timeProvider;
+    // #214 convergence: invoked whenever a load detects an actual content change, regardless of which
+    // entry point triggered the load (connect-path GetAsync vs. auto-refresh RefreshAsync). Without this,
+    // a connect-path load that silently updated the cache would mask the change from a subsequent
+    // RefreshAsync (which would see already-new data and report unchanged) — leaving established peers
+    // on stale routes. The callback is wired in Program.cs to ISessionManager.RefreshAllEstablishedAsync.
+    private readonly Func<string, Task>? _onSourceChanged;
     // #85: pre-built name→source lookup (replaces per-call FirstOrDefault linear scan).
     private readonly Dictionary<string, PrefixSourceConfig> _sourcesByName;
 
@@ -34,7 +40,8 @@ public sealed class PrefixSourceService : IPrefixSourceService
         ILogger<PrefixSourceService> logger,
         TimeSpan? cacheTtl = null,
         TimeSpan? negativeTtl = null,
-        TimeProvider? timeProvider = null)
+        TimeProvider? timeProvider = null,
+        Func<string, Task>? onSourceChanged = null)
     {
         var duplicate = config.PrefixSources
             .GroupBy(s => s.Name)
@@ -49,6 +56,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
         _cacheTtl = cacheTtl ?? TimeSpan.FromHours(1);
         _negativeTtl = negativeTtl ?? TimeSpan.FromSeconds(30);
         _timeProvider = timeProvider ?? TimeProvider.System;
+        _onSourceChanged = onSourceChanged;
         _sourcesByName = config.PrefixSources.ToDictionary(s => s.Name);
     }
 
@@ -60,7 +68,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
             return [];
         }
 
-        try { return await LoadCachedAsync(source, ct); }
+        try { return (await LoadCachedAsync(source, ct)).Prefixes; }
         catch (OperationCanceledException) { throw; }
         catch (Exception ex)
         {
@@ -81,7 +89,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
             return [];
         }
 
-        try { return await LoadCachedAsync(source, ct); }
+        try { return (await LoadCachedAsync(source, ct)).Prefixes; }
         catch (OperationCanceledException) { throw; }
         catch (Exception ex)
         {
@@ -96,7 +104,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
         foreach (var source in _config.PrefixSources)
         {
             IReadOnlyList<(uint Prefix, byte Length)> prefixes;
-            try { prefixes = await LoadCachedAsync(source, ct); }
+            try { prefixes = (await LoadCachedAsync(source, ct)).Prefixes; }
             catch (OperationCanceledException) { throw; }
             catch (Exception ex)
             {
@@ -115,43 +123,70 @@ public sealed class PrefixSourceService : IPrefixSourceService
     }
 
     /// <summary>
-    /// #214: Force-refresh all configured sources, bypassing the TTL. Used by the auto-refresh timer.
-    /// Returns the set of source names whose content actually changed (for selective peer refresh).
+    /// #214: Force-refresh a single source, bypassing the TTL. Returns whether the content actually
+    /// changed. Used by the auto-refresh timer, which polls each source on its own interval (jittered
+    /// between sources) — so the timer owns timing AND the peer push (LoopAsync aggregates all changed
+    /// sources into ONE RefreshAllEstablishedAsync call), this method owns only the atomic load+compare.
+    /// Therefore it does NOT fire the onSourceChanged callback — that would cause a double push (once
+    /// per changed source here, once aggregated in LoopAsync). The connect-path (GetAsync) DOES fire
+    /// the callback, because it is not part of the auto-refresh aggregation.
     /// </summary>
-    public async Task<HashSet<string>> RefreshAllAsync(CancellationToken ct = default)
+    public async Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default)
     {
-        var changed = new HashSet<string>();
-        foreach (var source in _config.PrefixSources)
+        if (!_sourcesByName.TryGetValue(sourceName, out var source))
         {
-            try
-            {
-                var before = _cache.TryGetValue(source.Name, out var entry) ? entry : null;
-                await LoadCachedAsync(source, ct, forceRefresh: true);
-                if (_cache.TryGetValue(source.Name, out var after) && after.List is not null)
-                {
-                    if (before is null || before.List is null || !before.List.SequenceEqual(after.List))
-                        changed.Add(source.Name);
-                }
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException)
-            {
-                _logger.LogWarning(ex, "Auto-refresh: failed to reload source '{Name}'.", source.Name);
-            }
+            _logger.LogWarning("Auto-refresh: source '{Name}' not found in configuration.", sourceName);
+            return false;
         }
-        return changed;
+        try
+        {
+            var (_, changed) = await LoadCachedAsync(source, ct, forceRefresh: true, triggerCallback: false);
+            return changed;
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Auto-refresh: failed to reload source '{Name}'.", source.Name);
+            return false;
+        }
     }
 
-    private async Task<IReadOnlyList<(uint Prefix, byte Length)>> LoadCachedAsync(PrefixSourceConfig source, CancellationToken ct, bool forceRefresh = false)
+    /// <summary>
+    /// #214: Whether the source supports conditional requests (ETag/Last-Modified). The auto-refresh
+    /// timer uses this to pick the poll interval: conditional sources poll at <c>IntervalSeconds</c>
+    /// (304s are cheap), non-conditional at the longer <c>NoEtagIntervalSeconds</c>.
+    /// </summary>
+    public bool SourceSupportsConditional(string sourceName)
+    {
+        if (!_sourcesByName.TryGetValue(sourceName, out var source))
+            return true; // conservative: treat unknown as conditional (short interval)
+        try { return _factory.Get(source.Kind).SupportsConditionalRequests; }
+        catch { return true; } // unknown Kind — conservative default
+    }
+
+    /// <summary>
+    /// Loads <paramref name="source"/> through the cache, returning the prefix list plus whether the
+    /// content actually changed on this load (#214). <paramref name="forceRefresh"/> bypasses the TTL
+    /// (used by the auto-refresh timer). <c>Changed</c> is computed INSIDE the per-source gate —
+    /// atomically with the cache write — so a concurrent <c>GetAsync</c> cannot insert a newer list
+    /// between the before/after snapshots (the prior TOCTOU that masked real changes). When a change
+    /// is detected (by any entry point), <c>_onSourceChanged</c> is invoked AFTER releasing the gate
+    /// so the callback (peer refresh) can't deadlock on the per-source lock.
+    /// </summary>
+    private async Task<(IReadOnlyList<(uint Prefix, byte Length)> Prefixes, bool Changed)> LoadCachedAsync(
+        PrefixSourceConfig source, CancellationToken ct, bool forceRefresh = false, bool triggerCallback = true)
     {
         if (!forceRefresh && TryGetFresh(source.Name, out var fresh))
-            return fresh;
+            return (fresh, Changed: false);
 
         var gate = _locks.GetOrAdd(source.Name, _ => new SemaphoreSlim(1, 1));
         await gate.WaitAsync(ct);
+        bool changed;
+        IReadOnlyList<(uint Prefix, byte Length)> loaded;
         try
         {
             if (!forceRefresh && TryGetFresh(source.Name, out var rechecked))
-                return rechecked;
+                return (rechecked, Changed: false);
 
             // #214: read stale validators for conditional request.
             string? etag = null;
@@ -175,7 +210,8 @@ public sealed class PrefixSourceService : IPrefixSourceService
                 {
                     _logger.LogWarning("Source '{Name}' load failed; serving cached copy ({Count} prefixes).",
                         source.Name, staleCopy.List.Count);
-                    return staleCopy.List;
+                    // Serving stale: no content change relative to what's already cached.
+                    return (staleCopy.List, Changed: false);
                 }
                 _cache[source.Name] = new CacheEntry([], _timeProvider.GetUtcNow().UtcDateTime, true);
                 throw;
@@ -192,22 +228,40 @@ public sealed class PrefixSourceService : IPrefixSourceService
                         ETag = result.ETag ?? existing.ETag,
                         LastModified = result.LastModified ?? existing.LastModified
                     };
-                    return existing.List;
+                    return (existing.List, Changed: false);
                 }
-                // No prior data (first load got 304?) — treat as empty.
+                // No prior data (first load got 304?) — treat as empty, no change.
                 _cache[source.Name] = new CacheEntry([], _timeProvider.GetUtcNow().UtcDateTime, false,
                     result.ETag, result.LastModified);
-                return [];
+                return ([], Changed: false);
             }
 
             var now = _timeProvider.GetUtcNow().UtcDateTime;
+            // Compute Changed atomically with the cache write: compare the freshly loaded list with the
+            // list that was in the cache before this load (captured above as `stale`, re-read here to
+            // be safe under the gate — only this task holds the gate, so `stale` is still authoritative).
+            var previousList = (stale is not null && !stale.Negative) ? stale.List : null;
+            changed = previousList is null || !previousList.SequenceEqual(result.Prefixes);
             _cache[source.Name] = new CacheEntry(result.Prefixes, now, false, result.ETag, result.LastModified);
-            return result.Prefixes;
+            loaded = result.Prefixes;
         }
         finally
         {
             gate.Release();
         }
+
+        // #214 convergence: fire the change callback AFTER releasing the gate, so a connect-path load
+        // (GetAsync) that updates the cache also notifies established peers — not just the auto-refresh
+        // path. Without this, established peers stay on stale routes until the source changes AGAIN.
+        // Skipped from RefreshAsync (triggerCallback=false): the auto-refresh timer aggregates all
+        // changed sources into ONE peer push in LoopAsync, so firing the callback here would double-push.
+        if (changed && triggerCallback && _onSourceChanged is not null)
+        {
+            try { await _onSourceChanged(source.Name); }
+            catch (Exception ex) { _logger.LogWarning(ex, "OnSourceChanged callback failed for '{Name}'.", source.Name); }
+        }
+
+        return (loaded, changed);
     }
 
     private bool TryGetFresh(string name, out IReadOnlyList<(uint Prefix, byte Length)> list)

--- a/BGPLite.Providers/SourceLoadResult.cs
+++ b/BGPLite.Providers/SourceLoadResult.cs
@@ -1,0 +1,22 @@
+namespace BGPLite.Providers;
+
+/// <summary>
+/// Result of loading a prefix source — carries the parsed prefixes plus the HTTP validators
+/// (ETag / Last-Modified) that enable conditional re-fetches on subsequent loads (#214).
+/// When <see cref="NotModified"/> is true, the server returned 304 Not Modified and the caller
+/// should keep the existing cached data (just refresh the timestamp).
+/// </summary>
+public sealed record SourceLoadResult(
+    IReadOnlyList<(uint Prefix, byte Length)> Prefixes,
+    string? ETag = null,
+    DateTimeOffset? LastModified = null,
+    bool NotModified = false)
+{
+    /// <summary>Convenience for a normal (200 OK) load — prefixes + validators from the response.</summary>
+    public static SourceLoadResult Ok(IReadOnlyList<(uint Prefix, byte Length)> prefixes, string? etag = null, DateTimeOffset? lastModified = null) =>
+        new(prefixes, etag, lastModified, NotModified: false);
+
+    /// <summary>Convenience for a 304 Not Modified response — no prefixes, caller keeps cached data.</summary>
+    public static SourceLoadResult NotModifiedResult(string? etag = null, DateTimeOffset? lastModified = null) =>
+        new([], etag, lastModified, NotModified: true);
+}

--- a/BGPLite.Server/BgpServer.cs
+++ b/BGPLite.Server/BgpServer.cs
@@ -368,15 +368,26 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
             .FirstOrDefault();
     }
 
-    /// <summary>#214: Refresh ALL established sessions — used by the auto-refresh timer.</summary>
+    /// <summary>#214: Refresh ALL established sessions — used by the auto-refresh timer.
+    /// Each session is refreshed independently so a hung/slow peer doesn't block the rest.</summary>
     public async Task RefreshAllEstablishedAsync()
     {
         var established = _sessions.Values.Where(s => s.IsEstablished).ToList();
         if (established.Count == 0) return;
 
         _logger.LogInformation("Auto-refresh: refreshing {Count} established sessions", established.Count);
+        var failures = 0;
         foreach (var session in established)
-            await session.RefreshRoutesAsync();
+        {
+            try { await session.RefreshRoutesAsync(); }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                failures++;
+                _logger.LogWarning(ex, "Auto-refresh: failed to refresh session {Peer}", session.Peer);
+            }
+        }
+        if (failures > 0)
+            _logger.LogWarning("Auto-refresh: {Failed}/{Total} sessions failed to refresh", failures, established.Count);
     }
 
     public void Dispose()

--- a/BGPLite.Server/BgpServer.cs
+++ b/BGPLite.Server/BgpServer.cs
@@ -368,8 +368,9 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
             .FirstOrDefault();
     }
 
-    /// <summary>#214: Refresh ALL established sessions — used by the auto-refresh timer.
-    /// Each session is refreshed independently so a hung/slow peer doesn't block the rest.</summary>
+    /// <summary>#214: Refresh ALL established sessions concurrently — used by the auto-refresh timer
+    /// and the onSourceChanged convergence callback. Sessions refresh in parallel so a single slow
+    /// peer (TCP receive window full → WriteAsync blocks) can't stall the rest.</summary>
     public async Task RefreshAllEstablishedAsync()
     {
         var established = _sessions.Values.Where(s => s.IsEstablished).ToList();
@@ -377,15 +378,18 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
 
         _logger.LogInformation("Auto-refresh: refreshing {Count} established sessions", established.Count);
         var failures = 0;
-        foreach (var session in established)
+        // Parallel: each session refreshes independently. Per-session try/catch keeps one failure
+        // from faulting the aggregate — collected here for the summary log.
+        var tasks = established.Select(async session =>
         {
             try { await session.RefreshRoutesAsync(); }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                failures++;
+                Interlocked.Increment(ref failures);
                 _logger.LogWarning(ex, "Auto-refresh: failed to refresh session {Peer}", session.Peer);
             }
-        }
+        }).ToArray();
+        await Task.WhenAll(tasks);
         if (failures > 0)
             _logger.LogWarning("Auto-refresh: {Failed}/{Total} sessions failed to refresh", failures, established.Count);
     }

--- a/BGPLite.Server/BgpServer.cs
+++ b/BGPLite.Server/BgpServer.cs
@@ -368,6 +368,17 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
             .FirstOrDefault();
     }
 
+    /// <summary>#214: Refresh ALL established sessions — used by the auto-refresh timer.</summary>
+    public async Task RefreshAllEstablishedAsync()
+    {
+        var established = _sessions.Values.Where(s => s.IsEstablished).ToList();
+        if (established.Count == 0) return;
+
+        _logger.LogInformation("Auto-refresh: refreshing {Count} established sessions", established.Count);
+        foreach (var session in established)
+            await session.RefreshRoutesAsync();
+    }
+
     public void Dispose()
     {
         Volatile.Write(ref _acceptingConnections, 0);

--- a/BGPLite.Server/ISessionManager.cs
+++ b/BGPLite.Server/ISessionManager.cs
@@ -10,4 +10,6 @@ public interface ISessionManager
     List<string> GetActivePeerIps();
     /// <summary>Actual advertised prefix count (post-aggregation, post-dedup), or 0 (#212).</summary>
     int GetAdvertisedPrefixCount(string peerIp, uint asn);
+    /// <summary>#214: Refresh ALL established sessions (unsolicited UPDATE to every peer).</summary>
+    Task RefreshAllEstablishedAsync();
 }

--- a/BGPLite.Tests/FilePrefixProviderTests.cs
+++ b/BGPLite.Tests/FilePrefixProviderTests.cs
@@ -15,7 +15,7 @@ public class FilePrefixProviderTests
         {
             var provider = new FilePrefixProvider(NullLogger<FilePrefixProvider>.Instance);
             var result = await provider.LoadAsync(new PrefixSourceConfig { Name = "t", Kind = "file", Path = path });
-            Assert.Equal(2, result.Count);
+            Assert.Equal(2, result.Prefixes.Count);
         }
         finally { File.Delete(path); }
     }

--- a/BGPLite.Tests/HttpPrefixProviderTests.cs
+++ b/BGPLite.Tests/HttpPrefixProviderTests.cs
@@ -77,7 +77,7 @@ public class HttpPrefixProviderTests
     {
         var provider = Provider(new StubHandler(HttpStatusCode.OK, "1.2.3.0/24\n5.6.0.0/16\n"));
         var result = await provider.LoadAsync(HttpSource("https://raw.githubusercontent.com/o/r/main/x.txt"));
-        Assert.Equal(2, result.Count);
+        Assert.Equal(2, result.Prefixes.Count);
     }
 
     [Fact]
@@ -89,7 +89,7 @@ public class HttpPrefixProviderTests
 
         var result = await provider.LoadAsync(HttpSource("https://example.com/lists/ru.txt"));
 
-        Assert.Single(result);
+        Assert.Single(result.Prefixes);
         Assert.Equal("https://example.com/lists/ru.txt", handler.LastRequestUri!.ToString());
     }
 

--- a/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
+++ b/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
@@ -1,0 +1,220 @@
+using BGPLite.Configuration;
+using BGPLite.Providers;
+using BGPLite.Server;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// Tests for <see cref="PrefixAutoRefreshService"/> (#214): per-source poll interval and jitter.
+/// Uses <see cref="FakeTimeProvider"/> to advance the clock instantly (no real-second waits) and a
+/// counting fake <see cref="IPrefixSourceService"/> to assert which sources were polled when.
+/// </summary>
+public class PrefixAutoRefreshServiceTests
+{
+    /// <summary>
+    /// A fake IPrefixSourceService that counts RefreshAsync calls per source name and reports a
+    /// configurable change outcome. Used to assert poll frequency per source. Set ReportChanged=true
+    /// to make RefreshAsync return true (triggers a peer refresh).
+    /// </summary>
+    private class CountingPrefixSourceService : IPrefixSourceService
+    {
+        public Dictionary<string, int> RefreshCalls { get; } = new();
+        public Dictionary<string, bool> Conditional { get; } = new();
+        public bool ReportChanged { get; set; }
+
+        public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default)
+        {
+            RefreshCalls[sourceName] = RefreshCalls.TryGetValue(sourceName, out var c) ? c + 1 : 1;
+            return Task.FromResult(ReportChanged);
+        }
+
+        public bool SourceSupportsConditional(string sourceName)
+            => Conditional.TryGetValue(sourceName, out var v) ? v : true;
+
+        // Unused by the auto-refresh service (it reads source names from AppConfig), but required by the interface.
+        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<(uint Prefix, byte Length)>)>>([]);
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetDefaultAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    /// <summary>A no-op ISessionManager that records RefreshAllEstablishedAsync invocations.</summary>
+    private sealed class RecordingSessionManager : ISessionManager
+    {
+        public int RefreshAllCalls;
+        public Task RefreshPeerAsync(string peerIp, uint asn) => Task.CompletedTask;
+        public List<string> GetActivePeerIps() => [];
+        public int GetAdvertisedPrefixCount(string peerIp, uint asn) => 0;
+        public Task RefreshAllEstablishedAsync() { RefreshAllCalls++; return Task.CompletedTask; }
+    }
+
+    private static AppConfig ConfigWith(AutoRefreshConfig autoRefresh, params (string Name, string Kind)[] sources)
+    {
+        var yaml = "Bgp:\n  Asn: 65444\n  RouterId: 10.0.0.1\nPrefixSources:\n";
+        foreach (var (name, kind) in sources)
+            yaml += $"  - Name: {name}\n    Kind: {kind}\n";
+        yaml += $"AutoRefresh:\n  Enabled: {autoRefresh.Enabled.ToString().ToLower()}" +
+                $"\n  IntervalSeconds: {autoRefresh.IntervalSeconds}" +
+                $"\n  NoEtagIntervalSeconds: {autoRefresh.NoEtagIntervalSeconds}" +
+                $"\n  MaxJitterMs: {autoRefresh.MaxJitterMs}\n";
+        return ConfigLoader.LoadFromText(yaml);
+    }
+
+    /// <summary>
+    /// #214: a source supporting conditional requests is polled at IntervalSeconds; a source without
+    /// ETag support (asn) is polled at the longer NoEtagIntervalSeconds. On a timer tick that falls
+    /// between the two intervals, only the conditional source is re-polled.
+    /// </summary>
+    [Fact]
+    public async Task PollsConditionalSourceMoreOftenThanNoEtagSource()
+    {
+        var time = new FakeTimeProvider();
+        var svc = new CountingPrefixSourceService
+        {
+            Conditional = { ["http-src"] = true, ["asn-src"] = false }
+        };
+        var sessions = new RecordingSessionManager();
+        var config = ConfigWith(
+            new AutoRefreshConfig { Enabled = true, IntervalSeconds = 60, NoEtagIntervalSeconds = 600, MaxJitterMs = 0 },
+            ("http-src", "http"), ("asn-src", "asn"));
+        // tick = min(60, 600) = 60s
+        using var service = new PrefixAutoRefreshService(svc, sessions, config,
+            NullLogger<PrefixAutoRefreshService>.Instance, time, new Random(0));
+
+        await service.StartAsync(CancellationToken.None);
+
+        // Tick 1 (t=60s): both sources due (first check) → 1 call each.
+        time.Advance(TimeSpan.FromSeconds(60));
+        await Task.Delay(50); // let the loop observe the tick
+        Assert.Equal(1, svc.RefreshCalls.GetValueOrDefault("http-src"));
+        Assert.Equal(1, svc.RefreshCalls.GetValueOrDefault("asn-src"));
+
+        // Tick 2 (t=120s): http-src due again (interval=60s), asn-src NOT due (next at 60+600=660s).
+        time.Advance(TimeSpan.FromSeconds(60));
+        await Task.Delay(50);
+        Assert.Equal(2, svc.RefreshCalls.GetValueOrDefault("http-src"));
+        Assert.Equal(1, svc.RefreshCalls.GetValueOrDefault("asn-src"));
+
+        await service.StopAsync(CancellationToken.None);
+    }
+
+    /// <summary>
+    /// #214: jitter applies a delay between source checks within a tick. With MaxJitterMs=100 and two
+    /// sources, the second source's RefreshAsync is NOT called until the clock has advanced past the
+    /// jitter window. Verified by checking the call happens only AFTER advancing FakeTimeProvider.
+    /// </summary>
+    [Fact]
+    public async Task JitterDelaysBetweenSourceChecks()
+    {
+        var time = new FakeTimeProvider();
+        var svc = new CountingPrefixSourceService
+        {
+            Conditional = { ["a"] = true, ["b"] = true }
+        };
+        var sessions = new RecordingSessionManager();
+        var config = ConfigWith(
+            new AutoRefreshConfig { Enabled = true, IntervalSeconds = 60, NoEtagIntervalSeconds = 60, MaxJitterMs = 5000 },
+            ("a", "http"), ("b", "http"));
+        using var service = new PrefixAutoRefreshService(svc, sessions, config,
+            NullLogger<PrefixAutoRefreshService>.Instance, time, new Random(0));
+
+        await service.StartAsync(CancellationToken.None);
+
+        // Tick 1 (t=60s): first source checked immediately (no jitter on the very first check), then
+        // the second is delayed by jitter (0..5000ms). Advance the clock to release the jittered delay.
+        time.Advance(TimeSpan.FromSeconds(60));
+        await Task.Delay(50); // let the loop start the tick
+        // Only 'a' (first source, no jitter) has been polled so far; 'b' is waiting on the jitter delay.
+        Assert.Equal(1, svc.RefreshCalls.GetValueOrDefault("a"));
+        Assert.Equal(0, svc.RefreshCalls.GetValueOrDefault("b"));
+
+        // Advance past the jitter window (Random(0).Next(0, 5001) is deterministic = some value ≤5000ms).
+        time.Advance(TimeSpan.FromMilliseconds(5000));
+        await Task.Delay(50);
+        // Now 'b' has been polled too.
+        Assert.Equal(1, svc.RefreshCalls.GetValueOrDefault("b"));
+
+        await service.StopAsync(CancellationToken.None);
+    }
+
+    /// <summary>#214: disabled by default — StartAsync is a no-op, no timer/loop is created.</summary>
+    [Fact]
+    public async Task DisabledByDefault_NoTimerCreated()
+    {
+        var time = new FakeTimeProvider();
+        var svc = new CountingPrefixSourceService();
+        var sessions = new RecordingSessionManager();
+        var config = ConfigWith(new AutoRefreshConfig { Enabled = false }, ("a", "http"));
+        using var service = new PrefixAutoRefreshService(svc, sessions, config,
+            NullLogger<PrefixAutoRefreshService>.Instance, time);
+
+        await service.StartAsync(CancellationToken.None);
+
+        // Advancing the clock must NOT trigger any refresh (service disabled).
+        time.Advance(TimeSpan.FromHours(1));
+        await Task.Delay(50);
+        Assert.Empty(svc.RefreshCalls);
+        Assert.Equal(0, sessions.RefreshAllCalls);
+
+        await service.StopAsync(CancellationToken.None);
+    }
+
+    /// <summary>#214: when a source reports changed, all established peers get a refresh push.</summary>
+    [Fact]
+    public async Task ChangedSource_TriggersPeerRefresh()
+    {
+        var time = new FakeTimeProvider();
+        var svc = new CountingPrefixSourceService { Conditional = { ["a"] = true }, ReportChanged = true };
+        var sessions = new RecordingSessionManager();
+        var config = ConfigWith(
+            new AutoRefreshConfig { Enabled = true, IntervalSeconds = 60, NoEtagIntervalSeconds = 60, MaxJitterMs = 0 },
+            ("a", "http"));
+        using var service = new PrefixAutoRefreshService(svc, sessions, config,
+            NullLogger<PrefixAutoRefreshService>.Instance, time, new Random(0));
+
+        await service.StartAsync(CancellationToken.None);
+
+        time.Advance(TimeSpan.FromSeconds(60));
+        await Task.Delay(50);
+
+        Assert.Equal(1, sessions.RefreshAllCalls);
+
+        await service.StopAsync(CancellationToken.None);
+    }
+
+    /// <summary>
+    /// #214 regression: multiple changed sources in one tick trigger a SINGLE peer refresh (aggregated
+    /// push), not one-per-source plus one. The convergence callback must NOT fire from the auto-refresh
+    /// RefreshAsync path (that would double-push); only LoopAsync aggregates and pushes once.
+    /// </summary>
+    [Fact]
+    public async Task MultipleChangedSources_SingleAggregatedPeerRefresh()
+    {
+        var time = new FakeTimeProvider();
+        var svc = new CountingPrefixSourceService
+        {
+            Conditional = { ["a"] = true, ["b"] = true, ["c"] = true },
+            ReportChanged = true
+        };
+        var sessions = new RecordingSessionManager();
+        var config = ConfigWith(
+            new AutoRefreshConfig { Enabled = true, IntervalSeconds = 60, NoEtagIntervalSeconds = 60, MaxJitterMs = 0 },
+            ("a", "http"), ("b", "http"), ("c", "http"));
+        using var service = new PrefixAutoRefreshService(svc, sessions, config,
+            NullLogger<PrefixAutoRefreshService>.Instance, time, new Random(0));
+
+        await service.StartAsync(CancellationToken.None);
+
+        time.Advance(TimeSpan.FromSeconds(60));
+        await Task.Delay(50);
+
+        // All 3 sources changed, but exactly ONE aggregated peer refresh (not 3+1).
+        Assert.Equal(1, sessions.RefreshAllCalls);
+
+        await service.StopAsync(CancellationToken.None);
+    }
+}

--- a/BGPLite.Tests/PrefixSourceProviderFactoryTests.cs
+++ b/BGPLite.Tests/PrefixSourceProviderFactoryTests.cs
@@ -9,6 +9,7 @@ public class PrefixSourceProviderFactoryTests
     {
         public string Kind { get; }
         public StubProvider(string kind) => Kind = kind;
+        public bool SupportsConditionalRequests => true;
         public Task<SourceLoadResult> LoadAsync(PrefixSourceConfig source, string? etag = null, DateTimeOffset? lastModified = null, CancellationToken ct = default)
             => Task.FromResult(SourceLoadResult.Ok([]));
     }

--- a/BGPLite.Tests/PrefixSourceProviderFactoryTests.cs
+++ b/BGPLite.Tests/PrefixSourceProviderFactoryTests.cs
@@ -9,8 +9,8 @@ public class PrefixSourceProviderFactoryTests
     {
         public string Kind { get; }
         public StubProvider(string kind) => Kind = kind;
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> LoadAsync(PrefixSourceConfig source, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint, byte)>>([]);
+        public Task<SourceLoadResult> LoadAsync(PrefixSourceConfig source, string? etag = null, DateTimeOffset? lastModified = null, CancellationToken ct = default)
+            => Task.FromResult(SourceLoadResult.Ok([]));
     }
 
     [Fact]

--- a/BGPLite.Tests/PrefixSourceServiceTests.cs
+++ b/BGPLite.Tests/PrefixSourceServiceTests.cs
@@ -344,11 +344,27 @@ public class PrefixSourceServiceTests
     }
 
     /// <summary>
-    /// #214 convergence: when a connect-path load (GetAsync) detects a content change, the
-    /// onSourceChanged callback fires so established peers get the update too — not just the
-    /// auto-refresh path. Without this, a silent cache update via GetAsync masks the change from a
-    /// subsequent RefreshAsync, leaving established peers on stale routes.
+    /// #214 order-independence: RIPEstat and some HTTP sources return the same prefix set in a different
+    /// order between requests. SequenceEqual there would report a phantom change and trigger an
+    /// unnecessary BGP re-announcement. SamePrefixes must treat them as unchanged.
     /// </summary>
+    [Fact]
+    public async Task RefreshAsync_OrderIndependentComparison_NoPhantomChange()
+    {
+        // v1 and v2 contain the SAME prefixes in a DIFFERENT order → must report unchanged.
+        var provider = new SequenceProvider(
+            [(1u, (byte)24), (2u, (byte)16)],   // call 1: [a, b]
+            [(2u, (byte)16), (1u, (byte)24)]);  // call 2: [b, a] — same set, reversed
+        var svc = new PrefixSourceService(
+            ConfigWith("ru"),
+            new PrefixSourceProviderFactory([provider]),
+            NullLogger<PrefixSourceService>.Instance);
+
+        await svc.GetAsync("ru");        // prime with v1
+        var changed = await svc.RefreshAsync("ru");  // v2 = same set, different order
+
+        Assert.False(changed, "a re-ordered prefix set must NOT be reported as a change");
+    }
     [Fact]
     public async Task GetAsync_OnChange_InvokesCallback()
     {

--- a/BGPLite.Tests/PrefixSourceServiceTests.cs
+++ b/BGPLite.Tests/PrefixSourceServiceTests.cs
@@ -13,17 +13,17 @@ public class PrefixSourceServiceTests
         private readonly IReadOnlyList<(uint, byte)> _list;
         public CountingProvider(IReadOnlyList<(uint, byte)> list) => _list = list;
 
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> LoadAsync(PrefixSourceConfig source, CancellationToken ct = default)
+        public Task<SourceLoadResult> LoadAsync(PrefixSourceConfig source, string? etag = null, DateTimeOffset? lastModified = null, CancellationToken ct = default)
         {
             Calls++;
-            return Task.FromResult(_list);
+            return Task.FromResult(SourceLoadResult.Ok(_list));
         }
     }
 
     private sealed class ThrowingProvider : IPrefixSourceProvider
     {
         public string Kind => "stub";
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> LoadAsync(PrefixSourceConfig source, CancellationToken ct = default)
+        public Task<SourceLoadResult> LoadAsync(PrefixSourceConfig source, string? etag = null, DateTimeOffset? lastModified = null, CancellationToken ct = default)
             => throw new InvalidOperationException("boom");
     }
 
@@ -139,11 +139,11 @@ public class PrefixSourceServiceTests
         private readonly IReadOnlyList<(uint, byte)> _first;
         public ToggleProvider(IReadOnlyList<(uint, byte)> first) => _first = first;
 
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> LoadAsync(PrefixSourceConfig source, CancellationToken ct = default)
+        public Task<SourceLoadResult> LoadAsync(PrefixSourceConfig source, string? etag = null, DateTimeOffset? lastModified = null, CancellationToken ct = default)
         {
             _calls++;
             return _calls == 1
-                ? Task.FromResult(_first)
+                ? Task.FromResult(SourceLoadResult.Ok(_first))
                 : throw new InvalidOperationException("boom");
         }
     }

--- a/BGPLite.Tests/PrefixSourceServiceTests.cs
+++ b/BGPLite.Tests/PrefixSourceServiceTests.cs
@@ -9,6 +9,7 @@ public class PrefixSourceServiceTests
     private sealed class CountingProvider : IPrefixSourceProvider
     {
         public string Kind => "stub";
+        public bool SupportsConditionalRequests => true;
         public int Calls { get; private set; }
         private readonly IReadOnlyList<(uint, byte)> _list;
         public CountingProvider(IReadOnlyList<(uint, byte)> list) => _list = list;
@@ -23,6 +24,7 @@ public class PrefixSourceServiceTests
     private sealed class ThrowingProvider : IPrefixSourceProvider
     {
         public string Kind => "stub";
+        public bool SupportsConditionalRequests => true;
         public Task<SourceLoadResult> LoadAsync(PrefixSourceConfig source, string? etag = null, DateTimeOffset? lastModified = null, CancellationToken ct = default)
             => throw new InvalidOperationException("boom");
     }
@@ -135,6 +137,7 @@ public class PrefixSourceServiceTests
     private sealed class ToggleProvider : IPrefixSourceProvider
     {
         public string Kind => "stub";
+        public bool SupportsConditionalRequests => true;
         private int _calls;
         private readonly IReadOnlyList<(uint, byte)> _first;
         public ToggleProvider(IReadOnlyList<(uint, byte)> first) => _first = first;
@@ -190,5 +193,183 @@ public class PrefixSourceServiceTests
                 NullLogger<PrefixSourceService>.Instance));
 
         Assert.Contains("ru", ex.Message);
+    }
+
+    /// <summary>
+    /// Returns a different prefix list on each call — used to exercise #214 change-detection in
+    /// RefreshAsync (the first call populates the cache, subsequent calls return a new list that must
+    /// be detected as "changed"). Yields before returning so the call is genuinely async (mirrors real
+    /// HttpPrefixProvider/AsnPrefixProvider) — required for the TOCTOU test to actually exercise the
+    /// race where a concurrent GetAsync may enter the per-source gate first.
+    /// </summary>
+    private sealed class SequenceProvider : IPrefixSourceProvider
+    {
+        public string Kind => "stub";
+        public bool SupportsConditionalRequests => true;
+        public int Calls { get; private set; }
+        private readonly IReadOnlyList<IReadOnlyList<(uint, byte)>> _lists;
+        public SequenceProvider(params IReadOnlyList<(uint, byte)>[] lists) => _lists = lists;
+
+        public async Task<SourceLoadResult> LoadAsync(PrefixSourceConfig source, string? etag = null, DateTimeOffset? lastModified = null, CancellationToken ct = default)
+        {
+            await Task.Yield();
+            var list = _lists[Math.Min(Calls, _lists.Count - 1)];
+            Calls++;
+            return SourceLoadResult.Ok(list);
+        }
+    }
+
+    /// <summary>Returns NotModified when etag is supplied, else Ok(list) — exercises the 304 branch.</summary>
+    private sealed class ConditionalProvider : IPrefixSourceProvider
+    {
+        public string Kind => "stub";
+        public bool SupportsConditionalRequests => true;
+        public int Calls { get; private set; }
+        private readonly IReadOnlyList<(uint, byte)> _list;
+        public ConditionalProvider(IReadOnlyList<(uint, byte)> list) => _list = list;
+
+        public Task<SourceLoadResult> LoadAsync(PrefixSourceConfig source, string? etag = null, DateTimeOffset? lastModified = null, CancellationToken ct = default)
+        {
+            Calls++;
+            // Second+ call with an etag → 304 Not Modified (data unchanged).
+            return Task.FromResult(etag is null
+                ? SourceLoadResult.Ok(_list, etag: "\"v1\"")
+                : SourceLoadResult.NotModifiedResult(etag: "\"v1\""));
+        }
+    }
+
+    /// <summary>#214: RefreshAsync reports true when the source content actually changed.</summary>
+    [Fact]
+    public async Task RefreshAsync_ReportsChanged_WhenContentDiffers()
+    {
+        var provider = new SequenceProvider([(1u, (byte)24)], [(1u, (byte)24), (2u, (byte)16)]);
+        var svc = new PrefixSourceService(
+            ConfigWith("ru"),
+            new PrefixSourceProviderFactory([provider]),
+            NullLogger<PrefixSourceService>.Instance);
+
+        // Prime the cache via the normal load path (first list).
+        await svc.GetAsync("ru");
+        // Force-refresh: provider returns the second (different) list → changed=true.
+        var changed = await svc.RefreshAsync("ru");
+
+        Assert.True(changed);
+        Assert.Equal(2, provider.Calls);
+    }
+
+    /// <summary>#214: RefreshAsync reports false when the source content is identical (no change).</summary>
+    [Fact]
+    public async Task RefreshAsync_ReportsUnchanged_WhenContentIdentical()
+    {
+        var provider = new SequenceProvider([(1u, (byte)24)], [(1u, (byte)24)]);
+        var svc = new PrefixSourceService(
+            ConfigWith("ru"),
+            new PrefixSourceProviderFactory([provider]),
+            NullLogger<PrefixSourceService>.Instance);
+
+        await svc.GetAsync("ru");
+        var changed = await svc.RefreshAsync("ru");
+
+        Assert.False(changed);
+    }
+
+    /// <summary>#214: a 304 Not Modified response is reported as unchanged (data identical by definition).</summary>
+    [Fact]
+    public async Task RefreshAsync_ReportsUnchanged_OnNotModified304()
+    {
+        var provider = new ConditionalProvider([(1u, (byte)24)]);
+        var svc = new PrefixSourceService(
+            ConfigWith("ru"),
+            new PrefixSourceProviderFactory([provider]),
+            NullLogger<PrefixSourceService>.Instance);
+
+        await svc.GetAsync("ru");       // first load: Ok(list, etag)
+        var changed = await svc.RefreshAsync("ru");  // second load: 304 Not Modified
+
+        Assert.False(changed, "a 304 response means the content is unchanged");
+        Assert.Equal(2, provider.Calls);
+    }
+
+    /// <summary>
+    /// #214 TOCTOU regression: the changed-detection must be computed inside the per-source gate, so a
+    /// concurrent GetAsync (TTL-expired connect path) that itself loads the new list cannot mask the
+    /// change by making before==after. SequenceProvider returns the new list on the 2nd call regardless
+    /// of which caller wins the gate — and RefreshAsync must still report changed=true.
+    /// </summary>
+    [Fact]
+    public async Task RefreshAsync_DetectsChange_DespiteConcurrentGetAsync()
+    {
+        var provider = new SequenceProvider([(1u, (byte)24)], [(1u, (byte)24), (2u, (byte)16)]);
+        var svc = new PrefixSourceService(
+            ConfigWith("ru"),
+            new PrefixSourceProviderFactory([provider]),
+            NullLogger<PrefixSourceService>.Instance,
+            cacheTtl: TimeSpan.Zero); // TTL=0 forces GetAsync to always refetch (races RefreshAsync)
+
+        await svc.GetAsync("ru"); // prime with first list
+
+        // Concurrent: GetAsync (TTL=0 → refetches, may grab the gate first) and RefreshAsync.
+        var getTask = Task.Run(() => svc.GetAsync("ru"));
+        var refreshTask = svc.RefreshAsync("ru");
+        await Task.WhenAll(getTask, refreshTask);
+
+        // Regardless of which task loaded the new list first, RefreshAsync must report the change.
+        Assert.True(await refreshTask, "RefreshAsync must detect the change even if GetAsync raced ahead");
+    }
+
+    /// <summary>#214: SourceSupportsConditional reflects the provider's SupportsConditionalRequests.</summary>
+    [Fact]
+    public void SourceSupportsConditional_ReflectsProvider()
+    {
+        var etagProvider = new CountingProvider([(1u, (byte)24)]);
+        var noEtagProvider = new NoEtagStubProvider();
+        var yaml = "Bgp:\n  Asn: 65444\n  RouterId: 10.0.0.1\n" +
+                   "PrefixSources:\n  - Name: http-src\n    Kind: http\n  - Name: asn-src\n    Kind: asn\n";
+        var svc = new PrefixSourceService(
+            ConfigLoader.LoadFromText(yaml),
+            new PrefixSourceProviderFactory([etagProvider, noEtagProvider]),
+            NullLogger<PrefixSourceService>.Instance);
+
+        Assert.True(svc.SourceSupportsConditional("http-src"));
+        Assert.False(svc.SourceSupportsConditional("asn-src"));
+    }
+
+    /// <summary>A stub provider that does NOT support conditional requests (Kind="asn"-like).</summary>
+    private sealed class NoEtagStubProvider : IPrefixSourceProvider
+    {
+        public string Kind => "asn";
+        public bool SupportsConditionalRequests => false;
+        public Task<SourceLoadResult> LoadAsync(PrefixSourceConfig source, string? etag = null, DateTimeOffset? lastModified = null, CancellationToken ct = default)
+            => Task.FromResult(SourceLoadResult.Ok([(1u, (byte)24)]));
+    }
+
+    /// <summary>
+    /// #214 convergence: when a connect-path load (GetAsync) detects a content change, the
+    /// onSourceChanged callback fires so established peers get the update too — not just the
+    /// auto-refresh path. Without this, a silent cache update via GetAsync masks the change from a
+    /// subsequent RefreshAsync, leaving established peers on stale routes.
+    /// </summary>
+    [Fact]
+    public async Task GetAsync_OnChange_InvokesCallback()
+    {
+        // v1 (first load) → v2 (changed) → v2 again (no change). Models: source changes once, then
+        // stays stable; a subsequent TTL-expired GetAsync must NOT re-fire the callback.
+        var provider = new SequenceProvider(
+            [(1u, (byte)24)],                       // call 1: v1
+            [(1u, (byte)24), (2u, (byte)16)],        // call 2: v2 (changed)
+            [(1u, (byte)24), (2u, (byte)16)]);       // call 3: v2 (same — no change)
+        var changed = new List<string>();
+        var svc = new PrefixSourceService(
+            ConfigWith("ru"),
+            new PrefixSourceProviderFactory([provider]),
+            NullLogger<PrefixSourceService>.Instance,
+            cacheTtl: TimeSpan.Zero,
+            onSourceChanged: name => { changed.Add(name); return Task.CompletedTask; });
+
+        await svc.GetAsync("ru"); // v1 → cache empty → change → callback
+        await svc.GetAsync("ru"); // v2 → differs from v1 → change → callback
+        await svc.GetAsync("ru"); // v2 → identical → NO change → no callback
+
+        Assert.Equal(2, changed.Count(n => n == "ru"));
     }
 }

--- a/BGPLite/PrefixAutoRefreshService.cs
+++ b/BGPLite/PrefixAutoRefreshService.cs
@@ -167,16 +167,28 @@ internal sealed class PrefixAutoRefreshService : IHostedService, IDisposable
                     await Task.Delay(jitter, _timeProvider, ct);
             }
 
-            var isChanged = await _prefixSources.RefreshAsync(name, ct);
-            if (isChanged)
-                changed.Add(name);
-            polledInThisCycle++;
+            // Per-source isolation: a single failing source (RefreshAsync throws unexpectedly, or
+            // SourceSupportsConditional faults on a bad factory lookup) must NOT abort the whole cycle
+            // and skip the remaining due sources. RefreshAsync already swallows per-source load errors
+            // internally (returns false); this guards the rest of the iteration.
+            try
+            {
+                var isChanged = await _prefixSources.RefreshAsync(name, ct);
+                if (isChanged)
+                    changed.Add(name);
+                polledInThisCycle++;
 
-            // Schedule the next check based on whether the source supports conditional requests:
-            // 304-capable sources are cheap → short interval; RIPEstat-style → long interval.
-            var supportsConditional = _prefixSources.SourceSupportsConditional(name);
-            var interval = supportsConditional ? etagInterval : noEtagInterval;
-            _nextCheck[name] = _timeProvider.GetUtcNow() + interval;
+                // Schedule the next check based on whether the source supports conditional requests:
+                // 304-capable sources are cheap → short interval; RIPEstat-style → long interval.
+                var supportsConditional = _prefixSources.SourceSupportsConditional(name);
+                var interval = supportsConditional ? etagInterval : noEtagInterval;
+                _nextCheck[name] = _timeProvider.GetUtcNow() + interval;
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Auto-refresh: source '{Name}' check failed; skipping this cycle", name);
+            }
         }
         return changed;
     }

--- a/BGPLite/PrefixAutoRefreshService.cs
+++ b/BGPLite/PrefixAutoRefreshService.cs
@@ -11,6 +11,18 @@ namespace BGPLite;
 /// requests (ETag / Last-Modified → 304 Not Modified) so unchanged sources cost ~1 KB per check.
 /// Only sources whose data actually changed trigger peer route refreshes — no unnecessary BGP churn.
 /// <para>
+/// Per-source poll interval: sources supporting conditional requests (HTTP/file) are polled at
+/// <see cref="AutoRefreshConfig.IntervalSeconds"/> (304s are cheap); sources without ETag support
+/// (RIPEstat ASN) at the longer <see cref="AutoRefreshConfig.NoEtagIntervalSeconds"/> to avoid
+/// hammering the upstream. A single timer ticks at <c>min(IntervalSeconds, NoEtagIntervalSeconds)</c>;
+/// each tick re-polls only sources whose per-source next-check time has elapsed.
+/// </para>
+/// <para>
+/// Jitter: between source checks within a tick, a random delay up to
+/// <see cref="AutoRefreshConfig.MaxJitterMs"/> spreads conditional requests to avoid a burst to the
+/// same host (GitHub rate limits, RIPEstat 429s).
+/// </para>
+/// <para>
 /// Disabled by default. Enable via <c>AutoRefresh: Enabled: true</c> in config.
 /// </para>
 /// </summary>
@@ -21,7 +33,13 @@ internal sealed class PrefixAutoRefreshService : IHostedService, IDisposable
     private readonly AutoRefreshConfig _config;
     private readonly ILogger<PrefixAutoRefreshService> _logger;
     private readonly TimeProvider _timeProvider;
+    private readonly Random _jitterRandom;
     private readonly CancellationTokenSource _cts = new();
+    // Source names are fixed at process start (config is not hot-reloaded for PrefixSources). Captured
+    // once from AppConfig — avoids sync-over-async enumeration through the service at tick time.
+    private readonly List<string> _sourceNames;
+    // Per-source next-check instant (UTC). A source is re-polled when the timer ticks past this.
+    private readonly Dictionary<string, DateTimeOffset> _nextCheck = new();
     private PeriodicTimer? _timer;
     private Task? _loopTask;
 
@@ -30,13 +48,16 @@ internal sealed class PrefixAutoRefreshService : IHostedService, IDisposable
         ISessionManager sessionManager,
         AppConfig appConfig,
         ILogger<PrefixAutoRefreshService> logger,
-        TimeProvider? timeProvider = null)
+        TimeProvider? timeProvider = null,
+        Random? jitterRandom = null)
     {
         _prefixSources = prefixSources;
         _sessionManager = sessionManager;
         _config = appConfig.AutoRefresh ?? new AutoRefreshConfig();
         _logger = logger;
         _timeProvider = timeProvider ?? TimeProvider.System;
+        _jitterRandom = jitterRandom ?? new Random();
+        _sourceNames = [.. appConfig.PrefixSources.Select(s => s.Name)];
     }
 
     public Task StartAsync(CancellationToken cancellationToken)
@@ -54,11 +75,18 @@ internal sealed class PrefixAutoRefreshService : IHostedService, IDisposable
             return Task.CompletedTask;
         }
 
-        var interval = TimeSpan.FromSeconds(Math.Max(60, _config.IntervalSeconds));
-        _timer = new PeriodicTimer(interval, _timeProvider);
+        var intervalSeconds = Math.Max(60, _config.IntervalSeconds);
+        var noEtagSeconds = _config.NoEtagIntervalSeconds > 0
+            ? Math.Max(intervalSeconds, _config.NoEtagIntervalSeconds)
+            : intervalSeconds;
+        // Tick at the shorter interval so conditional sources are polled on schedule; non-conditional
+        // sources are gated by their own per-source nextCheck (noEtagSeconds) and skipped on most ticks.
+        var tickSeconds = Math.Min(intervalSeconds, noEtagSeconds);
+        _timer = new PeriodicTimer(TimeSpan.FromSeconds(tickSeconds), _timeProvider);
         _loopTask = Task.Run(() => LoopAsync(_cts.Token), cancellationToken);
-        _logger.LogInformation("Auto-refresh: enabled, checking every {Interval} min",
-            interval.TotalMinutes);
+        _logger.LogInformation(
+            "Auto-refresh: enabled, tick every {Tick}s (etag interval {Etag}s, no-etag interval {NoEtag}s)",
+            tickSeconds, intervalSeconds, noEtagSeconds);
         return Task.CompletedTask;
     }
 
@@ -81,7 +109,7 @@ internal sealed class PrefixAutoRefreshService : IHostedService, IDisposable
             try
             {
                 _logger.LogDebug("Auto-refresh: starting check cycle");
-                var changed = await _prefixSources.RefreshAllAsync(ct);
+                var changed = await CheckSourcesAsync(ct);
 
                 if (changed.Count > 0)
                 {
@@ -99,6 +127,58 @@ internal sealed class PrefixAutoRefreshService : IHostedService, IDisposable
                 _logger.LogWarning(ex, "Auto-refresh: cycle failed");
             }
         }
+    }
+
+    /// <summary>
+    /// Polls every source whose next-check time has elapsed, applying jitter between checks. Returns
+    /// the names of sources whose content actually changed. Updates each polled source's next-check
+    /// time according to its conditional-request support.
+    /// </summary>
+    private async Task<HashSet<string>> CheckSourcesAsync(CancellationToken ct)
+    {
+        var changed = new HashSet<string>();
+        var now = _timeProvider.GetUtcNow();
+        var etagInterval = TimeSpan.FromSeconds(Math.Max(60, _config.IntervalSeconds));
+        var noEtagInterval = _config.NoEtagIntervalSeconds > 0
+            ? TimeSpan.FromSeconds(Math.Max(_config.IntervalSeconds, _config.NoEtagIntervalSeconds))
+            : etagInterval;
+        var maxJitter = _config.MaxJitterMs > 0
+            ? TimeSpan.FromMilliseconds(Math.Min(_config.MaxJitterMs, 60_000))
+            : TimeSpan.Zero;
+
+        var polledInThisCycle = 0;
+        foreach (var name in _sourceNames)
+        {
+            // First tick: _nextCheck has no entry yet — poll immediately to populate the cache.
+            if (_nextCheck.TryGetValue(name, out var due) && now < due)
+                continue; // not due yet (typical for no-ETag sources between their long intervals)
+
+            // Jitter between source checks within a cycle: avoids a burst of conditional requests to
+            // the same host (GitHub rate limits: 60 req/min unauthenticated). Applied before every
+            // polled source EXCEPT the first in this cycle, so startup isn't artificially delayed and
+            // sources already spaced by their per-source intervals don't stack an extra delay.
+            if (maxJitter > TimeSpan.Zero && polledInThisCycle > 0)
+            {
+                // Cap the exclusive upper bound for Random.Next at int.MaxValue to avoid overflow on
+                // the +1 (MaxJitterMs is already clamped to 60s above, so this is belt-and-braces).
+                var upperExclusive = (int)Math.Min(maxJitter.TotalMilliseconds + 1, int.MaxValue);
+                var jitter = TimeSpan.FromMilliseconds(_jitterRandom.Next(0, upperExclusive));
+                if (jitter > TimeSpan.Zero)
+                    await Task.Delay(jitter, _timeProvider, ct);
+            }
+
+            var isChanged = await _prefixSources.RefreshAsync(name, ct);
+            if (isChanged)
+                changed.Add(name);
+            polledInThisCycle++;
+
+            // Schedule the next check based on whether the source supports conditional requests:
+            // 304-capable sources are cheap → short interval; RIPEstat-style → long interval.
+            var supportsConditional = _prefixSources.SourceSupportsConditional(name);
+            var interval = supportsConditional ? etagInterval : noEtagInterval;
+            _nextCheck[name] = _timeProvider.GetUtcNow() + interval;
+        }
+        return changed;
     }
 
     public void Dispose()

--- a/BGPLite/PrefixAutoRefreshService.cs
+++ b/BGPLite/PrefixAutoRefreshService.cs
@@ -47,14 +47,18 @@ internal sealed class PrefixAutoRefreshService : IHostedService, IDisposable
             return Task.CompletedTask;
         }
 
-        // Sources without ETag (RIPEstat) are checked less often — use the longer interval.
-        // The timer fires at the shorter interval (IntervalSeconds); the loop decides per-source
-        // whether to check based on whether the source has an ETag or not.
+        // Guard: Enabled must be true AND IntervalSeconds must be > 0 (CodeRabbit #215).
+        if (_config.IntervalSeconds <= 0)
+        {
+            _logger.LogWarning("Auto-refresh: Enabled=true but IntervalSeconds={Sec} — disabled", _config.IntervalSeconds);
+            return Task.CompletedTask;
+        }
+
         var interval = TimeSpan.FromSeconds(Math.Max(60, _config.IntervalSeconds));
         _timer = new PeriodicTimer(interval, _timeProvider);
         _loopTask = Task.Run(() => LoopAsync(_cts.Token), cancellationToken);
-        _logger.LogInformation("Auto-refresh: enabled, checking every {Interval} min (no-ETag sources every {NoEtag} min)",
-            interval.TotalMinutes, _config.NoEtagIntervalSeconds / 60.0);
+        _logger.LogInformation("Auto-refresh: enabled, checking every {Interval} min",
+            interval.TotalMinutes);
         return Task.CompletedTask;
     }
 

--- a/BGPLite/PrefixAutoRefreshService.cs
+++ b/BGPLite/PrefixAutoRefreshService.cs
@@ -1,0 +1,106 @@
+using BGPLite.Configuration;
+using BGPLite.Providers;
+using BGPLite.Server;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace BGPLite;
+
+/// <summary>
+/// Background timer that periodically checks all prefix sources for changes (#214). Uses conditional
+/// requests (ETag / Last-Modified → 304 Not Modified) so unchanged sources cost ~1 KB per check.
+/// Only sources whose data actually changed trigger peer route refreshes — no unnecessary BGP churn.
+/// <para>
+/// Disabled by default. Enable via <c>AutoRefresh: Enabled: true</c> in config.
+/// </para>
+/// </summary>
+internal sealed class PrefixAutoRefreshService : IHostedService, IDisposable
+{
+    private readonly IPrefixSourceService _prefixSources;
+    private readonly ISessionManager _sessionManager;
+    private readonly AutoRefreshConfig _config;
+    private readonly ILogger<PrefixAutoRefreshService> _logger;
+    private readonly TimeProvider _timeProvider;
+    private readonly CancellationTokenSource _cts = new();
+    private PeriodicTimer? _timer;
+    private Task? _loopTask;
+
+    public PrefixAutoRefreshService(
+        IPrefixSourceService prefixSources,
+        ISessionManager sessionManager,
+        AppConfig appConfig,
+        ILogger<PrefixAutoRefreshService> logger,
+        TimeProvider? timeProvider = null)
+    {
+        _prefixSources = prefixSources;
+        _sessionManager = sessionManager;
+        _config = appConfig.AutoRefresh ?? new AutoRefreshConfig();
+        _logger = logger;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (!_config.Enabled)
+        {
+            _logger.LogDebug("Auto-refresh: disabled (AutoRefresh.Enabled = false)");
+            return Task.CompletedTask;
+        }
+
+        // Sources without ETag (RIPEstat) are checked less often — use the longer interval.
+        // The timer fires at the shorter interval (IntervalSeconds); the loop decides per-source
+        // whether to check based on whether the source has an ETag or not.
+        var interval = TimeSpan.FromSeconds(Math.Max(60, _config.IntervalSeconds));
+        _timer = new PeriodicTimer(interval, _timeProvider);
+        _loopTask = Task.Run(() => LoopAsync(_cts.Token), cancellationToken);
+        _logger.LogInformation("Auto-refresh: enabled, checking every {Interval} min (no-ETag sources every {NoEtag} min)",
+            interval.TotalMinutes, _config.NoEtagIntervalSeconds / 60.0);
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        _cts.Cancel();
+        _timer?.Dispose();
+        if (_loopTask is not null)
+        {
+            try { await _loopTask.WaitAsync(cancellationToken); }
+            catch (OperationCanceledException) { }
+            catch (Exception ex) { _logger.LogWarning(ex, "Auto-refresh loop faulted on shutdown"); }
+        }
+    }
+
+    private async Task LoopAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested && await _timer!.WaitForNextTickAsync(ct))
+        {
+            try
+            {
+                _logger.LogDebug("Auto-refresh: starting check cycle");
+                var changed = await _prefixSources.RefreshAllAsync(ct);
+
+                if (changed.Count > 0)
+                {
+                    _logger.LogInformation("Auto-refresh: {Count} sources changed — refreshing peers", changed.Count);
+                    await _sessionManager.RefreshAllEstablishedAsync();
+                }
+                else
+                {
+                    _logger.LogDebug("Auto-refresh: no sources changed");
+                }
+            }
+            catch (OperationCanceledException) { break; }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Auto-refresh: cycle failed");
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        _cts.Dispose();
+        _timer?.Dispose();
+    }
+}

--- a/BGPLite/Program.cs
+++ b/BGPLite/Program.cs
@@ -178,6 +178,14 @@ builder.Services.AddHostedService(sp => new ConfigReloader(
     sp.GetRequiredService<ManagementApi>(),
     sp.GetRequiredService<ILogger<ConfigReloader>>()));
 
+// #214: periodic auto-refresh — checks prefix sources for changes via conditional requests (304).
+// Only enabled when AutoRefresh.Enabled = true in config.
+builder.Services.AddHostedService(sp => new PrefixAutoRefreshService(
+    sp.GetRequiredService<IPrefixSourceService>(),
+    sp.GetRequiredService<ISessionManager>(),
+    config,
+    sp.GetRequiredService<ILogger<PrefixAutoRefreshService>>()));
+
 if (config.RipeStat is { AsnLists.Count: > 0 })
 {
     foreach (var list in config.RipeStat.AsnLists)

--- a/BGPLite/Program.cs
+++ b/BGPLite/Program.cs
@@ -102,7 +102,19 @@ builder.Services.AddSingleton<FilePrefixProvider>();
 builder.Services.AddSingleton<IPrefixSourceProvider>(sp => sp.GetRequiredService<HttpPrefixProvider>());
 builder.Services.AddSingleton<IPrefixSourceProvider>(sp => sp.GetRequiredService<FilePrefixProvider>());
 builder.Services.AddSingleton<PrefixSourceProviderFactory>();
-builder.Services.AddSingleton<PrefixSourceService>();
+// #214 convergence: when any load detects a content change (connect-path GetAsync OR auto-refresh
+// RefreshAsync), push updated prefixes to all established peers. Resolved lazily inside the callback
+// (ISessionManager is registered later, line ~164) — singletons are constructed on first use.
+builder.Services.AddSingleton(sp => new PrefixSourceService(
+    sp.GetRequiredService<AppConfig>(),
+    sp.GetRequiredService<PrefixSourceProviderFactory>(),
+    sp.GetRequiredService<ILogger<PrefixSourceService>>(),
+    onSourceChanged: async name =>
+    {
+        // Push updated prefixes to all established peers. ISessionManager resolved lazily (registered
+        // later) — singletons are constructed on first use.
+        await sp.GetRequiredService<ISessionManager>().RefreshAllEstablishedAsync();
+    }));
 builder.Services.AddSingleton<IPrefixSourceService>(sp => sp.GetRequiredService<PrefixSourceService>());
 
 // RIPE Stat provider — registered unconditionally so arbitrary ASNs (peer custom ASNs,


### PR DESCRIPTION
Closes #214

## Problem

When an operator updates prefix lists, peers don't receive updated prefixes until they reconnect or send ROUTE_REFRESH (and the cache TTL expires). No automatic push mechanism exists.

## Fix

### ETag / Conditional requests (Phase 1)
- `SourceLoadResult` record carries prefixes + ETag + LastModified + NotModified flag
- `IPrefixSourceProvider.LoadAsync` accepts etag/lastModified for conditional requests
- `HttpPrefixProvider`: sends `If-None-Match`/`If-Modified-Since`, handles 304 (skips body download), extracts ETag from 200
- `FilePrefixProvider`: compares `LastWriteTimeUtc` (zero network cost)
- `AsnPrefixProvider`: no ETag (RIPEstat doesn't support it)
- `PrefixSourceService.CacheEntry`: stores ETag/LastModified, passes stale validators to provider on cache-miss, handles 304 by refreshing timestamp without re-parsing

### AutoRefreshConfig (Phase 2)
- `AutoRefreshConfig`: Enabled, IntervalSeconds (600), NoEtagIntervalSeconds (3600), MaxJitterMs (2000)

### PrefixAutoRefreshService (Phase 3)
- Background `IHostedService` with `PeriodicTimer`
- Calls `PrefixSourceService.RefreshAllAsync` (force-refresh, returns changed source names)
- If any source changed → `BgpServer.RefreshAllEstablishedAsync` (push UPDATE to all peers)
- Disabled by default — no behavior change unless opted in

### Config example
```yaml
AutoRefresh:
  Enabled: true
  IntervalSeconds: 600        # 304 checks every 10 min (~1 KB per source)
  NoEtagIntervalSeconds: 3600 # RIPEstat hourly
  MaxJitterMs: 2000           # jitter between source checks
```

## Verification
- `dotnet build BGPLite.sln` ✅
- `dotnet test BGPLite.sln` ✅ 476 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional automatic refreshing of prefix sources on a configurable schedule.
  * Supports conditional HTTP checks and file-change detection to avoid unnecessary reloads.
  * Refreshes established BGP sessions only when prefix content changes.
  * Added force-refresh capability for individual sources and all configured sources.
* **Configuration**
  * Added settings for refresh intervals, disabled behavior, and request jitter.
* **Performance**
  * Unchanged sources retain cached data without reparsing or reprocessing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->