### PR TITLE
fix(protocol): carry specific RFC 4271 §6.3 subcodes instead of Unspecific

### DIFF
--- a/BGPLite.Protocol/AttributeHelper.cs
+++ b/BGPLite.Protocol/AttributeHelper.cs
@@ -67,7 +67,8 @@ public static class AttributeHelper
     {
         _ = fourByteAsn; // retained for API compatibility; AGGREGATOR is always 6 octets (RFC 6793 §3).
         if (attr.Data.Length != 6)
-            throw new BgpParseException($"Malformed AGGREGATOR attribute: expected 6 bytes, got {attr.Data.Length}");
+            throw new BgpParseException($"Malformed AGGREGATOR attribute: expected 6 bytes, got {attr.Data.Length}",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.OptionalAttributeError);
 
         return BinaryPrimitives.ReadUInt16BigEndian(attr.Data);
     }
@@ -82,7 +83,8 @@ public static class AttributeHelper
     public static uint ReadAs4AggregatorAsn(PathAttribute attr)
     {
         if (attr.Data.Length != 8)
-            throw new BgpParseException($"Malformed AS4_AGGREGATOR attribute: expected 8 bytes, got {attr.Data.Length}");
+            throw new BgpParseException($"Malformed AS4_AGGREGATOR attribute: expected 8 bytes, got {attr.Data.Length}",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.OptionalAttributeError);
 
         return BinaryPrimitives.ReadUInt32BigEndian(attr.Data);
     }
@@ -130,7 +132,8 @@ public static class AttributeHelper
     public static (uint Global, uint Local1, uint Local2)[] ReadLargeCommunities(PathAttribute attr)
     {
         if (attr.Data.Length == 0 || attr.Data.Length % 12 != 0)
-            throw new BgpParseException("Large Communities attribute length must be a non-zero multiple of 12");
+            throw new BgpParseException("Large Communities attribute length must be a non-zero multiple of 12",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.OptionalAttributeError);
 
         var count = attr.Data.Length / 12;
         var large = new (uint Global, uint Local1, uint Local2)[count];
@@ -201,11 +204,13 @@ public static class AttributeHelper
             var segmentLength = data[offset++];
 
             if (segmentType != BgpConstants.AsPath.AsSequence && segmentType != BgpConstants.AsPath.AsSet)
-                throw new BgpParseException($"Invalid {attributeName} segment type: {segmentType}");
+                throw new BgpParseException($"Invalid {attributeName} segment type: {segmentType}",
+                    BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAsPath);
 
             var segBytes = segmentLength * asSize;
             if (offset + segBytes > data.Length)
-                throw new BgpParseException($"Truncated {attributeName} segment");
+                throw new BgpParseException($"Truncated {attributeName} segment",
+                    BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAsPath);
 
             for (var i = 0; i < segmentLength; i++)
             {
@@ -220,7 +225,8 @@ public static class AttributeHelper
         }
 
         if (offset != data.Length)
-            throw new BgpParseException($"Malformed {attributeName} attribute");
+            throw new BgpParseException($"Malformed {attributeName} attribute",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAsPath);
 
         return ases.ToArray();
     }

--- a/BGPLite.Protocol/AttributeHelper.cs
+++ b/BGPLite.Protocol/AttributeHelper.cs
@@ -56,21 +56,23 @@ public static class AttributeHelper
 
     /// <summary>
     /// Reads the aggregator ASN from a legacy AGGREGATOR attribute (type 7). Per RFC 6793 §3 the
-    /// AGGREGATOR attribute is unconditionally 6 octets: a 2-octet AS followed by a 4-octet IPv4
-    /// address — independent of whether the session negotiated 4-byte AS support. The 4-byte AS
+    /// attribute carries a four-octet AS (8 octets total: AS + IPv4) between NEW — 4-octet-AS —
+    /// speakers, and a two-octet AS (6 octets total) when an OLD speaker is involved; the
+    /// <paramref name="fourByteAsn"/> flag selects the negotiated form. The 4-octet-AS-on-OLD-session
     /// form lives in the separate AS4_AGGREGATOR attribute (type 18, see <see cref="ReadAs4AggregatorAsn"/>).
