### PR TITLE
fix(protocol,routing,api): address 2026-08-03 audit findings

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -34,6 +34,15 @@ public sealed class ManagementApi : IHostedService, IDisposable
     private readonly ILogger<ManagementApi> _logger;
     private readonly int _port;
     private readonly string _listenAddress;  // #90: bind address — loopback by default
+
+    /// <summary>
+    /// #238: default in-flight cap for accepted-but-not-yet-completed requests. The #119
+    /// concurrency limiter is opt-in; without this bound a connection burst spawns unbounded
+    /// fire-and-forget tasks, each potentially doing DB work or RIPEstat fetches. Backpressure
+    /// is applied in the accept loop: at capacity it waits for a slot instead of spawning.
+    /// </summary>
+    private const int DefaultInflightCap = 64;
+    private readonly SemaphoreSlim _inflightCap = new(DefaultInflightCap);
     private HttpListener? _listener;
     private Task? _listenTask;
     private readonly CancellationTokenSource _cts = new();
@@ -183,13 +192,38 @@ public sealed class ManagementApi : IHostedService, IDisposable
             {
                 var ctx = await _listener!.GetContextAsync();
                 if (ct.IsCancellationRequested) break;
-                _ = HandleAsync(ctx);
+                // #238: acquire an in-flight slot before spawning so the default posture is
+                // bounded even when the operator has not enabled the #119 concurrency limiter.
+                await _inflightCap.WaitAsync(ct);
+                _ = HandleWithInflightReleaseAsync(ctx);
             }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested) { break; }
             catch (HttpListenerException) when (ct.IsCancellationRequested) { break; }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Management API error");
             }
+        }
+    }
+
+    /// <summary>
+    /// Wraps <see cref="HandleAsync"/> so the <see cref="_inflightCap"/> slot acquired by the
+    /// accept loop is released on every exit path (HandleAsync has early returns before its own
+    /// try/finally). Faults are logged here rather than escaping into an unobserved task.
+    /// </summary>
+    private async Task HandleWithInflightReleaseAsync(HttpListenerContext ctx)
+    {
+        try
+        {
+            await HandleAsync(ctx);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Management API request handling faulted");
+        }
+        finally
+        {
+            _inflightCap.Release();
         }
     }
 
@@ -580,7 +614,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         var customPrefixes = new List<(string Prefix, byte Length)>();
 
         _logger.LogInformation("CreatePeer deserialized: AsnLists={Lists}, CustomPrefixes={Prefixes}, CustomAsns={Asns}",
-            string.Join(",", asnLists), string.Join(",", data.CustomPrefixes ?? []),
+            SanitizeForLog(string.Join(",", asnLists)), string.Join(",", data.CustomPrefixes ?? []),
             string.Join(",", data.CustomAsns ?? []));
 
         if (data.CustomPrefixes is not null)
