### PR TITLE
fix(protocol): reject truncated OPEN optional-params/capabilities

### DIFF
--- a/BGPLite.Protocol/BgpMessageReader.cs
+++ b/BGPLite.Protocol/BgpMessageReader.cs
@@ -66,8 +66,18 @@ public static class BgpMessageReader
         var optParamsLen = payload[9];
 
         var capabilities = new List<BgpCapabilityInfo>();
-        if (optParamsLen > 0 && payload.Length >= 10 + optParamsLen)
+        if (optParamsLen > 0)
+        {
+            // #234: the declared optional-parameters length is authoritative (RFC 4271 §4.2) — a
+            // value running past the message bytes is a malformed OPEN, not a silently shrinkable
+            // one. Previously the guard skipped parsing entirely, dropping capabilities (e.g. a
+            // corrupted Four-Octet-ASN TLV silently downgraded the session to 2-byte AS).
+            if (payload.Length < 10 + optParamsLen)
+                throw new BgpParseException(
+                    $"OPEN optional-parameters length {optParamsLen} exceeds message: have {payload.Length - 10} bytes",
+                    BgpConstants.Error.OpenMessageError, BgpConstants.SubError.Unspecific);
             ParseOptParameters(payload[10..][..optParamsLen], capabilities);
+        }
 
         return new BgpOpenMessage
         {
@@ -79,16 +89,26 @@ public static class BgpMessageReader
         };
     }
 
