### PR TITLE
fix(protocol,api): unify CIDR parsing — single PrefixCidr with host-bit masking and /0 rejection

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -1060,33 +1060,21 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
     /// <summary>
     /// Parses a single user-supplied custom prefix CIDR ("<prefix>/<length>") into a validated
-    /// (prefix, mask length) tuple. Splitting is done on the first '/', requiring exactly two
-    /// parts. The prefix is validated with <see cref="IPAddress.TryParse"/> (IPv4 only — IPv6 is
-    /// rejected); the length must parse as a byte in 0..32. Returns null on any failure so callers
-    /// can reject the whole request with a 400 before touching the store (no partial mutation).
-    /// Extracted as a pure helper for unit tests (#100).
+    /// (prefix, mask length) tuple, delegating to the canonical <see cref="PrefixCidr"/> parser
+    /// (#236). Host bits are masked to the network address (so <c>10.0.0.5/24</c> normalizes to
+    /// <c>10.0.0.0/24</c> and dedups against the same network submitted via a file source); <c>/0</c>
+    /// (the default route) is rejected — a route server must not originate a default from the API.
+    /// Returns null on any failure so callers can reject the whole request with a 400 before touching
+    /// the store (no partial mutation). Extracted as a pure helper for unit tests (#100).
     /// </summary>
     internal static (string Prefix, byte Length)? ParseCustomPrefix(string? cidr)
     {
-        if (string.IsNullOrWhiteSpace(cidr))
+        if (!PrefixCidr.TryParse(cidr, out var prefix, out var length))
             return null;
 
-        var parts = cidr.Split('/');
-        if (parts.Length != 2)
-            return null;
-
-        var prefix = parts[0];
-        var lengthStr = parts[1];
-
-        // IPv4 only: reject IPv6 (and any non-IP string).
-        if (!IPAddress.TryParse(prefix, out var addr) || addr.AddressFamily != AddressFamily.InterNetwork)
-            return null;
-
-        // Length must be a byte in the valid IPv4 range 0..32 (rejects 33..255, negatives, non-numeric).
-        if (!byte.TryParse(lengthStr, out byte length) || length > 32)
-            return null;
-
-        return (prefix, length);
+        // Return the masked network address in dotted-quad form (matches how it is stored in the DB
+        // and re-parsed by the BGP send path, so the round-trip is byte-identical).
+        return (BgpConstants.UintToIPAddress(prefix).ToString(), length);
     }
 
     private string GetClientIp(HttpListenerContext ctx) =>

