### PR TITLE
fix(startup): seed routes in the background — listeners start immediately

### DIFF
--- a/BGPLite.Tests/RouteSeedingServiceTests.cs
+++ b/BGPLite.Tests/RouteSeedingServiceTests.cs
@@ -1,0 +1,134 @@
+using BGPLite.Configuration;
+using BGPLite.Contracts;
+using BGPLite.Providers;
+using BGPLite.Routing;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #251: route seeding must not block listener startup. StartAsync returns immediately even while
+/// the RIPEstat warm-up hangs; configured sources (the local nets.txt fallback) seed the table in
+/// the background; and sessions established meanwhile receive the full set via
+/// ISessionManager.RefreshAllEstablishedAsync once warm-up completes.
+/// </summary>
+public class RouteSeedingServiceTests
+{
+    private sealed class HangingPrefixService : IPrefixService
+    {
+        public TaskCompletionSource WarmUpGate { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        // Starts as a never-completing task so assertions cannot race the seeding task's entry
+        // into WarmUpAsync (where it becomes WarmUpGate.Task.WaitAsync(ct)).
+        public Task WarmUpCompleted { get; private set; } = new TaskCompletionSource().Task;
+
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default) => Task.FromResult(new List<(uint, byte, uint)>());
+        public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
+        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default) => Task.FromResult(new List<(uint, byte, uint)>());
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task WarmUpAsync(CancellationToken ct = default) =>
+            WarmUpCompleted = WarmUpGate.Task.WaitAsync(ct);
+    }
+
+    private sealed class FakeSourceService : IPrefixSourceService
+    {
+        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>> LoadAllAsync(CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>>(new List<(PrefixSourceConfig, IReadOnlyList<(uint, byte)>)>
+            {
+                (new PrefixSourceConfig { Name = "nets", Kind = "file", Url = "nets.txt" },
+                    new List<(uint, byte)> { (0xC0A80000u, 24), (0x0A000000u, 8) })
+            });
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetDefaultAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);
+        public bool SourceSupportsConditional(string sourceName) => false;
+    }
+
+    private sealed class RecordingSessionManager : ISessionManager
+    {
+        public int RefreshAllCalls;
+        public Task RefreshPeerAsync(string peerIp, uint asn) => Task.CompletedTask;
+        public List<string> GetActivePeerIps() => [];
+        public int GetAdvertisedPrefixCount(string peerIp, uint asn) => 0;
+        public Task RefreshAllEstablishedAsync() { RefreshAllCalls++; return Task.CompletedTask; }
+    }
+
+    private static RouteSeedingService NewService(
+        HangingPrefixService prefix, FakeSourceService sources, RouteTable table, RecordingSessionManager sessions) =>
+        new(prefix, sources, table,
+            new AppConfig { Bgp = new BgpConfig { Asn = 65001, RouterId = "10.0.0.1" } },
+            sessions, NullLogger<RouteSeedingService>.Instance);
+
+    [Fact]
+    public async Task StartAsync_ReturnsImmediately_WhileWarmUpHangs()
+    {
+        var prefix = new HangingPrefixService();
+        var table = new RouteTable();
+        using var service = NewService(prefix, new FakeSourceService(), table, new RecordingSessionManager());
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        await service.StartAsync(CancellationToken.None);
+        sw.Stop();
+
+        // The listener-start path must not wait on network I/O — 5s is a very generous bound.
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(5), $"StartAsync blocked for {sw.Elapsed}");
+        Assert.False(prefix.WarmUpCompleted.IsCompleted); // warm-up is still hanging in the background
+    }
+
+    [Fact]
+    public async Task Sources_SeedRouteTable_InBackground()
+    {
+        var prefix = new HangingPrefixService();
+        var table = new RouteTable();
+        using var service = NewService(prefix, new FakeSourceService(), table, new RecordingSessionManager());
+
+        await service.StartAsync(CancellationToken.None);
+
+        // Sources seed before the warm-up await — wait for the 2 prefixes without depending on warm-up.
+        for (var i = 0; i < 100 && table.Count < 2; i++)
+            await Task.Delay(20);
+        Assert.Equal(2, table.Count);
+    }
+
+    [Fact]
+    public async Task WarmUpCompletion_PushesRefreshToEstablishedSessions()
+    {
+        var prefix = new HangingPrefixService();
+        var table = new RouteTable();
+        var sessions = new RecordingSessionManager();
+        using var service = NewService(prefix, new FakeSourceService(), table, sessions);
+
+        await service.StartAsync(CancellationToken.None);
+        for (var i = 0; i < 100 && table.Count < 2; i++)
+            await Task.Delay(20);
+        Assert.Equal(0, sessions.RefreshAllCalls); // not yet — warm-up still hanging
+
+        prefix.WarmUpGate.SetResult();
+        for (var i = 0; i < 100 && sessions.RefreshAllCalls == 0; i++)
+            await Task.Delay(20);
+
+        Assert.Equal(1, sessions.RefreshAllCalls);
+    }
+
+    [Fact]
+    public async Task StopAsync_CancelsHangingWarmUp_AndCompletes()
+    {
+        var prefix = new HangingPrefixService();
+        var table = new RouteTable();
+        using var service = NewService(prefix, new FakeSourceService(), table, new RecordingSessionManager());
+
+        await service.StartAsync(CancellationToken.None);
+        await service.StopAsync(TimeSpan.FromSeconds(5).Equals(TimeSpan.Zero)
+            ? CancellationToken.None
+            : new CancellationTokenSource(TimeSpan.FromSeconds(5)).Token);
+
+        // Shutdown does not throw and does not hang; seeding ended in the cancelled state.
+        Assert.True(prefix.WarmUpCompleted.IsCompleted);
+    }
+}

