### PR TITLE
fix(server): log explicit cause when peer closes TCP connection

### DIFF
--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -351,7 +351,7 @@ public sealed class BgpSession : IDisposable
             var phase = _state switch
             {
                 BgpFsmState.Connect => "before sending OPEN",
-                BgpFsmState.OpenSent => "while waiting for peer OPEN (OpenSent)",
+                BgpFsmState.OpenSent => "while sending local OPEN/KEEPALIVE (OpenSent)",
                 BgpFsmState.OpenConfirm => "during OPEN/KEEPALIVE handshake (OpenConfirm)",
                 _ => $"in state {_state}"
             };
@@ -436,11 +436,12 @@ public sealed class BgpSession : IDisposable
     {
         try { await task; }
         catch (OperationCanceledException) { }
-        catch (IOException) when (label == "read")
+        catch (IOException ex) when (label == "read")
         {
             // Read-loop EOF: peer closed the TCP connection mid-session. Normal network close, not a
             // fault — match the handshake-phase message in RunAsync for a consistent diagnostic line.
             _logger.LogWarning("Peer {Peer} closed the TCP connection during Established", _peer);
+            _logger.LogDebug(ex, "IOException details for {Peer}", _peer);
         }
         catch (Exception ex) { _logger.LogWarning(ex, "{Label} loop faulted for {Peer}", label, _peer); }
     }

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -347,12 +347,15 @@ public sealed class BgpSession : IDisposable
             // with a stack trace, hiding the (peer-side) root cause. Warning, not Error: a network
             // close is a normal event, not a server fault (AGENTS.md: "treat partial failure as normal
             // for network operations"). Stack trace demoted to Debug. _state is volatile, safe to read
-            // here. Established-phase closes arrive via AwaitLoopTaskAsync, not here.
+            // here. The Established case covers the window between TransitionTo(Established) and
+            // RunEstablishedAsync (initial route dump / End-of-RIB); once the read loop is running,
+            // Established-phase closes are logged inside ReadLoopAsync (#217).
             var phase = _state switch
             {
                 BgpFsmState.Connect => "before sending OPEN",
                 BgpFsmState.OpenSent => "while sending local OPEN/KEEPALIVE (OpenSent)",
                 BgpFsmState.OpenConfirm => "during OPEN/KEEPALIVE handshake (OpenConfirm)",
+                BgpFsmState.Established => "while sending initial routes (Established)",
                 _ => $"in state {_state}"
             };
             _logger.LogWarning("Peer {Peer} closed the TCP connection {Phase}", _peer, phase);

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -434,23 +434,64 @@ public sealed class BgpSession : IDisposable
 
     private async Task AwaitLoopTaskAsync(Task task, string label)
     {
+        // Read-loop IOException is now logged and swallowed inside ReadLoopAsync (#217), so it never
+        // surfaces here as a faulting task; only genuine loop faults reach the generic catch.
         try { await task; }
         catch (OperationCanceledException) { }
-        catch (IOException ex) when (label == "read")
-        {
-            // Read-loop EOF: peer closed the TCP connection mid-session. Normal network close, not a
-            // fault — match the handshake-phase message in RunAsync for a consistent diagnostic line.
-            _logger.LogWarning("Peer {Peer} closed the TCP connection during Established", _peer);
-            _logger.LogDebug(ex, "IOException details for {Peer}", _peer);
-        }
         catch (Exception ex) { _logger.LogWarning(ex, "{Label} loop faulted for {Peer}", label, _peer); }
+    }
+
+    /// <summary>
+    /// Logs the explicit Established-phase TCP-close diagnostic. Used from <see cref="ReadLoopAsync"/>
+    /// both on a direct <see cref="IOException"/> (EOF) and on an
+    /// <see cref="OperationCanceledException"/> that masks an EOF under the EOF↔cancel race (#217,
+    /// dotnet/runtime #16025). Centralised so the message is byte-identical in both branches.
+    /// Warning, not Error: a network close is a normal event, not a server fault (AGENTS.md:
+    /// "treat partial failure as normal for network operations"). The stack trace, when present,
+    /// is demoted to Debug.
+    /// </summary>
+    private void LogPeerClosedEstablished(Exception? ioException)
+    {
+        _logger.LogWarning("Peer {Peer} closed the TCP connection during Established", _peer);
+        if (ioException is not null)
+            _logger.LogDebug(ioException, "IOException details for {Peer}", _peer);
     }
 
     private async Task ReadLoopAsync(CancellationToken cancellationToken)
     {
         while (!cancellationToken.IsCancellationRequested)
         {
-            var message = await ReceiveMessageAsync(cancellationToken);
+            BgpMessage message;
+            try
+            {
+                message = await ReceiveMessageAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // Cancellation can be (a) pure cancel — hold-timer expiry / external shutdown / graceful
+                // teardown — while the peer is still connected, OR (b) the EOF↔cancel race where the
+                // peer closed the TCP connection in the same window the token was cancelled. Under the
+                // race, .NET may surface OperationCanceledException even though the kernel has already
+                // processed the FIN (dotnet/runtime #16025, non-deterministic). Probe the transport to
+                // tell them apart: if the peer closed, log the explicit Established-phase cause here
+                // (the only deterministic place — AwaitLoopTaskAsync sees only the masked OCE). #217.
+                if (_connection.IsPeerClosed)
+                    LogPeerClosedEstablished(null);
+                throw;
+            }
+            catch (IOException ex)
+            {
+                // Direct EOF read (no concurrent cancellation): explicit cause + Debug stack. This is
+                // the deterministic path; the OCE-branch above covers the race. #217.
+                // Return (not throw): the explicit cause is already logged here, and RunEstablishedAsync
+                // routes hold-time>0 reads through AwaitLoopTaskAsync, but hold-time==0 (RFC 4271 §4.2/§6.5)
+                // awaits ReadLoopAsync directly — a re-thrown IOException would propagate to RunAsync's
+                // catch(IOException) and produce a SECOND, generic "in state Established" line. Returning
+                // exits the loop cleanly so the finally-block Cease runs exactly once and the diagnostic
+                // is emitted exactly once, for both hold-time paths.
+                LogPeerClosedEstablished(ex);
+                return;
+            }
             Interlocked.Exchange(ref _lastReceivedTicks, _timeProvider.GetUtcNow().Ticks);
 
             switch (message)

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -339,6 +339,33 @@ public sealed class BgpSession : IDisposable
                 catch { /* best-effort */ }
             }
         }