-    /// The <paramref name="fourByteAsn"/> parameter is retained for signature compatibility with
-    /// the call site but no longer affects the wire format — the prior branch accepted a malformed
-    /// 8-byte AGGREGATOR and rejected every legal 6-byte one on a 4-byte session (regression of #31).
+    /// The #154 fix made this unconditionally 6 octets, rejecting every legal AGGREGATOR from a
+    /// 4-octet peer — corrected per the RFC text in the #245 review.
     /// </summary>
     public static uint ReadAggregatorAsn(PathAttribute attr, bool fourByteAsn = false)
     {
-        _ = fourByteAsn; // retained for API compatibility; AGGREGATOR is always 6 octets (RFC 6793 §3).
-        if (attr.Data.Length != 6)
-            throw new BgpParseException($"Malformed AGGREGATOR attribute: expected 6 bytes, got {attr.Data.Length}",
+        var expectedLength = fourByteAsn ? 8 : 6;
+        if (attr.Data.Length != expectedLength)
+            throw new BgpParseException($"Malformed AGGREGATOR attribute: expected {expectedLength} bytes on a {(fourByteAsn ? "4-octet" : "2-octet")}-AS session, got {attr.Data.Length}",
                 BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.OptionalAttributeError);
 
-        return BinaryPrimitives.ReadUInt16BigEndian(attr.Data);
+        return fourByteAsn
+            ? BinaryPrimitives.ReadUInt32BigEndian(attr.Data)
+            : BinaryPrimitives.ReadUInt16BigEndian(attr.Data);
     }
 
     /// <summary>

--- a/BGPLite.Protocol/BgpConstants.cs
+++ b/BGPLite.Protocol/BgpConstants.cs
@@ -54,7 +54,8 @@ public static class BgpConstants
         public const byte AttributeFlagsError = 4;
         public const byte AttributeLengthError = 5;
         public const byte InvalidOriginAttribute = 6;
-        public const byte AsRoutingLoop = 7;
+        // Subcode 7 (AS Routing Loop) is "[Deprecated - see Appendix A]" in RFC 4271 §4.5 and
+        // is intentionally not defined here.
         public const byte InvalidNextHopAttribute = 8;
         public const byte OptionalAttributeError = 9;
         public const byte InvalidNetworkField = 10;

--- a/BGPLite.Protocol/BgpConstants.cs
+++ b/BGPLite.Protocol/BgpConstants.cs
@@ -34,12 +34,31 @@ public static class BgpConstants
     public static class SubError
     {
         public const byte Unspecific = 0;
+
+        // Subcode namespaces are per-error-code: the same numeric value means different things
+        // under Open Message Error (2) and Update Message Error (3) — e.g. 3 is Bad BGP Identifier
+        // in the former and Missing Well-known Attribute in the latter (RFC 4271 §6.2/§6.3).
+        // The dual naming below (BadBgpIdentifier/MissingWellKnownAttribute both = 3) is intentional.
+
+        // Open Message Error subcodes (RFC 4271 §6.2) — used with ErrorCode = OpenMessageError
         public const byte UnsupportedVersion = 1;
         public const byte BadPeerAs = 2;
-        public const byte MissingWellKnownAttribute = 3;
         public const byte BadBgpIdentifier = 3;
         public const byte UnacceptableHoldTime = 6;
         public const byte UnsupportedCapability = 7;
+
+        // Update Message Error subcodes (RFC 4271 §6.3) — used with ErrorCode = UpdateMessageError
+        public const byte MalformedAttributeList = 1;
+        public const byte UnrecognizedWellKnownAttribute = 2;
+        public const byte MissingWellKnownAttribute = 3;
+        public const byte AttributeFlagsError = 4;
+        public const byte AttributeLengthError = 5;
+        public const byte InvalidOriginAttribute = 6;
+        public const byte AsRoutingLoop = 7;
+        public const byte InvalidNextHopAttribute = 8;
+        public const byte OptionalAttributeError = 9;
+        public const byte InvalidNetworkField = 10;
+        public const byte MalformedAsPath = 11;
 
         // RFC 4486 Cease subcodes (apply when ErrorCode = Cease = 6)
         public const byte CeaseMaxPrefixes = 1;

--- a/BGPLite.Protocol/BgpMessageReader.cs
+++ b/BGPLite.Protocol/BgpMessageReader.cs
@@ -152,7 +152,7 @@ public static class BgpMessageReader
         offset += 2;
         if (offset + attrsLen > payload.Length)
             throw new BgpParseException($"UPDATE path-attributes length {attrsLen} exceeds payload",
-                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific);
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList);
 
         var attributes = new List<PathAttribute>();
         if (attrsLen > 0)
@@ -189,10 +189,13 @@ public static class BgpMessageReader
         // of Span.Slice / indexing, which escaped ReadLoopAsync (it only catches OCE/IOException) and
         // tore down the session with a generic Cease — a single malformed UPDATE killed the peer.
         // Now these surface as BgpParseException (Update Message Error) and are handled by the
-        // treat-as-withdraw path. RFC 7606 §2 / RFC 4271 §6.3.
+        // treat-as-withdraw path. RFC 7606 §2 / RFC 4271 §6.3. Subcodes (#235): a header that
+        // cannot even be read (flags/type/length bytes missing) is a malformed attribute list (1);
+        // a readable header whose declared value length overshoots the buffer is an attribute
+        // length error (5).
         if (data.Length < 2)
             throw new BgpParseException($"Truncated path attribute header: have {data.Length}, need 2",
-                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific);
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList);
 
         var flags = data[0];
         var typeCode = data[1];
