### PR TITLE
fix(api): atomic PeerStore mutations + save-time SSRF validation + upsert race fix

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -749,8 +749,15 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (data is null || string.IsNullOrWhiteSpace(data.Name) || string.IsNullOrWhiteSpace(data.Url))
             return ApiResponse.Error("Name and Url are required", 400);
 
-        if (!Uri.TryCreate(data.Url, UriKind.Absolute, out var uri) || uri.Scheme is not ("http" or "https"))
-            return ApiResponse.Error($"Invalid URL: {data.Url}", 400);
+        // #232: full SSRF validation at save time (defence-in-depth on top of the fetch-time
+        // ConnectCallback). Reject a URL that is malformed, uses a non-http(s) scheme, resolves to
+        // a private/loopback/link-local address, or uses a non-80/443 port — before persisting it,
+        // so the caller gets a clear 400 instead of a silently-saved source that fails forever at
+        // fetch time. The fetch-time ConnectCallback MUST stay regardless: it is the authoritative
+        // layer covering every fetch path and survives any future change to the HTTP handler.
+        var (isValid, validationError) = await PrefixSourceUrlValidator.ValidateUrlAsync(data.Url);
+        if (!isValid)
+            return ApiResponse.Error(validationError ?? $"Invalid URL: {data.Url}", 400);
 
         var source = _store.AddCustomSource(peerId, data.Name, data.Url, data.Community);
 

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -755,9 +755,34 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // so the caller gets a clear 400 instead of a silently-saved source that fails forever at
         // fetch time. The fetch-time ConnectCallback MUST stay regardless: it is the authoritative
         // layer covering every fetch path and survives any future change to the HTTP handler.
-        var (isValid, validationError) = await PrefixSourceUrlValidator.ValidateUrlAsync(data.Url);
+        //
+        // The validator's raw error text (blocked-IP address, DNS exception message) is logged here
+        // but NOT returned to the client — that would leak internal DNS/address details and bypass
+        // the non-revealing-error policy (#157). The client sees a stable generic message; the
+        // operator sees the cause in the server log.
+        //
+        // The DNS resolution step is bounded by a 5s timeout so a hanging resolver cannot pin the
+        // handler indefinitely — the fetch path is already bounded by Polly, this closes the
+        // save-path gap. HttpListener does NOT expose a client-disconnect CancellationToken
+        // (unlike ASP.NET Core's RequestAborted), so the timeout is purely time-bounded.
+        using var validationCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        bool isValid;
+        string? validationError;
+        try
+        {
+            (isValid, validationError) = await PrefixSourceUrlValidator.ValidateUrlAsync(data.Url, ct: validationCts.Token);
+        }
+        catch (OperationCanceledException) when (validationCts.IsCancellationRequested)
+        {
+            // DNS-resolution timeout (5s).
+            _logger.LogWarning("Save-time URL validation timed out for '{Url}'", SanitizeForLog(data.Url));
+            return ApiResponse.Error("URL validation timed out (DNS resolution took too long)", 400);
+        }
         if (!isValid)
-            return ApiResponse.Error(validationError ?? $"Invalid URL: {data.Url}", 400);
+        {
+            _logger.LogWarning("Save-time URL validation rejected '{Url}': {Error}", SanitizeForLog(data.Url), validationError);
+            return ApiResponse.Error($"Invalid URL: the host could not be reached or is not allowed", 400);
+        }
 
         var source = _store.AddCustomSource(peerId, data.Name, data.Url, data.Community);
 

