### PR TITLE
fix(protocol): negotiate hold time as min(local, peer) per RFC 4271 §6.2.2

### DIFF
--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -1149,7 +1149,7 @@ public sealed class BgpSession : IDisposable
     private void ValidateOpen(BgpOpenMessage open)
     {
         var localRouterId = BgpConstants.IPAddressToUint(_bgpConfig.GetRouterIdAddress());
-        var negotiation = ValidateOpen(open, _peerConfig.RemoteAsn, localRouterId);
+        var negotiation = ValidateOpen(open, _peerConfig.RemoteAsn, localRouterId, _bgpConfig.HoldTime);
 
         _remoteAsn = negotiation.RemoteAsn;
         _remoteFourByteAsn = negotiation.RemoteFourByteAsn;
@@ -1172,7 +1172,7 @@ public sealed class BgpSession : IDisposable
     }
 
     /// <summary>
-    /// Negotiated OPEN parameters produced by <see cref="ValidateOpen(BgpOpenMessage, uint?, uint)"/>.
+    /// Negotiated OPEN parameters produced by <see cref="ValidateOpen(BgpOpenMessage, uint?, uint, int)"/>.
     /// </summary>
     internal sealed record OpenNegotiation(
         uint RemoteAsn,
@@ -1191,9 +1191,25 @@ public sealed class BgpSession : IDisposable
     /// <see cref="BgpNotificationException"/> with the RFC-mandated error/sub-error on rejection.
     /// Extracted as <c>internal static</c> so every branch is unit-testable without a live socket
     /// (mirrors <see cref="GetMalformedFourOctetAsnCapabilityData"/> / MergeAsPathWithAs4Path).
+    /// <para>
+    /// Hold time negotiation (#224, RFC 4271 §6.2.2): the negotiated value is the smaller of the
+    /// locally configured <paramref name="localHoldTime"/> and the peer's <c>open.HoldTime</c>. A
+    /// value of 0 means "timer disabled" (RFC 4271 §4.2) — if either side proposes 0, the negotiated
+    /// hold time is 0 and the keepalive/hold timers are disabled for the session. This matches the
+    /// common practice of major implementations (Cisco/Juniper) and preserves the existing
+    /// HoldTime_Zero_Accepted_WithZeroKeepAlive contract.
+    /// </para>
     /// </summary>
-    internal static OpenNegotiation ValidateOpen(BgpOpenMessage open, uint? expectedRemoteAsn, uint localRouterId)
+    internal static OpenNegotiation ValidateOpen(BgpOpenMessage open, uint? expectedRemoteAsn, uint localRouterId, int localHoldTime)
     {
+        // #224: the local hold time is the locally configured BgpConfig.HoldTime (validated at
+        // config-load: 0 or ≥3). Guard the static entry point defensively so a future caller (or a
+        // unit test) cannot pass an out-of-range value that would silently corrupt the negotiation:
+        // a negative value would survive the Math.Min below and truncate to a bogus ushort.
+        if (localHoldTime != 0 && localHoldTime < 3)
+            throw new ArgumentOutOfRangeException(nameof(localHoldTime), localHoldTime,
+                $"Local hold time must be 0 (disabled) or at least 3 seconds (RFC 4271 §4.2).");
+
         if (open.Version != BgpConstants.BgpVersion)
             throw new BgpNotificationException(BgpConstants.Error.OpenMessageError, BgpConstants.SubError.UnsupportedVersion, $"Unsupported BGP version: {open.Version}");
 
@@ -1214,9 +1230,9 @@ public sealed class BgpSession : IDisposable
         if (expectedRemoteAsn.HasValue && remoteAsn != expectedRemoteAsn.Value)
             throw new BgpNotificationException(BgpConstants.Error.OpenMessageError, BgpConstants.SubError.BadPeerAs, $"Unexpected ASN: expected {expectedRemoteAsn}, got {remoteAsn}");
 
-        var holdTime = open.HoldTime;
-        if (holdTime != 0 && holdTime < 3)
-            throw new BgpNotificationException(BgpConstants.Error.OpenMessageError, BgpConstants.SubError.UnacceptableHoldTime, $"Unacceptable hold time: {holdTime}");
+        var peerHoldTime = open.HoldTime;
+        if (peerHoldTime != 0 && peerHoldTime < 3)
+            throw new BgpNotificationException(BgpConstants.Error.OpenMessageError, BgpConstants.SubError.UnacceptableHoldTime, $"Unacceptable hold time: {peerHoldTime}");
 
         // BGP Identifier must be non-zero and must not collide with our own (RFC 4271 §6.2).
         if (open.RouterId == 0)
@@ -1225,16 +1241,24 @@ public sealed class BgpSession : IDisposable
         if (open.RouterId == localRouterId)
             throw new BgpNotificationException(BgpConstants.Error.OpenMessageError, BgpConstants.SubError.BadBgpIdentifier, "BGP identifier collision with local RouterId");
 
-        var keepAliveInterval = holdTime == 0
+        // #224: negotiate hold time = min(local, peer) per RFC 4271 §6.2.2. A 0 on either side
+        // disables the timer (RFC 4271 §4.2) — Math.Min with 0 yields 0 naturally, so no special
+        // case is needed: either-side-zero → zero, which is exactly the "either side disables"
+        // semantics. The peer's value was already validated above (0 or ≥3); local is validated at
+        // config-load time (BgpConfig), and the argument guard at the top of this method rejects
+        // out-of-range local values before reaching here.
+        var negotiatedHoldTime = (ushort)Math.Min(localHoldTime, peerHoldTime);
+
+        var keepAliveInterval = negotiatedHoldTime == 0
             ? TimeSpan.Zero
-            : TimeSpan.FromSeconds(Math.Max(holdTime / 3, 1));
+            : TimeSpan.FromSeconds(Math.Max(negotiatedHoldTime / 3, 1));
 
         return new OpenNegotiation(
             remoteAsn,
             remoteFourByteAsn,
             remoteFourByteAsn, // RFC 6793 §6: AS_PATH encoding follows the negotiated capability
             remoteRouteRefresh,
-            holdTime,
+            negotiatedHoldTime,
             keepAliveInterval);
     }
 

--- a/BGPLite.Tests/BgpSessionValidateOpenTests.cs
+++ b/BGPLite.Tests/BgpSessionValidateOpenTests.cs
@@ -4,15 +4,22 @@ using BGPLite.Server;
 namespace BGPLite.Tests;
 
 /// <summary>
-/// Direct unit tests for the pure <see cref="BgpSession.ValidateOpen(BgpOpenMessage, uint?, uint)"/>
+/// Direct unit tests for the pure <see cref="BgpSession.ValidateOpen(BgpOpenMessage, uint?, uint, int)"/>
 /// extraction (#97). Every OPEN-validation branch is exercised without standing up a BgpSession
 /// over a live socket — mirroring how the RFC-6793 tests exercise MergeAsPathWithAs4Path.
+/// <para>
+/// The <c>Negotiate</c> helper defaults <c>localHoldTime</c> to <c>180</c> (the <c>BgpConfig</c>
+/// default), so the legacy tests where the peer also proposes 180 keep their original semantics.
+/// The #224 hold-time-negotiation tests pass an explicit <c>localHoldTime</c> to exercise the
+/// <c>min(local, peer)</c> rule.
+/// </para>
 /// </summary>
 public class BgpSessionValidateOpenTests
 {
     private const uint LocalRouterId = 0x0A000001u; // 10.0.0.1
     private const uint PeerRouterId = 0x0A000002u;  // 10.0.0.2
     private const uint AsnFourOctet = 200000u;      // > 16 bits → exercises the 4-octet capability
+    private const int DefaultLocalHoldTime = 180;    // matches BgpConfig.HoldTime default
 
     private static BgpOpenMessage Open(
         ushort holdTime = 180,
@@ -29,6 +36,11 @@ public class BgpSessionValidateOpenTests
             Capabilities = capabilities ?? [BgpCapabilityInfo.FourOctetAsn(AsnFourOctet)]
         };
 
+    /// <summary>Shorthand for the 4-arg ValidateOpen with the default local hold time (180s).</summary>
+    private static BgpSession.OpenNegotiation Negotiate(
+        BgpOpenMessage open, uint? expectedRemoteAsn = AsnFourOctet, int localHoldTime = DefaultLocalHoldTime) =>
+        BgpSession.ValidateOpen(open, expectedRemoteAsn, LocalRouterId, localHoldTime);
+
     [Fact]
     public void ValidOpen_NegotiatesFourByteAsn_RouteRefresh_KeepAlive()
     {
@@ -38,7 +50,7 @@ public class BgpSessionValidateOpenTests
             new() { Code = BgpConstants.Capability.RouteRefresh }
         ]);
 
-        var n = BgpSession.ValidateOpen(open, expectedRemoteAsn: AsnFourOctet, LocalRouterId);
+        var n = Negotiate(open, expectedRemoteAsn: AsnFourOctet);
 
         Assert.Equal(AsnFourOctet, n.RemoteAsn);
         Assert.True(n.RemoteFourByteAsn);
@@ -53,7 +65,7 @@ public class BgpSessionValidateOpenTests
     {
         var open = Open(asn: 65002, capabilities: []); // no 4-octet capability, no route refresh
 
-        var n = BgpSession.ValidateOpen(open, expectedRemoteAsn: 65002, LocalRouterId);
+        var n = Negotiate(open, expectedRemoteAsn: 65002);
 
         Assert.Equal(65002u, n.RemoteAsn);
         Assert.False(n.RemoteFourByteAsn);
@@ -64,7 +76,7 @@ public class BgpSessionValidateOpenTests
     [Fact]
     public void HoldTime_Zero_Accepted_WithZeroKeepAlive()
     {
-        var n = BgpSession.ValidateOpen(Open(holdTime: 0), AsnFourOctet, LocalRouterId);
+        var n = Negotiate(Open(holdTime: 0));
 
         Assert.Equal(0, n.NegotiatedHoldTime);
         Assert.Equal(TimeSpan.Zero, n.KeepAliveInterval);
@@ -73,7 +85,7 @@ public class BgpSessionValidateOpenTests
     [Fact]
     public void HoldTime_Three_Accepted_KeepAliveClampedToOne()
     {
-        var n = BgpSession.ValidateOpen(Open(holdTime: 3), AsnFourOctet, LocalRouterId);
+        var n = Negotiate(Open(holdTime: 3));
 
         Assert.Equal(TimeSpan.FromSeconds(1), n.KeepAliveInterval); // max(3/3, 1) = 1
     }
@@ -82,7 +94,7 @@ public class BgpSessionValidateOpenTests
     public void UnsupportedVersion_Throws()
     {
         var ex = Assert.Throws<BgpNotificationException>(
-            () => BgpSession.ValidateOpen(Open(version: 3), AsnFourOctet, LocalRouterId));
+            () => Negotiate(Open(version: 3)));
 
         Assert.Equal(BgpConstants.Error.OpenMessageError, ex.ErrorCode);
         Assert.Equal(BgpConstants.SubError.UnsupportedVersion, ex.SubErrorCode);
@@ -97,7 +109,7 @@ public class BgpSessionValidateOpenTests
         ]);
 
         var ex = Assert.Throws<BgpNotificationException>(
-            () => BgpSession.ValidateOpen(open, expectedRemoteAsn: null, LocalRouterId));
+            () => Negotiate(open, expectedRemoteAsn: null));
 
         Assert.Equal(BgpConstants.Error.OpenMessageError, ex.ErrorCode);
         Assert.Equal(BgpConstants.SubError.UnsupportedCapability, ex.SubErrorCode);