@@ -203,7 +206,7 @@ public static class BgpMessageReader
         {
             if (data.Length < offset + 2)
                 throw new BgpParseException($"Truncated extended-length path attribute: have {data.Length}, need {offset + 2}",
-                    BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific);
+                    BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList);
             length = BinaryPrimitives.ReadUInt16BigEndian(data[offset..]);
             offset += 2;
         }
@@ -211,14 +214,14 @@ public static class BgpMessageReader
         {
             if (data.Length < offset + 1)
                 throw new BgpParseException($"Truncated path attribute length byte: have {data.Length}, need {offset + 1}",
-                    BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific);
+                    BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList);
             length = data[offset];
             offset += 1;
         }
 
         if (offset + length > data.Length)
             throw new BgpParseException($"Truncated path attribute value: declared {length} at offset {offset}, have {data.Length}",
-                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific);
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.AttributeLengthError);
 
         var attrData = new byte[length];
         data.Slice(offset, length).CopyTo(attrData);

--- a/BGPLite.Protocol/BgpMessageReader.cs
+++ b/BGPLite.Protocol/BgpMessageReader.cs
@@ -132,9 +132,11 @@ public static class BgpMessageReader
         // #222: a declared length that runs past the payload is stream-level corruption, not a
         // per-UPDATE content error — surface it as a parse exception (Update Message Error) so the
         // caller can treat-as-withdraw instead of throwing ArgumentOutOfRangeException out of Slice.
+        // RFC 4271 §6.3: "If the Withdrawn Routes Length or Total Attribute Length is too large
+        // ... the Error Subcode MUST be set to Malformed Attribute List."
         if (offset + withdrawnLen > payload.Length)
             throw new BgpParseException($"UPDATE withdrawn-routes length {withdrawnLen} exceeds payload",
-                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific);
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList);
 
         var withdrawn = new List<IpPrefix>();
         if (withdrawnLen > 0)
@@ -160,7 +162,10 @@ public static class BgpMessageReader
             var attrsEnd = offset + attrsLen;
             while (offset < attrsEnd)
             {
-                var (attr, consumed) = ParseAttribute(payload[offset..]);
+                // Slice to the declared end of the attribute section (not payload end): an
+                // attribute TLV whose declared value crosses attrsEnd must be rejected instead
+                // of silently consuming NLRI bytes as attribute data (#245 review finding).
+                var (attr, consumed) = ParseAttribute(payload.Slice(offset, attrsEnd - offset));
                 attributes.Add(attr);
                 offset += consumed;
             }

--- a/BGPLite.Protocol/PrefixCodec.cs
+++ b/BGPLite.Protocol/PrefixCodec.cs
@@ -33,21 +33,22 @@ public static class PrefixCodec
 
     /// <summary>
     /// Decodes one NLRI prefix from the head of <paramref name="buffer"/>. Throws