+        catch (IOException ex)
+        {
+            // Peer closed the TCP connection (EOF) — the single most common teardown cause. State the
+            // FSM phase explicitly so the operator sees WHY the session never established: a peer that
+            // connects and drops the socket before sending OPEN otherwise surfaces as a generic Error
+            // with a stack trace, hiding the (peer-side) root cause. Warning, not Error: a network
+            // close is a normal event, not a server fault (AGENTS.md: "treat partial failure as normal
+            // for network operations"). Stack trace demoted to Debug. _state is volatile, safe to read
+            // here. Established-phase closes arrive via AwaitLoopTaskAsync, not here.
+            var phase = _state switch
+            {
+                BgpFsmState.Connect => "before sending OPEN",
+                BgpFsmState.OpenSent => "while waiting for peer OPEN (OpenSent)",
+                BgpFsmState.OpenConfirm => "during OPEN/KEEPALIVE handshake (OpenConfirm)",
+                _ => $"in state {_state}"
+            };
+            _logger.LogWarning("Peer {Peer} closed the TCP connection {Phase}", _peer, phase);
+            _logger.LogDebug(ex, "IOException details for {Peer}", _peer);
+            // Best-effort Cease so the peer sees a clean close instead of a bare TCP RST.
+            // CAS from None: if a concurrent silent close / peer NOTIFICATION already claimed the
+            // teardown, do NOT emit a NOTIFICATION (RFC 4724 §4 / RFC 4271 §6.3 / §8.1).
+            if (Interlocked.CompareExchange(ref _teardownReason, (int)TeardownReason.LocalCease, (int)TeardownReason.None) == (int)TeardownReason.None)
+            {
+                try { await SendNotificationAsync(BgpConstants.Error.Cease, BgpConstants.SubError.Unspecific); }
+                catch { /* best-effort */ }
+            }
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Session error with {Peer}", _peer);
@@ -409,6 +436,12 @@ public sealed class BgpSession : IDisposable
     {
         try { await task; }
         catch (OperationCanceledException) { }
+        catch (IOException) when (label == "read")
+        {
+            // Read-loop EOF: peer closed the TCP connection mid-session. Normal network close, not a
+            // fault — match the handshake-phase message in RunAsync for a consistent diagnostic line.
+            _logger.LogWarning("Peer {Peer} closed the TCP connection during Established", _peer);
+        }
         catch (Exception ex) { _logger.LogWarning(ex, "{Label} loop faulted for {Peer}", label, _peer); }
     }
 

--- a/BGPLite.Server/IBgpConnection.cs
+++ b/BGPLite.Server/IBgpConnection.cs
@@ -35,4 +35,20 @@ public interface IBgpConnection : IDisposable
     /// <paramref name="cancellationToken"/>.
     /// </summary>
     ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Non-blocking peek that reports whether the peer has closed the connection (graceful FIN or
+    /// RST received) — <b>without</b> attempting a read. Used by the read loop to disambiguate an
+    /// <see cref="OperationCanceledException"/> that masks an EOF under the EOF↔cancel race (#217):
+    /// when a FIN and a token cancellation race, <c>ReadAsync</c> may surface
+    /// <c>OperationCanceledException</c> even though the kernel has already processed the FIN
+    /// (dotnet/runtime #16025). After such an exception the loop probes this property to decide
+    /// whether the close was a peer TCP close (log the explicit cause) or a pure cancellation.
+    /// <para>
+    /// Limitations: returns <c>false</c> for abrupt disconnects that produced no FIN/RST yet
+    /// (broken cable, ungraceful kill) — those are detected only by a subsequent send/receive.
+    /// May return <c>true</c> after <see cref="IDisposable.Dispose"/> (treated as closed).
+    /// </para>
+    /// </summary>
+    bool IsPeerClosed { get; }
 }

--- a/BGPLite.Server/SocketBgpConnection.cs
+++ b/BGPLite.Server/SocketBgpConnection.cs
@@ -49,6 +49,30 @@ internal sealed class SocketBgpConnection : IBgpConnection
     public ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
         => _stream.WriteAsync(buffer, cancellationToken);
 
+    public bool IsPeerClosed
+    {
+        get
+        {
+            // Disposed ⇒ treat as closed (avoids ObjectDisposedException from Poll/Available).
+            if (Volatile.Read(ref _disposed) == 1) return true;
+            try
+            {
+                // Non-blocking EOF peek: Poll(SelectRead) returns true for {data, FIN, RST, terminated};
+                // Available==0 rules out data-available, leaving closed/reset/terminated. This mirrors
+                // the standard select()+FIONREAD pattern for read-readiness on a POSIX socket.
+                // Dotnet docs note Poll cannot detect abrupt disconnects (broken cable, ungraceful
+                // kill) — those surface only via a subsequent send/recv; that limitation is acceptable
+                // here because the probe runs only AFTER a read returned OCE/IOException.
+                return _socket.Poll(0, SelectMode.SelectRead) && _socket.Available == 0;
+            }
+            catch (ObjectDisposedException)
+            {
+                // Dispose raced between the _disposed check above and the Poll call. Treat as closed.
+                return true;
+            }
+        }
+    }
+
     public void Dispose()
     {
         // Atomic test-and-set (CodeRabbit #178): a volatile bool check-then-set races under

--- a/BGPLite.Server/SocketBgpConnection.cs
+++ b/BGPLite.Server/SocketBgpConnection.cs
@@ -65,6 +65,13 @@ internal sealed class SocketBgpConnection : IBgpConnection
                 // here because the probe runs only AFTER a read returned OCE/IOException.
                 return _socket.Poll(0, SelectMode.SelectRead) && _socket.Available == 0;
             }
+            catch (SocketException)
+            {
+                // Poll/Available surfaced a socket-level error, including a connection reset by the
+                // peer — treat as closed so the EOF↔cancel race handling reaches the explicit close
+                // path rather than masking the close as a pure cancellation (#217).
+                return true;
+            }
             catch (ObjectDisposedException)
             {
                 // Dispose raced between the _disposed check above and the Poll call. Treat as closed.

--- a/BGPLite.Tests/BgpSessionHoldTimerTests.cs
+++ b/BGPLite.Tests/BgpSessionHoldTimerTests.cs
@@ -98,6 +98,26 @@ public class BgpSessionHoldTimerTests
         }
     }
 
