### PR TITLE
refactor(protocol): move inbound UPDATE attribute pipeline into UpdateCodec

### DIFF
--- a/BGPLite.Protocol/AttributeHelper.cs
+++ b/BGPLite.Protocol/AttributeHelper.cs
@@ -133,6 +133,12 @@ public static class AttributeHelper
 
     public static uint[] ReadCommunities(PathAttribute attr)
     {
+        // RFC 1997 §3: each community is exactly 4 octets — a non-multiple-of-4 payload would
+        // silently drop tail bytes otherwise (#272; mirrors the % 12 rule of ReadLargeCommunities).
+        if (attr.Data.Length % 4 != 0)
+            throw new BgpParseException($"COMMUNITY attribute length must be a multiple of 4, got {attr.Data.Length}",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.OptionalAttributeError);
+
         var count = attr.Data.Length / 4;
         var communities = new uint[count];
         for (var i = 0; i < count; i++)

--- a/BGPLite.Protocol/BgpConstants.cs
+++ b/BGPLite.Protocol/BgpConstants.cs
@@ -90,6 +90,8 @@ public static class BgpConstants
         public const byte FlagTransitive = 0x40;
         public const byte FlagPartial = 0x20;
         public const byte FlagExtendedLength = 0x10;
+        /// <summary>RFC 4271 §4.3: bit 0x08 is reserved and MUST be zero on the wire.</summary>
+        public const byte FlagReserved = 0x08;
     }
 
     public static class AsPath

--- a/BGPLite.Protocol/BgpMessageReader.cs
+++ b/BGPLite.Protocol/BgpMessageReader.cs
@@ -229,6 +229,11 @@ public static class BgpMessageReader
                 BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList);
 
         var flags = data[0];
+        // RFC 4271 §4.3: flag bit 0x08 is reserved and MUST be zero — an attribute with it set
+        // is malformed (Attribute Flags Error, subcode 4) and is rejected via treat-as-withdraw (#272).
+        if ((flags & BgpConstants.Attribute.FlagReserved) != 0)
+            throw new BgpParseException($"Reserved attribute flag bit 0x08 set (flags=0x{flags:X2})",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.AttributeFlagsError);
         var typeCode = data[1];
         var offset = 2;
 

--- a/BGPLite.Protocol/BgpMessageWriter.cs
+++ b/BGPLite.Protocol/BgpMessageWriter.cs
@@ -146,11 +146,23 @@ public static class BgpMessageWriter
         foreach (var w in msg.WithdrawnRoutes)
             p += PrefixCodec.Encode(w, buffer[p..]);
 
-        // Path attributes
-        var attrsLen = GetAttributesLength(msg.PathAttributes);
+        // Path attributes. RFC 4271 §5: well-known attributes MUST be sent ordered by type code
+        // (ORIGIN → AS_PATH → NEXT_HOP → MED → LOCAL_PREF — ascending). Producers already emit
+        // ordered (UpdateCodec.BuildUpdateAttributes); a stable sort here makes the writer
+        // guarantee it for any future producer (#272, epic #6).
+        var attrs = msg.PathAttributes;
+        List<PathAttribute>? sorted = null;
+        if (attrs.Count > 1)
+        {
+            sorted = new List<PathAttribute>(attrs);
+            sorted.Sort(static (a, b) => a.TypeCode.CompareTo(b.TypeCode));
+            attrs = sorted;
+        }
+
+        var attrsLen = GetAttributesLength(attrs);
         BinaryPrimitives.WriteUInt16BigEndian(buffer[p..], (ushort)attrsLen);
         p += 2;
-        foreach (var attr in msg.PathAttributes)
+        foreach (var attr in attrs)
             p += WriteAttribute(attr, buffer[p..]);
 
         // NLRI

--- a/BGPLite.Protocol/BgpMessageWriter.cs
+++ b/BGPLite.Protocol/BgpMessageWriter.cs
@@ -148,16 +148,12 @@ public static class BgpMessageWriter
 
         // Path attributes. RFC 4271 §5: well-known attributes MUST be sent ordered by type code
         // (ORIGIN → AS_PATH → NEXT_HOP → MED → LOCAL_PREF — ascending). Producers already emit
-        // ordered (UpdateCodec.BuildUpdateAttributes); a stable sort here makes the writer
-        // guarantee it for any future producer (#272, epic #6).
-        var attrs = msg.PathAttributes;
-        List<PathAttribute>? sorted = null;
-        if (attrs.Count > 1)
-        {
-            sorted = new List<PathAttribute>(attrs);
-            sorted.Sort(static (a, b) => a.TypeCode.CompareTo(b.TypeCode));
-            attrs = sorted;
-        }
+        // ordered (UpdateCodec.BuildUpdateAttributes); an OrderBy here makes the writer guarantee
+        // it for any future producer — LINQ OrderBy is stable, so equal type codes keep their
+        // caller-supplied relative order (#272, epic #6).
+        var attrs = msg.PathAttributes.Count > 1
+            ? [.. msg.PathAttributes.OrderBy(static a => a.TypeCode)]
+            : msg.PathAttributes;
 
         var attrsLen = GetAttributesLength(attrs);
         BinaryPrimitives.WriteUInt16BigEndian(buffer[p..], (ushort)attrsLen);