--- a/BGPLite.Protocol/PrefixCidr.cs
+++ b/BGPLite.Protocol/PrefixCidr.cs
@@ -1,0 +1,75 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace BGPLite.Protocol;
+
+/// <summary>
+/// The single canonical CIDR parser for the project (#236). Every input path — operator file
+/// sources (<c>PrefixListParser</c>), the management API (<c>ParseCustomPrefix</c>), and the
+/// BGP send path's DB-load (<c>RouteAssembler</c>) — routes through <see cref="TryParse"/> so the
+/// validation and masking policy is defined in exactly one place. Three divergent parsers
+/// previously caused dedup/aggregation breakage (the same network submitted two ways was stored as
+/// two distinct keys) and a route-leak vector (the API accepted <c>/0</c>, the default route).
+/// <para>
+/// <b>Policy</b> (locked down here, recorded in #236):
+/// <list type="bullet">
+/// <item><b>Host-bit masking is ALWAYS applied</b> — <c>10.0.0.5/24</c> normalizes to
+/// <c>10.0.0.0/24</c>. Without this the route table, the aggregator, and the duplicate-NLRI
+/// merger key on the raw <c>(uint, byte)</c> and treat the two forms as distinct networks.</item>
+/// <item><b>Length range is 1..32</b> by default. <c>/0</c> (the default route) is rejected for
+/// user-supplied sources — a route server must not originate a default. <c>allowDefault: true</c>
+/// permits <c>/0</c> for the rare operator-config default-route case (kept for completeness; no
+/// caller currently uses it).</item>
+/// <item><b>IPv4 only.</b> IPv6 is rejected (the route table stores <c>(uint, byte)</c> IPv4 keys).</item>
+/// <item><b>Garbage is rejected, never thrown.</b> Returns <c>false</c> on any malformed input so
+/// callers can surface a clean 400 / skip the line, rather than propagating a <c>FormatException</c>.</item>
+/// </list>
+/// </para>
+/// </summary>
+public static class PrefixCidr
+{
+    /// <summary>
+    /// Parses a CIDR string ("<c>a.b.c.d/len</c>") into a packed IPv4 prefix + mask length, applying
+    /// the canonical policy (host-bit masking, length range, IPv4-only). Returns <c>false</c> (with
+    /// <paramref name="prefix"/>/<paramref name="length"/> zeroed) on any malformed or out-of-policy
+    /// input — callers should report/skip, not throw.
+    /// </summary>
+    /// <param name="cidr">The CIDR string to parse.</param>
+    /// <param name="prefix">On success, the masked network address as a packed big-endian uint.</param>
+    /// <param name="length">On success, the prefix length (0 only when <paramref name="allowDefault"/>
+    /// is true; otherwise 1..32).</param>
+    /// <param name="allowDefault">When <c>true</c>, accept <c>/0</c> (the default route). Default
+    /// <c>false</c> — user-supplied sources (API/file/URL) must not originate a default.</param>
+    /// <returns><c>true</c> if the string is a valid IPv4 CIDR within policy; <c>false</c> otherwise.</returns>
+    public static bool TryParse(string? cidr, out uint prefix, out byte length, bool allowDefault = false)
+    {
+        prefix = 0;
+        length = 0;
+
+        if (string.IsNullOrWhiteSpace(cidr))
+            return false;
+
+        var slash = cidr.IndexOf('/');
+        if (slash <= 0 || slash == cidr.Length - 1)
+            return false;
+
+        if (!IPAddress.TryParse(cidr[..slash], out var addr) || addr.AddressFamily != AddressFamily.InterNetwork)
+            return false; // IPv4 only
+
+        if (!byte.TryParse(cidr[(slash + 1)..], out var len))
+            return false;
+
+        var minLen = allowDefault ? 0 : 1;
+        if (len < minLen || len > 32)
+            return false;
+
+        var packed = BgpConstants.IPAddressToUint(addr);
+        // Mask host bits to the network address. For /0 (allowDefault) the shift would be <<32,
+        // which is UB-adjacent in C# (shifts are masked to 5 bits → <<0); handle it explicitly so
+        // the masked value is 0 (the true 0.0.0.0/0 network), not the packed address.
+        var masked = len == 0 ? 0u : packed & (0xFFFFFFFFu << (32 - len));
+        prefix = masked;
+        length = len;
+        return true;
+    }
+}

--- a/BGPLite.Providers/PrefixListParser.cs
+++ b/BGPLite.Providers/PrefixListParser.cs
@@ -1,5 +1,3 @@
-using System.Net;
-using System.Net.Sockets;
 using BGPLite.Protocol;
 
 namespace BGPLite.Providers;
@@ -10,12 +8,11 @@ namespace BGPLite.Providers;
 /// lines are skipped silently (the route table only stores IPv4 <c>(uint, byte)</c> keys).
 /// </summary>
 /// <remarks>
-/// <b>Length and host-bit handling (#162).</b> Prefix length is constrained to the valid IPv4 range
-/// 1..32 — a stray <c>0.0.0.0/0</c> line would otherwise advertise the entire IPv4 space (a
-/// catastrophic route leak from a peer-supplied URL list, #147). Length 0 is rejected: a route
-/// server should not originate a default. Host bits are masked to the network address so that
-/// <c>10.0.0.5/24</c> normalizes to <c>10.0.0.0/24</c> — without this, the same network submitted
-/// with different host bits is stored as distinct rows and breaks dedup / longest-prefix-match.
+/// <b>Length and host-bit handling (#162 / #236).</b> Validation, host-bit masking, and the IPv4-only
+/// constraint now live in the single canonical <see cref="PrefixCidr"/> parser — every CIDR input
+/// path (file, API, DB-load) routes through it so the policy is defined exactly once. <c>/0</c> is
+/// rejected (a route server must not originate a default route from a peer-supplied URL list, #147);
+/// host bits are masked so <c>10.0.0.5/24</c> normalizes to <c>10.0.0.0/24</c> and dedups correctly.
 /// </remarks>
 public static class PrefixListParser
 {
@@ -34,19 +31,11 @@ public static class PrefixListParser
             var line = raw.Trim();
             if (line.Length == 0 || line[0] == '#') continue;
 
-            var slash = line.IndexOf('/');
-            if (slash < 0) continue;
-            if (!IPAddress.TryParse(line[..slash], out var ip)) continue;
-            if (!byte.TryParse(line[(slash + 1)..], out var length)) continue;
-            if (ip.AddressFamily != AddressFamily.InterNetwork) continue; // IPv4 only
-            // Reject 0 (default route — a route server should not originate one) and > 32 (nonsensical
-            // IPv4 length that byte.TryParse accepted). Length 1..32 only.
-            if (length is 0 or > 32) continue;
-
-            // Mask host bits to the network address so equivalent prefixes normalize to one key.
-            var packed = BgpConstants.IPAddressToUint(ip);
-            var masked = packed & (0xFFFFFFFFu << (32 - length));
-            result.Add((masked, length));
+            // Delegate to the canonical parser (#236): host-bit masking, /0 rejection, IPv4-only,
+            // range 1..32 — one policy, shared with the API and the BGP send path.
+            if (!PrefixCidr.TryParse(line, out var prefix, out var length))
+                continue;
+            result.Add((prefix, length));
         }
 
         return result;