@@ -108,7 +120,7 @@ public class BgpSessionValidateOpenTests
     public void UnexpectedAsn_Throws_BadPeerAs()
     {
         var ex = Assert.Throws<BgpNotificationException>(
-            () => BgpSession.ValidateOpen(Open(), expectedRemoteAsn: 65010, LocalRouterId));
+            () => Negotiate(Open(), expectedRemoteAsn: 65010));
 
         Assert.Equal(BgpConstants.SubError.BadPeerAs, ex.SubErrorCode);
     }
@@ -116,7 +128,7 @@ public class BgpSessionValidateOpenTests
     [Fact]
     public void ExpectedAsn_Null_AcceptsAnyAsn() // auto-register / unknown-peer path
     {
-        var n = BgpSession.ValidateOpen(Open(), expectedRemoteAsn: null, LocalRouterId);
+        var n = Negotiate(Open(), expectedRemoteAsn: null);
 
         Assert.Equal(AsnFourOctet, n.RemoteAsn);
     }
@@ -125,7 +137,7 @@ public class BgpSessionValidateOpenTests
     public void HoldTime_TooLow_Throws_UnacceptableHoldTime()
     {
         var ex = Assert.Throws<BgpNotificationException>(
-            () => BgpSession.ValidateOpen(Open(holdTime: 2), AsnFourOctet, LocalRouterId));
+            () => Negotiate(Open(holdTime: 2)));
 
         Assert.Equal(BgpConstants.SubError.UnacceptableHoldTime, ex.SubErrorCode);
     }