--- a/BGPLite.Protocol/OpenNegotiator.cs
+++ b/BGPLite.Protocol/OpenNegotiator.cs
@@ -1,0 +1,98 @@
+namespace BGPLite.Protocol;
+
+/// <summary>
+/// Negotiated OPEN parameters produced by <see cref="OpenNegotiator.Validate"/>.
+/// </summary>
+public sealed record OpenNegotiation(
+    uint RemoteAsn,
+    bool RemoteFourByteAsn,
+    bool LocalFourByteAsn,
+    bool RemoteRouteRefresh,
+    ushort NegotiatedHoldTime,
+    TimeSpan KeepAliveInterval);
+
+/// <summary>
+/// Pure OPEN validation + capability negotiation (RFC 4271 §4.2/§6.2, RFC 6793, RFC 2918). Verifies
+/// the BGP version, 4-octet-ASN capability well-formedness, the expected peer ASN
+/// (<paramref name="expectedRemoteAsn"/> is null for auto-registered/unknown peers, accepting any
+/// declared ASN), the hold time (0 or ≥ 3), and the BGP Identifier (non-zero, no collision with the
+/// local router ID), then derives the negotiated session parameters. Throws
+/// <see cref="BgpNotificationException"/> with the RFC-mandated error/sub-error on rejection —
+/// the session layer catches it and emits the NOTIFICATION.
+/// <para>
+/// Hold time negotiation (#224, RFC 4271 §6.2.2): the negotiated value is the smaller of the
+/// locally configured <paramref name="localHoldTime"/> and the peer's <c>open.HoldTime</c>. A
+/// value of 0 means "timer disabled" (RFC 4271 §4.2) — if either side proposes 0, the negotiated
+/// hold time is 0 and the keepalive/hold timers are disabled for the session. This matches the
+/// common practice of major implementations (Cisco/Juniper).
+/// </para>
+/// <para>
+/// #269: moved verbatim from <c>BgpSession</c> (Server) so the protocol library owns the full
+/// OPEN contract — a consumer of the standalone package needs no session machinery to validate
+/// an OPEN.
+/// </para>
+/// </summary>
+public static class OpenNegotiator
+{
+    public static OpenNegotiation Validate(BgpOpenMessage open, uint? expectedRemoteAsn, uint localRouterId, int localHoldTime)
+    {
+        // #224: the local hold time is the locally configured BgpConfig.HoldTime (validated at
+        // config-load: 0 or ≥3). Guard the entry point defensively so a future caller (or a
+        // unit test) cannot pass an out-of-range value that would silently corrupt the negotiation:
+        // a negative value would survive the Math.Min below and truncate to a bogus ushort.
+        if (localHoldTime != 0 && localHoldTime < 3)
+            throw new ArgumentOutOfRangeException(nameof(localHoldTime), localHoldTime,
+                $"Local hold time must be 0 (disabled) or at least 3 seconds (RFC 4271 §4.2).");
+
+        if (open.Version != BgpConstants.BgpVersion)
+            throw new BgpNotificationException(BgpConstants.Error.OpenMessageError, BgpConstants.SubError.UnsupportedVersion, $"Unsupported BGP version: {open.Version}");
+
+        var malformedFourOctetAsnCapability = UpdateCodec.GetMalformedFourOctetAsnCapabilityData(open);
+        if (malformedFourOctetAsnCapability.Length > 0)
+        {
+            throw new BgpNotificationException(
+                BgpConstants.Error.OpenMessageError,
+                BgpConstants.SubError.UnsupportedCapability,
+                "Malformed 4-octet ASN capability",
+                malformedFourOctetAsnCapability);
+        }
+
+        var remoteFourByteAsn = CapabilityHelper.GetRemoteAsn(open).HasValue;
+        var remoteAsn = CapabilityHelper.GetEffectiveAsn(open);
+        var remoteRouteRefresh = open.Capabilities.Any(c => c.Code == BgpConstants.Capability.RouteRefresh);
+
+        if (expectedRemoteAsn.HasValue && remoteAsn != expectedRemoteAsn.Value)
+            throw new BgpNotificationException(BgpConstants.Error.OpenMessageError, BgpConstants.SubError.BadPeerAs, $"Unexpected ASN: expected {expectedRemoteAsn}, got {remoteAsn}");
+
+        var peerHoldTime = open.HoldTime;
+        if (peerHoldTime != 0 && peerHoldTime < 3)
+            throw new BgpNotificationException(BgpConstants.Error.OpenMessageError, BgpConstants.SubError.UnacceptableHoldTime, $"Unacceptable hold time: {peerHoldTime}");
+
+        // BGP Identifier must be non-zero and must not collide with our own (RFC 4271 §6.2).
+        if (open.RouterId == 0)
+            throw new BgpNotificationException(BgpConstants.Error.OpenMessageError, BgpConstants.SubError.BadBgpIdentifier, "Invalid BGP identifier: 0.0.0.0");
+
+        if (open.RouterId == localRouterId)
+            throw new BgpNotificationException(BgpConstants.Error.OpenMessageError, BgpConstants.SubError.BadBgpIdentifier, "BGP identifier collision with local RouterId");
+
+        // #224: negotiate hold time = min(local, peer) per RFC 4271 §6.2.2. A 0 on either side
+        // disables the timer (RFC 4271 §4.2) — Math.Min with 0 yields 0 naturally, so no special
+        // case is needed: either-side-zero → zero, which is exactly the "either side disables"
+        // semantics. The peer's value was already validated above (0 or ≥3); local is validated at
+        // config-load time (BgpConfig), and the argument guard at the top of this method rejects
+        // out-of-range local values before reaching here.
+        var negotiatedHoldTime = (ushort)Math.Min(localHoldTime, peerHoldTime);
+
+        var keepAliveInterval = negotiatedHoldTime == 0
+            ? TimeSpan.Zero
+            : TimeSpan.FromSeconds(Math.Max(negotiatedHoldTime / 3, 1));
+
+        return new OpenNegotiation(
+            remoteAsn,
+            remoteFourByteAsn,
+            remoteFourByteAsn, // RFC 6793 §6: AS_PATH encoding follows the negotiated capability
+            remoteRouteRefresh,
+            negotiatedHoldTime,
+            keepAliveInterval);
+    }
+}

