### PR TITLE
fix(protocol): handle malformed UPDATE without tearing down session

### DIFF
--- a/BGPLite.Protocol/BgpMessageReader.cs
+++ b/BGPLite.Protocol/BgpMessageReader.cs
@@ -52,11 +52,13 @@ public static class BgpMessageReader
     private static BgpOpenMessage ParseOpen(ReadOnlySpan<byte> payload)
     {
         if (payload.Length < 10)
-            throw new BgpParseException($"OPEN message too short: {payload.Length}");
+            throw new BgpParseException($"OPEN message too short: {payload.Length}",
+                BgpConstants.Error.OpenMessageError, BgpConstants.SubError.Unspecific);
 
         var version = payload[0];
         if (version != BgpConstants.BgpVersion)
-            throw new BgpParseException($"Unsupported BGP version: {version}");
+            throw new BgpParseException($"Unsupported BGP version: {version}",
+                BgpConstants.Error.OpenMessageError, BgpConstants.SubError.UnsupportedVersion);
 
         var asn = BinaryPrimitives.ReadUInt16BigEndian(payload[1..]);
         var holdTime = BinaryPrimitives.ReadUInt16BigEndian(payload[3..]);
@@ -120,12 +122,19 @@ public static class BgpMessageReader
     private static BgpUpdateMessage ParseUpdate(ReadOnlySpan<byte> payload)
     {
         if (payload.Length < 4)
-            throw new BgpParseException($"UPDATE message too short: {payload.Length}");
+            throw new BgpParseException($"UPDATE message too short: {payload.Length}",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific);
 
         var offset = 0;
 
         var withdrawnLen = BinaryPrimitives.ReadUInt16BigEndian(payload[offset..]);
         offset += 2;
+        // #222: a declared length that runs past the payload is stream-level corruption, not a
+        // per-UPDATE content error — surface it as a parse exception (Update Message Error) so the
+        // caller can treat-as-withdraw instead of throwing ArgumentOutOfRangeException out of Slice.
+        if (offset + withdrawnLen > payload.Length)
+            throw new BgpParseException($"UPDATE withdrawn-routes length {withdrawnLen} exceeds payload",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific);
 
         var withdrawn = new List<IpPrefix>();
         if (withdrawnLen > 0)
@@ -141,6 +150,9 @@ public static class BgpMessageReader
 
         var attrsLen = BinaryPrimitives.ReadUInt16BigEndian(payload[offset..]);
         offset += 2;
+        if (offset + attrsLen > payload.Length)
+            throw new BgpParseException($"UPDATE path-attributes length {attrsLen} exceeds payload",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific);
 
         var attributes = new List<PathAttribute>();
         if (attrsLen > 0)
@@ -172,6 +184,16 @@ public static class BgpMessageReader
 
     private static (PathAttribute attr, int consumed) ParseAttribute(ReadOnlySpan<byte> data)
     {
+        // #222: bounds-check before every indexed read. Previously a truncated TLV (declared length
+        // larger than the buffer, or fewer than 2 header bytes) threw ArgumentOutOfRangeException out
+        // of Span.Slice / indexing, which escaped ReadLoopAsync (it only catches OCE/IOException) and
+        // tore down the session with a generic Cease — a single malformed UPDATE killed the peer.
+        // Now these surface as BgpParseException (Update Message Error) and are handled by the
+        // treat-as-withdraw path. RFC 7606 §2 / RFC 4271 §6.3.
+        if (data.Length < 2)
+            throw new BgpParseException($"Truncated path attribute header: have {data.Length}, need 2",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific);
+
         var flags = data[0];
         var typeCode = data[1];
         var offset = 2;
@@ -179,14 +201,24 @@ public static class BgpMessageReader
         int length;
         if ((flags & BgpConstants.Attribute.FlagExtendedLength) != 0)
         {
+            if (data.Length < offset + 2)
+                throw new BgpParseException($"Truncated extended-length path attribute: have {data.Length}, need {offset + 2}",
+                    BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific);
             length = BinaryPrimitives.ReadUInt16BigEndian(data[offset..]);
             offset += 2;
         }
         else
         {
+            if (data.Length < offset + 1)
+                throw new BgpParseException($"Truncated path attribute length byte: have {data.Length}, need {offset + 1}",
+                    BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific);
             length = data[offset];
             offset += 1;
         }
+
+        if (offset + length > data.Length)
+            throw new BgpParseException($"Truncated path attribute value: declared {length} at offset {offset}, have {data.Length}",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific);
 
         var attrData = new byte[length];
         data.Slice(offset, length).CopyTo(attrData);
@@ -241,8 +273,31 @@ public static class BgpMessageReader
     #endregion
 }
 
+/// <summary>
+/// Thrown by the BGP message codec when an inbound message is malformed. Carries the
+/// RFC 4271 NOTIFICATION error code/subcode that should be sent to the peer so the session
+/// handler (<c>BgpSession.RunAsync</c>) emits the right NOTIFICATION instead of a generic
+/// Message Header Error (issue #223).
+/// <para>
+/// <see cref="ErrorCode"/>/<see cref="SubErrorCode"/> are nullable: a <c>null</c> error code
+/// means "this was a fixed-header (marker/length/type) parse failure" → Message Header Error
+/// (RFC 4271 §6.1). OPEN-body failures set Open Message Error (§6.2); UPDATE-body failures
+/// set Update Message Error (§6.3). A <c>null</c> sub-error code maps to Unspecific (0).
+/// </para>
+/// </summary>
 public sealed class BgpParseException : Exception
 {
-    public BgpParseException(string message) : base(message) { }
+    public BgpParseException(string message, byte? errorCode = null, byte? subErrorCode = null) : base(message)
+    {
+        ErrorCode = errorCode;
+        SubErrorCode = subErrorCode;
+    }
+
     public BgpParseException(string message, Exception inner) : base(message, inner) { }
+
+    /// <summary>RFC 4271 §6 error code the peer should be notified with, or <c>null</c> for a
+    /// fixed-header failure (Message Header Error).</summary>
+    public byte? ErrorCode { get; }
+    /// <summary>RFC 4271 §6 sub-error code, or <c>null</c> for Unspecific (0).</summary>
+    public byte? SubErrorCode { get; }
 }

--- a/BGPLite.Protocol/PrefixCodec.cs
+++ b/BGPLite.Protocol/PrefixCodec.cs
@@ -31,21 +31,31 @@ public static class PrefixCodec
         return 1 + byteCount;
     }
 
+    /// <summary>
+    /// Decodes one NLRI prefix from the head of <paramref name="buffer"/>. Throws
+    /// <see cref="BgpParseException"/> (Update Message Error) on any malformed input — a prefix-length
+    /// byte &gt; 32, or a buffer shorter than the declared prefix bytes — so the caller surfaces it
+    /// through the treat-as-withdraw path instead of the previous <see cref="ArgumentOutOfRangeException"/>
+    /// that escaped the read loop and tore down the session (#222, RFC 4271 §6.3 / RFC 7606 §2).
+    /// </summary>
     public static (IpPrefix prefix, int bytesConsumed) Decode(ReadOnlySpan<byte> buffer)
     {
         if (buffer.IsEmpty)
-            throw new ArgumentOutOfRangeException(nameof(buffer), 0, "Buffer too small to contain a prefix length byte.");
+            throw new BgpParseException("Truncated NLRI: buffer too small to contain a prefix length byte",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific);
 
         var length = buffer[0];
         if (length > 32)
-            throw new ArgumentOutOfRangeException(nameof(buffer), length, "IPv4 prefix length must be in 0..32.");
+            throw new BgpParseException($"Invalid NLRI prefix length: {length} (must be 0..32)",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific);
 
         if (length == 0)
             return (new IpPrefix(0, 0), 1);
 
         var byteCount = (length + 7) / 8;
         if (buffer.Length < 1 + byteCount)
-            throw new ArgumentOutOfRangeException(nameof(buffer), buffer.Length, $"Buffer too small: need {1 + byteCount} bytes for prefix length {length}.");
+            throw new BgpParseException($"Truncated NLRI: need {1 + byteCount} bytes for prefix length {length}, have {buffer.Length}",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific);
         uint addr = 0;
         for (var i = 0; i < byteCount; i++)
             addr |= (uint)buffer[1 + i] << (24 - i * 8);

--- a/BGPLite.Providers/PrefixService.cs
+++ b/BGPLite.Providers/PrefixService.cs
@@ -229,9 +229,25 @@ public sealed class PrefixService : IPrefixService
                 gate.Release();
             }
         }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // #225: when the caller's token is cancelled (shutdown / refresh-with-cancel), the OCE