@@ -134,7 +146,7 @@ public class BgpSessionValidateOpenTests
     public void RouterId_Zero_Throws_BadBgpIdentifier()
     {
         var ex = Assert.Throws<BgpNotificationException>(
-            () => BgpSession.ValidateOpen(Open(routerId: 0), AsnFourOctet, LocalRouterId));
+            () => Negotiate(Open(routerId: 0)));
 
         Assert.Equal(BgpConstants.SubError.BadBgpIdentifier, ex.SubErrorCode);
     }
@@ -143,8 +155,66 @@ public class BgpSessionValidateOpenTests
     public void RouterId_CollisionWithLocal_Throws_BadBgpIdentifier()
     {
         var ex = Assert.Throws<BgpNotificationException>(
-            () => BgpSession.ValidateOpen(Open(routerId: LocalRouterId), AsnFourOctet, LocalRouterId));
+            () => Negotiate(Open(routerId: LocalRouterId)));
 
         Assert.Equal(BgpConstants.SubError.BadBgpIdentifier, ex.SubErrorCode);
+    }
+
+    // ---- #224: hold time negotiation = min(local, peer) per RFC 4271 §6.2.2 ----
+
+    /// <summary>
+    /// #224: when the peer proposes a SMALLER hold time than local, the negotiated value is the
+    /// peer's (min). Keepalive is derived from the negotiated value, not the peer's raw value —
+    /// so a peer that proposes 30 against a local 180 yields negotiated=30, keepalive=max(30/3,1)=10.
+    /// </summary>
+    [Fact]
+    public void HoldTime_PeerSmallerThanLocal_NegotiatesToPeer()
+    {
+        var n = Negotiate(Open(holdTime: 30), localHoldTime: 180);
+
+        Assert.Equal(30, n.NegotiatedHoldTime);
+        Assert.Equal(TimeSpan.FromSeconds(10), n.KeepAliveInterval); // max(30/3, 1) = 10
+    }
+
+    /// <summary>
+    /// #224: when the peer proposes a LARGER hold time than local, the negotiated value is the
+    /// local (min). Guards against the previous behaviour of always taking the peer's value — a
+    /// peer proposing 180 against a local 9 (the minimum useful hold time for fast dead-peer
+    /// detection) must yield 9, not 180.
+    /// </summary>
+    [Fact]
+    public void HoldTime_PeerLargerThanLocal_NegotiatesToLocal()
+    {
+        var n = Negotiate(Open(holdTime: 180), localHoldTime: 9);
+
+        Assert.Equal(9, n.NegotiatedHoldTime);
+        Assert.Equal(TimeSpan.FromSeconds(3), n.KeepAliveInterval); // max(9/3, 1) = 3
+    }
+
+    /// <summary>
+    /// #224: equal local and peer hold times negotiate to that value (boundary of the min rule).
+    /// </summary>
+    [Fact]
+    public void HoldTime_PeerEqualsLocal_NegotiatesToThatValue()
+    {
+        var n = Negotiate(Open(holdTime: 90), localHoldTime: 90);
+
+        Assert.Equal(90, n.NegotiatedHoldTime);
+        Assert.Equal(TimeSpan.FromSeconds(30), n.KeepAliveInterval);
+    }
+
+    /// <summary>
+    /// #224: if the LOCAL side disables the timer (0), the negotiated hold time is 0 even when the
+    /// peer proposes a positive value — the session runs without keepalive/hold timers. Matches the
+    /// "either side disables" semantics (RFC 4271 §4.2) and the common implementation practice
+    /// (Cisco/Juniper). Complements HoldTime_Zero_Accepted_WithZeroKeepAlive (peer=0 case).
+    /// </summary>
+    [Fact]
+    public void HoldTime_LocalZero_DisablesTimer_EvenWhenPeerProposesPositive()
+    {
+        var n = Negotiate(Open(holdTime: 180), localHoldTime: 0);
+
+        Assert.Equal(0, n.NegotiatedHoldTime);
+        Assert.Equal(TimeSpan.Zero, n.KeepAliveInterval);
     }
 }