--- a/BGPLite.Protocol/UpdateCodec.cs
+++ b/BGPLite.Protocol/UpdateCodec.cs
@@ -183,6 +183,95 @@ public static class UpdateCodec
     /// 4-octet-ASN capability has a wrong length. Scans the OPEN's capabilities for the first
     /// malformed FourOctetAsn entry and returns <c>[code, length, ...data]</c>; empty if none found.
     /// </summary>
+    /// <summary>
+    /// The parsed inbound attribute set of an announcing UPDATE — everything the routing layer
+    /// needs to build a route (#270). Produced by <see cref="ParseRouteAttributes"/>.
+    /// </summary>
+    public sealed record RouteAttributes(
+        uint[] AsPath,
+        uint NextHop,
+        uint[] Communities,
+        (uint Global, uint Local1, uint Local2)[] LargeCommunities);
+
+    /// <summary>
+    /// Parses and validates the path attributes of an announcing UPDATE per RFC 4271 §6.3 /
+    /// RFC 6793 / RFC 8092: per-attribute length and value checks (ORIGIN ∈ {0,1,2}, NEXT_HOP
+    /// 4-octet, COMMUNITY % 4, Large Communities % 12, AS_PATH/AS4_PATH segment rules), the
+    /// mandatory well-known set (ORIGIN/AS_PATH/NEXT_HOP), AS4_PATH trailing-sequence
+    /// reconstruction, and AGGREGATOR/AS4_AGGREGATOR consistency. On a 4-octet session
+    /// (<paramref name="fourByteAsnSession"/>) AS4_PATH/AS4_AGGREGATOR are skipped per RFC 6793 §4.1.
+    /// Throws <see cref="BgpNotificationException"/> carrying the RFC subcode (3/6/8/9/11) so the
+    /// caller can apply treat-as-withdraw (RFC 7606) — the exact pipeline previously inlined in
+    /// BgpSession.HandleUpdateAsync, moved verbatim (#270).
+    /// </summary>
+    public static RouteAttributes ParseRouteAttributes(BgpUpdateMessage update, bool fourByteAsnSession)
+    {
+        try
+        {
+            var originSeen = false;
+            var asPathSeen = false;
+            var nextHopSeen = false;
+            uint nextHop = 0;
+            uint[] asPath = [];
+            uint[] communities = [];
+            (uint Global, uint Local1, uint Local2)[] largeCommunities = [];
+            uint[] as4Path = [];
+            uint? aggregatorAsn = null;
+            uint? as4AggregatorAsn = null;
+
+            foreach (var attr in update.PathAttributes)
+            {
+                switch (attr.TypeCode)
+                {
+                    case BgpConstants.Attribute.Origin:
+                        if (attr.Data.Length < 1)
+                            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidOriginAttribute, "Malformed ORIGIN attribute");
+                        AttributeHelper.ReadOrigin(attr);
+                        originSeen = true;
+                        break;
+                    case BgpConstants.Attribute.AsPath:
+                        asPath = AttributeHelper.ReadAsPath(attr, fourByteAsnSession);
+                        asPathSeen = true;
+                        break;
+                    case BgpConstants.Attribute.As4Path when !fourByteAsnSession:
+                        as4Path = AttributeHelper.ReadAs4Path(attr);
+                        break;
+                    case BgpConstants.Attribute.NextHop:
+                        if (attr.Data.Length < 4)
+                            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNextHopAttribute, "Malformed NEXT_HOP attribute");
+                        nextHop = AttributeHelper.ReadNextHop(attr);
+                        nextHopSeen = true;
+                        break;
+                    case BgpConstants.Attribute.Community:
+                        communities = AttributeHelper.ReadCommunities(attr);
+                        break;
+                    case BgpConstants.Attribute.LargeCommunity:
+                        largeCommunities = AttributeHelper.ReadLargeCommunities(attr);
+                        break;
+                    case BgpConstants.Attribute.Aggregator:
+                        aggregatorAsn = AttributeHelper.ReadAggregatorAsn(attr, fourByteAsnSession);
+                        break;
+                    case BgpConstants.Attribute.As4Aggregator when !fourByteAsnSession:
+                        as4AggregatorAsn = AttributeHelper.ReadAs4AggregatorAsn(attr);
+                        break;
+                }
+            }
+
+            ValidateMandatoryAttributes(originSeen, asPathSeen, nextHopSeen);
+            asPath = MergeAsPathWithAs4Path(asPath, as4Path);
+            ValidateAggregatorReconstruction(aggregatorAsn, as4AggregatorAsn);
+
+            return new RouteAttributes(asPath, nextHop, communities, largeCommunities);
+        }
+        catch (BgpParseException ex)
+        {
+            // #235: preserve the RFC 4271 §6.3 subcode the codec recorded (e.g. Malformed AS_PATH
+            // from ReadAsPath, Optional Attribute Error from AGGREGATOR/Large Communities) instead
+            // of flattening it to Unspecific.
+            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, ex.SubErrorCode ?? BgpConstants.SubError.Unspecific, ex.Message);
+        }
+    }
+
     public static byte[] GetMalformedFourOctetAsnCapabilityData(BgpOpenMessage open)
     {
         foreach (var cap in open.Capabilities)

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -1152,7 +1152,9 @@ public sealed class BgpSession : IDisposable
     private void ValidateOpen(BgpOpenMessage open)
     {
         var localRouterId = BgpConstants.IPAddressToUint(_bgpConfig.GetRouterIdAddress());
-        var negotiation = ValidateOpen(open, _peerConfig.RemoteAsn, localRouterId, _bgpConfig.HoldTime);
+        // #269: OPEN negotiation/validation lives in the protocol library (OpenNegotiator); the
+        // session applies the negotiated values and owns only the I/O side effects below.
+        var negotiation = OpenNegotiator.Validate(open, _peerConfig.RemoteAsn, localRouterId, _bgpConfig.HoldTime);
 
         _remoteAsn = negotiation.RemoteAsn;
         _remoteFourByteAsn = negotiation.RemoteFourByteAsn;
@@ -1172,97 +1174,6 @@ public sealed class BgpSession : IDisposable
             peerGr.HasValue
                 ? $"supported (restartState={peerGr.Value.RestartState}, restartTime={peerGr.Value.RestartTime}s, IPv4/Unicast forwarding={peerGr.Value.Ipv4UnicastForwarding})"
                 : "not supported");
-    }
-
-    /// <summary>
-    /// Negotiated OPEN parameters produced by <see cref="ValidateOpen(BgpOpenMessage, uint?, uint, int)"/>.
-    /// </summary>
-    internal sealed record OpenNegotiation(
-        uint RemoteAsn,
-        bool RemoteFourByteAsn,
-        bool LocalFourByteAsn,
-        bool RemoteRouteRefresh,
-        ushort NegotiatedHoldTime,
-        TimeSpan KeepAliveInterval);
-
-    /// <summary>
-    /// Pure OPEN validation + capability negotiation. Verifies BGP version, 4-octet-ASN capability
-    /// well-formedness, the expected peer ASN (RFC 4271 §6.2 — <paramref name="expectedRemoteAsn"/>
-    /// is null for auto-registered/unknown peers, accepting any declared ASN), the hold time
-    /// (RFC 4271 §4.2 — 0 or ≥ 3), and the BGP Identifier (non-zero, no collision with the local
-    /// router ID), then derives the negotiated session parameters. Throws
-    /// <see cref="BgpNotificationException"/> with the RFC-mandated error/sub-error on rejection.
-    /// Extracted as <c>internal static</c> so every branch is unit-testable without a live socket
-    /// (mirrors <see cref="GetMalformedFourOctetAsnCapabilityData"/> / MergeAsPathWithAs4Path).
-    /// <para>
-    /// Hold time negotiation (#224, RFC 4271 §6.2.2): the negotiated value is the smaller of the
-    /// locally configured <paramref name="localHoldTime"/> and the peer's <c>open.HoldTime</c>. A
-    /// value of 0 means "timer disabled" (RFC 4271 §4.2) — if either side proposes 0, the negotiated
-    /// hold time is 0 and the keepalive/hold timers are disabled for the session. This matches the
-    /// common practice of major implementations (Cisco/Juniper) and preserves the existing
-    /// HoldTime_Zero_Accepted_WithZeroKeepAlive contract.
-    /// </para>
-    /// </summary>
-    internal static OpenNegotiation ValidateOpen(BgpOpenMessage open, uint? expectedRemoteAsn, uint localRouterId, int localHoldTime)
-    {
-        // #224: the local hold time is the locally configured BgpConfig.HoldTime (validated at
-        // config-load: 0 or ≥3). Guard the static entry point defensively so a future caller (or a
-        // unit test) cannot pass an out-of-range value that would silently corrupt the negotiation:
-        // a negative value would survive the Math.Min below and truncate to a bogus ushort.
-        if (localHoldTime != 0 && localHoldTime < 3)
-            throw new ArgumentOutOfRangeException(nameof(localHoldTime), localHoldTime,
-                $"Local hold time must be 0 (disabled) or at least 3 seconds (RFC 4271 §4.2).");
-
-        if (open.Version != BgpConstants.BgpVersion)
-            throw new BgpNotificationException(BgpConstants.Error.OpenMessageError, BgpConstants.SubError.UnsupportedVersion, $"Unsupported BGP version: {open.Version}");
-
-        var malformedFourOctetAsnCapability = UpdateCodec.GetMalformedFourOctetAsnCapabilityData(open);
-        if (malformedFourOctetAsnCapability.Length > 0)
-        {
-            throw new BgpNotificationException(
-                BgpConstants.Error.OpenMessageError,
-                BgpConstants.SubError.UnsupportedCapability,
-                "Malformed 4-octet ASN capability",
-                malformedFourOctetAsnCapability);
-        }
-
-        var remoteFourByteAsn = CapabilityHelper.GetRemoteAsn(open).HasValue;
-        var remoteAsn = CapabilityHelper.GetEffectiveAsn(open);
-        var remoteRouteRefresh = open.Capabilities.Any(c => c.Code == BgpConstants.Capability.RouteRefresh);
-
-        if (expectedRemoteAsn.HasValue && remoteAsn != expectedRemoteAsn.Value)
-            throw new BgpNotificationException(BgpConstants.Error.OpenMessageError, BgpConstants.SubError.BadPeerAs, $"Unexpected ASN: expected {expectedRemoteAsn}, got {remoteAsn}");
-
-        var peerHoldTime = open.HoldTime;
-        if (peerHoldTime != 0 && peerHoldTime < 3)
-            throw new BgpNotificationException(BgpConstants.Error.OpenMessageError, BgpConstants.SubError.UnacceptableHoldTime, $"Unacceptable hold time: {peerHoldTime}");
-
-        // BGP Identifier must be non-zero and must not collide with our own (RFC 4271 §6.2).
-        if (open.RouterId == 0)
-            throw new BgpNotificationException(BgpConstants.Error.OpenMessageError, BgpConstants.SubError.BadBgpIdentifier, "Invalid BGP identifier: 0.0.0.0");
-
-        if (open.RouterId == localRouterId)
-            throw new BgpNotificationException(BgpConstants.Error.OpenMessageError, BgpConstants.SubError.BadBgpIdentifier, "BGP identifier collision with local RouterId");
-
-        // #224: negotiate hold time = min(local, peer) per RFC 4271 §6.2.2. A 0 on either side
-        // disables the timer (RFC 4271 §4.2) — Math.Min with 0 yields 0 naturally, so no special
-        // case is needed: either-side-zero → zero, which is exactly the "either side disables"
-        // semantics. The peer's value was already validated above (0 or ≥3); local is validated at
-        // config-load time (BgpConfig), and the argument guard at the top of this method rejects
-        // out-of-range local values before reaching here.
-        var negotiatedHoldTime = (ushort)Math.Min(localHoldTime, peerHoldTime);
-
-        var keepAliveInterval = negotiatedHoldTime == 0
-            ? TimeSpan.Zero
-            : TimeSpan.FromSeconds(Math.Max(negotiatedHoldTime / 3, 1));
-
-        return new OpenNegotiation(
-            remoteAsn,
-            remoteFourByteAsn,
-            remoteFourByteAsn, // RFC 6793 §6: AS_PATH encoding follows the negotiated capability
-            remoteRouteRefresh,
-            negotiatedHoldTime,
-            keepAliveInterval);
     }
 
     #endregion

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -654,90 +654,33 @@ public sealed class BgpSession : IDisposable
         // Process announcements
         if (update.Nlri.Count > 0)
         {
-            try
+            // #270: the inbound attribute pipeline (per-attribute validation, mandatory set,
+            // AS4_PATH reconstruction, aggregator consistency — subcodes 3/6/8/9/11) lives in the
+            // protocol library. Its BgpNotificationException propagates to the treat-as-withdraw
+            // catch in the dispatch loop exactly as before.
+            var attrs = UpdateCodec.ParseRouteAttributes(update, _remoteFourByteAsn);
+            var filterPeerConfig = GetFilterPeerConfig();
+
+            foreach (var nlri in update.Nlri)
             {
-                var originSeen = false;
-                var asPathSeen = false;
-                var nextHopSeen = false;
-                uint nextHop = 0;
-                uint[] asPath = [];
-                uint[] communities = [];
-                (uint Global, uint Local1, uint Local2)[] largeCommunities = [];
-                uint[] as4Path = [];
-                uint? aggregatorAsn = null;
-                uint? as4AggregatorAsn = null;
-                var filterPeerConfig = GetFilterPeerConfig();
-
-                foreach (var attr in update.PathAttributes)
+                var route = new Route
                 {
-                    switch (attr.TypeCode)
-                    {
-                        case BgpConstants.Attribute.Origin:
-                            if (attr.Data.Length < 1)
-                                throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidOriginAttribute, "Malformed ORIGIN attribute");
-                            AttributeHelper.ReadOrigin(attr);
-                            originSeen = true;
-                            break;
-                        case BgpConstants.Attribute.AsPath:
-                            asPath = AttributeHelper.ReadAsPath(attr, _remoteFourByteAsn);
-                            asPathSeen = true;
-                            break;
-                        case BgpConstants.Attribute.As4Path when !_remoteFourByteAsn:
-                            as4Path = AttributeHelper.ReadAs4Path(attr);
-                            break;
-                        case BgpConstants.Attribute.NextHop:
-                            if (attr.Data.Length < 4)
-                                throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNextHopAttribute, "Malformed NEXT_HOP attribute");
-                            nextHop = AttributeHelper.ReadNextHop(attr);
-                            nextHopSeen = true;
-                            break;
-                        case BgpConstants.Attribute.Community:
-                            communities = AttributeHelper.ReadCommunities(attr);
-                            break;
-                        case BgpConstants.Attribute.LargeCommunity:
-                            largeCommunities = AttributeHelper.ReadLargeCommunities(attr);
-                            break;
-                        case BgpConstants.Attribute.Aggregator:
-                            aggregatorAsn = AttributeHelper.ReadAggregatorAsn(attr, _remoteFourByteAsn);
-                            break;
-                        case BgpConstants.Attribute.As4Aggregator when !_remoteFourByteAsn:
-                            as4AggregatorAsn = AttributeHelper.ReadAs4AggregatorAsn(attr);
-                            break;
-                    }
-                }
+                    Prefix = nlri.Address,
+                    PrefixLength = nlri.Length,
+                    NextHop = attrs.NextHop,
+                    AsPath = attrs.AsPath,
+                    Communities = attrs.Communities,
+                    LargeCommunities = attrs.LargeCommunities
+                };
 
