### PR TITLE
refactor(architecture): extract BGPLite.Contracts — remove Api→Server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ BGPLite is a lightweight BGP route server with dynamic prefix provisioning via R
 - RIPE Stat integration and prefix provisioning live in `BGPLite.Providers/`.
 - Unit tests live in `BGPLite.Tests/`.
 
-Keep the boundary clear: protocol correctness belongs in `BGPLite.Protocol`; session FSM and TCP handling belong in `BGPLite.Server`; routing and filtering belong in `BGPLite.Routing`; HTTP management and persistence belong in `BGPLite.Api`; prefix sourcing belongs in `BGPLite.Providers`; config loading belongs in `BGPLite.Configuration`.
+Keep the boundary clear: protocol correctness belongs in `BGPLite.Protocol`; shared contracts (interfaces + DTOs used by multiple layers) belong in `BGPLite.Contracts` — a dependency-free leaf; session FSM and TCP handling belong in `BGPLite.Server`; routing and filtering belong in `BGPLite.Routing`; HTTP management and persistence belong in `BGPLite.Api`; prefix sourcing belongs in `BGPLite.Providers`; config loading belongs in `BGPLite.Configuration`.
 
 ## Tech stack
 
@@ -31,8 +31,10 @@ Keep the boundary clear: protocol correctness belongs in `BGPLite.Protocol`; ses
 | Path | What |
 |---|---|
 | `BGPLite/` | application entrypoint and DI wiring |
+| `BGPLite.Contracts/` | shared contracts: IPeerStore, ISessionManager, IPrefixService, peer DTOs, BgpMetrics (dependency-free leaf) |
 | `BGPLite.Protocol/` | BGP message encoding/decoding, FSM states, capabilities, path attributes |
-| `BGPLite.Server/` | TCP listener, BGP session FSM, timers, metrics, service interfaces |
+| `BGPLite.Server/` | TCP listener, BGP session FSM, timers |
+| `BGPLite.Contracts/` | shared service interfaces, peer DTOs, BgpMetrics (see above) |
 | `BGPLite.Routing/` | route table, route filters, community-based filtering |
 | `BGPLite.Configuration/` | YAML config models and loading |
 | `BGPLite.Api/` | HTTP management API endpoints, SQLite peer store, EF Core entities |

--- a/BGPLite.Api/BGPLite.Api.csproj
+++ b/BGPLite.Api/BGPLite.Api.csproj
@@ -16,10 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\BGPLite.Contracts\BGPLite.Contracts.csproj" />
     <ProjectReference Include="..\BGPLite.Configuration\BGPLite.Configuration.csproj" />
     <ProjectReference Include="..\BGPLite.Providers\BGPLite.Providers.csproj" />
     <ProjectReference Include="..\BGPLite.Routing\BGPLite.Routing.csproj" />
-    <ProjectReference Include="..\BGPLite.Server\BGPLite.Server.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -9,9 +9,9 @@ using BGPLite.Configuration;
 using BGPLite.Protocol;
 using BGPLite.Providers;
 using BGPLite.Routing;
-using BGPLite.Server;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using BGPLite.Contracts;
 
 namespace BGPLite.Api;
 

--- a/BGPLite.Api/PeerDetailDto.cs
+++ b/BGPLite.Api/PeerDetailDto.cs
@@ -1,0 +1,27 @@
+namespace BGPLite.Api;
+
+/// <summary>
+/// Full per-peer read model for the management API's GET endpoints (#228). Replaces the 5–6
+/// separate <c>DbContext</c> roundtrips <c>BuildPeerDetail</c>/<c>HandleGetPeer</c> used to issue
+/// (one each for the peer row, subscriptions, custom prefixes, custom ASNs, communities, and — for
+/// <c>HandleGetPeer</c> — custom sources). Field shapes match the prior standalone getters so the
+/// JSON response is byte-identical. <c>CustomSources</c> carries ALL sources (including inactive)
+/// so the API can show a source's active toggle state; the send path uses <see cref="PeerRoutingView"/>
+/// which filters Active at the SQL level.
+/// </summary>
+
+public sealed record PeerSourceView(string Id, string Name, string Url, string? Community, bool Active);
+
+public sealed record PeerDetailDto(
+    string Id,
+    string Ip,
+    uint? Asn,
+    string? Description,
+    string Status,
+    DateTime CreatedAt,
+    DateTime? LastSessionAt,
+    List<string> Subscriptions,
+    List<string> CustomPrefixes,
+    List<uint> CustomAsns,
+    List<PeerSourceView> CustomSources,
+    List<long> Communities);

