### PR TITLE
fix(protocol): reserved flag 0x08, writer attribute ordering, COMMUNITY % 4

### DIFF
--- a/BGPLite.Protocol/AttributeHelper.cs
+++ b/BGPLite.Protocol/AttributeHelper.cs
@@ -133,6 +133,12 @@ public static class AttributeHelper
 
     public static uint[] ReadCommunities(PathAttribute attr)
     {
+        // RFC 1997 §3: each community is exactly 4 octets — a non-multiple-of-4 payload would
+        // silently drop tail bytes otherwise (#272; mirrors the % 12 rule of ReadLargeCommunities).
+        if (attr.Data.Length % 4 != 0)
+            throw new BgpParseException($"COMMUNITY attribute length must be a multiple of 4, got {attr.Data.Length}",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.OptionalAttributeError);
+
         var count = attr.Data.Length / 4;
         var communities = new uint[count];
         for (var i = 0; i < count; i++)

--- a/BGPLite.Protocol/BgpConstants.cs
+++ b/BGPLite.Protocol/BgpConstants.cs
@@ -90,6 +90,8 @@ public static class BgpConstants
         public const byte FlagTransitive = 0x40;
         public const byte FlagPartial = 0x20;
         public const byte FlagExtendedLength = 0x10;
+        /// <summary>RFC 4271 §4.3: bit 0x08 is reserved and MUST be zero on the wire.</summary>
+        public const byte FlagReserved = 0x08;
     }
 
     public static class AsPath

--- a/BGPLite.Protocol/BgpMessageReader.cs
+++ b/BGPLite.Protocol/BgpMessageReader.cs
@@ -229,6 +229,11 @@ public static class BgpMessageReader
                 BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList);
 
         var flags = data[0];
+        // RFC 4271 §4.3: flag bit 0x08 is reserved and MUST be zero — an attribute with it set
+        // is malformed (Attribute Flags Error, subcode 4) and is rejected via treat-as-withdraw (#272).
+        if ((flags & BgpConstants.Attribute.FlagReserved) != 0)
+            throw new BgpParseException($"Reserved attribute flag bit 0x08 set (flags=0x{flags:X2})",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.AttributeFlagsError);
         var typeCode = data[1];
         var offset = 2;
 

--- a/BGPLite.Protocol/BgpMessageWriter.cs
+++ b/BGPLite.Protocol/BgpMessageWriter.cs
@@ -146,11 +146,23 @@ public static class BgpMessageWriter
         foreach (var w in msg.WithdrawnRoutes)
             p += PrefixCodec.Encode(w, buffer[p..]);
 
-        // Path attributes
-        var attrsLen = GetAttributesLength(msg.PathAttributes);
+        // Path attributes. RFC 4271 §5: well-known attributes MUST be sent ordered by type code
+        // (ORIGIN → AS_PATH → NEXT_HOP → MED → LOCAL_PREF — ascending). Producers already emit
+        // ordered (UpdateCodec.BuildUpdateAttributes); a stable sort here makes the writer
+        // guarantee it for any future producer (#272, epic #6).
+        var attrs = msg.PathAttributes;
+        List<PathAttribute>? sorted = null;
+        if (attrs.Count > 1)
+        {
+            sorted = new List<PathAttribute>(attrs);
+            sorted.Sort(static (a, b) => a.TypeCode.CompareTo(b.TypeCode));
+            attrs = sorted;
+        }
+
+        var attrsLen = GetAttributesLength(attrs);
         BinaryPrimitives.WriteUInt16BigEndian(buffer[p..], (ushort)attrsLen);
         p += 2;
-        foreach (var attr in msg.PathAttributes)
+        foreach (var attr in attrs)
             p += WriteAttribute(attr, buffer[p..]);
 
         // NLRI

--- a/BGPLite.Protocol/BgpMessageWriter.cs
+++ b/BGPLite.Protocol/BgpMessageWriter.cs
@@ -148,16 +148,12 @@ public static class BgpMessageWriter
 
         // Path attributes. RFC 4271 §5: well-known attributes MUST be sent ordered by type code
         // (ORIGIN → AS_PATH → NEXT_HOP → MED → LOCAL_PREF — ascending). Producers already emit