@@ -993,7 +1027,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
     {
         var routes = _routeTable.GetAll();
         var byCommunity = routes
-            .SelectMany(r => r.Communities.Length == 0
+            .SelectMany(r => r.Communities.Count == 0
                 ? [(community: 0u, route: r)]
                 : r.Communities.Select(c => (community: c, route: r)))
             .GroupBy(x => x.community)
@@ -1262,6 +1296,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // (unlike ApplyConfig mid-flight where we leave old ones for GC per #137's CodeRabbit fix).
         Volatile.Read(ref _rateLimiter)?.Dispose();
         Volatile.Read(ref _concurrencyLimiter)?.Dispose();
+        _inflightCap.Dispose();
         _listener?.Close();
     }
 

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -43,6 +43,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
     /// </summary>
     private const int DefaultInflightCap = 64;
     private readonly SemaphoreSlim _inflightCap = new(DefaultInflightCap);
+    private readonly List<Task> _inflightHandlers = new();
     private HttpListener? _listener;
     private Task? _listenTask;
     private readonly CancellationTokenSource _cts = new();
@@ -182,26 +183,46 @@ public sealed class ManagementApi : IHostedService, IDisposable
         {
             try { await _listenTask; } catch { }
         }
+
+        // Drain in-flight handlers before the host disposes this service: a handler reaching
+        // _inflightCap.Release() after Dispose would hit ObjectDisposedException (#248 review).
+        Task[] pending;
+        lock (_inflightHandlers) pending = _inflightHandlers.ToArray();
+        if (pending.Length > 0)
+        {
+            try { await Task.WhenAll(pending); } catch { }
+        }
     }
 
     private async Task ListenAsync(CancellationToken ct)
     {
         while (!ct.IsCancellationRequested)
         {
+            HttpListenerContext? ctx = null;
             try
             {
-                var ctx = await _listener!.GetContextAsync();
+                ctx = await _listener!.GetContextAsync();
                 if (ct.IsCancellationRequested) break;
                 // #238: acquire an in-flight slot before spawning so the default posture is
                 // bounded even when the operator has not enabled the #119 concurrency limiter.
                 await _inflightCap.WaitAsync(ct);
-                _ = HandleWithInflightReleaseAsync(ctx);
+                var accepted = ctx;
+                ctx = null; // ownership transferred to the handler task
+                var handler = HandleWithInflightReleaseAsync(accepted);
+                lock (_inflightHandlers) _inflightHandlers.Add(handler);
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested) { break; }
             catch (HttpListenerException) when (ct.IsCancellationRequested) { break; }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Management API error");
+            }
+            finally
+            {
+                // An accepted context that never reached its handler task (shutdown cancelled
+                // the permit acquisition, or the ct-check raced the accept) must not leak an
+                // open response (#248 review).
+                try { ctx?.Response.Close(); } catch { /* best-effort on shutdown */ }
             }
         }
     }
@@ -223,7 +244,9 @@ public sealed class ManagementApi : IHostedService, IDisposable
         }
         finally
         {
-            _inflightCap.Release();
+            // Tolerate teardown racing the StopAsync drain (e.g. direct Dispose without StopAsync).
+            try { _inflightCap.Release(); }
+            catch (ObjectDisposedException) { /* cap already disposed */ }
         }
     }
 
@@ -614,7 +637,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         var customPrefixes = new List<(string Prefix, byte Length)>();
 
         _logger.LogInformation("CreatePeer deserialized: AsnLists={Lists}, CustomPrefixes={Prefixes}, CustomAsns={Asns}",
-            SanitizeForLog(string.Join(",", asnLists)), string.Join(",", data.CustomPrefixes ?? []),
+            SanitizeForLog(string.Join(",", asnLists)), SanitizeForLog(string.Join(",", data.CustomPrefixes ?? [])),
             string.Join(",", data.CustomAsns ?? []));
 
         if (data.CustomPrefixes is not null)

--- a/BGPLite.Protocol/AttributeHelper.cs
+++ b/BGPLite.Protocol/AttributeHelper.cs
@@ -56,7 +56,20 @@ public static class AttributeHelper
 
     public static uint[] ReadAs4Path(PathAttribute attr)
     {
-        return ReadPathData(attr.Data, 4, "AS4_PATH");
+        var ases = ReadPathData(attr.Data, 4, "AS4_PATH");
+
+        // AS_TRANS (23456) is the 2-octet placeholder for a non-mappable 4-octet AS (RFC 6793 §3)
+        // and is meaningless inside AS4_PATH, which is 4-octet-encoded by definition. Defensive
+        // check from the #238 audit (RFC 6793 contains no explicit prohibition — the audit's
+        // "§F.4" citation does not exist in the RFC text).
+        foreach (var asn in ases)
+        {
+            if (asn == BgpConstants.AsPath.AsTrans)
+                throw new BgpParseException($"AS4_PATH must not carry AS_TRANS ({BgpConstants.AsPath.AsTrans})",
+                    BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAsPath);
+        }
+
+        return ases;
     }
 
     public static uint ReadNextHop(PathAttribute attr)
