### PR TITLE
fix(server): enforce a real per-send timeout — async writes were unbounded

### DIFF
--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -635,7 +635,21 @@ public sealed class BgpSession : IDisposable
                 return;
             }
 
-            await SendKeepaliveAsync();
+            // #252: a failed/timed-out send (per-send budget in SocketBgpConnection) means the
+            // outbound path is dead — most commonly a peer that stopped reading. Claim the
+            // teardown and end this loop: Task.WhenAny in RunEstablishedAsync then cancels the
+            // read loop and the session unwinds (no NOTIFICATION is attempted — the peer is not
+            // reading by definition, so it would only block for another budget window).
+            try
+            {
+                await SendKeepaliveAsync();
+            }
+            catch (IOException ex)
+            {
+                _logger.LogWarning(ex, "Keepalive send to {Peer} failed/timed out — tearing down", _peer);
+                Interlocked.CompareExchange(ref _teardownReason, (int)TeardownReason.LocalCease, (int)TeardownReason.None);
+                return;
+            }
             _logger.LogDebug("KeepAliveSent to {Peer}", _peer);
         }
     }

--- a/BGPLite.Server/SocketBgpConnection.cs
+++ b/BGPLite.Server/SocketBgpConnection.cs
@@ -7,28 +7,33 @@ namespace BGPLite.Server;
 /// <see cref="NetworkStream"/> (owns the socket). Replaces the direct <c>_socket</c>/<c>_stream</c>
 /// fields that <see cref="BgpSession"/> previously held (#96).
 /// <para>
-/// Sets <see cref="Socket.SendTimeout"/> = 60s as a kernel-level backstop (#160): a peer that stops
-/// reading (TCP receive window full) blocks <c>WriteAsync</c> on the kernel send buffer until the
-/// OS TCP retransmission timeout (minutes). The per-send <c>CancellationToken</c> is the primary
-/// bound, but <c>SendTimeout</c> fires at the kernel level even if a future send path forgets to
-/// thread the token. 60s matches the per-send budget.
+/// #160 claimed <see cref="Socket.SendTimeout"/> = 60s as a "kernel-level backstop" for stuck
+/// sends — but per the .NET documentation SendTimeout applies to SYNCHRONOUS Send calls only, so
+/// every async write was effectively unbounded (#252): a peer that stops reading (TCP zero window)
+/// pinned <c>WriteAsync</c> until the OS retransmission timeout (~15 min), holding the session's
+/// send lock and paralyzing the keepalive loop. <see cref="WriteAsync"/> now enforces the per-send
+/// budget itself with a linked CTS: when the budget fires the pending write is aborted and
+/// surfaced as <see cref="IOException"/> (dead connection), regardless of the caller's token.
 /// </para>
 /// </summary>
 internal sealed class SocketBgpConnection : IBgpConnection
 {
-    /// <summary>Kernel-level send timeout backstop (#160). See class docs.</summary>
-    private const int SendTimeoutMs = 60_000;
+    /// <summary>Per-send budget: how long a single WriteAsync may block on a non-reading peer (#160/#252).</summary>
+    private const int DefaultSendTimeoutMs = 60_000;
+
+    private readonly int _sendTimeoutMs;
 
     private readonly Socket _socket;
     private readonly NetworkStream _stream;
     private int _disposed; // 0 = not disposed, 1 = disposed. Atomic CAS (matches BgpSession.Dispose).
 
-    public SocketBgpConnection(Socket socket)
+    public SocketBgpConnection(Socket socket) : this(socket, DefaultSendTimeoutMs) { }
+
+    /// <summary>Test seam: the per-send budget is injectable so the timeout is testable in milliseconds.</summary>
+    internal SocketBgpConnection(Socket socket, int sendTimeoutMs)
     {
         _socket = socket;
-        // Kernel-level send backstop. Set before wrapping in NetworkStream so the option is in
-        // place before any send. Safe to set on a connected socket.
-        _socket.SendTimeout = SendTimeoutMs;
+        _sendTimeoutMs = sendTimeoutMs;
         // ownsSocket:true so disposing the stream transitively closes the socket — same ownership
         // semantics as the prior `new NetworkStream(socket, ownsSocket: true)` in BgpSession.
         _stream = new NetworkStream(_socket, ownsSocket: true);
@@ -46,8 +51,30 @@ internal sealed class SocketBgpConnection : IBgpConnection
         }
     }
 