-    /// <see cref="BgpParseException"/> (Update Message Error) on any malformed input — a prefix-length
-    /// byte &gt; 32, or a buffer shorter than the declared prefix bytes — so the caller surfaces it
-    /// through the treat-as-withdraw path instead of the previous <see cref="ArgumentOutOfRangeException"/>
-    /// that escaped the read loop and tore down the session (#222, RFC 4271 §6.3 / RFC 7606 §2).
+    /// <see cref="BgpParseException"/> (Update Message Error, Invalid Network Field per RFC 4271
+    /// §6.3) on any malformed input — a prefix-length byte &gt; 32, or a buffer shorter than the
+    /// declared prefix bytes — so the caller surfaces it through the treat-as-withdraw path instead
+    /// of the previous <see cref="ArgumentOutOfRangeException"/> that escaped the read loop and
+    /// tore down the session (#222, RFC 4271 §6.3 / RFC 7606 §2).
     /// </summary>
     public static (IpPrefix prefix, int bytesConsumed) Decode(ReadOnlySpan<byte> buffer)
     {
         if (buffer.IsEmpty)
             throw new BgpParseException("Truncated NLRI: buffer too small to contain a prefix length byte",
-                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific);
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
 
         var length = buffer[0];
         if (length > 32)
             throw new BgpParseException($"Invalid NLRI prefix length: {length} (must be 0..32)",
-                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific);
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
 
         if (length == 0)
             return (new IpPrefix(0, 0), 1);
@@ -55,7 +56,7 @@ public static class PrefixCodec
         var byteCount = (length + 7) / 8;
         if (buffer.Length < 1 + byteCount)
             throw new BgpParseException($"Truncated NLRI: need {1 + byteCount} bytes for prefix length {length}, have {buffer.Length}",
-                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific);
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
         uint addr = 0;
         for (var i = 0; i < byteCount; i++)
             addr |= (uint)buffer[1 + i] << (24 - i * 8);

--- a/BGPLite.Protocol/UpdateCodec.cs
+++ b/BGPLite.Protocol/UpdateCodec.cs
@@ -142,7 +142,7 @@ public static class UpdateCodec
             return asPath;
 
         if (as4Path.Length > asPath.Length)
-            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, "AS4_PATH longer than AS_PATH");
+            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAsPath, "AS4_PATH longer than AS_PATH");
 
         if (as4Path.Length == asPath.Length)
             return as4Path;
@@ -151,7 +151,7 @@ public static class UpdateCodec
         for (var i = 0; i < leadingCount; i++)
         {
             if (asPath[i] == BgpConstants.AsPath.AsTrans)
-                throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, "Unresolved AS_TRANS in AS_PATH");
+                throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAsPath, "Unresolved AS_TRANS in AS_PATH");
         }
 
         var merged = new uint[asPath.Length];
@@ -168,10 +168,10 @@ public static class UpdateCodec
     public static void ValidateAggregatorReconstruction(uint? aggregatorAsn, uint? as4AggregatorAsn)
     {
         if (aggregatorAsn == BgpConstants.AsPath.AsTrans && as4AggregatorAsn is null)
-            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, "Missing AS4_AGGREGATOR for AGGREGATOR AS_TRANS");
+            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.OptionalAttributeError, "Missing AS4_AGGREGATOR for AGGREGATOR AS_TRANS");
 
         if (!aggregatorAsn.HasValue && as4AggregatorAsn.HasValue)
-            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, "Missing AGGREGATOR attribute for AS4_AGGREGATOR");
+            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.OptionalAttributeError, "Missing AGGREGATOR attribute for AS4_AGGREGATOR");
     }
 
     /// <summary>

--- a/BGPLite.Protocol/UpdateCodec.cs
+++ b/BGPLite.Protocol/UpdateCodec.cs
@@ -141,8 +141,12 @@ public static class UpdateCodec
         if (as4Path.Length == 0)
             return asPath;
 
+        // RFC 6793 §4.2.3: "If the number of AS numbers in the AS_PATH attribute is less than
+        // the number of AS numbers in the AS4_PATH attribute, then the AS4_PATH attribute SHALL
+        // be ignored, and the AS_PATH attribute SHALL be taken as the AS path information."
+        // (Happens when an intermediate aggregator truncated the AS_PATH — not a malformed UPDATE.)
         if (as4Path.Length > asPath.Length)
-            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAsPath, "AS4_PATH longer than AS_PATH");
+            return asPath;
 
         if (as4Path.Length == asPath.Length)
             return as4Path;

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -674,7 +674,7 @@ public sealed class BgpSession : IDisposable
                     {
                         case BgpConstants.Attribute.Origin:
                             if (attr.Data.Length < 1)
-                                throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, "Malformed ORIGIN attribute");
+                                throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidOriginAttribute, "Malformed ORIGIN attribute");
                             AttributeHelper.ReadOrigin(attr);
                             originSeen = true;
                             break;