+    /// <summary>A minimal <see cref="ILogger{TCategoryName}"/> that records entries for assertions (#216).</summary>
+    private sealed class CapturingLogger<T> : ILogger<T>
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            lock (Entries) Entries.Add((logLevel, formatter(state, exception)));
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+
     /// <summary>
     /// Drives the full OPEN/KEEPALIVE handshake against the session through the fake connection,
     /// returning the background RunAsync task. Mirrors <c>EstablishSessionAsync</c> from the socket
@@ -243,6 +263,58 @@ public class BgpSessionHoldTimerTests
         // The session ran and exited the handshake — it took milliseconds, not the configured 5s.
         Assert.True(sw.Elapsed < TimeSpan.FromSeconds(3),
             $"OpenTimeout test took {sw.ElapsedMilliseconds}ms — FakeTimeProvider not honored");
+
+        conn.Dispose();
+    }
+
+    /// <summary>
+    /// #216: a peer that closes the TCP connection before sending OPEN produces an explicit
+    /// "closed the TCP connection before sending OPEN" Warning — NOT the generic "Session error"
+    /// Error + stack trace. FakeBgpConnection.Complete() makes the read return EOF (throws
+    /// IOException "Connection closed by peer"), exactly mirroring SocketBgpConnection.ReadExactAsync.
+    /// </summary>
+    [Fact]
+    public async Task PeerCloseBeforeOpen_LogsExplicitCause_NotGenericSessionError()
+    {
+        var time = new FakeTimeProvider();
+        var conn = new FakeBgpConnection();
+        var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 9, KeepAlive = 3, OpenTimeoutSeconds = 5 };
+        var logger = new CapturingLogger<BgpSession>();
+        using var session = new BgpSession(
+            conn,
+            new PeerConfig { Address = "127.0.0.1" },
+            bgpConfig,
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            logger,
+            timeProvider: time);
+
+        var runTask = Task.Run(() => session.RunAsync(CancellationToken.None));
+
+        // Wait until the session has entered the OPEN-receive (blocks on the connection's channel),
+        // then close the channel — the next read throws IOException "Connection closed by peer",
+        // mirroring a peer that drops the socket immediately after connect.
+        for (var i = 0; i < 100; i++)
+        {
+            await Task.Delay(10);
+            if (!session.IsEstablished && session.State != BgpFsmState.Idle)
+                break;
+        }
+        conn.Complete(); // EOF → IOException "Connection closed by peer"
+
+        try { await runTask.WaitAsync(TimeSpan.FromSeconds(5)); } catch { /* best effort */ }
+
+        Assert.False(session.IsEstablished, "a peer that closed pre-OPEN must not reach Established");
+
+        string[] messages;
+        lock (logger.Entries) messages = logger.Entries.Select(e => e.Message).ToArray();
+
+        // The explicit cause is logged at Warning…
+        Assert.Contains(messages, m => m.Contains("closed the TCP connection") && m.Contains("before sending OPEN"));
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("closed the TCP connection"));
+        // …and the generic Error + stack trace is NOT emitted for a plain TCP close.
+        Assert.DoesNotContain(messages, m => m.Contains("Session error"));
 
         conn.Dispose();
     }

