### PR TITLE
fix(protocol): validate received ORIGIN is 0/1/2 per RFC 4271 §5.1.2

### DIFF
--- a/BGPLite.Protocol/AttributeHelper.cs
+++ b/BGPLite.Protocol/AttributeHelper.cs
@@ -4,9 +4,19 @@ namespace BGPLite.Protocol;
 
 public static class AttributeHelper
 {
+    /// <summary>
+    /// Reads the ORIGIN attribute value. RFC 4271 §5.1.2 defines exactly three origins —
+    /// IGP (0), EGP (1), INCOMPLETE (2) — any other value is a malformed UPDATE and is
+    /// rejected with Update Message Error / Invalid ORIGIN Attribute (§6.3 subcode 6) so
+    /// the session's treat-as-withdraw path applies instead of silently accepting garbage (#233).
+    /// </summary>
     public static BgpOrigin ReadOrigin(PathAttribute attr)
     {
-        return (BgpOrigin)attr.Data[0];
+        var value = attr.Data[0];
+        if (value > 2)
+            throw new BgpParseException($"Invalid ORIGIN value: {value} (must be 0=IGP, 1=EGP, or 2=INCOMPLETE)",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidOriginAttribute);
+        return (BgpOrigin)value;
     }
 
     public static PathAttribute WriteOrigin(BgpOrigin origin)

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -448,6 +448,43 @@ public class BgpMessageTests
         Assert.Equal(BgpConstants.SubError.MalformedAsPath, ex.SubErrorCode);
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    public void Origin_ValidValues_Accepted(byte value)
+    {
+        // RFC 4271 §5.1.2: IGP (0), EGP (1), INCOMPLETE (2) are the only defined origins.
+        var attr = new PathAttribute
+        {
+            Flags = BgpConstants.Attribute.FlagTransitive,
+            TypeCode = BgpConstants.Attribute.Origin,
+            Data = [value]
+        };
+
+        Assert.Equal((BgpOrigin)value, AttributeHelper.ReadOrigin(attr));
+    }
+
+    [Theory]
+    [InlineData(3)]
+    [InlineData(7)]
+    [InlineData(255)]
+    public void Origin_InvalidValues_Rejected(byte value)
+    {
+        // #233: ORIGIN outside {0,1,2} is a malformed UPDATE — Invalid ORIGIN Attribute (§6.3
+        // subcode 6), surfaced through treat-as-withdraw instead of being silently accepted.
+        var attr = new PathAttribute
+        {
+            Flags = BgpConstants.Attribute.FlagTransitive,
+            TypeCode = BgpConstants.Attribute.Origin,
+            Data = [value]
+        };
+
+        var ex = Assert.Throws<BgpParseException>(() => AttributeHelper.ReadOrigin(attr));
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.InvalidOriginAttribute, ex.SubErrorCode);
+    }
+
     [Fact]
     public void AsPath_2Byte_WithAsTrans_Roundtrip()
     {


### PR DESCRIPTION
Closes #233

⚠️ Stacked on #245 (uses `SubError.InvalidOriginAttribute` added there) — merge #245 first, then retarget this to main.

## Problem
`AttributeHelper.ReadOrigin` cast the ORIGIN byte straight to the enum without validating it, and the call site (`BgpSession.HandleUpdateAsync`) discarded the result — so an inbound UPDATE with `ORIGIN = 7` was silently accepted into the route table. RFC 4271 §5.1.2 defines exactly three origins; §6.3 mandates Update Message Error with subcode 6 (Invalid ORIGIN Attribute).

## Fix
`ReadOrigin` throws `BgpParseException(UpdateMessageError, InvalidOriginAttribute)` for values 3..255. The exception flows through `HandleUpdateAsync`'s existing `catch (BgpParseException)` re-wrap (which now preserves the subcode, thanks to #235) into the established treat-as-withdraw path: UPDATE discarded, session stays up, rejection log names the invalid value. Values 0/1/2 parse exactly as before. The zero-length ORIGIN case keeps the pre-existing length guard at the call site (also subcode 6 since #235).

Not a route-leak vector on its own (BGPLite rewrites ORIGIN to IGP on send), but this enforces the inbound contract and prevents a future path-selection change from inheriting garbage values.

## Verification
- `dotnet build BGPLite.sln -c Debug` — 0 errors.
- `dotnet test BGPLite.sln -c Debug` — 564 passed, 0 failed (new theories: valid 0/1/2 accepted; invalid 3/7/255 rejected with subcode 6).
- `dotnet format BGPLite.sln --no-restore --severity warn` — clean.