@@ -687,7 +687,7 @@ public sealed class BgpSession : IDisposable
                             break;
                         case BgpConstants.Attribute.NextHop:
                             if (attr.Data.Length < 4)
-                                throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, "Malformed NEXT_HOP attribute");
+                                throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNextHopAttribute, "Malformed NEXT_HOP attribute");
                             nextHop = AttributeHelper.ReadNextHop(attr);
                             nextHopSeen = true;
                             break;
@@ -734,7 +734,10 @@ public sealed class BgpSession : IDisposable
             }
             catch (BgpParseException ex)
             {
-                throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.Unspecific, ex.Message);
+                // #235: preserve the RFC 4271 §6.3 subcode the codec recorded (e.g. Malformed AS_PATH
+                // from ReadAsPath, Optional Attribute Error from AGGREGATOR/Large Communities) instead
+                // of flattening it to Unspecific.
+                throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, ex.SubErrorCode ?? BgpConstants.SubError.Unspecific, ex.Message);
             }
         }
 

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -397,7 +397,9 @@ public class BgpMessageTests
             Data = new byte[] { BgpConstants.AsPath.AsSequence, 2, 0x00, 0x01 }
         };
 
-        Assert.Throws<BgpParseException>(() => AttributeHelper.ReadAsPath(attr, fourByteAsn: false));
+        var ex = Assert.Throws<BgpParseException>(() => AttributeHelper.ReadAsPath(attr, fourByteAsn: false));
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.MalformedAsPath, ex.SubErrorCode);
     }
 
     [Fact]
@@ -410,7 +412,9 @@ public class BgpMessageTests
             Data = new byte[] { 0x7F, 1, 0x00, 0x01 }
         };
 
-        Assert.Throws<BgpParseException>(() => AttributeHelper.ReadAsPath(attr, fourByteAsn: false));
+        var ex = Assert.Throws<BgpParseException>(() => AttributeHelper.ReadAsPath(attr, fourByteAsn: false));
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.MalformedAsPath, ex.SubErrorCode);
     }
 
     [Fact]
@@ -423,7 +427,25 @@ public class BgpMessageTests
             Data = new byte[] { BgpConstants.AsPath.AsSequence, 2, 0x00, 0x00, 0x00, 0x01 }
         };
 
-        Assert.Throws<BgpParseException>(() => AttributeHelper.ReadAs4Path(attr));
+        var ex = Assert.Throws<BgpParseException>(() => AttributeHelper.ReadAs4Path(attr));
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.MalformedAsPath, ex.SubErrorCode);
+    }
+
+    [Fact]
+    public void AsPath_TrailingByteAfterSegment_Throws()
+    {
+        // #235: a complete 1-ASN segment followed by one stray byte — offset != data.Length.
+        var attr = new PathAttribute
+        {
+            Flags = BgpConstants.Attribute.FlagTransitive,
+            TypeCode = BgpConstants.Attribute.AsPath,
+            Data = new byte[] { BgpConstants.AsPath.AsSequence, 1, 0x00, 0x01, 0xFF }
+        };
+
+        var ex = Assert.Throws<BgpParseException>(() => AttributeHelper.ReadAsPath(attr, fourByteAsn: false));
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.MalformedAsPath, ex.SubErrorCode);
     }
 
     [Fact]

--- a/BGPLite.Tests/BgpSessionRfc6793Tests.cs
+++ b/BGPLite.Tests/BgpSessionRfc6793Tests.cs
@@ -29,7 +29,7 @@ public class BgpSessionRfc6793Tests
             UpdateCodec.MergeAsPathWithAs4Path([65010u, BgpConstants.AsPath.AsTrans, 65001u], [200000u]));
 
         Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
-        Assert.Equal(BgpConstants.SubError.Unspecific, ex.SubErrorCode);
+        Assert.Equal(BgpConstants.SubError.MalformedAsPath, ex.SubErrorCode);
     }
 
     [Fact]
@@ -55,7 +55,7 @@ public class BgpSessionRfc6793Tests
             UpdateCodec.MergeAsPathWithAs4Path([65001u], [200000u, 300000u]));
 
         Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
-        Assert.Equal(BgpConstants.SubError.Unspecific, ex.SubErrorCode);
+        Assert.Equal(BgpConstants.SubError.MalformedAsPath, ex.SubErrorCode);
     }
 
     [Fact]