+            // MUST propagate — otherwise GetPrefixesForAsns silently returns a partial prefix list
+            // (cancelled ASNs dropped to []) instead of throwing. This is the specific shutdown-path
+            // regression #225 fixes; it mirrors the OCP-propagation policy enforced across the rest
+            // of the prefix-sourcing stack (UserSourceCache #114, GetPrefixesAsync:97).
+            //
+            // The `when (ct.IsCancellationRequested)` guard is narrow on purpose: an OCE raised by
+            // something OTHER than the caller's token (e.g. a Polly pipeline internal timeout using
+            // its own linked CTS, surfacing here as OCE) is NOT rethrown — it falls through to the
+            // generic catch below and is treated as a transient per-ASN failure. That is the desired
+            // resilience behavior (one ASN's timeout should not abort the whole fan-out); only true
+            // caller-initiated cancellation propagates.
+            throw;
+        }
         catch
         {
-            // skip failed ASN (incl. cancellation while queued), continue with the others
+            // skip failed ASN (a transient RIPEstat error), continue with the others
             return [];
         }
     }

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -442,8 +442,15 @@ public sealed class BgpSession : IDisposable
     {
         // Read-loop IOException is now logged and swallowed inside ReadLoopAsync (#217), so it never
         // surfaces here as a faulting task; only genuine loop faults reach the generic catch.
+        // #223: a fixed-header BgpParseException (ErrorCode == null — invalid marker/length/type)
+        // MUST propagate to RunAsync's catch(BgpParseException) so the right NOTIFICATION
+        // (MessageHeaderError) is emitted before teardown. Without this rethrow the generic catch
+        // below would swallow it and the finally-block would send a generic Cease(6,0) instead —
+        // a regression of #223 for the HoldTime > 0 path (HoldTime == 0 awaits ReadLoopAsync
+        // directly and already propagates).
         try { await task; }
         catch (OperationCanceledException) { }
+        catch (BgpParseException) { throw; }
         catch (Exception ex) { _logger.LogWarning(ex, "{Label} loop faulted for {Peer}", label, _peer); }
     }
 

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -333,9 +333,12 @@ public sealed class BgpSession : IDisposable
         catch (BgpParseException ex)
         {
             _logger.LogError(ex, "Parse error from {Peer}", _peer);
+            // #223: emit the RFC 4271 §6 error code the parser recorded (Open/Update for a body
+            // failure, MessageHeaderError for a fixed-header failure). Defaults to MessageHeaderError
+            // when the parser did not specify one (e.g. marker/length/type validation in ReadMessage).
             if (Interlocked.CompareExchange(ref _teardownReason, (int)TeardownReason.LocalCease, (int)TeardownReason.None) == (int)TeardownReason.None)
             {
-                try { await SendNotificationAsync(BgpConstants.Error.MessageHeaderError, BgpConstants.SubError.Unspecific); }
+                try { await SendNotificationAsync(ex.ErrorCode ?? BgpConstants.Error.MessageHeaderError, ex.SubErrorCode ?? BgpConstants.SubError.Unspecific); }
                 catch { /* best-effort */ }
             }
         }