-                UpdateCodec.ValidateMandatoryAttributes(originSeen, asPathSeen, nextHopSeen);
-                asPath = UpdateCodec.MergeAsPathWithAs4Path(asPath, as4Path);
-                UpdateCodec.ValidateAggregatorReconstruction(aggregatorAsn, as4AggregatorAsn);
-
-                foreach (var nlri in update.Nlri)
+                if (_routeFilter.AcceptIncoming(route, filterPeerConfig))
                 {
-                    var route = new Route
-                    {
-                        Prefix = nlri.Address,
-                        PrefixLength = nlri.Length,
-                        NextHop = nextHop,
-                        AsPath = asPath,
-                        Communities = communities,
-                        LargeCommunities = largeCommunities
-                    };
-
-                    if (_routeFilter.AcceptIncoming(route, filterPeerConfig))
-                    {
-                        _routeTable.AddOrUpdate(route);
-                        // #85: guard the UintToIPAddress allocation behind IsEnabled — LogDebug
-                        // evaluates the arg eagerly even when Debug is filtered out.
-                        if (_logger.IsEnabled(LogLevel.Debug))
-                            _logger.LogDebug("Route added: {Prefix} via {NextHop}", nlri, BgpConstants.UintToIPAddress(nextHop));
-                    }
+                    _routeTable.AddOrUpdate(route);
+                    // #85: guard the UintToIPAddress allocation behind IsEnabled — LogDebug
+                    // evaluates the arg eagerly even when Debug is filtered out.
+                    if (_logger.IsEnabled(LogLevel.Debug))
+                        _logger.LogDebug("Route added: {Prefix} via {NextHop}", nlri, BgpConstants.UintToIPAddress(attrs.NextHop));
                 }