@@ -122,10 +135,10 @@ public static class AttributeHelper
         return communities;
     }
 
-    public static PathAttribute WriteCommunities(uint[] communities)
+    public static PathAttribute WriteCommunities(IReadOnlyList<uint> communities)
     {
-        var data = new byte[communities.Length * 4];
-        for (var i = 0; i < communities.Length; i++)
+        var data = new byte[communities.Count * 4];
+        for (var i = 0; i < communities.Count; i++)
             BinaryPrimitives.WriteUInt32BigEndian(data.AsSpan(i * 4), communities[i]);
         return new PathAttribute
         {
@@ -164,10 +177,10 @@ public static class AttributeHelper
     /// Encodes a BGP Large Communities attribute (RFC 8092 §2): 12 bytes per triplet, network
     /// byte order, flags OPTIONAL + TRANSITIVE (0xC0), type code 32.
     /// </summary>
-    public static PathAttribute WriteLargeCommunities((uint Global, uint Local1, uint Local2)[] large)
+    public static PathAttribute WriteLargeCommunities(IReadOnlyList<(uint Global, uint Local1, uint Local2)> large)
     {
-        var data = new byte[large.Length * 12];
-        for (var i = 0; i < large.Length; i++)
+        var data = new byte[large.Count * 12];
+        for (var i = 0; i < large.Count; i++)
         {
             var offset = i * 12;
             BinaryPrimitives.WriteUInt32BigEndian(data.AsSpan(offset), large[i].Global);
@@ -217,6 +230,13 @@ public static class AttributeHelper
 
             if (segmentType != BgpConstants.AsPath.AsSequence && segmentType != BgpConstants.AsPath.AsSet)
                 throw new BgpParseException($"Invalid {attributeName} segment type: {segmentType}",
+                    BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAsPath);
+
+            // RFC 4271 §4.3: a path segment value contains "one or more AS numbers" — a
+            // zero-length segment is malformed (#238).
+            if (segmentLength == 0)
+                throw new BgpParseException(
+                    $"Invalid {attributeName} segment length 0 (a segment carries one or more AS numbers)",
                     BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAsPath);
 
             var segBytes = segmentLength * asSize;

--- a/BGPLite.Protocol/AttributeHelper.cs
+++ b/BGPLite.Protocol/AttributeHelper.cs
@@ -46,6 +46,11 @@ public static class AttributeHelper
 
     public static PathAttribute WriteAs4Path(uint[] ases)
     {
+        // Write-side symmetry with ReadAs4Path: AS_TRANS is the 2-octet placeholder and must not
+        // be written into the 4-octet-encoded attribute the reader rejects (#248 review).
+        if (ases.Contains(BgpConstants.AsPath.AsTrans))
+            throw new ArgumentOutOfRangeException(nameof(ases), $"AS4_PATH must not carry AS_TRANS ({BgpConstants.AsPath.AsTrans}).");
+
         return new PathAttribute
         {
             Flags = BgpConstants.Attribute.FlagOptional | BgpConstants.Attribute.FlagTransitive,
@@ -270,6 +275,11 @@ public static class AttributeHelper
         // multiple segments.
         if (ases.Length > byte.MaxValue)
             throw new ArgumentOutOfRangeException(nameof(ases), $"{attributeName} segment length cannot exceed 255 ASNs.");
+
+        // An empty path is encoded as a zero-length attribute — NOT a zero-length segment, which
+        // RFC 4271 §4.3 forbids ("one or more AS numbers") and ReadPathData rejects (#248 review).
+        if (ases.Length == 0)
+            return [];
 
         var data = new byte[2 + ases.Length * asSize];
         data[0] = BgpConstants.AsPath.AsSequence;

--- a/BGPLite.Protocol/UpdateCodec.cs
+++ b/BGPLite.Protocol/UpdateCodec.cs
@@ -49,7 +49,7 @@ public static class UpdateCodec
     /// Builds outbound UPDATE path attributes in RFC order: ORIGIN, AS_PATH, NEXT_HOP,
     /// COMMUNITY, AS4_PATH.
     /// </summary>
-    public static List<PathAttribute> BuildUpdateAttributes(uint localAsn, bool localFourByteAsn, uint nextHop, uint[] communities)
+    public static List<PathAttribute> BuildUpdateAttributes(uint localAsn, bool localFourByteAsn, uint nextHop, IReadOnlyList<uint> communities)
     {
         var attrs = new List<PathAttribute>(5)
         {
@@ -60,7 +60,7 @@ public static class UpdateCodec
         attrs.Add(asPathAttrs[0]);
         attrs.Add(AttributeHelper.WriteNextHop(nextHop));
 
-        if (communities.Length > 0)
+        if (communities.Count > 0)
             attrs.Add(AttributeHelper.WriteCommunities(communities));
 
         if (asPathAttrs.Count > 1)
@@ -75,7 +75,7 @@ public static class UpdateCodec
     /// whole send, so identical community sets yield byte-identical <see cref="PathAttribute"/>
     /// lists that can be reused across the N 100-NLRI batches (#87).
     /// </summary>
-    public static Dictionary<uint[], List<PathAttribute>> CreateUpdateAttributeCache() =>
+    public static Dictionary<IReadOnlyList<uint>, List<PathAttribute>> CreateUpdateAttributeCache() =>
         new(CommunitySetComparer.Instance);
 
     /// <summary>
@@ -85,8 +85,8 @@ public static class UpdateCodec
     /// every UPDATE emitted for that community set.
     /// </summary>
     public static List<PathAttribute> GetCachedUpdateAttributes(
-        uint localAsn, bool localFourByteAsn, uint nextHop, uint[] communities,
-        Dictionary<uint[], List<PathAttribute>> cache)
+        uint localAsn, bool localFourByteAsn, uint nextHop, IReadOnlyList<uint> communities,
+        Dictionary<IReadOnlyList<uint>, List<PathAttribute>> cache)
     {
         if (cache.TryGetValue(communities, out var cached))
             return cached;
@@ -106,9 +106,9 @@ public static class UpdateCodec
     /// emitted attributes in ascending type-code order (32 sorts after AS4_PATH 17).
     /// </summary>
     public static List<PathAttribute> WithLargeCommunityAttribute(
-        List<PathAttribute> baseAttrs, (uint Global, uint Local1, uint Local2)[] largeCommunities)
+        List<PathAttribute> baseAttrs, IReadOnlyList<(uint Global, uint Local1, uint Local2)> largeCommunities)
     {
-        if (largeCommunities.Length == 0)
+        if (largeCommunities.Count == 0)
             return baseAttrs;
 
         var withLarge = new List<PathAttribute>(baseAttrs.Count + 1);
@@ -196,21 +196,21 @@ public static class UpdateCodec
     }
 }
 
-/// <summary>Sequence equality over a route's community array (set-equivalence within a batch).</summary>
-public sealed class CommunitySetComparer : IEqualityComparer<uint[]>
+/// <summary>Sequence equality over a route's community list (set-equivalence within a batch).</summary>
+public sealed class CommunitySetComparer : IEqualityComparer<IReadOnlyList<uint>>
 {
     public static readonly CommunitySetComparer Instance = new();
 
-    public bool Equals(uint[]? x, uint[]? y)
+    public bool Equals(IReadOnlyList<uint>? x, IReadOnlyList<uint>? y)
     {
         if (ReferenceEquals(x, y)) return true;
-        if (x is null || y is null || x.Length != y.Length) return false;
-        for (var i = 0; i < x.Length; i++)
+        if (x is null || y is null || x.Count != y.Count) return false;
+        for (var i = 0; i < x.Count; i++)
             if (x[i] != y[i]) return false;
         return true;
     }
 
-    public int GetHashCode(uint[] obj)
+    public int GetHashCode(IReadOnlyList<uint> obj)
     {
         var hc = new HashCode();
         foreach (var c in obj) hc.Add(c);
@@ -218,21 +218,21 @@ public sealed class CommunitySetComparer : IEqualityComparer<uint[]>
     }
 }
 
-/// <summary>Sequence equality over a route's Large Community array (RFC 8092 triplets).</summary>
-public sealed class LargeCommunitySetComparer : IEqualityComparer<(uint Global, uint Local1, uint Local2)[]>
+/// <summary>Sequence equality over a route's Large Community list (RFC 8092 triplets).</summary>
+public sealed class LargeCommunitySetComparer : IEqualityComparer<IReadOnlyList<(uint Global, uint Local1, uint Local2)>>
 {
     public static readonly LargeCommunitySetComparer Instance = new();
 
-    public bool Equals((uint Global, uint Local1, uint Local2)[]? x, (uint Global, uint Local1, uint Local2)[]? y)
+    public bool Equals(IReadOnlyList<(uint Global, uint Local1, uint Local2)>? x, IReadOnlyList<(uint Global, uint Local1, uint Local2)>? y)
     {
         if (ReferenceEquals(x, y)) return true;
-        if (x is null || y is null || x.Length != y.Length) return false;
-        for (var i = 0; i < x.Length; i++)
+        if (x is null || y is null || x.Count != y.Count) return false;
+        for (var i = 0; i < x.Count; i++)
             if (x[i] != y[i]) return false;
         return true;
     }
 
-    public int GetHashCode((uint Global, uint Local1, uint Local2)[] obj)
+    public int GetHashCode(IReadOnlyList<(uint Global, uint Local1, uint Local2)> obj)
     {
         var hc = new HashCode();
         foreach (var c in obj) hc.Add(c);
@@ -245,18 +245,18 @@ public sealed class LargeCommunitySetComparer : IEqualityComparer<(uint Global, 
 /// partition a send batch that spans more than one community set.
 /// </summary>
 public sealed class CommunitySetPairComparer
-    : IEqualityComparer<(uint[] Communities, (uint Global, uint Local1, uint Local2)[] LargeCommunities)>
+    : IEqualityComparer<(IReadOnlyList<uint> Communities, IReadOnlyList<(uint Global, uint Local1, uint Local2)> LargeCommunities)>
 {
     public static readonly CommunitySetPairComparer Instance = new();
 
     public bool Equals(
-        (uint[] Communities, (uint Global, uint Local1, uint Local2)[] LargeCommunities) x,
-        (uint[] Communities, (uint Global, uint Local1, uint Local2)[] LargeCommunities) y) =>
+        (IReadOnlyList<uint> Communities, IReadOnlyList<(uint Global, uint Local1, uint Local2)> LargeCommunities) x,
+        (IReadOnlyList<uint> Communities, IReadOnlyList<(uint Global, uint Local1, uint Local2)> LargeCommunities) y) =>
         CommunitySetComparer.Instance.Equals(x.Communities, y.Communities) &&
         LargeCommunitySetComparer.Instance.Equals(x.LargeCommunities, y.LargeCommunities);
 
     public int GetHashCode(
-        (uint[] Communities, (uint Global, uint Local1, uint Local2)[] LargeCommunities) obj)
+        (IReadOnlyList<uint> Communities, IReadOnlyList<(uint Global, uint Local1, uint Local2)> LargeCommunities) obj)
     {
         var hc = new HashCode();
         foreach (var c in obj.Communities) hc.Add(c);

--- a/BGPLite.Providers/PrefixService.cs
+++ b/BGPLite.Providers/PrefixService.cs
@@ -344,11 +344,11 @@ public sealed class PrefixService : IPrefixService
             try
             {
                 await GetPrefixesAsync(asn, ct);
-                Console.WriteLine($"  WarmUp: AS{asn} cached");
+                _logger?.LogInformation("WarmUp: AS{Asn} cached", asn);
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"  WarmUp: AS{asn} failed — {ex.Message}");
+                _logger?.LogWarning(ex, "WarmUp: AS{Asn} failed", asn);
             }
         }
 

--- a/BGPLite.Providers/PrefixSourceService.cs
+++ b/BGPLite.Providers/PrefixSourceService.cs
@@ -119,7 +119,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
     public async Task WarmUpAsync(CancellationToken ct = default)
     {
         foreach (var (source, prefixes) in await LoadAllAsync(ct))
-            Console.WriteLine($"  WarmUp: source '{source.Name}' — {prefixes.Count} prefixes");
+            _logger.LogInformation("WarmUp: source '{Name}' — {Count} prefixes", source.Name, prefixes.Count);
     }
 
     /// <summary>

--- a/BGPLite.Routing/ExactUnionPrefixAggregator.cs
+++ b/BGPLite.Routing/ExactUnionPrefixAggregator.cs
@@ -147,29 +147,25 @@ public sealed class ExactUnionPrefixAggregator : IPrefixAggregator
 
         public static AttributeKey From(Route route)
         {
-            var c = route.Communities;
-            // Communities are a set: dedup (and sort) so set-equivalent routes key together.
-            var communities = c.Length <= 1 ? c : NormalizeCommunities(c);
-
-            var l = route.LargeCommunities;
-            // Large Communities are likewise a set: dedup and order by (Global,Local1,Local2)
-            // so set-equivalent routes key together. (Value tuples have no IComparable, hence
-            // the explicit Comparison rather than Array.Sort(items).)
-            var large = l.Length <= 1 ? l : NormalizeLargeCommunities(l);
-
-            return new AttributeKey(communities, large);
+            // #238: Route collections are IReadOnlyList now — normalize into privately-owned
+            // arrays so the key never aliases a route's (shared) backing array.
+            return new AttributeKey(NormalizeCommunities(route.Communities), NormalizeLargeCommunities(route.LargeCommunities));
         }
 
-        private static uint[] NormalizeCommunities(uint[] communities)
+        private static uint[] NormalizeCommunities(IReadOnlyList<uint> communities)
         {
+            // Communities are a set: dedup (and sort) so set-equivalent routes key together.
             var sorted = communities.Distinct().ToArray();
             Array.Sort(sorted);
             return sorted;
         }
 
         private static (uint Global, uint Local1, uint Local2)[] NormalizeLargeCommunities(
-            (uint Global, uint Local1, uint Local2)[] large)
+            IReadOnlyList<(uint Global, uint Local1, uint Local2)> large)
         {
+            // Large Communities are likewise a set: dedup and order by (Global,Local1,Local2)
+            // so set-equivalent routes key together. (Value tuples have no IComparable, hence
+            // the explicit Comparison rather than Array.Sort(items).)
             var distinct = large.Distinct().ToArray();
             Array.Sort(distinct, LargeCommunityComparison);
             return distinct;

--- a/BGPLite.Routing/PeerCommunityFilter.cs
+++ b/BGPLite.Routing/PeerCommunityFilter.cs
@@ -33,7 +33,7 @@ public sealed class PeerCommunityFilter : IRouteFilter
         if (allowSet.Count == 0)
             return true; // no filter = all routes
 
-        if (route.Communities.Length == 0)
+        if (route.Communities.Count == 0)
             return true; // routes without community always pass
 
         foreach (var c in route.Communities)

--- a/BGPLite.Routing/Route.cs
+++ b/BGPLite.Routing/Route.cs
@@ -1,15 +1,20 @@
 namespace BGPLite.Routing;
 
+/// <summary>
+/// A route-server route. The path/community collections are exposed as read-only lists because
+/// the assembler and merge paths reuse the SAME backing array instances across many Route objects
+/// (#238) — a consumer mutating, say, <c>route.Communities[0]</c> would corrupt every sibling
+/// route. Callers that need a modified copy build a new array, as the merge paths already do.
+/// </summary>
 public sealed class Route
 {
     public required uint Prefix { get; init; }
     public required byte PrefixLength { get; init; }
     public required uint NextHop { get; init; }
-    public uint[] AsPath { get; init; } = [];
-    public uint[] Communities { get; init; } = [];
+    public IReadOnlyList<uint> AsPath { get; init; } = [];
+    public IReadOnlyList<uint> Communities { get; init; } = [];
     /// <summary>BGP Large Communities (RFC 8092): triplets of (Global : Local1 : Local2).</summary>
-    public (uint Global, uint Local1, uint Local2)[] LargeCommunities { get; init; } = [];
-    public DateTime UpdatedAt { get; init; } = DateTime.UtcNow;
+    public IReadOnlyList<(uint Global, uint Local1, uint Local2)> LargeCommunities { get; init; } = [];
 
     public (uint Prefix, byte Length) Key => (Prefix, PrefixLength);
 }

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -852,7 +852,7 @@ public sealed class BgpSession : IDisposable
         return [.. merged.Values];
     }
 
-    private async Task SendRouteBatchAsync(uint nextHop, List<Route> routes, Dictionary<uint[], List<PathAttribute>> attrCache)
+    private async Task SendRouteBatchAsync(uint nextHop, List<Route> routes, Dictionary<IReadOnlyList<uint>, List<PathAttribute>> attrCache)
     {
         // The COMMUNITY/LARGE_COMMUNITY path attributes apply to EVERY NLRI in an UPDATE, so
         // partition the batch by (community set, large-community set) and emit one UPDATE per

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -530,6 +530,40 @@ public class BgpMessageTests
     }
 
     [Fact]
+    public void AsPath_EmptySegment_Throws()
+    {
+        // RFC 4271 §4.3: a path segment value contains "one or more AS numbers" — a zero-length
+        // segment is malformed (#238).
+        var attr = new PathAttribute
+        {
+            Flags = BgpConstants.Attribute.FlagTransitive,
+            TypeCode = BgpConstants.Attribute.AsPath,
+            Data = new byte[] { BgpConstants.AsPath.AsSequence, 0 }
+        };
+
+        var ex = Assert.Throws<BgpParseException>(() => AttributeHelper.ReadAsPath(attr, fourByteAsn: false));
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.MalformedAsPath, ex.SubErrorCode);
+    }
+
+    [Fact]
+    public void As4Path_WithAsTrans_Throws()
+    {
+        // AS_TRANS (23456) is the 2-octet placeholder for a non-mappable 4-octet AS — meaningless
+        // inside the 4-octet-encoded AS4_PATH (#238 defensive check).
+        var attr = new PathAttribute
+        {
+            Flags = BgpConstants.Attribute.FlagOptional | BgpConstants.Attribute.FlagTransitive,
+            TypeCode = BgpConstants.Attribute.As4Path,
+            Data = new byte[] { BgpConstants.AsPath.AsSequence, 1, 0x00, 0x00, 0x5B, 0xA0 } // AS 23456
+        };
+
+        var ex = Assert.Throws<BgpParseException>(() => AttributeHelper.ReadAs4Path(attr));
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.MalformedAsPath, ex.SubErrorCode);
+    }
+
+    [Fact]
     public void AsPath_TrailingByteAfterSegment_Throws()
     {
         // #235: a complete 1-ASN segment followed by one stray byte — offset != data.Length.

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -564,6 +564,25 @@ public class BgpMessageTests
     }
 
     [Fact]
+    public void AsPath_Empty_RoundtripsAsZeroLengthAttribute()
+    {
+        // RFC 4271 §4.3: an empty path is a ZERO-LENGTH attribute — a zero-length SEGMENT is
+        // malformed. The writer must not emit what the reader rejects (#248 review).
+        var attr = AttributeHelper.WriteAsPath([], fourByteAsn: true);
+
+        Assert.Empty(attr.Data);
+        Assert.Equal([], AttributeHelper.ReadAsPath(attr, fourByteAsn: true));
+    }
+
+    [Fact]
+    public void As4Path_Write_WithAsTrans_Throws()
+    {
+        // Write-side symmetry with the reader's AS_TRANS rejection (#248 review).
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => AttributeHelper.WriteAs4Path([BgpConstants.AsPath.AsTrans]));
+    }
+
+    [Fact]
     public void AsPath_TrailingByteAfterSegment_Throws()
     {
         // #235: a complete 1-ASN segment followed by one stray byte — offset != data.Length.


### PR DESCRIPTION
Closes #238

## What
All five audit sub-items, each verified against code (and RFC text where cited) before fixing:

1. **AS_PATH empty segment / AS_TRANS in AS4_PATH** — RFC 4271 §4.3 says a path segment value contains "one or more AS numbers"; a zero-length segment is now rejected as Malformed AS_PATH (subcode 11). AS4_PATH carrying AS_TRANS (the 2-octet placeholder, meaningless in a 4-octet-encoded attribute) is rejected likewise. ⚠️ Deviation noted: the audit's "RFC 6793 §F.4" citation **does not exist** in the RFC text — I fetched and searched rfc6793.txt; the AS_TRANS check is implemented as a defensive measure consistent with the codebase's existing strict AS4_PATH policy, not as an RFC mandate.
2. **Warmup logging** — PrefixService/PrefixSourceService warmup output goes through `ILogger` instead of `Console.WriteLine`. Policy decision for Program.cs: the startup banner **stays on stdout** deliberately (it prints before DI logging is wired; console-app convention).
3. **Route immutability** — path/community collections are now `IReadOnlyList` (assembler/merge paths reuse the same backing arrays across routes; a consumer mutating `route.Communities[0]` corrupted sibling routes). The #87 attribute cache and set comparers moved to `IReadOnlyList` keys with the same structural comparer — semantics unchanged. The dead `UpdatedAt` property (always `DateTime.UtcNow`, never read anywhere, breaks content-equality) is **removed** rather than TimeProvider-wired — wiring a TimeProvider into an unused property would be ceremony.
4. **Log-forging consistency** — `HandleCreatePeer` logs asnLists through `SanitizeForLog` like the other handlers (#120).
5. **Bounded in-flight API requests** — the accept loop acquires a `SemaphoreSlim(64)` slot before spawning `HandleAsync` (the #119 concurrency limiter is opt-in; without this, a connection burst spawned unbounded fire-and-forget tasks doing DB/RIPEstat work). Backpressure waits for a slot; release covers every exit path including HandleAsync's early returns. Not unit-tested: needs a live `HttpListener` harness with >64 concurrent requests — the structural change is small and covered by build + existing API tests.

## Verification
- `dotnet build BGPLite.sln -c Debug` — 0 errors.
- `dotnet test BGPLite.sln -c Debug` — 577 passed, 0 failed (new: empty-segment → subcode 11; AS_TRANS-in-AS4_PATH → subcode 11).
- `dotnet format BGPLite.sln --no-restore --severity warn` — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Management API now limits concurrent requests to improve stability under heavy load.
  * Route and community collections now support read-only list interfaces for broader integration flexibility.
* **Bug Fixes**
  * Malformed AS paths, including empty segments and invalid `AS_TRANS` entries, are rejected correctly.
  * Route community handling now avoids unintended data sharing.
  * Management request failures are logged reliably, and cancellation is handled cleanly.
* **Improvements**
  * Provider warm-up progress and results are reported through structured logging.
  * Sensitive ASN-list values are sanitized in logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->