-        // ordered (UpdateCodec.BuildUpdateAttributes); a stable sort here makes the writer
-        // guarantee it for any future producer (#272, epic #6).
-        var attrs = msg.PathAttributes;
-        List<PathAttribute>? sorted = null;
-        if (attrs.Count > 1)
-        {
-            sorted = new List<PathAttribute>(attrs);
-            sorted.Sort(static (a, b) => a.TypeCode.CompareTo(b.TypeCode));
-            attrs = sorted;
-        }
+        // ordered (UpdateCodec.BuildUpdateAttributes); an OrderBy here makes the writer guarantee
+        // it for any future producer — LINQ OrderBy is stable, so equal type codes keep their
+        // caller-supplied relative order (#272, epic #6).
+        var attrs = msg.PathAttributes.Count > 1
+            ? [.. msg.PathAttributes.OrderBy(static a => a.TypeCode)]
+            : msg.PathAttributes;
 
         var attrsLen = GetAttributesLength(attrs);
         BinaryPrimitives.WriteUInt16BigEndian(buffer[p..], (ushort)attrsLen);

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -630,8 +630,10 @@ public class BgpMessageTests
         var written = BgpMessageWriter.WriteMessage(update, buffer);
         var read = Assert.IsType<BgpUpdateMessage>(BgpMessageReader.ReadMessage(buffer.AsSpan(0, written)));
 
-        Assert.Equal([0x11111111u], AttributeHelper.ReadCommunities(read.PathAttributes[1]));
-        Assert.Equal([0x22222222u], AttributeHelper.ReadCommunities(read.PathAttributes[2]));
+        // Stable: of the two COMMUNITY attributes (equal type code), `second` was supplied
+        // before `first`, so it must remain first among the equals.
+        Assert.Equal([0x22222222u], AttributeHelper.ReadCommunities(read.PathAttributes[1]));
+        Assert.Equal([0x11111111u], AttributeHelper.ReadCommunities(read.PathAttributes[2]));
     }
 
     [Theory]

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -612,6 +612,28 @@ public class BgpMessageTests
         ], typeCodes);
     }
 
+    [Fact]
+    public void Update_Writer_SortIsStable_ForEqualTypeCodes()
+    {
+        // #273 review: equal type codes must keep their caller-supplied relative order — the
+        // sort must be stable (List.Sort is not; OrderBy is).
+        var first = AttributeHelper.WriteCommunities([0x11111111u]);
+        var second = AttributeHelper.WriteCommunities([0x22222222u]);
+        var update = new BgpUpdateMessage
+        {
+            WithdrawnRoutes = [],
+            PathAttributes = [second, AttributeHelper.WriteOrigin(BgpOrigin.Igp), first],
+            Nlri = []
+        };
+
+        var buffer = new byte[512];
+        var written = BgpMessageWriter.WriteMessage(update, buffer);
+        var read = Assert.IsType<BgpUpdateMessage>(BgpMessageReader.ReadMessage(buffer.AsSpan(0, written)));
+
+        Assert.Equal([0x11111111u], AttributeHelper.ReadCommunities(read.PathAttributes[1]));
+        Assert.Equal([0x22222222u], AttributeHelper.ReadCommunities(read.PathAttributes[2]));
+    }
+
     [Theory]
     [InlineData(5)]
     [InlineData(7)]

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -583,6 +583,55 @@ public class BgpMessageTests
     }
 
     [Fact]