-            }
-            catch (BgpParseException ex)
-            {
-                // #235: preserve the RFC 4271 §6.3 subcode the codec recorded (e.g. Malformed AS_PATH
-                // from ReadAsPath, Optional Attribute Error from AGGREGATOR/Large Communities) instead
-                // of flattening it to Unspecific.
-                throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, ex.SubErrorCode ?? BgpConstants.SubError.Unspecific, ex.Message);
             }
         }
 

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -630,8 +630,10 @@ public class BgpMessageTests
         var written = BgpMessageWriter.WriteMessage(update, buffer);
         var read = Assert.IsType<BgpUpdateMessage>(BgpMessageReader.ReadMessage(buffer.AsSpan(0, written)));
 
-        Assert.Equal([0x11111111u], AttributeHelper.ReadCommunities(read.PathAttributes[1]));
-        Assert.Equal([0x22222222u], AttributeHelper.ReadCommunities(read.PathAttributes[2]));
+        // Stable: of the two COMMUNITY attributes (equal type code), `second` was supplied
+        // before `first`, so it must remain first among the equals.
+        Assert.Equal([0x22222222u], AttributeHelper.ReadCommunities(read.PathAttributes[1]));
+        Assert.Equal([0x11111111u], AttributeHelper.ReadCommunities(read.PathAttributes[2]));
     }
 
     [Theory]

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -612,6 +612,28 @@ public class BgpMessageTests
         ], typeCodes);
     }
 