--- a/BGPLite.Api/PeerStore.cs
+++ b/BGPLite.Api/PeerStore.cs
@@ -1,6 +1,6 @@
 using BGPLite.Api.Entities;
-using BGPLite.Server;
 using Microsoft.EntityFrameworkCore;
+using BGPLite.Contracts;
 
 namespace BGPLite.Api;
 

--- a/BGPLite.Contracts/BGPLite.Contracts.csproj
+++ b/BGPLite.Contracts/BGPLite.Contracts.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/BGPLite.Contracts/BgpMetrics.cs
+++ b/BGPLite.Contracts/BgpMetrics.cs
@@ -1,6 +1,8 @@
 using System.Threading;
 
-namespace BGPLite.Server;
+// #230: shared observability component — consumed by both Server (sessions) and Api (status
+// endpoints); dependency-free, so it lives in Contracts alongside the other shared types.
+namespace BGPLite.Contracts;
 
 public sealed class BgpMetrics
 {

--- a/BGPLite.Contracts/IPeerStore.cs
+++ b/BGPLite.Contracts/IPeerStore.cs
@@ -1,4 +1,4 @@
-namespace BGPLite.Server;
+namespace BGPLite.Contracts;
 
 public interface IPeerStore
 {
@@ -62,28 +62,3 @@ public sealed record PeerRoutingView(
     List<string> CustomPrefixes,
     List<uint> CustomAsns,
     List<CustomSourceView> UserSources);
-
-/// <summary>
-/// Full per-peer read model for the management API's GET endpoints (#228). Replaces the 5–6
-/// separate <c>DbContext</c> roundtrips <c>BuildPeerDetail</c>/<c>HandleGetPeer</c> used to issue
-/// (one each for the peer row, subscriptions, custom prefixes, custom ASNs, communities, and — for
-/// <c>HandleGetPeer</c> — custom sources). Field shapes match the prior standalone getters so the
-/// JSON response is byte-identical. <c>CustomSources</c> carries ALL sources (including inactive)
-/// so the API can show a source's active toggle state; the send path uses <see cref="PeerRoutingView"/>
-/// which filters Active at the SQL level.
-/// </summary>
-public sealed record PeerSourceView(string Id, string Name, string Url, string? Community, bool Active);
-
-public sealed record PeerDetailDto(
-    string Id,
-    string Ip,
-    uint? Asn,
-    string? Description,
-    string Status,
-    DateTime CreatedAt,
-    DateTime? LastSessionAt,
-    List<string> Subscriptions,
-    List<string> CustomPrefixes,
-    List<uint> CustomAsns,
-    List<PeerSourceView> CustomSources,
-    List<long> Communities);

--- a/BGPLite.Contracts/IPrefixService.cs
+++ b/BGPLite.Contracts/IPrefixService.cs
@@ -1,4 +1,4 @@
-namespace BGPLite.Configuration;
+namespace BGPLite.Contracts;
 
 /// <summary>
 /// Origin-AS / source prefix lookup contract. Lives in this neutral lower layer so that the

--- a/BGPLite.Contracts/ISessionManager.cs
+++ b/BGPLite.Contracts/ISessionManager.cs
@@ -1,4 +1,4 @@
-namespace BGPLite.Server;
+namespace BGPLite.Contracts;
 
 public interface ISessionManager
 {

--- a/BGPLite.Providers/BGPLite.Providers.csproj
+++ b/BGPLite.Providers/BGPLite.Providers.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\BGPLite.Contracts\BGPLite.Contracts.csproj" />
     <ProjectReference Include="..\BGPLite.Configuration\BGPLite.Configuration.csproj" />
     <ProjectReference Include="..\BGPLite.Protocol\BGPLite.Protocol.csproj" />
   </ItemGroup>

--- a/BGPLite.Providers/PrefixService.cs
+++ b/BGPLite.Providers/PrefixService.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using BGPLite.Configuration;
 using Microsoft.Extensions.Logging;
+using BGPLite.Contracts;
 
 namespace BGPLite.Providers;
 

--- a/BGPLite.Server/BGPLite.Server.csproj
+++ b/BGPLite.Server/BGPLite.Server.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\BGPLite.Contracts\BGPLite.Contracts.csproj" />
     <ProjectReference Include="..\BGPLite.Configuration\BGPLite.Configuration.csproj" />
     <ProjectReference Include="..\BGPLite.Protocol\BGPLite.Protocol.csproj" />
     <ProjectReference Include="..\BGPLite.Routing\BGPLite.Routing.csproj" />

--- a/BGPLite.Server/BgpServer.cs
+++ b/BGPLite.Server/BgpServer.cs
@@ -6,6 +6,7 @@ using BGPLite.Protocol;
 using BGPLite.Routing;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using BGPLite.Contracts;
 
 namespace BGPLite.Server;
 

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -5,6 +5,7 @@ using BGPLite.Configuration;
 using BGPLite.Protocol;
 using BGPLite.Routing;
 using Microsoft.Extensions.Logging;
+using BGPLite.Contracts;
 
 namespace BGPLite.Server;
 

--- a/BGPLite.Server/RouteAssembler.cs
+++ b/BGPLite.Server/RouteAssembler.cs
@@ -3,6 +3,7 @@ using BGPLite.Configuration;
 using BGPLite.Protocol;
 using BGPLite.Routing;
 using Microsoft.Extensions.Logging;
+using BGPLite.Contracts;
 
 namespace BGPLite.Server;
 

--- a/BGPLite.Tests/BgpSessionHoldTimerTests.cs
+++ b/BGPLite.Tests/BgpSessionHoldTimerTests.cs
@@ -4,6 +4,7 @@ using BGPLite.Routing;
 using BGPLite.Server;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Time.Testing;
+using BGPLite.Contracts;
 
 namespace BGPLite.Tests;
 

--- a/BGPLite.Tests/BgpSessionShutdownTests.cs
+++ b/BGPLite.Tests/BgpSessionShutdownTests.cs
@@ -5,6 +5,7 @@ using BGPLite.Protocol;
 using BGPLite.Routing;
 using BGPLite.Server;
 using Microsoft.Extensions.Logging;
+using BGPLite.Contracts;
 
 namespace BGPLite.Tests;
 

--- a/BGPLite.Tests/BgpSessionUserSourceTests.cs
+++ b/BGPLite.Tests/BgpSessionUserSourceTests.cs
@@ -4,6 +4,7 @@ using BGPLite.Routing;
 using BGPLite.Server;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
+using BGPLite.Contracts;
 
 namespace BGPLite.Tests;
 

--- a/BGPLite.Tests/ConfigHotReloadTests.cs
+++ b/BGPLite.Tests/ConfigHotReloadTests.cs
@@ -8,6 +8,7 @@ using BGPLite.Server;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using BGPLite.Contracts;
 
 namespace BGPLite.Tests;
 

--- a/BGPLite.Tests/LayeringTests.cs
+++ b/BGPLite.Tests/LayeringTests.cs
@@ -20,14 +20,67 @@ public class LayeringTests
     }
 
     [Fact]
-    public void PrefixService_implements_IPrefixService_from_configuration()
+    public void PrefixService_implements_IPrefixService_from_contracts()
     {
+        // #230: the contract moved from Configuration (its #88 workaround home) to the dedicated
+        // BGPLite.Contracts layer.
         var contract = typeof(PrefixService)
             .GetInterfaces()
             .SingleOrDefault(i => i.Name == "IPrefixService");
 
         Assert.NotNull(contract);
-        Assert.Equal("BGPLite.Configuration", contract!.Namespace);
+        Assert.Equal("BGPLite.Contracts", contract!.Namespace);
+    }
+
+    [Fact]
+    public void Dependency_graph_has_no_forbidden_edges()
+    {
+        // #230: the layering rules as an executable matrix — Protocol and Contracts are leaves,
+        // Routing sits on them, Server on Routing, Api/Providers on Contracts — never upward.
+        // Any PR that re-adds one of these edges turns this test red.
+        var assemblies = new Dictionary<string, System.Reflection.Assembly>
+        {
+            ["BGPLite.Protocol"] = typeof(BgpConstants).Assembly,
+            ["BGPLite.Contracts"] = typeof(BGPLite.Contracts.IPeerStore).Assembly,
+            ["BGPLite.Configuration"] = typeof(BGPLite.Configuration.ConfigLoader).Assembly,
+            ["BGPLite.Routing"] = typeof(BGPLite.Routing.Route).Assembly,
+            ["BGPLite.Server"] = typeof(BGPLite.Server.BgpServer).Assembly,
+            ["BGPLite.Providers"] = typeof(PrefixService).Assembly,
+            ["BGPLite.Api"] = typeof(BGPLite.Api.ManagementApi).Assembly,
+        };
+
+        var forbidden = new[]
+        {
+            ("BGPLite.Api", "BGPLite.Server"),       // #230 — the edge the Contracts extraction removed
+            ("BGPLite.Routing", "BGPLite.Api"),
+            ("BGPLite.Routing", "BGPLite.Server"),
+            ("BGPLite.Routing", "BGPLite.Providers"),
+            ("BGPLite.Server", "BGPLite.Api"),
+            ("BGPLite.Server", "BGPLite.Providers"),
+            ("BGPLite.Protocol", "BGPLite.Api"),
+            ("BGPLite.Protocol", "BGPLite.Server"),
+            ("BGPLite.Protocol", "BGPLite.Routing"),
+            ("BGPLite.Protocol", "BGPLite.Providers"),
+            ("BGPLite.Protocol", "BGPLite.Contracts"),
+            ("BGPLite.Protocol", "BGPLite.Configuration"),
+            ("BGPLite.Contracts", "BGPLite.Api"),
+            ("BGPLite.Contracts", "BGPLite.Server"),
+            ("BGPLite.Contracts", "BGPLite.Routing"),
+            ("BGPLite.Contracts", "BGPLite.Providers"),
+            ("BGPLite.Contracts", "BGPLite.Protocol"),
+            ("BGPLite.Contracts", "BGPLite.Configuration"),
+            ("BGPLite.Configuration", "BGPLite.Api"),
+            ("BGPLite.Configuration", "BGPLite.Server"),
+            ("BGPLite.Configuration", "BGPLite.Routing"),
+            ("BGPLite.Configuration", "BGPLite.Providers"),
+            ("BGPLite.Configuration", "BGPLite.Contracts"),
+        };
+
+        foreach (var (from, to) in forbidden)
+        {
+            var referenced = assemblies[from].GetReferencedAssemblies().Select(a => a.Name);
+            Assert.DoesNotContain(to, referenced);
+        }
     }
 
     [Fact]

--- a/BGPLite.Tests/MalformedUpdateResilienceTests.cs
+++ b/BGPLite.Tests/MalformedUpdateResilienceTests.cs
@@ -6,6 +6,7 @@ using BGPLite.Protocol;
 using BGPLite.Routing;
 using BGPLite.Server;
 using Microsoft.Extensions.Logging;
+using BGPLite.Contracts;
 
 namespace BGPLite.Tests;
 

--- a/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
+++ b/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
@@ -4,6 +4,7 @@ using BGPLite.Server;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
+using BGPLite.Contracts;
 
 namespace BGPLite.Tests;
 

--- a/BGPLite.sln
+++ b/BGPLite.sln
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BGPLite.Api", "BGPLite.Api\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BGPLite.Providers", "BGPLite.Providers\BGPLite.Providers.csproj", "{22F5F58A-345F-4149-AE26-6CAC4875BA60}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BGPLite.Contracts", "BGPLite.Contracts\BGPLite.Contracts.csproj", "{F40BD30A-8E53-45E7-B21D-BBC2DC79693B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -125,6 +127,18 @@ Global
 		{22F5F58A-345F-4149-AE26-6CAC4875BA60}.Release|x64.Build.0 = Release|Any CPU
 		{22F5F58A-345F-4149-AE26-6CAC4875BA60}.Release|x86.ActiveCfg = Release|Any CPU
 		{22F5F58A-345F-4149-AE26-6CAC4875BA60}.Release|x86.Build.0 = Release|Any CPU
+		{F40BD30A-8E53-45E7-B21D-BBC2DC79693B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F40BD30A-8E53-45E7-B21D-BBC2DC79693B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F40BD30A-8E53-45E7-B21D-BBC2DC79693B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F40BD30A-8E53-45E7-B21D-BBC2DC79693B}.Debug|x64.Build.0 = Debug|Any CPU
+		{F40BD30A-8E53-45E7-B21D-BBC2DC79693B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F40BD30A-8E53-45E7-B21D-BBC2DC79693B}.Debug|x86.Build.0 = Debug|Any CPU
+		{F40BD30A-8E53-45E7-B21D-BBC2DC79693B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F40BD30A-8E53-45E7-B21D-BBC2DC79693B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F40BD30A-8E53-45E7-B21D-BBC2DC79693B}.Release|x64.ActiveCfg = Release|Any CPU
+		{F40BD30A-8E53-45E7-B21D-BBC2DC79693B}.Release|x64.Build.0 = Release|Any CPU
+		{F40BD30A-8E53-45E7-B21D-BBC2DC79693B}.Release|x86.ActiveCfg = Release|Any CPU
+		{F40BD30A-8E53-45E7-B21D-BBC2DC79693B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/BGPLite/BGPLite.csproj
+++ b/BGPLite/BGPLite.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\BGPLite.Contracts\BGPLite.Contracts.csproj" />
     <ProjectReference Include="..\BGPLite.Protocol\BGPLite.Protocol.csproj" />
     <ProjectReference Include="..\BGPLite.Server\BGPLite.Server.csproj" />
     <ProjectReference Include="..\BGPLite.Routing\BGPLite.Routing.csproj" />

--- a/BGPLite/PrefixAutoRefreshService.cs
+++ b/BGPLite/PrefixAutoRefreshService.cs
@@ -3,6 +3,7 @@ using BGPLite.Providers;
 using BGPLite.Server;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using BGPLite.Contracts;
 
 namespace BGPLite;
 

--- a/BGPLite/Program.cs
+++ b/BGPLite/Program.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Logging;
 using Polly;
+using BGPLite.Contracts;
 
 var builder = Host.CreateApplicationBuilder(args);
 


### PR DESCRIPTION
Closes #230 (implements the plan from the audit comment)

⚠️ Top of a 4-PR stack: #273 → #274 → #275 → #276 → **this**. Merge bottom-up, retargeting each.

## What
New dependency-free leaf project **BGPLite.Contracts**:
- `IPeerStore`, `PeerInfo`, `CustomSourceView`, `PeerRoutingView` — moved from Server (the consumer-owned-contract anti-pattern)
- `ISessionManager` — moved from Server
- `IPrefixService` — moved from Configuration (retiring its #88 "neutral lower layer" workaround home)
- `BgpMetrics` — shared observability used by both Server (sessions) and Api (status endpoints); pure BCL counters

`PeerDetailDto`/`PeerSourceView` (the management API's read model, #228) moved into **BGPLite.Api**. The `BGPLite.Api → BGPLite.Server` ProjectReference is **deleted**; Server, Api, Providers and the entrypoint reference Contracts.

## Guard
`LayeringTests.Dependency_graph_has_no_forbidden_edges` — the full forbidden-edge matrix (Protocol and Contracts as pure leaves, Routing on them, Server on Routing, Api on Contracts, Configuration on nothing): re-adding any edge this PR removed — or any upward edge — fails a test. Plus: `Protocol_assembly_is_a_pure_leaf` (from #276) and the updated `PrefixService_implements_IPrefixService_from_contracts` assertion.

## Verification
- `dotnet build` — 0 errors (compiler-driven mechanical move: namespaces + usings only, zero behavior change).
- `dotnet test` — 591 passed, 0 failed.
- `dotnet format --severity warn` — clean.
- AGENTS.md architecture map updated (Contracts layer documented) — no doc drift this time.