@@ -83,7 +83,7 @@ public class BgpSessionRfc6793Tests
             UpdateCodec.ValidateAggregatorReconstruction(null, 200000u));
 
         Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
-        Assert.Equal(BgpConstants.SubError.Unspecific, ex.SubErrorCode);
+        Assert.Equal(BgpConstants.SubError.OptionalAttributeError, ex.SubErrorCode);
     }
 
     [Fact]
@@ -93,7 +93,7 @@ public class BgpSessionRfc6793Tests
             UpdateCodec.ValidateAggregatorReconstruction(BgpConstants.AsPath.AsTrans, null));
 
         Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
-        Assert.Equal(BgpConstants.SubError.Unspecific, ex.SubErrorCode);
+        Assert.Equal(BgpConstants.SubError.OptionalAttributeError, ex.SubErrorCode);
     }
 
     // --- #154: wire-format codec for AGGREGATOR (type 7) and AS4_AGGREGATOR (type 18) ---

--- a/BGPLite.Tests/BgpSessionRfc6793Tests.cs
+++ b/BGPLite.Tests/BgpSessionRfc6793Tests.cs
@@ -49,13 +49,15 @@ public class BgpSessionRfc6793Tests
     }
 
     [Fact]
-    public void MergeAsPathWithAs4Path_As4PathLongerThanAsPath_Throws()
+    public void MergeAsPathWithAs4Path_As4PathLongerThanAsPath_IgnoresAs4Path()
     {
-        var ex = Assert.Throws<BgpNotificationException>(() =>
-            UpdateCodec.MergeAsPathWithAs4Path([65001u], [200000u, 300000u]));
+        // RFC 6793 §4.2.3: "If the number of AS numbers in the AS_PATH attribute is less than
+        // the number of AS numbers in the AS4_PATH attribute, then the AS4_PATH attribute SHALL
+        // be ignored, and the AS_PATH attribute SHALL be taken as the AS path information."
+        // Previously this threw and discarded the route (#245 review finding).
+        var merged = UpdateCodec.MergeAsPathWithAs4Path([65001u], [200000u, 300000u]);
 
-        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
-        Assert.Equal(BgpConstants.SubError.MalformedAsPath, ex.SubErrorCode);
+        Assert.Equal([65001u], merged);
     }
 
     [Fact]
@@ -102,29 +104,42 @@ public class BgpSessionRfc6793Tests
     // wire format so the regression cannot slip back.
 
     [Fact]
-    public void ReadAggregatorAsn_LegacySixByteForm_ReadsTwoOctetAs()
+    public void ReadAggregatorAsn_TwoOctetSession_SixByteForm_ReadsTwoOctetAs()
     {
-        // RFC 6793 §3: AGGREGATOR is unconditionally 6 octets (2 AS + 4 IPv4), independent of the
-        // session's 4-byte-ASN capability. The fourByteAsn flag must NOT change the wire format.
+        // RFC 6793 §3: AGGREGATOR carries a two-octet AS (6 octets total) when an OLD
+        // (2-octet-AS) speaker is involved.
         var data = new byte[] { 0xFD, 0xE9, 10, 0, 0, 1 }; // AS 65001, aggregator IP 10.0.0.1
         var attr = new PathAttribute { Flags = BgpConstants.Attribute.FlagTransitive, TypeCode = BgpConstants.Attribute.Aggregator, Data = data };
 
         Assert.Equal(65001u, AttributeHelper.ReadAggregatorAsn(attr, fourByteAsn: false));
-        // The flag must be ignored — AGGREGATOR is always 6 bytes.
-        Assert.Equal(65001u, AttributeHelper.ReadAggregatorAsn(attr, fourByteAsn: true));
+    }
+
+    [Fact]
+    public void ReadAggregatorAsn_FourOctetSession_EightByteForm_ReadsFourOctetAs()
+    {
+        // RFC 6793 §3: "The same applies to the AGGREGATOR attribute -- the same attribute is
+        // used between NEW BGP speakers, except that the AS number carried in the attribute is
+        // encoded as a four-octet entity" — 8 octets total on a 4-octet-AS session. The #154
+        // code required 6 bytes unconditionally, rejecting every legal peer AGGREGATOR (#245
+        // review finding).
+        var data = new byte[] { 0x00, 0x03, 0x0D, 0x40, 10, 0, 0, 1 }; // AS 200000, IP 10.0.0.1
+        var attr = new PathAttribute { Flags = BgpConstants.Attribute.FlagTransitive, TypeCode = BgpConstants.Attribute.Aggregator, Data = data };
+
+        Assert.Equal(200000u, AttributeHelper.ReadAggregatorAsn(attr, fourByteAsn: true));
     }
 
     [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public void ReadAggregatorAsn_WrongLength_Throws(bool fourByteAsn)
+    [InlineData(false, 4)]
+    [InlineData(false, 8)] // the 4-octet form is AS4_AGGREGATOR's job on a 2-octet session
+    [InlineData(true, 4)]
+    [InlineData(true, 6)]  // the 2-octet form is wrong on a 4-octet-AS session
+    public void ReadAggregatorAsn_WrongLengthForSession_Throws(bool fourByteAsn, int len)
     {
-        // The old bug: passing fourByteAsn=true expected 8 bytes and rejected the legal 6-byte form.
-        var tooShort = new PathAttribute { TypeCode = BgpConstants.Attribute.Aggregator, Data = new byte[4] };
-        var tooLong = new PathAttribute { TypeCode = BgpConstants.Attribute.Aggregator, Data = new byte[8] };
+        var attr = new PathAttribute { TypeCode = BgpConstants.Attribute.Aggregator, Data = new byte[len] };
 
-        Assert.Throws<BgpParseException>(() => AttributeHelper.ReadAggregatorAsn(tooShort, fourByteAsn));
-        Assert.Throws<BgpParseException>(() => AttributeHelper.ReadAggregatorAsn(tooLong, fourByteAsn));
+        var ex = Assert.Throws<BgpParseException>(() => AttributeHelper.ReadAggregatorAsn(attr, fourByteAsn));
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.OptionalAttributeError, ex.SubErrorCode);
     }
 
     [Fact]