+    [Fact]
+    public void Update_Writer_SortIsStable_ForEqualTypeCodes()
+    {
+        // #273 review: equal type codes must keep their caller-supplied relative order — the
+        // sort must be stable (List.Sort is not; OrderBy is).
+        var first = AttributeHelper.WriteCommunities([0x11111111u]);
+        var second = AttributeHelper.WriteCommunities([0x22222222u]);
+        var update = new BgpUpdateMessage
+        {
+            WithdrawnRoutes = [],
+            PathAttributes = [second, AttributeHelper.WriteOrigin(BgpOrigin.Igp), first],
+            Nlri = []
+        };
+
+        var buffer = new byte[512];
+        var written = BgpMessageWriter.WriteMessage(update, buffer);
+        var read = Assert.IsType<BgpUpdateMessage>(BgpMessageReader.ReadMessage(buffer.AsSpan(0, written)));
+
+        Assert.Equal([0x11111111u], AttributeHelper.ReadCommunities(read.PathAttributes[1]));
+        Assert.Equal([0x22222222u], AttributeHelper.ReadCommunities(read.PathAttributes[2]));
+    }
+
     [Theory]
     [InlineData(5)]
     [InlineData(7)]

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -583,6 +583,55 @@ public class BgpMessageTests
     }
 
     [Fact]