@@ -494,6 +497,37 @@ public sealed class BgpSession : IDisposable
                 // is emitted exactly once, for both hold-time paths.
                 LogPeerClosedEstablished(ex);
                 return;
+            }
+            catch (BgpParseException ex) when (ex.ErrorCode is not null)
+            {
+                // #222: a malformed message BODY (truncated path attribute, out-of-range NLRI length,
+                // truncated OPEN/UPDATE) is a per-message content error, not stream-level corruption.
+                // RFC 7606 §2 / RFC 4271 §6.3 say: discard the bad message and KEEP THE SESSION up,
+                // reserving teardown for stream-level errors (FSM / message-header). The previous
+                // behavior let the exception escape the read loop → AwaitLoopTaskAsync logged
+                // "read loop faulted" → RunAsync finally sent a generic Cease(6,0), tearing down a
+                // long-lived session over a single bad/adversarial UPDATE.
+                //
+                // The `when (ex.ErrorCode is not null)` filter is critical: only body-parse failures
+                // (ParseOpen → Open Message Error, ParseUpdate/ParseAttribute/PrefixCodec → Update
+                // Message Error) set ErrorCode. Fixed-header failures (invalid marker/length/type from
+                // ReadMessage/ReceiveMessageAsync) leave ErrorCode == null and are NOT caught here —
+                // they propagate to RunAsync, which tears down the session with NOTIFICATION
+                // (MessageHeaderError). This preserves RFC 4271 §6.1 (stream-level corruption MUST
+                // tear down) AND avoids a desync hazard: a length-out-of-range from ReceiveMessageAsync
+                // is thrown AFTER the 19-byte header is read but BEFORE the payload, so continuing here
+                // would read payload bytes as the next header and desync the stream permanently.
+                // (Mirrors the existing treat-as-withdraw catch in HandleUpdateAsync dispatch at :508,
+                //  which only covers BgpNotificationException thrown AFTER successful parsing.)
+                //
+                // No NOTIFICATION is sent: RFC 7606 treat-as-withdraw keeps the session up without
+                // notifying (RFC 4271 §6.3 mandates the receiver of a NOTIFICATION tear down, which
+                // would defeat the point of preserving the session).
+                _metrics.UpdateRejected();
+                _logger.LogWarning(
+                    "Rejected malformed message from {Peer}: {Error}/{SubError} — {Reason}; session stays up",
+                    _peer, ex.ErrorCode, ex.SubErrorCode ?? BgpConstants.SubError.Unspecific, ex.Message);
+                continue;
             }
             Interlocked.Exchange(ref _lastReceivedTicks, _timeProvider.GetUtcNow().Ticks);
 