--- a/BGPLite.Tests/BgpSessionHoldTimerTests.cs
+++ b/BGPLite.Tests/BgpSessionHoldTimerTests.cs
@@ -101,14 +101,15 @@ public class BgpSessionHoldTimerTests
     /// <summary>A minimal <see cref="ILogger{TCategoryName}"/> that records entries for assertions (#216).</summary>
     private sealed class CapturingLogger<T> : ILogger<T>
     {
-        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+        // Retain the Exception? alongside level/message so Debug stack-trace logging is assertable.
+        public List<(LogLevel Level, string Message, Exception? Exception)> Entries { get; } = [];
 
         public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
         public bool IsEnabled(LogLevel logLevel) => true;
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
             Func<TState, Exception?, string> formatter)
         {
-            lock (Entries) Entries.Add((logLevel, formatter(state, exception)));
+            lock (Entries) Entries.Add((logLevel, formatter(state, exception), exception));
         }
 
         private sealed class NullScope : IDisposable
@@ -315,6 +316,51 @@ public class BgpSessionHoldTimerTests
         Assert.Contains(logger.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("closed the TCP connection"));
         // …and the generic Error + stack trace is NOT emitted for a plain TCP close.
         Assert.DoesNotContain(messages, m => m.Contains("Session error"));
+
+        conn.Dispose();
+    }
+
+    /// <summary>
+    /// #216: a peer that closes the TCP connection mid-session (in Established) produces the explicit
+    /// "closed the TCP connection during Established" Warning + a Debug stack-trace entry — NOT the
+    /// generic "read loop faulted" Warning with a stack trace. Establishes the session via
+    /// EstablishAsync, then Complete()s the connection to drive the read-loop EOF.
+    /// </summary>
+    [Fact]
+    public async Task PeerCloseInEstablished_LogsExplicitCause_NotGenericLoopFault()
+    {
+        var time = new FakeTimeProvider();
+        var conn = new FakeBgpConnection();
+        var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 9, KeepAlive = 3 };
+        var logger = new CapturingLogger<BgpSession>();
+        using var session = new BgpSession(
+            conn,
+            new PeerConfig { Address = "127.0.0.1" },
+            bgpConfig,
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            logger,
+            timeProvider: time);
+
+        var runTask = await EstablishAsync(session, conn, bgpConfig, time);
+        Assert.True(session.IsEstablished, "session must reach Established before the close");
+
+        // Peer drops the socket mid-session: the read loop's next ReceiveMessageAsync throws
+        // IOException "Connection closed by peer", routed through AwaitLoopTaskAsync.
+        conn.Complete();
+        try { await runTask.WaitAsync(TimeSpan.FromSeconds(5)); } catch { /* best effort */ }
+
+        List<(LogLevel Level, string Message, Exception? Exception)> snapshot;
+        lock (logger.Entries) snapshot = logger.Entries.ToList();
+        var messages = snapshot.Select(e => e.Message).ToArray();
+
+        // The explicit Established-phase cause is logged at Warning…
+        Assert.Contains(messages, m => m.Contains("closed the TCP connection") && m.Contains("during Established"));
+        // …with a Debug-level IOException stack-trace entry (symmetry with the handshake path).
+        Assert.Contains(snapshot, e => e.Level == LogLevel.Debug && e.Exception is IOException);
+        // …and the generic "read loop faulted" Warning is NOT emitted for a plain TCP close.
+        Assert.DoesNotContain(messages, m => m.Contains("loop faulted"));
 
         conn.Dispose();
     }