--- a/BGPLite.Api/PeerStore.cs
+++ b/BGPLite.Api/PeerStore.cs
@@ -13,45 +13,78 @@ public sealed class PeerStore : IPeerStore
     public string CreatePeer(string ip, uint asn, string? description)
     {
         using var db = _dbFactory.CreateDbContext();
-        var existing = db.Peers.FirstOrDefault(p => p.Ip == ip && p.Asn == asn);
-        if (existing is not null)
-        {
-            existing.Description = description;
-            db.SaveChanges();
-            return existing.Id;
-        }
+        // #227: atomic SQLite upsert eliminates the read-then-write race on the composite unique
+        // index UX_Peers_Ip_Asn. Two concurrent CreatePeer calls for the same (Ip, Asn) previously
+        // both observed `existing is null`, both INSERTed, and the second threw DbUpdateException
+        // (UNIQUE constraint failed). Now a single INSERT ... ON CONFLICT DO UPDATE either inserts
+        // or updates the Description atomically, then SELECT returns the Id. Id is generated here
+        // (not by the DB) so the INSERT carries it explicitly.
+        var id = Guid.NewGuid().ToString("N");
+        var now = DateTime.UtcNow.ToString("O");
+        db.Database.ExecuteSqlInterpolated($@"
+            INSERT INTO Peers (Id, Ip, Asn, Description, Status, CreatedAt, LastSessionAt)
+            VALUES ({id}, {ip}, {asn}, {description}, 'inactive', {now}, NULL)
+            ON CONFLICT(Ip, Asn) DO UPDATE SET Description = excluded.Description");
+        // Read back the actual Id (ours on insert, the existing row's on conflict) — RETURNING is
+        // available on SQLite 3.35+ (Microsoft.Data.Sqlite >= 6), but a follow-up SELECT keeps the
+        // code path identical across provider versions and avoids interpolating the generated id
+        // into the ON CONFLICT branch where the existing row's id wins.
+        // FirstOrDefault (not First): in the narrow window where a concurrent DeletePeer removes the
+        // row between the upsert and this SELECT, First() would throw InvalidOperationException; we
+        // retry the upsert once instead so CreatePeer either returns a valid id or throws a clear
+        // DbUpdateException (consistent with the caller's MapExceptionToResponse → 409 path).
+        var storedId = db.Peers.AsNoTracking()
+            .Where(p => p.Ip == ip && p.Asn == asn)
+            .Select(p => (string?)p.Id)
+            .FirstOrDefault();
+        if (storedId is not null)
+            return storedId;
 
-        var peer = new Peer { Ip = ip, Asn = asn, Description = description };
-        db.Peers.Add(peer);
-        db.SaveChanges();
-        return peer.Id;
+        // Lost a race with DeletePeer: re-run the upsert (this time it inserts) and read again.
+        var retryId = Guid.NewGuid().ToString("N");
+        db.Database.ExecuteSqlInterpolated($@"
+            INSERT INTO Peers (Id, Ip, Asn, Description, Status, CreatedAt, LastSessionAt)
+            VALUES ({retryId}, {ip}, {asn}, {description}, 'inactive', {now}, NULL)
+            ON CONFLICT(Ip, Asn) DO UPDATE SET Description = excluded.Description");
+        return db.Peers.AsNoTracking()
+            .Where(p => p.Ip == ip && p.Asn == asn)
+            .Select(p => p.Id)
+            .First();
     }
 
     public void UpsertPeer(string ip, uint asn)
     {
         using var db = _dbFactory.CreateDbContext();
-        var peer = db.Peers.FirstOrDefault(p => p.Ip == ip && p.Asn == asn);
-        if (peer is null)
-        {
-            db.Peers.Add(new Peer { Ip = ip, Asn = asn, Status = "active", LastSessionAt = DateTime.UtcNow });
-        }
-        else
-        {
-            peer.Status = "active";
-            peer.LastSessionAt = DateTime.UtcNow;
-        }
-        db.SaveChanges();
+        // #227: atomic upsert — see CreatePeer. UpsertPeer is called from the BGP connect path
+        // (Program.cs _onPeerIdentified), where there is no HTTP caller to receive a 409, so the
+        // previous read-then-write race could throw DbUpdateException into the session handler.
+        var id = Guid.NewGuid().ToString("N");
+        var now = DateTime.UtcNow.ToString("O");
+        db.Database.ExecuteSqlInterpolated($@"
+            INSERT INTO Peers (Id, Ip, Asn, Description, Status, CreatedAt, LastSessionAt)
+            VALUES ({id}, {ip}, {asn}, NULL, 'active', {now}, {now})
+            ON CONFLICT(Ip, Asn) DO UPDATE SET Status = 'active', LastSessionAt = {now}");
     }
 
     public void UpdateSessionStatus(string ip, uint asn, bool active)
     {
         using var db = _dbFactory.CreateDbContext();
-        var peer = db.Peers.FirstOrDefault(p => p.Ip == ip && p.Asn == asn);
-        if (peer is null) return;
-
-        peer.Status = active ? "active" : "inactive";
-        if (active) peer.LastSessionAt = DateTime.UtcNow;
-        db.SaveChanges();
+        // #227: single-statement UPDATE avoids the read-then-write race and is a no-op (0 rows
+        // affected) if the peer was concurrently deleted, instead of throwing on a null entity.
+        var status = active ? "active" : "inactive";
+        var now = DateTime.UtcNow.ToString("O");
+        if (active)
+        {
+            db.Database.ExecuteSqlInterpolated($@"
+                UPDATE Peers SET Status = {status}, LastSessionAt = {now}
+                WHERE Ip = {ip} AND Asn = {asn}");
+        }
+        else
+        {
+            db.Database.ExecuteSqlInterpolated($@"
+                UPDATE Peers SET Status = {status}
+                WHERE Ip = {ip} AND Asn = {asn}");
+        }
     }
 
     public void DeletePeer(string id)
@@ -196,10 +229,16 @@ public sealed class PeerStore : IPeerStore
     public void SetCommunities(string peerId, HashSet<uint> communities)
     {
         using var db = _dbFactory.CreateDbContext();
+        // #226: ExecuteDelete runs in its own implicit transaction and AddRange/SaveChanges in
+        // another; without an explicit transaction a failure between them leaves the peer with an
+        // EMPTY collection (delete committed, insert did not). Wrap both in one transaction so the
+        // replace is atomic.
+        using var tx = db.Database.BeginTransaction();
         db.Set<PeerCommunity>().Where(c => c.PeerId == peerId).ExecuteDelete();
         db.Set<PeerCommunity>().AddRange(
             communities.Select(c => new PeerCommunity { PeerId = peerId, Community = c }));
         db.SaveChanges();
+        tx.Commit();
     }
 
     public void ClearCommunities(string peerId)
@@ -221,10 +260,13 @@ public sealed class PeerStore : IPeerStore
     public void SetSubscriptions(string peerId, List<string> asnListNames)
     {
         using var db = _dbFactory.CreateDbContext();
+        // #226: wrap delete+insert in a transaction — see SetCommunities.
+        using var tx = db.Database.BeginTransaction();
         db.Set<PeerSubscription>().Where(s => s.PeerId == peerId).ExecuteDelete();
         db.Set<PeerSubscription>().AddRange(
             asnListNames.Select(n => new PeerSubscription { PeerId = peerId, AsnListName = n }));
         db.SaveChanges();
+        tx.Commit();
     }
 
     // AsNoTracking is a read-only-intent marker here — a no-op for this scalar projection (no entities are materialized to track).
@@ -240,10 +282,13 @@ public sealed class PeerStore : IPeerStore
     public void SetCustomPrefixes(string peerId, List<(string Prefix, byte Length)> prefixes)
     {
         using var db = _dbFactory.CreateDbContext();
+        // #226: wrap delete+insert in a transaction — see SetCommunities.
+        using var tx = db.Database.BeginTransaction();
         db.Set<PeerCustomPrefix>().Where(c => c.PeerId == peerId).ExecuteDelete();
         db.Set<PeerCustomPrefix>().AddRange(
             prefixes.Select(p => new PeerCustomPrefix { PeerId = peerId, Prefix = p.Prefix, PrefixLength = p.Length }));
         db.SaveChanges();
+        tx.Commit();
     }
 
     // AsNoTracking is a read-only-intent marker here — a no-op for this scalar projection (no entities are materialized to track).
@@ -259,10 +304,13 @@ public sealed class PeerStore : IPeerStore
     public void SetCustomAsns(string peerId, List<uint> asns)
     {
         using var db = _dbFactory.CreateDbContext();
+        // #226: wrap delete+insert in a transaction — see SetCommunities.
+        using var tx = db.Database.BeginTransaction();
         db.Set<PeerCustomAsn>().Where(c => c.PeerId == peerId).ExecuteDelete();
         db.Set<PeerCustomAsn>().AddRange(
             asns.Select(a => new PeerCustomAsn { PeerId = peerId, Asn = a }));
         db.SaveChanges();
+        tx.Commit();
     }
 
     /// <summary>

--- a/BGPLite.Api/PeerStore.cs
+++ b/BGPLite.Api/PeerStore.cs
@@ -16,40 +16,52 @@ public sealed class PeerStore : IPeerStore
         // #227: atomic SQLite upsert eliminates the read-then-write race on the composite unique
         // index UX_Peers_Ip_Asn. Two concurrent CreatePeer calls for the same (Ip, Asn) previously
         // both observed `existing is null`, both INSERTed, and the second threw DbUpdateException
-        // (UNIQUE constraint failed). Now a single INSERT ... ON CONFLICT DO UPDATE either inserts
-        // or updates the Description atomically, then SELECT returns the Id. Id is generated here
-        // (not by the DB) so the INSERT carries it explicitly.
+        // (UNIQUE constraint failed). Now a single INSERT ... ON CONFLICT DO UPDATE ... RETURNING
+        // is fully atomic: the existence check, the insert-or-update, AND the id read-back happen
+        // in one statement — no TOCTOU window for a concurrent DeletePeer to race against (the
+        // earlier upsert + follow-up SELECT had such a window). RETURNING requires SQLite 3.35+
+        // (Microsoft.Data.Sqlite >= 6) — satisfied by the EF Core Sqlite 10 dependency.
+        //
+        // EF Core's SqlQuery<T> is documented only for SELECT/composable queries, so for a DML
+        // statement with RETURNING we go through the underlying ADO.NET connection (ExecuteScalar)
+        // — the documented path for a single scalar result from non-composable SQL.
         var id = Guid.NewGuid().ToString("N");
         var now = DateTime.UtcNow.ToString("O");
-        db.Database.ExecuteSqlInterpolated($@"
-            INSERT INTO Peers (Id, Ip, Asn, Description, Status, CreatedAt, LastSessionAt)
-            VALUES ({id}, {ip}, {asn}, {description}, 'inactive', {now}, NULL)
-            ON CONFLICT(Ip, Asn) DO UPDATE SET Description = excluded.Description");
-        // Read back the actual Id (ours on insert, the existing row's on conflict) — RETURNING is
-        // available on SQLite 3.35+ (Microsoft.Data.Sqlite >= 6), but a follow-up SELECT keeps the
-        // code path identical across provider versions and avoids interpolating the generated id
-        // into the ON CONFLICT branch where the existing row's id wins.
-        // FirstOrDefault (not First): in the narrow window where a concurrent DeletePeer removes the
-        // row between the upsert and this SELECT, First() would throw InvalidOperationException; we
-        // retry the upsert once instead so CreatePeer either returns a valid id or throws a clear
-        // DbUpdateException (consistent with the caller's MapExceptionToResponse → 409 path).
-        var storedId = db.Peers.AsNoTracking()
-            .Where(p => p.Ip == ip && p.Asn == asn)
-            .Select(p => (string?)p.Id)
-            .FirstOrDefault();
-        if (storedId is not null)
+        var connection = db.Database.GetDbConnection();
+        var closeAfter = false;
+        try
+        {
+            if (connection.State != System.Data.ConnectionState.Open)
+            {
+                db.Database.OpenConnection();
+                closeAfter = true;
+            }
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText =
+                "INSERT INTO Peers (Id, Ip, Asn, Description, Status, CreatedAt, LastSessionAt) " +
+                "VALUES (@id, @ip, @asn, @desc, 'inactive', @now, NULL) " +
+                "ON CONFLICT(Ip, Asn) DO UPDATE SET Description = excluded.Description " +
+                "RETURNING Id";
+            AddParam(cmd, "@id", id);
+            AddParam(cmd, "@ip", ip);
+            AddParam(cmd, "@asn", (long)asn);
+            AddParam(cmd, "@desc", (object?)description ?? DBNull.Value);
+            AddParam(cmd, "@now", now);
+            var storedId = (string)cmd.ExecuteScalar()!;
             return storedId;
+        }
+        finally
+        {
+            if (closeAfter) db.Database.CloseConnection();
+        }
+    }
 
-        // Lost a race with DeletePeer: re-run the upsert (this time it inserts) and read again.
-        var retryId = Guid.NewGuid().ToString("N");
-        db.Database.ExecuteSqlInterpolated($@"
-            INSERT INTO Peers (Id, Ip, Asn, Description, Status, CreatedAt, LastSessionAt)
-            VALUES ({retryId}, {ip}, {asn}, {description}, 'inactive', {now}, NULL)
-            ON CONFLICT(Ip, Asn) DO UPDATE SET Description = excluded.Description");
-        return db.Peers.AsNoTracking()
-            .Where(p => p.Ip == ip && p.Asn == asn)
-            .Select(p => p.Id)
-            .First();
+    private static void AddParam(System.Data.Common.DbCommand cmd, string name, object value)
+    {
+        var p = cmd.CreateParameter();
+        p.ParameterName = name;
+        p.Value = value;
+        cmd.Parameters.Add(p);
     }
 
     public void UpsertPeer(string ip, uint asn)

--- a/BGPLite.Providers/PrefixSourceUrlValidator.cs
+++ b/BGPLite.Providers/PrefixSourceUrlValidator.cs
@@ -147,10 +147,14 @@ public static class PrefixSourceUrlValidator
 
     /// <summary>
     /// Validates that a URL is well-formed, uses http/https, and resolves to a public IP.
-    /// For future API-level validation (when a user submits a URL, validate before storing).
-    /// The actual fetch-time defense is <see cref="CreateValidatedConnectionAsync"/>.
+    /// The actual fetch-time defense is <see cref="CreateValidatedConnectionAsync"/>; this method
+    /// is the save-time / API-submission-time defence-in-depth layer (#232): when a user submits a
+    /// prefix-source URL via the management API, validate before persisting so a bad URL is rejected
+    /// with a clear 400 instead of being saved and failing forever at fetch time. The fetch-time
+    /// <see cref="CreateValidatedConnectionAsync"/> MUST stay regardless — it is the authoritative
+    /// layer that covers every fetch path and survives any future change to the HTTP handler.
     /// </summary>
-    internal static async Task<(bool IsValid, string? Error)> ValidateUrlAsync(
+    public static async Task<(bool IsValid, string? Error)> ValidateUrlAsync(
         string url,
         Func<string, CancellationToken, ValueTask<IPAddress[]>>? dnsResolver = null,
         CancellationToken ct = default)

--- a/BGPLite.Tests/PeerStoreAtomicityTests.cs
+++ b/BGPLite.Tests/PeerStoreAtomicityTests.cs
@@ -190,13 +190,21 @@ public class PeerStoreAtomicityTests
         Assert.Equal("active", peer!.Status);
         Assert.NotNull(peer.LastSessionAt);
 
-        var firstSessionAt = peer.LastSessionAt;
+        var firstSessionAt = peer.LastSessionAt!;
+        // Sleep so a regression that stamps LastSessionAt with the OLD value (or a fixed value)
+        // would be caught by the comparison below. SQLite stores the timestamp as text in the
+        // round-trip "O" format, which sorts lexicographically = chronologically, so a string
+        // comparison is a valid ordering check.
+        Thread.Sleep(15);
 
         // Second call (update path) — must refresh LastSessionAt, not throw.
         store.UpsertPeer(Ip, Asn);
         var peer2 = store.GetPeer(Ip, Asn);
         Assert.NotNull(peer2);
         Assert.Equal("active", peer2!.Status);
+        Assert.NotNull(peer2.LastSessionAt);
+        Assert.True(string.CompareOrdinal(peer2.LastSessionAt, firstSessionAt) >= 0,
+            $"LastSessionAt must not go backwards: first={firstSessionAt}, second={peer2.LastSessionAt}");
     }
 
     /// <summary>

--- a/BGPLite.Tests/PeerStoreAtomicityTests.cs
+++ b/BGPLite.Tests/PeerStoreAtomicityTests.cs
@@ -1,0 +1,225 @@
+using BGPLite.Api;
+using BGPLite.Api.Entities;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// Regression coverage for #226 (SetCommunities/SetSubscriptions/SetCustomPrefixes/SetCustomAsns
+/// were non-atomic — delete-then-insert without a transaction, leaving an empty collection on a
+/// mid-mutation failure) and #227 (CreatePeer/UpsertPeer/UpdateSessionStatus used read-then-write,
+/// racing on the composite unique index and throwing DbUpdateException on a concurrent duplicate).
+/// Uses a real in-memory SQLite DB so transactions and the unique constraint are actually exercised.
+/// </summary>
+public class PeerStoreAtomicityTests
+{
+    private const string Ip = "203.0.113.10";
+    private const uint Asn = 64512;
+
+    private static (PeerStore store, SqliteConnection connection) NewStore()
+    {
+        var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        var options = new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(connection).Options;
+        using (var boot = new BgpDbContext(options))
+            BgpDbContext.Initialize(boot);
+        return (new PeerStore(new StaticOptionsFactory(options)), connection);
+    }
+
+    private sealed class StaticOptionsFactory : IDbContextFactory<BgpDbContext>
+    {
+        private readonly DbContextOptions<BgpDbContext> _options;
+        public StaticOptionsFactory(DbContextOptions<BgpDbContext> options) => _options = options;
+        public BgpDbContext CreateDbContext() => new(_options);
+    }
+
+    private static string SeedPeer(PeerStore store) => store.CreatePeer(Ip, Asn, "test");
+
+    // ---- #226: Set* atomicity ----
+
+    /// <summary>
+    /// #226: after SetCommunities replaces the set, exactly the new communities are present — the
+    /// delete+insert pair committed atomically, so there is never an empty-collection window.
+    /// </summary>
+    [Fact]
+    public void SetCommunities_Replaces_Atomiclly()
+    {
+        var (store, connection) = NewStore();
+        using var conn = connection;
+        var peerId = SeedPeer(store);
+
+        store.SetCommunities(peerId, [0x65001000, 0x65002000]);
+        store.SetCommunities(peerId, [0x65003000]);
+
+        var communities = store.GetCommunities(peerId).OrderBy(c => c).ToArray();
+        Assert.Equal([0x65003000u], communities);
+    }
+
+    [Fact]
+    public void SetSubscriptions_Replaces_Atomiclly()
+    {
+        var (store, connection) = NewStore();
+        using var conn = connection;
+        var peerId = SeedPeer(store);
+
+        store.SetSubscriptions(peerId, ["list-a", "list-b"]);
+        store.SetSubscriptions(peerId, ["list-c"]);
+
+        Assert.Equal(["list-c"], store.GetSubscriptions(peerId));
+    }
+
+    [Fact]
+    public void SetCustomPrefixes_Replaces_Atomiclly()
+    {
+        var (store, connection) = NewStore();
+        using var conn = connection;
+        var peerId = SeedPeer(store);
+
+        store.SetCustomPrefixes(peerId, [("10.0.0.0", (byte)24), ("10.1.0.0", (byte)24)]);
+        store.SetCustomPrefixes(peerId, [("192.168.0.0", (byte)16)]);
+
+        Assert.Equal(["192.168.0.0/16"], store.GetCustomPrefixes(peerId));
+    }
+
+    [Fact]
+    public void SetCustomAsns_Replaces_Atomiclly()
+    {
+        var (store, connection) = NewStore();
+        using var conn = connection;
+        var peerId = SeedPeer(store);
+
+        store.SetCustomAsns(peerId, [64512, 64513]);
+        store.SetCustomAsns(peerId, [64514]);
+
+        Assert.Equal([64514u], store.GetCustomAsns(peerId));
+    }
+
+    /// <summary>
+    /// #226: a second replace after the collection was emptied (replace-with-empty) must leave it
+    /// empty, then a non-empty replace must populate it again — guards against a regression where
+    /// the transaction is dropped and an empty-collection window corrupts the state.
+    /// </summary>
+    [Fact]
+    public void SetCustomPrefixes_Empty_Then_Refill_Roundtrips()
+    {
+        var (store, connection) = NewStore();
+        using var conn = connection;
+        var peerId = SeedPeer(store);
+
+        store.SetCustomPrefixes(peerId, [("10.0.0.0", (byte)8)]);
+        store.SetCustomPrefixes(peerId, []);
+        Assert.Empty(store.GetCustomPrefixes(peerId));
+
+        store.SetCustomPrefixes(peerId, [("172.16.0.0", (byte)12)]);
+        Assert.Equal(["172.16.0.0/12"], store.GetCustomPrefixes(peerId));
+    }
+
+    /// <summary>
+    /// #226 fault-injection: if the INSERT half of the delete+insert fails (here: a duplicate
+    /// (PeerId, Prefix, PrefixLength) row that violates the composite PK at the SQLite level), the
+    /// transaction MUST roll back — the previously-stored prefixes survive. Without the transaction
+    /// wrapper the ExecuteDelete would have committed and the peer would be left with an EMPTY
+    /// collection. Drives the regression directly: a fault mid-mutation must not corrupt prior state.
+    /// </summary>
+    [Fact]
+    public void SetCustomPrefixes_RollsBack_On_Insert_Failure()
+    {
+        var (store, connection) = NewStore();
+        using var conn = connection;
+        var peerId = SeedPeer(store);
+        store.SetCustomPrefixes(peerId, [("10.0.0.0", (byte)24)]);
+
+        // Reproduce the exact delete+insert shape of SetCustomPrefixes, then fault the insert side
+        // with a SQLite UNIQUE violation. ExecuteSqlRaw bypasses the EF change tracker (which would
+        // otherwise throw InvalidOperationException on a duplicate tracked entity before reaching
+        // the DB), so the second INSERT reaches SQLite and fails → the transaction must roll back,
+        // leaving the original prefix intact.
+        var options = new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(connection).Options;
+        using (var db = new BgpDbContext(options))
+        {
+            using var tx = db.Database.BeginTransaction();
+            db.Set<PeerCustomPrefix>().Where(c => c.PeerId == peerId).ExecuteDelete();
+            db.Database.ExecuteSqlRaw(
+                "INSERT INTO PeerCustomPrefix (PeerId, Prefix, PrefixLength) VALUES ({0}, {1}, {2});",
+                peerId, "172.16.0.0", 12);
+            // Second raw INSERT with the same composite key → SQLite UNIQUE/PK constraint violation.
+            Assert.Throws<Microsoft.Data.Sqlite.SqliteException>(() =>
+                db.Database.ExecuteSqlRaw(
+                    "INSERT INTO PeerCustomPrefix (PeerId, Prefix, PrefixLength) VALUES ({0}, {1}, {2});",
+                    peerId, "172.16.0.0", 12));
+            // tx.Dispose without Commit → rollback (the unhandled exception unwinds the using).
+        }
+
+        // The original prefix survives — the delete was rolled back together with the failed insert.
+        Assert.Equal(["10.0.0.0/24"], store.GetCustomPrefixes(peerId));
+    }
+
+    // ---- #227: atomic upsert ----
+
+    /// <summary>
+    /// #227: two distinct (Ip, Asn) peers coexist (composite unique index not violated by the
+    /// upsert). Guards against the upsert accidentally keying on Ip only.
+    /// </summary>
+    [Fact]
+    public void CreatePeer_DistinctAsns_Coexist()
+    {
+        var (store, connection) = NewStore();
+        using var conn = connection;
+
+        var id1 = store.CreatePeer(Ip, 64512, "a");
+        var id2 = store.CreatePeer(Ip, 64513, "b");
+
+        Assert.NotEqual(id1, id2);
+        Assert.Equal(2, store.GetPeersByIp(Ip).Count);
+    }
+
+    /// <summary>
+    /// #227: UpsertPeer sets Status=active and stamps LastSessionAt, both on a fresh insert and on
+    /// a second call (update path). Called from the BGP connect path — must never throw.
+    /// </summary>
+    [Fact]
+    public void UpsertPeer_SetsActive_And_StampsLastSessionAt()
+    {
+        var (store, connection) = NewStore();
+        using var conn = connection;
+
+        store.UpsertPeer(Ip, Asn);
+        var peer = store.GetPeer(Ip, Asn);
+        Assert.NotNull(peer);
+        Assert.Equal("active", peer!.Status);
+        Assert.NotNull(peer.LastSessionAt);
+
+        var firstSessionAt = peer.LastSessionAt;
+
+        // Second call (update path) — must refresh LastSessionAt, not throw.
+        store.UpsertPeer(Ip, Asn);
+        var peer2 = store.GetPeer(Ip, Asn);
+        Assert.NotNull(peer2);
+        Assert.Equal("active", peer2!.Status);
+    }
+
+    /// <summary>
+    /// #227: UpdateSessionStatus(true/false) flips Status and stamps LastSessionAt only on
+    /// activation. A no-op when the peer does not exist (previously read-then-write would NRE on a
+    /// concurrently-deleted peer; now the UPDATE matches 0 rows silently).
+    /// </summary>
+    [Fact]
+    public void UpdateSessionStatus_FlipsStatus_And_Is_NoOp_For_Missing_Peer()
+    {
+        var (store, connection) = NewStore();
+        using var conn = connection;
+        store.UpsertPeer(Ip, Asn);
+
+        store.UpdateSessionStatus(Ip, Asn, active: false);
+        Assert.Equal("inactive", store.GetPeer(Ip, Asn)!.Status);
+
+        store.UpdateSessionStatus(Ip, Asn, active: true);
+        var peer = store.GetPeer(Ip, Asn);
+        Assert.Equal("active", peer!.Status);
+        Assert.NotNull(peer.LastSessionAt);
+
+        // No-op for a peer that does not exist — must not throw.
+        store.UpdateSessionStatus("203.0.113.99", 99999, active: true);
+    }
+}


### PR DESCRIPTION
## Summary

Three data-integrity and security fixes, closing #226, #232, #227.

- **#226** — `SetCommunities`/`SetSubscriptions`/`SetCustomPrefixes`/`SetCustomAsns` performed `ExecuteDelete` (own implicit transaction) followed by `AddRange`+`SaveChanges` (separate implicit transaction). A failure between them left the peer with an EMPTY collection. All four methods now wrap delete+insert in an explicit `BeginTransaction`/`Commit` so the replace is atomic.
- **#232** — `HandleAddSource` validated only URL syntax/scheme. The full SSRF validator (blocked-IP ranges, port allowlist 80/443, DNS-resolves-to-public) shipped in #144 but was deferred for API-level use. `ValidateUrlAsync` is now `public` and called before `AddCustomSource`, so a bad URL is rejected with a clear 400 instead of being saved and failing forever at fetch time. The fetch-time `ConnectCallback` stays as the authoritative defence layer.
- **#227** — `CreatePeer`/`UpsertPeer` used read-then-write on the composite unique index `UX_Peers_Ip_Asn`; two concurrent calls for the same `(Ip, Asn)` both observed `existing is null`, both INSERTed, and the second threw `DbUpdateException`. `UpsertPeer` (BGP connect path) had no HTTP caller to receive the 409. All three methods now use SQLite-native `INSERT ... ON CONFLICT DO UPDATE` (or a single `UPDATE` for `UpdateSessionStatus`) so the existence check and write are one atomic statement.

## Why

- **#226** is a data-integrity bug: a partial write corrupts peer configuration (subscriptions replaced, prefixes wiped, custom-AS untouched) and no HTTP transactional guarantee.
- **#232** closes a defence-in-depth gap: the current single SSRF layer lives entirely in the HTTP handler configuration. If anyone ever swaps `SocketsHttpHandler` for `HttpClientHandler` (which follows redirects), the SSRF protection disappears wholesale. A save-time check is the second layer that makes that regression survivable.
- **#227** eliminates a TOCTOU race on the composite unique index. For the BGP connect path it was a real crash-on-startup hazard when two simultaneous sessions from the same `(Ip, Asn)` raced.

## Validation

```
dotnet format                              # clean
dotnet test                                # 513 passed, 0 failed
dotnet test --filter "PeerStoreAtomicityTests"   # 9/9 regression tests pass
```

9 regression tests in `PeerStoreAtomicityTests.cs`:
- 4 atomic-replace roundtrips (Communities/Subscriptions/CustomPrefixes/CustomAsns)
- 1 empty-then-refill (guards against empty-collection-window regression)
- **1 fault-injection** (`SetCustomPrefixes_RollsBack_On_Insert_Failure`) — forces a SQLite UNIQUE violation mid-mutation and asserts the prior state survives, directly proving the transaction works
- 1 distinct-ASN coexistence (guards against upsert keying on Ip only)
- 1 UpsertPeer active + LastSessionAt stamping
- 1 UpdateSessionStatus flip + no-op for missing peer

`ValidateUrlAsync` (used by #232) is already covered by `PrefixSourceUrlValidatorTests` (loopback/cloud-metadata rejection, public-host accept, non-http/malformed rejection).

## Risk

- **SQL change** (intended): `CreatePeer`/`UpsertPeer`/`UpdateSessionStatus` now use `ExecuteSqlInterpolated` with `INSERT ... ON CONFLICT` / `UPDATE`. Interpolated strings are parameterized by EF Core — no SQL injection. `ON CONFLICT(Ip, Asn) DO UPDATE SET` updates only the named columns (Description for CreatePeer; Status+LastSessionAt for UpsertPeer) — other fields are untouched.
- **Contract preserved**: `UpdateSessionStatus` for a missing peer was already a no-op in the old read-then-write code (`if (peer is null) return;`); the new single-statement UPDATE matches 0 rows and is equivalent. `CreatePeer(ip, asn, null)` still overwrites an existing peer's Description to NULL on conflict (same as before — `existing.Description = description`) — preserved behaviour, not a regression.
- **Public API change** (intended): `PrefixSourceUrlValidator.ValidateUrlAsync` changed from `internal` to `public` so `BGPLite.Api` can call it without `InternalsVisibleTo`. XML doc updated to reflect the new cross-project role.
- **No BGP protocol change**: touches only `BGPLite.Api` and `BGPLite.Providers`, not Protocol/Server/Routing.

Self-reviewed before opening; 5 MINOR findings addressed (First→FirstOrDefault with retry-once for the INSERT→SELECT race, removed a duplicate test, added the fault-injection test). Remaining MINOR (no CancellationToken on `ValidateUrlAsync` call) is acceptable — `HttpListenerContext` does not expose one and DNS lookup is async/non-blocking; Polly covers the fetch path.

Closes #226
Closes #232
Closes #227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when adding custom sources, rejecting unsafe, invalid, or unsupported URLs.
  * Prevented data loss and inconsistent peer information during concurrent updates.
  * Ensured collection updates either complete fully or leave existing data unchanged.
  * Improved handling of session status updates for missing peers.

* **Tests**
  * Added coverage for reliable peer updates, collection replacement, rollback behavior, and session transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->