+    public void Update_Writer_SortsAttributesByTypeCode_OnWire()
+    {
+        // #272 / epic #6: RFC 4271 §5 — well-known attributes ordered by type code on the wire,
+        // regardless of the order the caller supplied.
+        var update = new BgpUpdateMessage
+        {
+            WithdrawnRoutes = [],
+            PathAttributes =
+            [
+                AttributeHelper.WriteNextHop(0x0A000001),                  // type 3
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),                // type 1
+                AttributeHelper.WriteAsPath([65001u], fourByteAsn: false), // type 2
+            ],
+            Nlri = [new IpPrefix(0xC0A80000, 24)]
+        };
+
+        var buffer = new byte[512];
+        var written = BgpMessageWriter.WriteMessage(update, buffer);
+        var read = Assert.IsType<BgpUpdateMessage>(BgpMessageReader.ReadMessage(buffer.AsSpan(0, written)));
+
+        var typeCodes = read.PathAttributes.Select(a => a.TypeCode).ToArray();
+        Assert.Equal(
+        [
+            BgpConstants.Attribute.Origin,
+            BgpConstants.Attribute.AsPath,
+            BgpConstants.Attribute.NextHop
+        ], typeCodes);
+    }
+
+    [Theory]
+    [InlineData(5)]
+    [InlineData(7)]
+    public void Communities_NonMultipleOf4Length_Rejected(int length)
+    {
+        // RFC 1997 §3: every community is exactly 4 octets (#272) — mirrors the % 12 rule of
+        // ReadLargeCommunities.
+        var attr = new PathAttribute
+        {
+            Flags = BgpConstants.Attribute.FlagOptional | BgpConstants.Attribute.FlagTransitive,
+            TypeCode = BgpConstants.Attribute.Community,
+            Data = new byte[length]
+        };
+
+        var ex = Assert.Throws<BgpParseException>(() => AttributeHelper.ReadCommunities(attr));
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.OptionalAttributeError, ex.SubErrorCode);
+    }
+
+    [Fact]
     public void AsPath_TrailingByteAfterSegment_Throws()
     {
         // #235: a complete 1-ASN segment followed by one stray byte — offset != data.Length.

--- a/BGPLite.Tests/MalformedUpdateResilienceTests.cs
+++ b/BGPLite.Tests/MalformedUpdateResilienceTests.cs
@@ -46,6 +46,19 @@ public class MalformedUpdateResilienceTests
         Assert.Equal(BgpConstants.SubError.MalformedAttributeList, ex.SubErrorCode);
     }
 
+    [Theory]
+    [InlineData(0x08)]
+    [InlineData(0x18)] // ExtendedLength | reserved
+    public void ParseAttribute_ReservedFlagBitSet_RejectedWithAttributeFlagsError(byte flags)
+    {
+        // RFC 4271 §4.3: bit 0x08 is reserved and MUST be zero (#272, epic #6).
+        var attrBytes = new byte[] { flags, 0x01, 0x01, 0x00 };
+
+        var ex = Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(BuildUpdateFrame([.. attrBytes])));
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.AttributeFlagsError, ex.SubErrorCode);
+    }
+
     [Fact]
     public void ParseUpdate_WithdrawnLengthExceedsPayload_ThrowsBgpParseException()
     {


### PR DESCRIPTION
Closes #272 (retires epic #6)

## Changes
1. **Reserved flag bit 0x08** (RFC 4271 §4.3): `ParseAttribute` rejects attributes with the reserved bit set via `AttributeFlagsError` (subcode 4) — treat-as-withdraw path, session stays up. Tests: flags `0x08` and `0x18`.
2. **Writer attribute ordering** (RFC 4271 §5): `WriteUpdate` stable-sorts path attributes by type code so the on-wire order is guaranteed regardless of caller order (producers already emit ordered — this is the writer-level guarantee the epic's acceptance asked for). On-wire order regression test added.
3. **COMMUNITY length % 4** (RFC 1997 §3): non-multiple-of-4 payloads rejected with `OptionalAttributeError` (subcode 9) instead of silently dropping tail bytes — consistent with `ReadLargeCommunities`' % 12 validation. Tests: lengths 5 and 7.

## Verification
- `dotnet build` — 0 errors; `dotnet format --severity warn` — clean.
- `dotnet test` — 585 passed, 0 failed (+5 new: 2 reserved-flag, 1 writer order, 2 community length).
- Epic #6 checklist: all items now closed (progress table in the epic comment).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid COMMUNITY attributes with malformed lengths are now rejected with appropriate errors.
  - UPDATE messages with reserved attribute flags are rejected according to protocol requirements.
  - Path attributes are serialized in consistent ascending type-code order.

- **Tests**
  - Added coverage for malformed COMMUNITY attributes, reserved flags, and attribute ordering during UPDATE message round trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->