### PR DESCRIPTION
## Summary

Closes #224. `ValidateOpen` returned the peer's HoldTime verbatim as the negotiated value, ignoring the locally configured `BgpConfig.HoldTime`. The local value IS advertised in the outbound OPEN (`SendOpenAsync`), so the peer computes `min` on its side — but BGPLite always took the peer's value, an asymmetric hold timer that diverged from the peer's at boundary values.

Now `negotiated = min(local, peer)` per RFC 4271 §6.2.2:

- peer < local → negotiated = peer (existing behavior preserved)
- peer > local → negotiated = local (**FIX**: was peer's — a peer proposing 180 against a local 9 for fast dead-peer detection now yields 9, not 180)
- either side = 0 → negotiated = 0 (timer disabled, RFC 4271 §4.2 — `Math.Min` with 0 yields 0 naturally, no special case)

`KeepAliveInterval` is now derived from `negotiatedHoldTime` (was `peerHoldTime`), so it stays consistent with the timer that actually drives the session. The default path (local=180, peer=180) is unchanged: negotiated=180, keepalive=60.

## Why

RFC 4271 §6.2.2 mandates the negotiated Hold Time be the smaller of the two proposed values. The bug meant a peer could force a longer hold time than the operator configured, defeating fast dead-peer detection, or force a shorter one, causing unnecessary keepalive chatter. The fix is one line in the negotiation formula plus threading `localHoldTime` through the (already pure, unit-tested) `ValidateOpen` static method.

## Validation

```
dotnet format                              # clean
dotnet test                                # 517 passed, 0 failed
dotnet test --filter "BgpSessionValidateOpen"   # 15/15 (11 legacy + 4 new)
```

4 new regression tests:
- `HoldTime_PeerSmallerThanLocal_NegotiatesToPeer` (30 vs 180 → 30, keepalive 10)
- `HoldTime_PeerLargerThanLocal_NegotiatesToLocal` (180 vs 9 → 9, keepalive 3) — the core fix
- `HoldTime_PeerEqualsLocal_NegotiatesToThatValue` (90 vs 90 → 90)
- `HoldTime_LocalZero_DisablesTimer_EvenWhenPeerProposesPositive` (180 vs 0 → 0)

The existing `ValidOpen_NegotiatesFourByteAsn_RouteRefresh_KeepAlive` and `HoldTime_Zero_Accepted_WithZeroKeepAlive` preserve their semantics via a `Negotiate` helper that defaults `localHoldTime=180` (the `BgpConfig` default).

## Risk

- **Behaviour change** (intended): a peer proposing a hold time larger than the local config no longer gets its way — the negotiated value is now the local (smaller) one. Peers that depended on the old always-peer behaviour will see a tighter timer. This is RFC-compliant and matches Cisco/Juniper practice.
- **API change** (internal): `ValidateOpen` gained a 4th parameter (`int localHoldTime`). All callers updated. A defensive guard rejects out-of-range local values (`< 0` or `1..2`) that would otherwise corrupt the `(ushort)Math.Min` cast.
- **No wire-format change**: the outbound OPEN still advertises the local configured value; only the negotiated (inbound-computed) timer changes.

Self-reviewed before opening; 3 MINOR findings addressed (simplified the formula so the comment matches the code — the ternary was redundant since `Math.Min` with 0 already yields 0; added an argument guard for the static entry point). One pre-existing MINOR (no upper bound on `BgpConfig.HoldTime` — silent ushort truncation at >65535) is out of scope and worth a separate issue.

Closes #224