--- a/BGPLite.Tests/MalformedUpdateResilienceTests.cs
+++ b/BGPLite.Tests/MalformedUpdateResilienceTests.cs
@@ -1,0 +1,304 @@
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+using BGPLite.Configuration;
+using BGPLite.Protocol;
+using BGPLite.Routing;
+using BGPLite.Server;
+using Microsoft.Extensions.Logging;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// Regression tests for #222 (malformed path attribute / NLRI tore down the session via
+/// ArgumentOutOfRangeException that escaped the read loop) and #223 (BgpParseException was
+/// mapped to MessageHeaderError regardless of which body — OPEN/UPDATE — failed to parse).
+/// These tests build malformed message frames at the byte level (so they hit the codec, not
+/// the post-parse attribute validators already covered by #94) and assert the session stays
+/// Established and the NOTIFICATION carries the RFC-correct error code.
+/// </summary>
+public class MalformedUpdateResilienceTests
+{
+    [Fact]
+    public void ParseAttribute_TruncatedHeaderValue_ThrowsBgpParseException_NotAOORE()
+    {
+        // #222: a path attribute declaring more bytes than the buffer holds previously threw
+        // ArgumentOutOfRangeException out of Span.Slice, escaping ReadLoopAsync and tearing down
+        // the session. Now it must surface as BgpParseException so treat-as-withdraw applies.
+        // One attribute header: flags=0, type=ORIGIN(1), length byte=5 — but only 1 data byte
+        // follows, so the declared 5 bytes overshoot the buffer.
+        var attrBytes = new byte[] { 0x00, 0x01, 0x05, 0xFF };
+
+        var ex = Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(BuildUpdateFrame([.. attrBytes])));
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void ParseAttribute_ExtendedLengthFlag_TooFewHeaderBytes_ThrowsBgpParseException()
+    {
+        // #222: Extended-Length flag set (0x10) but only the 2 fixed header bytes present — the
+        // 2-byte length read would index past the buffer. Must be BgpParseException, not AOORE.
+        var attrBytes = new byte[] { 0x10, 0x02 };
+
+        var ex = Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(BuildUpdateFrame([.. attrBytes])));
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void ParseUpdate_WithdrawnLengthExceedsPayload_ThrowsBgpParseException()
+    {
+        // #222: withdrawn-routes length field larger than the UPDATE payload — stream-level
+        // corruption that previously threw AOORE out of the Slice in the withdrawn-routes loop.
+        // Build the UPDATE payload directly (not via BuildUpdateFrame, which wraps bytes as attrs):
+        // withdrawn_len=0xFFFF, attrs_len=0 — the declared 65535 withdrawn bytes overshoot the
+        // 4-byte payload.
+        var payload = new byte[4];
+        BinaryPrimitives.WriteUInt16BigEndian(payload, 0xFFFF); // withdrawn length = 65535
+        BinaryPrimitives.WriteUInt16BigEndian(payload.AsSpan(2), 0); // attrs length = 0
+        var frame = BuildMessage(BgpMessageType.Update, payload);
+
+        var ex = Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(frame));
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void ParseOpen_TooShort_PropagatesOpenMessageErrorCode()
+    {
+        // #223: an OPEN body too short to even read the fixed fields must report Open Message
+        // Error (2), not MessageHeaderError (1).
+        var payload = new byte[5]; // OPEN fixed part is 10 bytes
+        var frame = BuildMessage(BgpMessageType.Open, payload);
+
+        var ex = Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(frame));
+        Assert.Equal(BgpConstants.Error.OpenMessageError, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void ParseOpen_UnsupportedVersion_PropagatesOpenMessageErrorSubcode1()
+    {
+        // #223: version != 4 → Open Message Error, subcode 1 (Unsupported Version).
+        var payload = new byte[10];
+        payload[0] = 5; // version = 5
+        var frame = BuildMessage(BgpMessageType.Open, payload);
+
+        var ex = Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(frame));
+        Assert.Equal(BgpConstants.Error.OpenMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.UnsupportedVersion, ex.SubErrorCode);
+    }
+
+    [Fact]
+    public async Task MalformedUpdate_OnWire_KeepsSessionEstablished()
+    {
+        // End-to-end regression for #222: a malformed UPDATE frame sent on a live socket must
+        // NOT tear the session down. The read loop catches BgpParseException (treat-as-withdraw)
+        // and continues; no NOTIFICATION is emitted.
+        var (server, client) = ConnectedPair();
+        using var clientSock = client;
+        var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
+        var metrics = new BgpMetrics();
+        using var session = new BgpSession(
+            new SocketBgpConnection(server),
+            new PeerConfig { Address = "127.0.0.1" },
+            bgpConfig,
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            metrics,
+            new NopLogger<BgpSession>());
+
+        var runTask = await EstablishSessionAsync(session, client, bgpConfig);
+
+        // Build a truncated-attribute UPDATE frame by hand: valid header, valid withdrawn/attrs
+        // length, but an attribute that declares 5 bytes of value and provides only 1.
+        var malformedFrame = BuildUpdateFrame(0x00, 0x01, 0x05, 0xFF); // flags, ORIGIN, len=5, 1 byte
+        client.Send(malformedFrame, 0, malformedFrame.Length, SocketFlags.None);
+
+        // Give the read loop a bounded window to receive + reject the bad frame, with a fallback
+        // re-check so the test is not purely timing-dependent.
+        for (var i = 0; i < 20 && metrics.UpdatesRejected == 0; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(50));
+
+        Assert.True(session.IsEstablished, "session must survive a malformed-attribute UPDATE (#222)");
+        Assert.True(metrics.UpdatesRejected >= 1, "the malformed UPDATE must be counted as rejected");
+
+        // No NOTIFICATION on the wire — we keep the session (RFC 7606: no notify on treat-as-withdraw).
+        var sent = await DrainAsync(client, TimeSpan.FromSeconds(2));
+        Assert.DoesNotContain(sent, m => m is BgpNotificationMessage);
+
+        session.MarkSilentClose();
+        await runTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    /// <summary>
+    /// Complement to <see cref="MalformedUpdate_OnWire_KeepsSessionEstablished"/>: a STREAM-LEVEL
+    /// corruption (invalid marker/length/type in the fixed 19-byte header — BgpParseException with
+    /// <c>ErrorCode == null</c>) MUST still tear the session down with NOTIFICATION(MessageHeaderError),
+    /// per RFC 4271 §6.1. The treat-as-withdraw catch in ReadLoopAsync filters on
+    /// <c>ErrorCode is not null</c>, so fixed-header failures propagate to RunAsync. This test guards
+    /// against a regression where that filter is dropped (which would also desync the byte stream:
+    /// the payload of the bad frame would be read as the next header).
+    /// </summary>
+    [Fact]
+    public async Task InvalidHeaderLength_OnWire_TearsDownSession_With_MessageHeaderError()
+    {
+        var (server, client) = ConnectedPair();
+        using var clientSock = client;
+        var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
+        using var session = new BgpSession(
+            new SocketBgpConnection(server),
+            new PeerConfig { Address = "127.0.0.1" },
+            bgpConfig,
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            new NopLogger<BgpSession>());
+
+        var runTask = await EstablishSessionAsync(session, client, bgpConfig);
+
+        // A frame whose declared length is below the BGP minimum (19): valid marker + a 2-byte
+        // length of 5 + a type byte. ReceiveMessageAsync throws BgpParseException (ErrorCode == null)
+        // AFTER reading the 19-byte header but BEFORE reading any payload.
+        var badHeader = new byte[BgpConstants.MessageHeaderSize];
+        BgpConstants.Marker.CopyTo(badHeader.AsSpan(0, BgpConstants.MarkerSize));
+        BinaryPrimitives.WriteUInt16BigEndian(badHeader.AsSpan(16, 2), 5); // length < MinMessageSize
+        badHeader[18] = (byte)BgpMessageType.Update;
+        client.Send(badHeader, 0, badHeader.Length, SocketFlags.None);
+
+        // The session must tear down: RunAsync unwinds, finally transitions to Idle.
+        for (var i = 0; i < 40 && session.IsEstablished; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(50));
+        Assert.False(session.IsEstablished, "session must tear down on a fixed-header error (RFC 4271 §6.1)");
+
+        // And a MessageHeaderError NOTIFICATION must be on the wire.
+        var sent = await DrainAsync(client, TimeSpan.FromSeconds(2));
+        var notif = sent.OfType<BgpNotificationMessage>().SingleOrDefault();
+        Assert.NotNull(notif);
+        Assert.Equal(BgpConstants.Error.MessageHeaderError, notif!.ErrorCode);
+
+        try { await runTask.WaitAsync(TimeSpan.FromSeconds(5)); }
+        catch (OperationCanceledException) { /* session torn down */ }
+        catch (IOException) { /* client socket closed by teardown */ }
+    }
+
+    // ---- helpers ----
+
+    private static byte[] BuildUpdateFrame(params byte[] attributeBytes)
+    {
+        // withdrawn_len=0, attrs_len=len(attr bytes), the attr bytes, no NLRI.
+        var payload = new byte[4 + attributeBytes.Length];
+        BinaryPrimitives.WriteUInt16BigEndian(payload.AsSpan(0, 2), 0); // withdrawn len
+        BinaryPrimitives.WriteUInt16BigEndian(payload.AsSpan(2, 2), (ushort)attributeBytes.Length); // attrs len
+        Array.Copy(attributeBytes, 0, payload, 4, attributeBytes.Length);
+        return BuildMessage(BgpMessageType.Update, payload);
+    }
+
+    private static byte[] BuildMessage(BgpMessageType type, byte[] payload)
+    {
+        var frame = new byte[BgpConstants.MessageHeaderSize + payload.Length];
+        BgpConstants.Marker.CopyTo(frame.AsSpan(0, BgpConstants.MarkerSize));
+        BinaryPrimitives.WriteUInt16BigEndian(frame.AsSpan(16, 2), (ushort)frame.Length);
+        frame[18] = (byte)type;
+        Array.Copy(payload, 0, frame, BgpConstants.MessageHeaderSize, payload.Length);
+        return frame;
+    }
+
+    private static (Socket server, Socket client) ConnectedPair()
+    {
+        using var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        listener.Listen(1);
+        var client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        client.Connect(listener.LocalEndPoint!);
+        return (listener.Accept(), client);
+    }
+
+    private static void ReadExact(Socket s, byte[] buf, int offset, int count)
+    {
+        var got = 0;
+        while (got < count)
+        {
+            var n = s.Receive(buf, offset + got, count - got, SocketFlags.None);
+            if (n == 0) throw new IOException("socket closed");
+            got += n;
+        }
+    }
+
+    private static async Task<Task> EstablishSessionAsync(BgpSession session, Socket client, BgpConfig bgpConfig)
+    {
+        var runTask = session.RunAsync();
+        // Send OPEN + KEEPALIVE; drain the server's OPEN/KEEPALIVE so the session reaches Established.
+        var open = new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = (ushort)bgpConfig.HoldTime,
+            RouterId = 0x0A000002,
+            Capabilities = [BgpCapabilityInfo.FourOctetAsn(65002)]
+        };
+        Send(client, open);
+        var keepalive = new BgpKeepaliveMessage();
+        Send(client, keepalive);
+        // Drain server-side OPEN + KEEPALIVE (the handshake response) so the session advances.
+        await DrainAsync(client, TimeSpan.FromSeconds(5));
+        // Wait until Established (initial route dump is async on holdTime=0 → ReadLoopAsync).
+        for (var i = 0; i < 50 && !session.IsEstablished; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(20));
+        Assert.True(session.IsEstablished, "session must reach Established before injecting the malformed frame");
+        return runTask;
+    }
+
+    private static void Send(Socket s, BgpMessage msg)
+    {
+        var buf = new byte[BgpMessageWriter.GetBufferSize(msg)];
+        var n = BgpMessageWriter.WriteMessage(msg, buf);
+        s.Send(buf, 0, n, SocketFlags.None);
+    }
+
+    private static async Task<List<BgpMessage>> DrainAsync(Socket client, TimeSpan timeout)
+    {
+        var sent = new List<BgpMessage>();
+        client.ReceiveTimeout = (int)timeout.TotalMilliseconds;
+        var buf = new byte[4096];
+        var deadline = DateTime.UtcNow + timeout;
+        try
+        {
+            while (DateTime.UtcNow < deadline)
+            {
+                if (client.Poll(100_000, SelectMode.SelectRead)) // 100ms
+                {
+                    var available = client.Available;
+                    if (available == 0) break; // peer closed
+                    var got = client.Receive(buf, 0, Math.Min(available, buf.Length), SocketFlags.None);
+                    if (got == 0) break;
+                    ParseAll(buf, got, sent);
+                }
+            }
+        }
+        catch (SocketException) { /* timeout / peer closed */ }
+        return sent;
+    }
+
+    private static void ParseAll(byte[] buffer, int length, List<BgpMessage> into)
+    {
+        var offset = 0;
+        while (offset + BgpConstants.MessageHeaderSize <= length)
+        {
+            var msgLen = BgpMessageReader.GetMessageLength(buffer.AsSpan(offset, length - offset));
+            if (msgLen <= 0 || offset + msgLen > length) break;
+            try { into.Add(BgpMessageReader.ReadMessage(buffer.AsSpan(offset, msgLen))); }
+            catch (BgpParseException) { /* ignore unparseable outbound frame */ }
+            offset += msgLen;
+        }
+    }
+
+    private sealed class NopLogger<T> : ILogger<T>
+    {
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NopDisposable.Instance;
+        public bool IsEnabled(LogLevel logLevel) => false;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) { }
+        private sealed class NopDisposable : IDisposable
+        {
+            public static readonly NopDisposable Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/BGPLite.Tests/MalformedUpdateResilienceTests.cs
+++ b/BGPLite.Tests/MalformedUpdateResilienceTests.cs
@@ -136,13 +136,21 @@ public class MalformedUpdateResilienceTests
     /// <c>ErrorCode is not null</c>, so fixed-header failures propagate to RunAsync. This test guards
     /// against a regression where that filter is dropped (which would also desync the byte stream:
     /// the payload of the bad frame would be read as the next header).
+    /// <para>
+    /// Parameterized over HoldTime: <c>0</c> takes the direct <c>ReadLoopAsync</c> path in
+    /// <c>RunEstablishedAsync</c>; <c>60</c> takes the <c>Task.WhenAny</c>/<c>AwaitLoopTaskAsync</c>
+    /// path. The latter has its own propagation gap (AwaitLoopTaskAsync's generic catch used to swallow
+    /// the BgpParseException and fall back to the finally-block Cease), so both paths are covered.
+    /// </para>
     /// </summary>
-    [Fact]
-    public async Task InvalidHeaderLength_OnWire_TearsDownSession_With_MessageHeaderError()
+    [Theory]
+    [InlineData(0)]   // holdTime=0: ReadLoopAsync awaited directly → propagates
+    [InlineData(60)]  // holdTime>0: Task.WhenAny → AwaitLoopTaskAsync → must rethrow BgpParseException
+    public async Task InvalidHeaderLength_OnWire_TearsDownSession_With_MessageHeaderError(int holdTime)
     {
         var (server, client) = ConnectedPair();
         using var clientSock = client;
-        var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
+        var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = holdTime, KeepAlive = Math.Max(1, holdTime / 3) };
         using var session = new BgpSession(
             new SocketBgpConnection(server),
             new PeerConfig { Address = "127.0.0.1" },
@@ -168,7 +176,8 @@ public class MalformedUpdateResilienceTests
             await Task.Delay(TimeSpan.FromMilliseconds(50));
         Assert.False(session.IsEstablished, "session must tear down on a fixed-header error (RFC 4271 §6.1)");
 
-        // And a MessageHeaderError NOTIFICATION must be on the wire.
+        // And a MessageHeaderError NOTIFICATION must be on the wire (not a generic Cease — that would
+        // indicate AwaitLoopTaskAsync swallowed the BgpParseException and the finally-block fired).
         var sent = await DrainAsync(client, TimeSpan.FromSeconds(2));
         var notif = sent.OfType<BgpNotificationMessage>().SingleOrDefault();
         Assert.NotNull(notif);

--- a/BGPLite.Tests/PrefixCodecTests.cs
+++ b/BGPLite.Tests/PrefixCodecTests.cs
@@ -101,9 +101,13 @@ public class PrefixCodecTests
     [InlineData(255)]
     public void Decode_LengthAbove32_Throws(int badLength)
     {
+        // #222: a malformed NLRI prefix-length byte is a wire-level error and now surfaces as
+        // BgpParseException (Update Message Error) so the session can treat-as-withdraw instead of
+        // tearing down. Previously this was ArgumentOutOfRangeException which escaped the read loop.
         var buffer = new byte[8] { (byte)badLength, 0xC0, 0xA8, 0x00, 0x00, 0, 0, 0 };
 
-        Assert.Throws<ArgumentOutOfRangeException>(() => PrefixCodec.Decode(buffer));
+        var ex = Assert.Throws<BgpParseException>(() => PrefixCodec.Decode(buffer));
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
     }
 
     [Fact]
@@ -149,12 +153,15 @@ public class PrefixCodecTests
     [Fact]
     public void Decode_EmptyBuffer_Throws()
     {
+        // #222: a truncated NLRI is now BgpParseException (Update Message Error), not
+        // ArgumentOutOfRangeException — so the session treats it as withdraw, not teardown.
         var buffer = Array.Empty<byte>();
-        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        var ex = Assert.Throws<BgpParseException>(() =>
         {
             var span = new ReadOnlySpan<byte>(buffer);
             PrefixCodec.Decode(span);
         });
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
     }
 
     [Fact]
@@ -162,8 +169,10 @@ public class PrefixCodecTests
     {
         // /24 needs 4 bytes total (1 length + 3 data). 2-byte buffer is truncated
         // mid-prefix and must be rejected before any read past the length byte.
+        // #222: surfaces as BgpParseException (Update Message Error).
         var buffer = new byte[] { 24, 0xC0 };
 
-        Assert.Throws<ArgumentOutOfRangeException>(() => PrefixCodec.Decode(buffer));
+        var ex = Assert.Throws<BgpParseException>(() => PrefixCodec.Decode(buffer));
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
     }
 }

--- a/BGPLite.Tests/PrefixServiceTests.cs
+++ b/BGPLite.Tests/PrefixServiceTests.cs
@@ -129,6 +129,26 @@ public class PrefixServiceTests
         Assert.Empty(result);
     }
 
+    /// <summary>
+    /// Regression for #225: when the cancellation token is cancelled, GetPrefixesForAsns must
+    /// throw OperationCanceledException (or a TaskCanceledException subclass — the OCE family)
+    /// instead of returning a partial list (cancelled ASNs were silently dropped to [] by
+    /// ResolveAsnAsync's bare catch). The cancellation contract — OCE always propagates, never
+    /// swallowed (#114) — must hold here as it does everywhere else. ThrowsAnyAsync accepts the
+    /// TaskCanceledException subclass that the gate.WaitAsync(ct) surfaces when the token is
+    /// already cancelled.
+    /// </summary>
+    [Fact]
+    public async Task GetPrefixesForAsns_CancelledToken_PropagatesOperationCanceledException()
+    {
+        var service = Service(new PerAsnHandler());
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            service.GetPrefixesForAsns([100, 200, 300], cts.Token));
+    }
+
     [Fact]
     public async Task GetPrefixesForAsns_RepeatedAsn_DeduplicatesViaCache()
     {


### PR DESCRIPTION
## Summary

Three BGP protocol correctness fixes, closing #222, #223, #225.

- **#222** — `ParseAttribute` / `PrefixCodec.Decode` threw `ArgumentOutOfRangeException` on malformed/truncated path attributes and NLRI. It escaped `ReadLoopAsync` (which only caught `OperationCanceledException` / `IOException`) and tore down long-lived sessions with a generic `Cease(6,0)`. Now these surface as `BgpParseException` (Update Message Error) and are handled by a **treat-as-withdraw** catch in `ReadLoopAsync` (RFC 7606 §2 / RFC 4271 §6.3). The catch filters on `ErrorCode is not null` so **fixed-header errors (marker/length/type) still propagate to teardown** per RFC 4271 §6.1 — this avoids a stream-desync hazard where a length-out-of-range leaves the payload unread.
- **#223** — `BgpParseException` now carries the RFC 4271 §6 error code/subcode the parser recorded (`Open Message Error` for OPEN body, `Update Message Error` for UPDATE body, `null` for fixed-header). `RunAsync` emits the right NOTIFICATION instead of always `MessageHeaderError`.
- **#225** — `ResolveAsnAsync` swallowed all exceptions including `OperationCanceledException`, silently returning a partial prefix list on shutdown/refresh-with-cancel. Now OCE propagates when the caller's token is cancelled (per the #114 policy).

## Why

A single malformed or adversarial inbound UPDATE should not cost a route-server its long-lived session — the peer then has no session to learn routes from, and the operator sees only `"read loop faulted" / Cease 6/0` with no real cause. This is the single highest-risk bug from the 2026-08-03 audit: a production outage triggered by one packet. The NOTIFICATION-error-code and cancellation fixes ride along because they touch the same code paths.

## Validation

```
dotnet format                              # clean
dotnet test                                # 503 passed, 0 failed, 0 skipped
dotnet test --filter "MalformedUpdateResilience"   # 7/7 regression tests pass
dotnet test --filter "BgpMessage|BgpSession|PrefixCodec|PrefixService"   # green
```

Updated 3 existing `PrefixCodec.Decode` tests to the new contract (`ArgumentOutOfRangeException` → `BgpParseException` + `ErrorCode` assertion). Added 7 regression tests:
- `ParseAttribute_TruncatedHeaderValue_ThrowsBgpParseException_NotAOORE`
- `ParseAttribute_ExtendedLengthFlag_TooFewHeaderBytes_ThrowsBgpParseException`
- `ParseUpdate_WithdrawnLengthExceedsPayload_ThrowsBgpParseException`
- `ParseOpen_TooShort_PropagatesOpenMessageErrorCode`
- `ParseOpen_UnsupportedVersion_PropagatesOpenMessageErrorSubcode1`
- `MalformedUpdate_OnWire_KeepsSessionEstablished` (end-to-end, session stays up)
- `InvalidHeaderLength_OnWire_TearsDownSession_With_MessageHeaderError` (fixed-header still tears down — guards against dropping the `ErrorCode is not null` filter, which would also desync the byte stream)
- `GetPrefixesForAsns_CancelledToken_PropagatesOperationCanceledException`

## Risk

- **Behaviour change** (intended): a malformed inbound UPDATE no longer tears down the session — it is discarded, logged, and counted (`metrics.UpdateRejected`). This is RFC 7606 compliant. Peers that relied on the teardown as a signal will see the session persist instead.
- **Exception-type change** (intended): `PrefixCodec.Decode` now throws `BgpParseException` instead of `ArgumentOutOfRangeException`. Any external caller depending on the old type would break — but all callers are in-tree and updated.
- **No protocol wire-format change**: outbound bytes are unchanged.

Self-reviewed before opening; two BLOCKER findings from the review (catch too broad, misleading comment) were fixed before commit.

Closes #222
Closes #223
Closes #225

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed BGP OPEN and UPDATE messages with clearer protocol error details.
  * Prevented malformed updates from unnecessarily terminating established sessions.
  * Invalid prefix data now produces consistent parsing errors.
  * Caller-requested cancellation now propagates correctly instead of returning partial results.
* **Reliability**
  * Fixed truncated and invalid message data handling to avoid unexpected runtime exceptions.
  * Fixed-header errors continue to close affected sessions appropriately.
* **Tests**
  * Added coverage for malformed messages, session resilience, prefix validation, and cancellation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->