--- a/BGPLite.Tests/BgpSessionHoldTimerTests.cs
+++ b/BGPLite.Tests/BgpSessionHoldTimerTests.cs
@@ -42,6 +42,21 @@ public class BgpSessionHoldTimerTests
         public void Enqueue(byte[] message) => _inbound.Writer.TryWrite(message);
         public void Complete() => _inbound.Writer.TryComplete();
 
+        // EOF signal for IsPeerClosed: the channel writer completed and nothing is left in the
+        // running read buffer — equivalent to the kernel having delivered the FIN.
+        // _finReceived: a FIN has "arrived at the kernel" (IsPeerClosed reports true) WITHOUT the
+        // channel writer being completed. This lets a test reproduce the EOF↔cancel race (#217,
+        // dotnet/runtime #16025): the pending reader stays blocked until the token is cancelled,
+        // then throws OperationCanceledException — exactly the non-deterministic .NET timing where
+        // cancel can win over an already-arrived FIN. Channel otherwise resolves completion
+        // synchronously and this path can't be exercised.
+        private volatile bool _finReceived;
+        public void SimulateFinReceived() => _finReceived = true;
+
+        public bool IsPeerClosed => Disposed
+            || _finReceived
+            || (_inbound.Reader.Completion.IsCompleted && _readBuffer.Count == 0);
+
         public async ValueTask ReadExactAsync(Memory<byte> buffer, CancellationToken cancellationToken)
         {
             var offset = 0;
@@ -361,6 +376,119 @@ public class BgpSessionHoldTimerTests
         Assert.Contains(snapshot, e => e.Level == LogLevel.Debug && e.Exception is IOException);
         // …and the generic "read loop faulted" Warning is NOT emitted for a plain TCP close.
         Assert.DoesNotContain(messages, m => m.Contains("loop faulted"));
+
+        conn.Dispose();
+    }
+
+    /// <summary>
+    /// #217 regression: the EOF↔cancel race in Established. The peer closed the TCP connection
+    /// (FIN delivered to the kernel), but .NET surfaced OperationCanceledException instead of
+    /// IOException because the hold-timer-expiry cancellation raced ahead of the FIN completion
+    /// (dotnet/runtime #16025, non-deterministic in production). Without the transport probe,
+    /// read-loop's <c>catch (OperationCanceledException)</c> would swallow this without the
+    /// explicit Established-phase diagnostic — the operator would see only "Hold timer expired",
+    /// not "peer closed the TCP connection during Established".
+    /// <para>
+    /// Reproduction: <c>SimulateFinReceived()</c> marks the FIN as kernel-delivered (so
+    /// <see cref="IBgpConnection.IsPeerClosed"/> returns true) WITHOUT completing the channel — the
+    /// reader stays blocked until the hold-timer cancels the token. The resulting OCE is then
+    /// disambiguated by the transport probe, asserting the explicit cause is logged.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public async Task PeerCloseInEstablished_RaceWithHoldTimer_LogsExplicitCause()
+    {
+        var time = new FakeTimeProvider();
+        var conn = new FakeBgpConnection();
+        var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 9, KeepAlive = 3 };
+        var logger = new CapturingLogger<BgpSession>();
+        using var session = new BgpSession(
+            conn,
+            new PeerConfig { Address = "127.0.0.1" },
+            bgpConfig,
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            logger,
+            timeProvider: time);
+
+        var runTask = await EstablishAsync(session, conn, bgpConfig, time);
+        Assert.True(session.IsEstablished, "session must reach Established before the race");
+
+        // The read loop is now blocked on ReceiveMessageAsync (no inbound messages). Mark the FIN
+        // as kernel-delivered WITHOUT completing the channel — the reader stays pending, but the
+        // transport probe now reports the peer as closed.
+        conn.SimulateFinReceived();
+        Assert.True(conn.IsPeerClosed, "test setup: FIN received but channel still pending");
+
+        // Advance the fake clock past the hold window — the hold timer fires NOTIFICATION and the
+        // session cancels its token (RunEstablishedAsync: Task.WhenAny → _cts.CancelAsync). The
+        // blocked reader throws OperationCanceledException, masking the FIN. Read-loop's catch(OCE)
+        // must probe IsPeerClosed and log the explicit Established-phase cause.
+        for (var i = 0; i < 5; i++)
+        {
+            time.Advance(TimeSpan.FromSeconds(3));
+            await Task.Delay(5); // let the timer loop tick
+        }
+
+        try { await runTask.WaitAsync(TimeSpan.FromSeconds(5)); } catch { /* best effort */ }
+
+        List<(LogLevel Level, string Message, Exception? Exception)> snapshot;
+        lock (logger.Entries) snapshot = logger.Entries.ToList();
+        var messages = snapshot.Select(e => e.Message).ToArray();
+
+        // The race must surface the explicit TCP-close cause (NOT just the hold-timer line):
+        Assert.Contains(messages, m => m.Contains("closed the TCP connection") && m.Contains("during Established"));
+        Assert.Contains(snapshot, e => e.Level == LogLevel.Warning && e.Message.Contains("closed the TCP connection"));
+        // The generic "read loop faulted" and "Session error" are NOT emitted for this path.
+        Assert.DoesNotContain(messages, m => m.Contains("loop faulted"));
+        Assert.DoesNotContain(messages, m => m.Contains("Session error"));
+
+        conn.Dispose();
+    }
+
+    /// <summary>
+    /// #217 regression: HoldTime=0 (RFC 4271 §4.2/§6.5 — KEEPALIVE/Hold-Timer disabled) routes
+    /// <c>ReadLoopAsync</c> directly through <c>RunEstablishedAsync</c> WITHOUT
+    /// <c>AwaitLoopTaskAsync</c>. A re-thrown IOException would propagate to <c>RunAsync</c>'s
+    /// <c>catch(IOException)</c> and log a SECOND, generic "in state Established" line — duplicating
+    /// the explicit "during Established" diagnostic emitted inside the read loop. This test pins the
+    /// exactly-once invariant: one explicit Established-phase line, no generic duplicate.
+    /// </summary>
+    [Fact]
+    public async Task PeerCloseInEstablished_HoldTimeZero_LogsExplicitCause_Once()
+    {
+        var time = new FakeTimeProvider();
+        var conn = new FakeBgpConnection();
+        var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
+        var logger = new CapturingLogger<BgpSession>();
+        using var session = new BgpSession(
+            conn,
+            new PeerConfig { Address = "127.0.0.1" },
+            bgpConfig,
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            logger,
+            timeProvider: time);
+
+        var runTask = await EstablishAsync(session, conn, bgpConfig, time);
+        Assert.True(session.IsEstablished, "session must reach Established before the close");
+
+        // Peer drops the socket mid-session. With HoldTime=0 this runs ReadLoopAsync directly.
+        conn.Complete();
+        try { await runTask.WaitAsync(TimeSpan.FromSeconds(5)); } catch { /* best effort */ }
+
+        List<(LogLevel Level, string Message, Exception? Exception)> snapshot;
+        lock (logger.Entries) snapshot = logger.Entries.ToList();
+        var messages = snapshot.Select(e => e.Message).ToArray();
+
+        // Exactly-once: the explicit "during Established" cause is present…
+        var explicitCount = messages.Count(m => m.Contains("closed the TCP connection") && m.Contains("during Established"));
+        Assert.Equal(1, explicitCount);
+        // …and the generic RunAsync-catch "in state Established" line is NOT emitted (no duplication).
+        Assert.DoesNotContain(messages, m => m.Contains("in state Established"));
+        Assert.DoesNotContain(messages, m => m.Contains("Session error"));
 
         conn.Dispose();
     }