+    public void Update_Writer_SortsAttributesByTypeCode_OnWire()
+    {
+        // #272 / epic #6: RFC 4271 §5 — well-known attributes ordered by type code on the wire,
+        // regardless of the order the caller supplied.
+        var update = new BgpUpdateMessage
+        {
+            WithdrawnRoutes = [],
+            PathAttributes =
+            [
+                AttributeHelper.WriteNextHop(0x0A000001),                  // type 3
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),                // type 1
+                AttributeHelper.WriteAsPath([65001u], fourByteAsn: false), // type 2
+            ],
+            Nlri = [new IpPrefix(0xC0A80000, 24)]
+        };
+
+        var buffer = new byte[512];
+        var written = BgpMessageWriter.WriteMessage(update, buffer);
+        var read = Assert.IsType<BgpUpdateMessage>(BgpMessageReader.ReadMessage(buffer.AsSpan(0, written)));
+
+        var typeCodes = read.PathAttributes.Select(a => a.TypeCode).ToArray();
+        Assert.Equal(
+        [
+            BgpConstants.Attribute.Origin,
+            BgpConstants.Attribute.AsPath,
+            BgpConstants.Attribute.NextHop
+        ], typeCodes);
+    }
+
+    [Theory]
+    [InlineData(5)]
+    [InlineData(7)]
+    public void Communities_NonMultipleOf4Length_Rejected(int length)
+    {
+        // RFC 1997 §3: every community is exactly 4 octets (#272) — mirrors the % 12 rule of
+        // ReadLargeCommunities.
+        var attr = new PathAttribute
+        {
+            Flags = BgpConstants.Attribute.FlagOptional | BgpConstants.Attribute.FlagTransitive,
+            TypeCode = BgpConstants.Attribute.Community,
+            Data = new byte[length]
+        };
+
+        var ex = Assert.Throws<BgpParseException>(() => AttributeHelper.ReadCommunities(attr));
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.OptionalAttributeError, ex.SubErrorCode);
+    }
+
+    [Fact]
     public void AsPath_TrailingByteAfterSegment_Throws()
     {
         // #235: a complete 1-ASN segment followed by one stray byte — offset != data.Length.

--- a/BGPLite.Tests/BgpSessionRfc6793Tests.cs
+++ b/BGPLite.Tests/BgpSessionRfc6793Tests.cs
@@ -61,6 +61,71 @@ public class BgpSessionRfc6793Tests
     }
 
     [Fact]
+    public void ParseRouteAttributes_HappyPath_ParsesAndMerges()
+    {
+        // #270: the inbound pipeline through the public protocol API — 2-byte session with
+        // AS4_PATH reconstruction, communities and large communities.
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+                AttributeHelper.WriteAsPath([65010u, BgpConstants.AsPath.AsTrans, 65001u], fourByteAsn: false),
+                AttributeHelper.WriteAs4Path([200000u, 65001u]),
+                AttributeHelper.WriteNextHop(0x0A000001),
+                AttributeHelper.WriteCommunities([65000u, 100u]),
+                AttributeHelper.WriteLargeCommunities([(64512u, 1u, 2u)]),
+            ],
+            Nlri = []
+        };
+
+        var attrs = UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: false);
+
+        Assert.Equal([65010u, 200000u, 65001u], attrs.AsPath); // AS4_PATH trailing reconstruction
+        Assert.Equal(0x0A000001u, attrs.NextHop);
+        Assert.Equal([65000u, 100u], attrs.Communities);
+        Assert.Equal([(64512u, 1u, 2u)], attrs.LargeCommunities);
+    }
+
+    [Fact]
+    public void ParseRouteAttributes_MissingMandatoryAttribute_ThrowsSubcode3()
+    {
+        // ORIGIN + AS_PATH but no NEXT_HOP.
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+                AttributeHelper.WriteAsPath([65001u], fourByteAsn: true),
+            ],
+            Nlri = []
+        };
+
+        var ex = Assert.Throws<BgpNotificationException>(() => UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: true));
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.MissingWellKnownAttribute, ex.SubErrorCode);
+    }
+
+    [Fact]
+    public void ParseRouteAttributes_InvalidOriginValue_ThrowsSubcode6()
+    {
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                new PathAttribute { Flags = BgpConstants.Attribute.FlagTransitive, TypeCode = BgpConstants.Attribute.Origin, Data = [7] },
+                AttributeHelper.WriteAsPath([65001u], fourByteAsn: true),
+                AttributeHelper.WriteNextHop(0x0A000001),
+            ],
+            Nlri = []
+        };
+
+        var ex = Assert.Throws<BgpNotificationException>(() => UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: true));
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.InvalidOriginAttribute, ex.SubErrorCode);
+    }
+
+    [Fact]
     public void ValidateAggregatorReconstruction_AsTransWithAs4Aggregator_DoesNotThrow()
     {
         UpdateCodec.ValidateAggregatorReconstruction(BgpConstants.AsPath.AsTrans, 200000u);

--- a/BGPLite.Tests/MalformedUpdateResilienceTests.cs
+++ b/BGPLite.Tests/MalformedUpdateResilienceTests.cs
@@ -46,6 +46,19 @@ public class MalformedUpdateResilienceTests
         Assert.Equal(BgpConstants.SubError.MalformedAttributeList, ex.SubErrorCode);
     }
 