--- a/BGPLite/Program.cs
+++ b/BGPLite/Program.cs
@@ -177,6 +177,17 @@ builder.Services.AddSingleton(sp =>
         prefixService,
         communityResolver: sp.GetRequiredService<ICommunityResolver>());
 });
+// #251: route seeding (sources + RIPEstat warm-up) runs as a BACKGROUND task — the listeners
+// start immediately, the local nets.txt fallback seeds in milliseconds, and established sessions
+// get the full set pushed once warm-up completes. Registered before the BGP server so seeding
+// begins before any session can be accepted (hosted services start in registration order).
+builder.Services.AddHostedService(sp => new RouteSeedingService(
+    sp.GetRequiredService<IPrefixService>(),
+    sp.GetRequiredService<IPrefixSourceService>(),
+    routeTable,
+    config,
+    sp.GetRequiredService<ISessionManager>(),
+    sp.GetRequiredService<ILogger<RouteSeedingService>>()));
 builder.Services.AddHostedService(sp => sp.GetRequiredService<BgpServer>());
 builder.Services.AddSingleton<ISessionManager>(sp => sp.GetRequiredService<BgpServer>());
 
@@ -239,36 +250,6 @@ using (var scope = host.Services.CreateScope())
 var logger = host.Services.GetRequiredService<ILogger<Program>>();
 logger.LogInformation("BGPLite starting — ASN={Asn}, RouterId={RouterId}", config.Bgp.Asn, config.Bgp.RouterId);
 
-// Pre-warm prefix cache before accepting BGP connections (RIPE + all configured sources)
-Console.WriteLine("Warming up prefix cache...");
-var prefixService = host.Services.GetRequiredService<IPrefixService>();
-await prefixService.WarmUpAsync();
-Console.WriteLine("Prefix cache ready");
-
-// Seed the route table from configured prefix sources, attaching each source's community.
-var sourceSvc = host.Services.GetRequiredService<IPrefixSourceService>();
-foreach (var (source, prefixes) in await sourceSvc.LoadAllAsync())
-{
-    var communities = string.IsNullOrEmpty(source.Community)
-        ? Array.Empty<uint>()
-        : new[] { CommunityCodec.Parse(source.Community!) };
-
-    foreach (var (prefix, length) in prefixes)
-    {
-        routeTable.AddOrUpdate(new Route
-        {
-            Prefix = prefix,
-            PrefixLength = length,
-            NextHop = nextHop,
-            Communities = communities
-        });
-    }
-
-    Console.WriteLine($"  Source '{source.Name}': {prefixes.Count} prefixes" +
-                      (source.Community is null ? "" : $" community={source.Community}"));
-}
-
-logger.LogInformation("Loaded routes: {RouteCount}", routeTable.Count);
 
 // #104 / #107: resilience pipelines for the http and ripestat named clients. Uses
 // Microsoft.Extensions.Http.Resilience (Polly v8 integrated) — the .NET 8+ standard — instead of