--- a/BGPLite.Tests/LargeCommunityCodecTests.cs
+++ b/BGPLite.Tests/LargeCommunityCodecTests.cs
@@ -76,6 +76,8 @@ public class LargeCommunityCodecTests
         };
         var ex = Assert.Throws<BgpParseException>(() => AttributeHelper.ReadLargeCommunities(attr));
         Assert.Contains("multiple of 12", ex.Message);
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.OptionalAttributeError, ex.SubErrorCode);
     }
 
     [Fact]

--- a/BGPLite.Tests/MalformedUpdateResilienceTests.cs
+++ b/BGPLite.Tests/MalformedUpdateResilienceTests.cs
@@ -31,6 +31,7 @@ public class MalformedUpdateResilienceTests
 
         var ex = Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(BuildUpdateFrame([.. attrBytes])));
         Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.AttributeLengthError, ex.SubErrorCode);
     }
 
     [Fact]
@@ -42,6 +43,7 @@ public class MalformedUpdateResilienceTests
 
         var ex = Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(BuildUpdateFrame([.. attrBytes])));
         Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.MalformedAttributeList, ex.SubErrorCode);
     }
 
     [Fact]
@@ -59,6 +61,21 @@ public class MalformedUpdateResilienceTests
 
         var ex = Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(frame));
         Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void ParseUpdate_AttrsLengthExceedsPayload_ThrowsMalformedAttributeList()
+    {
+        // #235: a declared path-attributes length that runs past the payload is a malformed
+        // attribute list (RFC 4271 §6.3 subcode 1), not Unspecific.
+        var payload = new byte[4];
+        BinaryPrimitives.WriteUInt16BigEndian(payload, 0); // withdrawn length = 0
+        BinaryPrimitives.WriteUInt16BigEndian(payload.AsSpan(2), 0xFFFF); // attrs length = 65535
+        var frame = BuildMessage(BgpMessageType.Update, payload);
+
+        var ex = Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(frame));
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.MalformedAttributeList, ex.SubErrorCode);
     }
 
     [Fact]

--- a/BGPLite.Tests/MalformedUpdateResilienceTests.cs
+++ b/BGPLite.Tests/MalformedUpdateResilienceTests.cs
@@ -60,7 +60,32 @@ public class MalformedUpdateResilienceTests
         var frame = BuildMessage(BgpMessageType.Update, payload);
 
         var ex = Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(frame));
+        // RFC 4271 §6.3: an oversized Withdrawn Routes Length (or Total Attribute Length) MUST
+        // carry subcode 1 (Malformed Attribute List) — #245 review finding.
         Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.MalformedAttributeList, ex.SubErrorCode);