--- a/BGPLite.Server/RouteAssembler.cs
+++ b/BGPLite.Server/RouteAssembler.cs
@@ -184,13 +184,18 @@ internal sealed class RouteAssembler
                     _peer, routes.Count, customPrefixes.Count);
 
                 // Custom prefixes carry the static "custom prefix" community (<Asn>:100).
+                // #236: parse via the canonical PrefixCidr parser — host-bit masking + range check +
+                // IPv4-only, shared with the API and file sources. Custom prefixes are validated at
+                // write time (ParseCustomPrefix), but a corrupt row or a write path that bypassed the
+                // API must not throw a FormatException out of the BGP send path — skip + log instead.
                 var customPrefixComms = _communityResolver.Resolve(new CommunitySource(CommunitySourceKind.Custom));
                 foreach (var cidr in customPrefixes)
                 {
-                    var slash = cidr.IndexOf('/');
-                    var ip = IPAddress.Parse(cidr[..slash]);
-                    var length = byte.Parse(cidr[(slash + 1)..]);
-                    var prefix = BgpConstants.IPAddressToUint(ip);
+                    if (!PrefixCidr.TryParse(cidr, out var prefix, out var length))
+                    {
+                        _logger.LogWarning("Skipping malformed custom prefix '{Cidr}' for {Peer}", cidr, _peer);
+                        continue;
+                    }
                     routes.Add(MakeRoute(prefix, length, nextHop, null, customPrefixComms));
                 }
 

--- a/BGPLite.Tests/CustomPrefixValidationTests.cs
+++ b/BGPLite.Tests/CustomPrefixValidationTests.cs
@@ -3,19 +3,37 @@ using BGPLite.Api;
 namespace BGPLite.Tests;
 
 /// <summary>