--- a/BGPLite/RouteSeedingService.cs
+++ b/BGPLite/RouteSeedingService.cs
@@ -1,0 +1,105 @@
+using BGPLite.Configuration;
+using BGPLite.Contracts;
+using BGPLite.Protocol;
+using BGPLite.Providers;
+using BGPLite.Routing;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace BGPLite;
+
+/// <summary>
+/// #251: seeds the route table from the configured prefix sources and warms the RIPEstat cache as a
+/// BACKGROUND task, so the BGP listener (:179) and the management API start immediately. Previously
+/// both waited on the top-level <c>await WarmUpAsync()</c> — a hanging RIPEstat fetch (firewall DROP
+/// × N ASNs × 3 attempts × 180 s) could delay every listener for hours.
+/// <para>
+/// Seeding order inside the background task: sources first — the local nets.txt fallback seeds in
+/// milliseconds even under a total RIPE blackout — then the per-ASN cache warm-up. When seeding
+/// completes, any session established in the meantime receives the full set as an unsolicited
+/// UPDATE via <see cref="ISessionManager.RefreshAllEstablishedAsync"/> (the #214 push mechanism),
+/// so an early peer first gets the local fallback and then the complete table.
+/// </para>
+/// <para>
+/// Registered BEFORE the BGP server hosted service: hosted services start in registration order,
+/// and although <see cref="StartAsync"/> returns immediately (listeners never wait on network I/O),
+/// the ordering documents the intent — seeding begins before any session can possibly be accepted,
+/// and the single task means seeding itself cannot race.
+/// </para>
+/// </summary>
+internal sealed class RouteSeedingService(
+    IPrefixService prefixService,
+    IPrefixSourceService sources,
+    RouteTable routeTable,
+    AppConfig config,
+    ISessionManager sessionManager,
+    ILogger<RouteSeedingService> logger) : IHostedService, IDisposable
+{
+    private readonly CancellationTokenSource _cts = new();
+    private Task? _seedTask;
+
+    public void Dispose() => _cts.Dispose();
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        // Never block listener startup on network I/O — the whole point of #251.
+        _seedTask = Task.Run(() => SeedAsync(_cts.Token), CancellationToken.None);
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        _cts.Cancel();
+        if (_seedTask is null) return;
+        try { await _seedTask.WaitAsync(cancellationToken); }
+        catch (OperationCanceledException) { /* shutdown raced the seeding — fine */ }
+        catch (Exception ex) { logger.LogError(ex, "Route seeding faulted during shutdown"); }
+    }
+
+    private async Task SeedAsync(CancellationToken ct)
+    {
+        var nextHop = BgpConstants.IPAddressToUint(config.Bgp.GetRouterIdAddress());
+        try
+        {
+            foreach (var (source, prefixes) in await sources.LoadAllAsync(ct))
+            {
+                var communities = string.IsNullOrEmpty(source.Community)
+                    ? Array.Empty<uint>()
+                    : new[] { CommunityCodec.Parse(source.Community!) };
+
+                foreach (var (prefix, length) in prefixes)
+                {
+                    routeTable.AddOrUpdate(new Route
+                    {
+                        Prefix = prefix,
+                        PrefixLength = length,
+                        NextHop = nextHop,
+                        Communities = communities
+                    });
+                }
+
+                logger.LogInformation("Source '{Name}': {Count} prefixes{Community}",
+                    source.Name, prefixes.Count,
+                    source.Community is null ? "" : $" community={source.Community}");
+            }
+
+            logger.LogInformation("Loaded routes: {RouteCount} — warming RIPEstat cache", routeTable.Count);
+
+            await prefixService.WarmUpAsync(ct);
+            logger.LogInformation("Prefix cache warm — {RouteCount} routes on the wire", routeTable.Count);
+
+            // Sessions established while seeding ran get the full set now (#214 push).
+            await sessionManager.RefreshAllEstablishedAsync();
+        }
+        catch (OperationCanceledException)
+        {
+            logger.LogInformation("Route seeding cancelled at shutdown — {RouteCount} routes were seeded", routeTable.Count);
+        }
+        catch (Exception ex)
+        {
+            // The server keeps serving whatever seeded (local fallback / stale-on-failure caches);
+            // per-source failures were already absorbed by LoadAllAsync.
+            logger.LogError(ex, "Route seeding failed — serving with {RouteCount} routes", routeTable.Count);
+        }
+    }
+}


### PR DESCRIPTION
Closes #251

## Problem
`await prefixService.WarmUpAsync()` sat in top-level Program.cs before `host.RunAsync()` — the BGP listener and the management API did not start until every RIPEstat ASN fetch completed. Under firewall-DROP each ASN ≈ 9.5 min (180 s × 3 attempts); 50 ASNs ≈ hours of blackout; nets.txt fallback does not participate in warm-up.

## Fix
`RouteSeedingService` (new `IHostedService`, registered **before** the BGP server so seeding begins before any session can be accepted):
- `StartAsync` returns immediately — listeners start in ~0 s regardless of RIPEstat health.
- Background task: seed configured sources first (`nets.txt` = milliseconds) → warm the ASN cache → push the full set to sessions established meanwhile via `RefreshAllEstablishedAsync` (#214 push). Early peers get the local fallback, then an unsolicited UPDATE with the complete table.
- `StopAsync` cancels + drains; per-source failures already absorbed by stale-on-failure — the server serves whatever seeded.
- The ~70-line procedural block leaves Program.cs (audit item A3 folded in).

## Verification
- `dotnet test` — 595 passed, 0 failed (4 new: StartAsync immediate under a hanging warm-up; sources seed in background; refresh pushed on completion; StopAsync cancels and completes — timing-race in the first draft caught by 8× repeat runs and fixed).
- `dotnet build` 0 errors; `dotnet format --severity warn` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The server now starts accepting connections immediately without waiting for route data to load.
  - Routes and prefix information are populated in the background from configured sources.
  - Established sessions are refreshed automatically when route seeding completes.
  - Shutdown now safely cancels ongoing background loading.

- **Bug Fixes**
  - Prevented delayed startup when route or prefix services are slow or unavailable.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->