+    // #234: a TLV whose declared length runs past the buffer is malformed OPEN content
+    // (RFC 4271 §4.2, RFC 5492 §3) and must reject the message — the previous silent `break`
+    // treated truncation as "capability absent", masking wire corruption (e.g. a truncated
+    // Four-Octet-ASN TLV silently downgraded the session to a 2-byte AS).
     private static void ParseOptParameters(ReadOnlySpan<byte> data, List<BgpCapabilityInfo> capabilities)
     {
         var offset = 0;
         while (offset < data.Length)
         {
-            if (offset + 2 > data.Length) break;
+            if (offset + 2 > data.Length)
+                throw new BgpParseException(
+                    $"Truncated OPEN optional-parameter header at offset {offset}: have {data.Length - offset} bytes, need 2",
+                    BgpConstants.Error.OpenMessageError, BgpConstants.SubError.Unspecific);
             var paramType = data[offset++];
             var paramLen = data[offset++];
 
-            if (offset + paramLen > data.Length) break;
+            if (offset + paramLen > data.Length)
+                throw new BgpParseException(
+                    $"Truncated OPEN optional-parameter value: type {paramType} declares {paramLen} bytes at offset {offset}, have {data.Length - offset}",
+                    BgpConstants.Error.OpenMessageError, BgpConstants.SubError.Unspecific);
 
             if (paramType == 2) // Capability
                 ParseCapabilities(data[offset..][..paramLen], capabilities);
@@ -100,12 +120,19 @@ public static class BgpMessageReader
     private static void ParseCapabilities(ReadOnlySpan<byte> data, List<BgpCapabilityInfo> capabilities)
     {
         var offset = 0;
-        while (offset + 2 <= data.Length)
+        while (offset < data.Length)
         {
+            if (offset + 2 > data.Length)
+                throw new BgpParseException(
+                    $"Truncated capability header at offset {offset}: have {data.Length - offset} bytes, need 2",
+                    BgpConstants.Error.OpenMessageError, BgpConstants.SubError.Unspecific);
             var code = data[offset++];
             var len = data[offset++];
 
-            if (offset + len > data.Length) break;
+            if (offset + len > data.Length)
+                throw new BgpParseException(
+                    $"Truncated capability value: code {code} declares {len} bytes at offset {offset}, have {data.Length - offset}",
+                    BgpConstants.Error.OpenMessageError, BgpConstants.SubError.Unspecific);
 
             var capData = new byte[len];
             data.Slice(offset, len).CopyTo(capData);

--- a/BGPLite.Protocol/BgpMessageReader.cs
+++ b/BGPLite.Protocol/BgpMessageReader.cs
@@ -66,18 +66,17 @@ public static class BgpMessageReader
         var optParamsLen = payload[9];
 
         var capabilities = new List<BgpCapabilityInfo>();
+        // #234: the declared optional-parameters length is authoritative (RFC 4271 §4.2) — it
+        // must match the bytes present exactly, including the zero-length case. Previously a
+        // length running past the message silently skipped parsing (dropping capabilities, e.g.
+        // corrupting a Four-Octet-ASN TLV into a 2-byte-AS session), while surplus trailing
+        // bytes were silently ignored.
+        if (payload.Length != 10 + optParamsLen)
+            throw new BgpParseException(
+                $"OPEN optional-parameters length {optParamsLen} does not match message: have {payload.Length - 10} bytes",
+                BgpConstants.Error.OpenMessageError, BgpConstants.SubError.Unspecific);
         if (optParamsLen > 0)
-        {
-            // #234: the declared optional-parameters length is authoritative (RFC 4271 §4.2) — a
-            // value running past the message bytes is a malformed OPEN, not a silently shrinkable
-            // one. Previously the guard skipped parsing entirely, dropping capabilities (e.g. a
-            // corrupted Four-Octet-ASN TLV silently downgraded the session to 2-byte AS).
-            if (payload.Length < 10 + optParamsLen)
-                throw new BgpParseException(
-                    $"OPEN optional-parameters length {optParamsLen} exceeds message: have {payload.Length - 10} bytes",
-                    BgpConstants.Error.OpenMessageError, BgpConstants.SubError.Unspecific);
             ParseOptParameters(payload[10..][..optParamsLen], capabilities);
-        }
 
         return new BgpOpenMessage
         {

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -69,6 +69,92 @@ public class BgpMessageTests
         Assert.Equal(asn, effectiveAsn);
     }
 
+    // Builds a raw OPEN message: marker + length + type + fixed 10-byte body + optional parameters.
+    // Unlike BgpMessageWriter, this lets a test declare an optParamsLen that disagrees with the
+    // bytes actually present — the malformed framing the #234 truncation cases need.
+    private static byte[] BuildRawOpen(byte optParamsLen, byte[] optParams)
+    {
+        var length = BgpConstants.MessageHeaderSize + 10 + optParams.Length;
+        var message = new byte[length];
+        BgpConstants.Marker.CopyTo(message);
+        BinaryPrimitives.WriteUInt16BigEndian(message.AsSpan(16), (ushort)length);
+        message[18] = (byte)BgpMessageType.Open;
+        message[19] = 4; // version
+        BinaryPrimitives.WriteUInt16BigEndian(message.AsSpan(20), (ushort)65000); // ASN
+        BinaryPrimitives.WriteUInt16BigEndian(message.AsSpan(22), (ushort)180);   // hold time
+        BinaryPrimitives.WriteUInt32BigEndian(message.AsSpan(24), 0x0A000001);    // router ID
+        message[28] = optParamsLen;
+        optParams.AsSpan().CopyTo(message.AsSpan(29));
+        return message;
+    }
+
+    [Fact]
+    public void Open_WellFormedRawOptParams_Parses()
+    {
+        // Capability parameter (type 2) carrying a Four-Octet-ASN TLV (code 65, len 4, ASN 200000).
+        // Validates the raw builder so the truncation tests below fail for the right reason.
+        var message = BuildRawOpen(8, [0x02, 0x06, 0x41, 0x04, 0x00, 0x03, 0x0D, 0x40]);
+
+        var open = Assert.IsType<BgpOpenMessage>(BgpMessageReader.ReadMessage(message));
+
+        var cap = Assert.Single(open.Capabilities);
+        Assert.Equal(BgpConstants.Capability.FourOctetAsn, cap.Code);
+        Assert.Equal(200000u, CapabilityHelper.GetEffectiveAsn(open));
+    }
+
+    [Fact]
+    public void Open_OptParamsLengthExceedsMessage_Rejected()
+    {
+        // Declared optParamsLen=10 but only 4 parameter bytes present — previously parsing was
+        // silently skipped and all capabilities dropped (#234).
+        var message = BuildRawOpen(10, [0x02, 0x02, 0x41, 0x00]);
+
+        var ex = Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(message));
+        Assert.Equal(BgpConstants.Error.OpenMessageError, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Open_TruncatedOptParamHeader_Rejected()
+    {
+        // A complete capability param followed by one stray byte — the trailing 1-byte TLV header
+        // needs 2 bytes; previously the loop just broke out of it.
+        var message = BuildRawOpen(5, [0x02, 0x02, 0x41, 0x00, 0x02]);
+
+        var ex = Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(message));
+        Assert.Equal(BgpConstants.Error.OpenMessageError, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Open_TruncatedOptParamValue_Rejected()
+    {
+        // Parameter type 2 declares 4 bytes of capability data but only 2 follow.
+        var message = BuildRawOpen(4, [0x02, 0x04, 0x41, 0x04]);
+
+        var ex = Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(message));
+        Assert.Equal(BgpConstants.Error.OpenMessageError, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Open_TruncatedCapabilityHeader_Rejected()
+    {
+        // Capability parameter whose payload is a single stray byte (a TLV header needs 2).
+        var message = BuildRawOpen(3, [0x02, 0x01, 0x41]);
+
+        var ex = Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(message));
+        Assert.Equal(BgpConstants.Error.OpenMessageError, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Open_TruncatedFourOctetAsnCapability_Rejected()
+    {
+        // The #234 headline case: a Four-Octet-ASN TLV declaring 4 data bytes with only 2 present.
+        // Previously the capability was silently dropped and the session downgraded to a 2-byte AS.
+        var message = BuildRawOpen(6, [0x02, 0x04, 0x41, 0x04, 0x00, 0x00]);
+
+        var ex = Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(message));
+        Assert.Equal(BgpConstants.Error.OpenMessageError, ex.ErrorCode);
+    }
+
     [Fact]
     public void Notification_WriteThenRead_Roundtrip()
     {

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -156,6 +156,17 @@ public class BgpMessageTests
     }
 
     [Fact]
+    public void Open_SurplusBytesAfterOptParams_Rejected()
+    {
+        // optParamsLen declares 0 but one surplus byte follows — the declared length must match
+        // the message exactly (RFC 4271 §4.2, CodeRabbit review on #244).
+        var message = BuildRawOpen(0, [0x00]);
+
+        var ex = Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(message));
+        Assert.Equal(BgpConstants.Error.OpenMessageError, ex.ErrorCode);
+    }
+
+    [Fact]
     public void Notification_WriteThenRead_Roundtrip()
     {
         var notif = new BgpNotificationMessage


### PR DESCRIPTION
Closes #234

## Problem
`BgpMessageReader.ParseOptParameters` / `ParseCapabilities` silently `break` when a declared TLV length runs past the buffer, and `ParseOpen` silently skips parsing when the declared optional-parameters length exceeds the message bytes. A malformed OPEN was accepted with capabilities dropped — most damagingly, a truncated Four-Octet-ASN capability TLV silently downgraded the session to a 2-byte AS (`GetRemoteAsn` → null → 16-bit `open.Asn` fallback), producing a confusing Bad Peer AS NOTIFICATION on real 4-byte peers and masking wire-level corruption (RFC 4271 §4.2/§6.2, RFC 5492 §3).

## Fix
- `ParseOpen`: the `payload.Length >= 10 + optParamsLen` guard is now a hard check — a declared length past the message bytes throws `BgpParseException(OpenMessageError)`.
- `ParseOptParameters` / `ParseCapabilities`: every silent `break` replaced with an explicit `BgpParseException` carrying `OpenMessageError`; the capability loop condition changed from `offset + 2 <= data.Length` to `offset < data.Length` so a trailing partial TLV header (one stray byte) is also rejected instead of silently ending the loop.
- The exception surfaces through the existing `RunAsync` catch (`BgpSession.cs:333`) → NOTIFICATION(2, 0) before teardown, per the #223 error-code plumbing.

## Behavior change
Malformed/truncated OPENs are now rejected with an Open Message Error NOTIFICATION instead of being silently accepted with capabilities dropped. Well-formed OPENs parse identically.

## Verification
- `dotnet build BGPLite.sln -c Debug` — 0 errors.
- `dotnet test BGPLite.sln -c Debug` — 562 passed, 0 failed (6 new tests: well-formed raw OPEN parses; opt-params length exceeds message; truncated opt-param header; truncated opt-param value; truncated capability header; truncated Four-Octet-ASN capability — the issue's headline case).
- `dotnet format BGPLite.sln --no-restore --severity warn` — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of BGP OPEN optional parameters and capabilities.
  * Malformed or truncated messages are now rejected with appropriate OPEN Message Error details instead of being silently ignored.

* **Tests**
  * Added coverage for valid capability parsing and multiple malformed-message scenarios, including invalid lengths and incomplete capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->