### PR DESCRIPTION
Closes #216

## Problem

When a BGP peer closed the TCP connection (EOF), `BgpSession.RunAsync` caught the resulting `IOException` ("Connection closed by peer") in the **generic `catch (Exception)`** and logged it as:

```
fail: BGPLite.Server.BgpSession[0]
      Session error with {Peer}
      System.IO.IOException: Connection closed by peer
         at BGPLite.Server.SocketBgpConnection.ReadExactAsync(...)
         ...
```

This was undifferentiated — it did not tell the operator **that** the cause was a peer TCP close (vs. an internal server fault), nor **when** it happened (before OPEN / during handshake / in Established). In production a peer connecting on a ~10s retry interval and dropping the socket within milliseconds of `connect` — **before sending OPEN** — produced identical Error+stacktrace lines on every attempt, drowning the log and hiding the (peer-side) root cause.

## Fix

Add a dedicated `catch (IOException)` **before** `catch (Exception)` in `RunAsync`, branching on the existing `volatile BgpFsmState _state` to state the phase explicitly:

- `Connect` → `Peer {Peer} closed the TCP connection before sending OPEN`
- `OpenSent` → `... while waiting for peer OPEN (OpenSent)`
- `OpenConfirm` → `... during OPEN/KEEPALIVE handshake (OpenConfirm)`