+    }
+
+    [Fact]
+    public void ParseUpdate_AttributeValueCrossingAttrsEnd_Rejected()
+    {
+        // #245 review finding: an attribute TLV whose declared value length reaches past the
+        // declared end of the attribute section must be rejected — previously the parser sliced
+        // to the payload end, silently consuming NLRI bytes as attribute data.
+        // Layout: withdrawn_len=0, attrs_len=4, attr TLV [flags=0, type=ORIGIN(1), len=5] with
+        // only 1 byte left in the attrs section, followed by 8 NLRI bytes the old code would eat.
+        var payload = new byte[4 + 4 + 8];
+        BinaryPrimitives.WriteUInt16BigEndian(payload.AsSpan(0, 2), 0); // withdrawn len
+        BinaryPrimitives.WriteUInt16BigEndian(payload.AsSpan(2, 2), 4); // attrs len
+        payload[4] = 0x00; // flags
+        payload[5] = 0x01; // type = ORIGIN
+        payload[6] = 0x05; // declared length 5 — crosses attrsEnd (only 1 byte left there)
+        payload[7] = 0xFF;
+        var frame = BuildMessage(BgpMessageType.Update, payload);
+
+        var ex = Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(frame));
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.AttributeLengthError, ex.SubErrorCode);
     }
 
     [Fact]

--- a/BGPLite.Tests/PrefixCodecTests.cs
+++ b/BGPLite.Tests/PrefixCodecTests.cs
@@ -108,6 +108,7 @@ public class PrefixCodecTests
 
         var ex = Assert.Throws<BgpParseException>(() => PrefixCodec.Decode(buffer));
         Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.InvalidNetworkField, ex.SubErrorCode);
     }
 
     [Fact]
@@ -162,6 +163,7 @@ public class PrefixCodecTests
             PrefixCodec.Decode(span);
         });
         Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.InvalidNetworkField, ex.SubErrorCode);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #235

## Problem
`BgpConstants.SubError` defined only the OPEN subcodes, so most malformed-UPDATE rejections (bad AS_PATH segment, truncated attribute TLV, invalid NLRI, AS4_PATH merge errors, …) were NOTIFIED with subcode 0 (Unspecific) — RFC 4271 §6.3 defines a specific subcode for each, and subcode 0 gives the peer operator no diagnostic.

## Fix
- `SubError` now carries the full Update Message Error table 1..11 (MalformedAttributeList … MalformedAsPath). The shared-value-3 ambiguity (`BadBgpIdentifier` vs `MissingWellKnownAttribute`) is resolved with a namespace-per-error-code comment, per the issue's option (no public API split — `SubError` is a public flat class and splitting would churn every call site).
- Throw sites mapped to the specific subcode: AS_PATH/AS4_PATH segment + merge errors → 11; AGGREGATOR/AS4_AGGREGATOR/ Large Communities (optional attrs) → 9; truncated attribute TLV header → 1; declared attribute value length overshooting → 5; path-attributes length exceeding UPDATE → 1; NLRI decode errors → 10; ORIGIN length → 6; NEXT_HOP length → 8.
- `BgpSession` re-wrap of `BgpParseException` now preserves `ex.SubErrorCode` instead of flattening to 0.

## Intentional deviation (narrower than the issue's table)
UPDATE-too-short (< 4 bytes) and withdrawn-routes-length-exceeds-payload keep subcode 0: RFC 4271 §6.3 defines no specific subcode for either framing case, and inventing one would be speculation. Also ORIGIN **value** validation is deliberately untouched — that is issue #233 (companion), which consumes `InvalidOriginAttribute` added here.

## Verification
- `dotnet build BGPLite.sln -c Debug` — 0 errors.
- `dotnet test BGPLite.sln -c Debug` — 558 passed, 0 failed (existing subcode assertions updated from Unspecific to the specific codes; new tests: AS_PATH trailing-byte → 11, attrs-length-exceeds-payload → 1).
- `dotnet format BGPLite.sln --no-restore --severity warn` — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BGP UPDATE error reporting with specific RFC-defined error and sub-error codes.
  * More accurately identifies malformed path attributes, AS paths, aggregators, network fields, and community data.
  * Preserves detailed parsing diagnostics when handling malformed UPDATE messages.
* **Tests**
  * Expanded coverage for truncated, malformed, oversized, and trailing BGP message data.
  * Updated validation to confirm the appropriate error classifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->