-    public ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
-        => _stream.WriteAsync(buffer, cancellationToken);
+    public async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+    {
+        // #252: Socket.SendTimeout does not bound async writes — enforce the budget here so a
+        // non-reading peer can never pin the send lock for minutes. The linked CTS also honors the
+        // caller's token; distinguishing "budget fired" from "caller cancelled" keeps the benign
+        // cancellation contract of the send paths intact.
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(_sendTimeoutMs);
+        try
+        {
+            await _stream.WriteAsync(buffer, timeoutCts.Token);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw; // caller-initiated cancel — the send paths treat this as a normal cancelled send
+        }
+        catch (OperationCanceledException)
+        {
+            // The per-send budget fired: the peer is not reading. Aborting an in-flight socket
+            // write leaves the connection unusable — surface it as the dead-connection exception
+            // every send path already handles (same as a reset), not as a benign cancellation.
+            throw new IOException($"Send timed out after {_sendTimeoutMs} ms — peer is not reading (TCP zero window)");
+        }
+    }
 
     public bool IsPeerClosed
     {

--- a/BGPLite.Tests/SendTimeoutTests.cs
+++ b/BGPLite.Tests/SendTimeoutTests.cs
@@ -1,0 +1,64 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using BGPLite.Server;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #252: the per-send budget in SocketBgpConnection. Socket.SendTimeout does not apply to async
+/// writes, so a peer that stops reading (TCP zero window) previously pinned WriteAsync — and the
+/// session's send lock — until the OS retransmission timeout (minutes). A real socket pair where
+/// the receiving side never reads exercises the timeout end-to-end.
+/// </summary>
+public class SendTimeoutTests
+{
+    [Fact]
+    public async Task WriteAsync_AbortsWithinBudget_WhenPeerStopsReading()
+    {
+        using var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        listener.Listen(1);
+
+        using var client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        client.Connect(listener.LocalEndPoint!);
+        using var server = listener.Accept();
+        server.ReceiveBufferSize = 8 * 1024; // shrink kernel buffers so the send side fills fast
+        client.SendBufferSize = 8 * 1024;
+
+        using var connection = new SocketBgpConnection(client, sendTimeoutMs: 200);
+
+        var sw = Stopwatch.StartNew();
+        // 8 MB into a peer that never reads: kernel buffers fill and the write blocks — only the
+        // per-send budget can break it (the caller token is never cancelled).
+        var ex = await Assert.ThrowsAsync<IOException>(
+            () => connection.WriteAsync(new byte[8 * 1024 * 1024], CancellationToken.None).AsTask());
+        sw.Stop();
+
+        Assert.Contains("timed out", ex.Message);
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(10),
+            $"the per-send budget must bound the write, took {sw.Elapsed}");
+    }
+
+    [Fact]
+    public async Task WriteAsync_HonorsCallerCancellation_WithDifferentException()
+    {
+        using var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        listener.Listen(1);
+
+        using var client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        client.Connect(listener.LocalEndPoint!);
+        using var server = listener.Accept();
+        server.ReceiveBufferSize = 8 * 1024;
+        client.SendBufferSize = 8 * 1024;
+
+        using var connection = new SocketBgpConnection(client, sendTimeoutMs: 60_000);
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+
+        // Caller-initiated cancellation surfaces as OperationCanceledException — the benign-cancel
+        // contract of the send paths — not as the dead-connection IOException.
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => connection.WriteAsync(new byte[8 * 1024 * 1024], cts.Token).AsTask());
+    }
+}


### PR DESCRIPTION
Closes #252

## Problem
`Socket.SendTimeout` (set by #160 as the "kernel-level backstop") applies to **synchronous** Send calls only — all BGPLite sends are async and passed `CancellationToken.None`, so a peer that stopped reading (TCP zero window) pinned `WriteAsync` until the OS retransmission timeout (~15 min): send lock held, keepalive loop paralyzed, finally-Cease blocked on the lock, non-cancellable refreshes queued. Zombie sessions for tens of minutes — the core goal of #160 was never actually achieved.

## Fix
- `SocketBgpConnection.WriteAsync` enforces the per-send budget itself: linked CTS + `CancelAfter(60s)` (injectable — tests use 200 ms). Budget expiry aborts the in-flight write and throws **IOException** (dead-connection semantics every send path already handles); caller-initiated cancellation still surfaces as `OperationCanceledException` (the benign-cancel contract). The ineffective `SendTimeout` option and the false doc claims are removed.
- `HoldTimerLoopAsync`: a failed/timed-out keepalive claims the teardown latch and ends the loop; `Task.WhenAny` in `RunEstablishedAsync` then cancels the read loop and the session unwinds. No NOTIFICATION is attempted — the peer is not reading by definition.

## Scope note
Threading real tokens through the remaining send call sites (WithdrawAll/batches/open) deliberately stays with #254 (ct normalization + refresh debounce own that area) — the transport-level budget now bounds **every** send regardless of the caller's token, which satisfies both acceptance criteria of this issue.

## Verification
- `dotnet test` — 597 passed, 0 failed (+2: real socket pair, never-reading peer → IOException within budget; caller-cancel distinguishes as OCE — run 3× for timing stability).
- `dotnet build` 0 errors; `dotnet format --severity warn` clean.