+    [Theory]
+    [InlineData(0x08)]
+    [InlineData(0x18)] // ExtendedLength | reserved
+    public void ParseAttribute_ReservedFlagBitSet_RejectedWithAttributeFlagsError(byte flags)
+    {
+        // RFC 4271 §4.3: bit 0x08 is reserved and MUST be zero (#272, epic #6).
+        var attrBytes = new byte[] { flags, 0x01, 0x01, 0x00 };
+
+        var ex = Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(BuildUpdateFrame([.. attrBytes])));
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.AttributeFlagsError, ex.SubErrorCode);
+    }
+
     [Fact]
     public void ParseUpdate_WithdrawnLengthExceedsPayload_ThrowsBgpParseException()
     {

--- a/BGPLite.Tests/OpenNegotiatorTests.cs
+++ b/BGPLite.Tests/OpenNegotiatorTests.cs
@@ -4,7 +4,7 @@ using BGPLite.Server;
 namespace BGPLite.Tests;
 
 /// <summary>
-/// Direct unit tests for the pure <see cref="BgpSession.ValidateOpen(BgpOpenMessage, uint?, uint, int)"/>
+/// Direct unit tests for the pure <see cref="OpenNegotiator.Validate(BgpOpenMessage, uint?, uint, int)"/>
 /// extraction (#97). Every OPEN-validation branch is exercised without standing up a BgpSession
 /// over a live socket — mirroring how the RFC-6793 tests exercise MergeAsPathWithAs4Path.
 /// <para>
@@ -14,7 +14,7 @@ namespace BGPLite.Tests;
 /// <c>min(local, peer)</c> rule.
 /// </para>
 /// </summary>
-public class BgpSessionValidateOpenTests
+public class OpenNegotiatorTests
 {
     private const uint LocalRouterId = 0x0A000001u; // 10.0.0.1
     private const uint PeerRouterId = 0x0A000002u;  // 10.0.0.2
@@ -37,9 +37,9 @@ public class BgpSessionValidateOpenTests
         };
 
     /// <summary>Shorthand for the 4-arg ValidateOpen with the default local hold time (180s).</summary>
-    private static BgpSession.OpenNegotiation Negotiate(
+    private static OpenNegotiation Negotiate(
         BgpOpenMessage open, uint? expectedRemoteAsn = AsnFourOctet, int localHoldTime = DefaultLocalHoldTime) =>
-        BgpSession.ValidateOpen(open, expectedRemoteAsn, LocalRouterId, localHoldTime);
+        OpenNegotiator.Validate(open, expectedRemoteAsn, LocalRouterId, localHoldTime);
 
     [Fact]
     public void ValidOpen_NegotiatesFourByteAsn_RouteRefresh_KeepAlive()


### PR DESCRIPTION
Closes #270

⚠️ Stacked on #274 (refactor/269-open-negotiation-protocol), which is itself stacked on #273 — merge bottom-up.

## What
The inbound UPDATE attribute pipeline — per-attribute validation (ORIGIN value/length → 6, NEXT_HOP length → 8, COMMUNITY % 4 → 9, Large Communities % 12 → 9, AS_PATH/AS4_PATH segment rules → 11), mandatory well-known set (→ 3), RFC 6793 AS4_PATH trailing-sequence reconstruction and AGGREGATOR consistency — was inlined in `BgpSession.HandleUpdateAsync`, mixing protocol decisions with `_routeFilter`/`_routeTable`/metrics side effects. Moved verbatim into the protocol assembly as public `UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession)` returning a `RouteAttributes` record; the session keeps transport, filtering, routing and logging, and the thrown `BgpNotificationException` flows to the existing treat-as-withdraw catch unchanged.

## Verification
- `dotnet build` — 0 errors; `dotnet format --severity warn` — clean.
- `dotnet test` — 589 passed, 0 failed: new API tests (happy path with AS4 merge; missing mandatory → subcode 3; invalid ORIGIN → subcode 6) plus the full existing session-level resilience matrix (treat-as-withdraw, on-wire malformed UPDATE) unchanged.
- With #269 and this, both protocol decision pipelines (OPEN negotiation, UPDATE processing) live in `BGPLite.Protocol` — a standalone-package consumer needs no session machinery.