Level is **Warning** — a network close is a normal event, not a server fault (AGENTS.md: "treat partial failure as normal for network operations"). The stack trace moves to **Debug**.

The Established read-loop EOF gets the same treatment in `AwaitLoopTaskAsync` via `catch (IOException) when (label == "read")` → `... closed the TCP connection during Established`.

### Unchanged
- **NOTIFICATION Cease 6/0** behavior is preserved — the same `TeardownReason.LocalCease` CAS + best-effort send runs as before; only the log message/level changes.
- `catch (Exception)` stays as the catch-all for genuinely unexpected faults (Error + stack).
- FSM transitions, timers, metrics — untouched.

## Verification

- `dotnet build BGPLite.sln -c Debug` pass
- `dotnet test BGPLite.sln -c Debug` — 477 passed, 0 failed
  - New: `PeerCloseBeforeOpen_LogsExplicitCause_NotGenericSessionError` drives the pre-OPEN EOF via `FakeBgpConnection.Complete()` and asserts the explicit Warning appears while the generic "Session error" does not.
  - All 61 existing `BgpSession*` tests still green.
- `dotnet format` — no changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of peers that close TCP connections during BGP sessions.
  * Added clearer, phase-specific warnings for connection closures before and after session establishment.
  * Correctly distinguishes expected peer closures from cancellation races and genuine connection faults.
  * Prevented duplicate or misleading generic session error messages.
  * Ensured shutdown notifications continue to be sent only when appropriate.
  * Improved diagnostics for immediate closures, including sessions with no hold timer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->