-/// Tests for <see cref="ManagementApi.ParseCustomPrefix"/> (#100): custom-prefix CIDRs supplied
-/// via the management API are validated (IPv4 only, mask 0..32) before reaching the store.
-/// Previously the parser only checked for a '/' and ran <c>byte.Parse</c> on the tail, accepting
-/// garbage like <c>1.2.3.4/250</c> (length 250) or non-IP prefixes, which corrupted export sets.
+/// Tests for <see cref="ManagementApi.ParseCustomPrefix"/> (#100 / #236): custom-prefix CIDRs
+/// supplied via the management API are validated (IPv4 only, mask 1..32, host bits masked to the
+/// network address) before reaching the store. Previously the parser only checked for a '/' and ran
+/// <c>byte.Parse</c> on the tail, accepting garbage like <c>1.2.3.4/250</c> (length 250) or
+/// <c>0.0.0.0/0</c> (the default route — a route-leak vector, #236) or non-IP prefixes.
 /// </summary>
 public class CustomPrefixValidationTests
 {
     [Theory]
     [InlineData("1.2.3.0/24", "1.2.3.0", 24)]
     [InlineData("10.0.0.0/8", "10.0.0.0", 8)]
-    [InlineData("0.0.0.0/0", "0.0.0.0", 0)]   // boundary: default route
     [InlineData("255.255.255.255/32", "255.255.255.255", 32)] // boundary: single host
     public void Parses_Valid_IPv4_CIDR(string cidr, string expectedPrefix, byte expectedLength)
+    {
+        var result = ManagementApi.ParseCustomPrefix(cidr);
+
+        Assert.NotNull(result);
+        Assert.Equal(expectedPrefix, result!.Value.Prefix);
+        Assert.Equal(expectedLength, result.Value.Length);
+    }
+
+    /// <summary>
+    /// #236: host bits are masked to the network address so <c>10.0.0.5/24</c> normalizes to
+    /// <c>10.0.0.0/24</c>. Without this the same network submitted two ways (API vs file source) is
+    /// stored as two distinct keys and breaks dedup / aggregation.
+    /// </summary>
+    [Theory]
+    [InlineData("10.0.0.5/24", "10.0.0.0", 24)]
+    [InlineData("192.168.1.255/24", "192.168.1.0", 24)]
+    [InlineData("172.16.5.1/16", "172.16.0.0", 16)]
+    public void Masks_Host_Bits_To_Network_Address(string cidr, string expectedPrefix, byte expectedLength)
     {
         var result = ManagementApi.ParseCustomPrefix(cidr);
 
@@ -37,6 +55,7 @@ public class CustomPrefixValidationTests
     [InlineData("1.2.3.4/24/extra")]     // more than one slash
     [InlineData("/24")]                  // empty prefix
     [InlineData("")]                     // empty input
+    [InlineData("0.0.0.0/0")]            // #236: default route rejected (route server must not originate a default)
     public void Rejects_Invalid_CIDR(string cidr)
     {
         Assert.Null(ManagementApi.ParseCustomPrefix(cidr));

--- a/BGPLite.Tests/PrefixCidrTests.cs
+++ b/BGPLite.Tests/PrefixCidrTests.cs
@@ -1,0 +1,155 @@
+using BGPLite.Protocol;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// Unit tests for the canonical <see cref="PrefixCidr"/> parser (#236) — the single policy point
+/// shared by the file source (<c>PrefixListParser</c>), the management API (<c>ParseCustomPrefix</c>),
+/// and the BGP send path (<c>RouteAssembler</c>). Covers host-bit masking, the <c>/0</c> default-route
+/// rejection (route-leak defense), the length range, IPv4-only, and the <c>allowDefault</c> escape hatch.
+/// </summary>
+public class PrefixCidrTests
+{
+    // ---- valid parsing + host-bit masking ----
+
+    [Theory]
+    [InlineData("10.0.0.0/8", 0x0A000000u, 8)]
+    [InlineData("192.168.1.0/24", 0xC0A80100u, 24)]
+    [InlineData("255.255.255.255/32", 0xFFFFFFFFu, 32)] // boundary: single host, no host bits to mask
+    [InlineData("1.2.3.4/31", 0x01020304u, 31)]          // /31: host bit is the last bit, kept
+    public void TryParse_NetworkAligned_CIDR_Succeeds(string cidr, uint expectedPrefix, byte expectedLength)
+    {
+        Assert.True(PrefixCidr.TryParse(cidr, out var prefix, out var length));
+        Assert.Equal(expectedPrefix, prefix);
+        Assert.Equal(expectedLength, length);
+    }
+
+    /// <summary>
+    /// #236: host bits are masked to the network address. <c>10.0.0.5/24</c> normalizes to
+    /// <c>10.0.0.0/24</c> — the canonical form the route table, aggregator, and duplicate-NLRI merger
+    /// key on. Without masking the same network submitted two ways is stored as two distinct keys.
+    /// </summary>
+    [Theory]
+    [InlineData("10.0.0.5/24", 0x0A000000u, 24)]   // host bits in last octet
+    [InlineData("192.168.1.255/24", 0xC0A80100u, 24)] // all-ones host bits
+    [InlineData("172.16.5.1/16", 0xAC100000u, 16)] // host bits in last two octets
+    public void TryParse_Masks_Host_Bits(string cidr, uint expectedPrefix, byte expectedLength)
+    {
+        Assert.True(PrefixCidr.TryParse(cidr, out var prefix, out var length));
+        Assert.Equal(expectedPrefix, prefix);
+        Assert.Equal(expectedLength, length);
+    }
+
+    // ---- /0 default-route handling ----
+
+    /// <summary>
+    /// #236: <c>/0</c> (the default route) is REJECTED by default — a route server must not originate
+    /// a default from a user-supplied source (file / API / peer URL). This is the route-leak defense
+    /// that the old API parser (<c>ParseCustomPrefix</c>) lacked.
+    /// </summary>
+    [Fact]
+    public void TryParse_Rejects_DefaultRoute_ByDefault()
+    {
+        Assert.False(PrefixCidr.TryParse("0.0.0.0/0", out var prefix, out var length));
+        Assert.Equal(0u, prefix);
+        Assert.Equal((byte)0, length);
+    }
+
+    /// <summary>
+    /// <c>allowDefault: true</c> accepts <c>/0</c> and returns the masked 0.0.0.0/0 network (prefix=0).
+    /// Kept for the rare operator-config default-route case; no caller uses it today, but the parser
+    /// must handle the <<32 shift edge case correctly (it would otherwise be a no-op shift in C#).
+    /// </summary>
+    [Fact]
+    public void TryParse_AllowDefault_Accepts_ZeroPrefix()
+    {
+        Assert.True(PrefixCidr.TryParse("0.0.0.0/0", out var prefix, out var length, allowDefault: true));
+        Assert.Equal(0u, prefix);
+        Assert.Equal((byte)0, length);
+    }
+
+    /// <summary>
+    /// <c>allowDefault</c> with a non-/0 input still masks host bits correctly (the escape hatch does
+    /// not disable masking, only the <c>/0</c> rejection).
+    /// </summary>
+    [Fact]
+    public void TryParse_AllowDefault_StillMasks_HostBits_ForNonZero()
+    {
+        Assert.True(PrefixCidr.TryParse("10.0.0.5/24", out var prefix, out var length, allowDefault: true));
+        Assert.Equal(0x0A000000u, prefix);
+        Assert.Equal((byte)24, length);
+    }
+
+    // ---- length range ----
+
+    [Theory]
+    [InlineData("1.2.3.4/33")]   // just over
+    [InlineData("1.2.3.4/250")]  // far over — byte.TryParse accepts, range check rejects
+    [InlineData("1.2.3.4/255")]  // max byte value
+    public void TryParse_Rejects_Length_Over_32(string cidr)
+    {
+        Assert.False(PrefixCidr.TryParse(cidr, out _, out _));
+    }
+
+    [Theory]
+    [InlineData("1.2.3.4/1")]    // minimum accepted length (default-policy)
+    [InlineData("1.2.3.4/32")]   // maximum accepted length
+    public void TryParse_Accepts_Length_Boundary(string cidr)
+    {
+        Assert.True(PrefixCidr.TryParse(cidr, out _, out var length));
+        Assert.True(length >= 1 && length <= 32);
+    }
+
+    /// <summary>
+    /// <c>byte.TryParse</c> with the default NumberStyles accepts a leading <c>+</c> sign, so
+    /// <c>1.2.3.4/+24</c> parses to length 24. This is benign (24 is valid, masking is identical to
+    /// <c>/24</c>, dedup is correct), but the behaviour is pinned here so a future tightening to
+    /// <c>NumberStyles.None</c> is a visible, tested change rather than a silent contract shift.
+    /// </summary>
+    [Fact]
+    public void TryParse_Accepts_Leading_Plus_Sign_In_Length()
+    {
+        Assert.True(PrefixCidr.TryParse("1.2.3.4/+24", out var prefix, out var length));
+        Assert.Equal((byte)24, length);
+        Assert.Equal(0x01020300u, prefix); // masked to 1.2.3.0/24
+    }
+
+    // ---- IPv4-only ----
+
+    [Theory]
+    [InlineData("::1/128")]       // IPv6 loopback
+    [InlineData("2001:db8::/32")] // IPv6 ULA
+    [InlineData("fe80::/10")]     // IPv6 link-local
+    public void TryParse_Rejects_IPv6(string cidr)
+    {
+        Assert.False(PrefixCidr.TryParse(cidr, out _, out _));
+    }
+
+    // ---- malformed input (never throws) ----
+
+    [Theory]
+    [InlineData("")]              // empty
+    [InlineData("   ")]           // whitespace
+    [InlineData("1.2.3.4")]       // no slash
+    [InlineData("1.2.3.4/")]      // slash at end
+    [InlineData("/24")]           // empty prefix
+    [InlineData("1.2.3.4/24/extra")] // double slash
+    [InlineData("not-an-ip/24")]  // non-IP prefix
+    [InlineData("1.2.3.4/abc")]   // non-numeric length
+    [InlineData("1.2.3.4/-1")]    // negative length (byte.TryParse rejects the '-')
+    [InlineData("256.1.1.1/24")]  // out-of-range octet
+    public void TryParse_Rejects_Malformed_Without_Throwing(string cidr)
+    {
+        Assert.False(PrefixCidr.TryParse(cidr, out var prefix, out var length));
+        Assert.Equal(0u, prefix);
+        Assert.Equal((byte)0, length);
+    }
+
+    [Fact]
+    public void TryParse_Rejects_Null()
+    {
+        Assert.False(PrefixCidr.TryParse(null, out var prefix, out var length));
+        Assert.Equal(0u, prefix);
+        Assert.Equal((byte)0, length);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #236. Three CIDR parsers with divergent policies caused two real problems:

- **Dedup/aggregation breakage**: the same network submitted two ways (`10.0.0.5/24` via the API vs `10.0.0.0/24` via a file source) was stored as two distinct `(uint, byte)` keys because the API parser did NOT mask host bits. The aggregator and duplicate-NLRI merger then treated them as separate networks, so the peer received two UPDATEs for one logical network.
- **Route-leak vector**: `ParseCustomPrefix` (API) accepted `/0` (the default route), so an operator could accidentally announce the default to peers — exactly the leak #162 hardened the file/URL source path against, but the API path was still open.

Add a single canonical `PrefixCidr.TryParse` in `BGPLite.Protocol` and route every CIDR input path through it:

- `PrefixListParser` (file/URL sources) — delegates; BOM-strip and `#`/blank-line skip preserved.
- `ManagementApi.ParseCustomPrefix` (API) — delegates, now masks host bits, rejects `/0`.
- `RouteAssembler` inline parse (BGP send path, DB-loaded prefixes) — delegates, now skip+log on malformed instead of throwing `FormatException` out of the send path.

**Policy (locked down in one place):**
- Host bits ALWAYS masked to the network address (canonical form for dedup).
- Length range 1..32 by default; `/0` rejected (a route server must not originate a default); `allowDefault:true` escape hatch kept for the rare operator-config case (no caller uses it today).
- IPv4 only; garbage returns `false` (never throws).
- Explicit `/0` handling avoids the C# `<<32` no-op-shift edge case.

## Why

The divergence was not theoretical: the file-source path already enforced masking + `/0` rejection (#162), but the API and the DB-load path did not. An operator entering `10.0.0.5/24` on the API got a different route-table key than the same network loaded from `nets.txt`, silently breaking the duplicate-NLRI merger (#209) and the aggregator. And `/0` on the API was a one-keystroke route leak. Unifying on one parser makes the policy impossible to get wrong per-path.

## Validation

```
dotnet format                              # clean
dotnet test                                # 556 passed, 0 failed
dotnet test --filter "PrefixCidr"          # 33/33 canonical-parser tests
dotnet test --filter "CustomPrefixValidation"  # 17/17 (updated for /0 + masking)
```

33 new `PrefixCidrTests` covering: masking across all length boundaries (1, 8, 16, 24, 31, 32), `/0` reject-by-default + accept-with-`allowDefault`, `allowDefault` still masks host bits for non-`/0`, length range (reject 33/250/255, accept 1/32), IPv6 reject, malformed-without-throwing (10 garbage shapes), null input, and a pinned leading-`+`-sign behaviour.

`CustomPrefixValidationTests` updated: `0.0.0.0/0` moved from the valid-case list to the invalid-case list (the route-leak fix), and three masking cases added.

## Risk

- **Behaviour change** (intended): `ParseCustomPrefix` now normalizes host bits. An API client sending `10.0.0.5/24` will see the stored form `10.0.0.0/24` on the next GET. The create/update response still echoes the raw input (pre-existing behaviour, unchanged) — documented as a cosmetic inconsistency in the self-review.
- **Behaviour change** (intended): the API now rejects `/0`. A peer previously configured with `0.0.0.0/0` via the API will get a 400 on the next create/update carrying it. This is the route-leak fix.
- **Backward-compat**: existing DB rows that stored host bits (written by the old non-masking API) are correctly masked at send time by the new `RouteAssembler` delegation — no migration needed.
- **No BGP wire-format change**: touches `BGPLite.Protocol` (new helper), `BGPLite.Providers`, `BGPLite.Api`, `BGPLite.Server`.

Self-reviewed before opening — verdict PRISTINE (no BLOCKER/MAJOR). Two cosmetic MINOR applied (collapsed a single-case Theory to Fact; pinned the leading-`+`-sign behaviour with an explicit test). One cosmetic MINOR skipped (HandleCreatePeer echoes raw input instead of the normalized form — pre-existing, not a regression).

Closes #236
