### PR TITLE
fix(server): normalize RefreshRoutesAsync token and coalesce stacked refreshes

### DIFF
--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -89,16 +89,54 @@ public sealed class BgpSession : IDisposable
 
     public async Task RefreshRoutesAsync(CancellationToken ct = default)
     {
+        // #254: default(CancellationToken) is CancellationToken.None — NOT "the session's own _cts"
+        // the previous comment claimed. Normalize so every token-less caller (management API
+        // RefreshPeerAsync / RefreshAllEstablishedAsync, onSourceChanged) has its refresh cancelled
+        // at session teardown instead of outliving the session.
+        if (ct == default)
+        {
+            CancellationToken sessionToken;
+            try { sessionToken = _cts.Token; }
+            catch (ObjectDisposedException) { return; } // session disposed — nothing to refresh
+            ct = sessionToken;
+        }
+
         if (!IsEstablished) return;
 
+        // #254 debounce: N stacked triggers must not produce N sequential full withdraw+re-announce
+        // dumps on the wire. One cycle runs; requests arriving mid-cycle set _refreshPending and
+        // return immediately — the runner's do/while coalesces them into a single extra lap, so the
+        // worst case is one in-flight cycle + one pending lap regardless of trigger count.
+        if (Interlocked.CompareExchange(ref _refreshRunning, 1, 0) != 0)
+        {
+            _refreshPending = true;
+            return;
+        }
+
+        try
+        {
+            do
+            {
+                _refreshPending = false;
+                await RefreshCycleAsync(ct);
+            } while (_refreshPending && !ct.IsCancellationRequested);
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _refreshRunning, 0);
+        }
+    }
+
+    private async Task RefreshCycleAsync(CancellationToken ct)
+    {
         // _sendLock is acquired inside SendMessageAsync, so each individual UPDATE is atomic on the
         // wire. _advertisedPrefixesLock serializes the (withdraw + re-announce) pair against the
         // initial-send, which mutates the same list concurrently. We do NOT hold _sendLock across
         // the whole pair: a HoldTimer expiry or peer NOTIFICATION that arrives between them would
         // otherwise deadlock waiting for the refresh to finish before it can send Cease/HoldTimerExpired.
-        // The token (default: the session's own _cts) bounds how long a management-API caller
-        // (RefreshPeerAsync) blocks here — a prior send stuck on a slow peer previously pinned the
-        // HTTP request thread indefinitely (#160).
+        // The token (normalized to the session's own _cts by RefreshRoutesAsync) bounds how long a
+        // management-API caller (RefreshPeerAsync) blocks here — a prior send stuck on a slow peer
+        // previously pinned the HTTP request thread indefinitely (#160).
         try
         {
             await _advertisedPrefixesLock.WaitAsync(ct);
@@ -415,6 +453,11 @@ public sealed class BgpSession : IDisposable
     // Guards mutations of _advertisedPrefixes so initial-send and RefreshRoutesAsync can't interleave.
     // SemaphoreSlim instead of lock{} so it composes correctly with await.
     private readonly SemaphoreSlim _advertisedPrefixesLock = new(1, 1);
+
+    // #254 refresh debounce: 0 = idle, 1 = a refresh cycle is executing; late requesters set
+    // _refreshPending and the running cycle performs one coalesced extra lap for them.
+    private int _refreshRunning;
+    private volatile bool _refreshPending;
 
     private async Task RunEstablishedAsync(CancellationToken cancellationToken)
     {

--- a/BGPLite.Tests/RefreshDebounceTests.cs
+++ b/BGPLite.Tests/RefreshDebounceTests.cs
@@ -1,0 +1,200 @@
+using System.Net;
+using System.Net.Sockets;
+using BGPLite.Contracts;
+using BGPLite.Configuration;
+using BGPLite.Providers;
+using BGPLite.Protocol;
+using BGPLite.Routing;
+using BGPLite.Server;
+using Microsoft.Extensions.Logging;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #254: RefreshRoutesAsync must (a) treat a default CancellationToken as the session token —
+/// default(CancellationToken) is CancellationToken.None, NOT _cts.Token as the old comment claimed —
+/// so token-less callers (management API, onSourceChanged) get their refresh cancelled at teardown;
+/// and (b) coalesce stacked refresh triggers into one in-flight cycle plus at most one pending lap,
+/// instead of N sequential full withdraw+re-announce dumps.
+/// </summary>
+public class RefreshDebounceTests
+{
+    private sealed class GatedCountingStore : IPeerStore
+    {
+        public volatile bool Armed;
+        public int LoadCalls;
+        public readonly ManualResetEventSlim Release = new(false);
+
+        public string CreatePeer(string ip, uint asn, string? description) => "peer";
+        public void UpsertPeer(string ip, uint asn) { }
+        public void UpdateSessionStatus(string ip, uint asn, bool active) { }
+        public void DeletePeer(string id) { }
+        public PeerInfo? GetPeerByIp(string ip) => null;
+        public PeerInfo? GetPeer(string ip, uint asn) => null;
+        public PeerInfo? GetPeerById(string id) => null;
+        public List<string> GetSubscriptions(string peerId) => [];
+        public List<string> GetCustomPrefixes(string peerId) => [];
+        public List<uint> GetCustomAsns(string peerId) => [];
+        public HashSet<uint> GetCommunities(string peerId) => [];
+        public HashSet<uint> GetCommunities(string ip, uint asn) => [];
+        public void SetCommunities(string peerId, HashSet<uint> communities) { }
+        public void ClearCommunities(string peerId) { }
+        public void SetDescription(string id, string description) { }
+
+        public PeerRoutingView? LoadPeerRoutingView(string ip, uint asn)
+        {
+            LoadCalls++;
+            if (Armed)
+                Release.Wait(); // block the refresh cycle mid-flight (sync contract)
+            return new PeerRoutingView("peer", [], [], [], []);
+        }
+    }
+
+    private static async Task<Task> EstablishAsync(BgpSession session, Socket client, BgpConfig cfg)
+    {
+        var runTask = Task.Run(() => session.RunAsync(CancellationToken.None));
+        var open = new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = 0,
+            RouterId = 0x7F000002,
+            Capabilities = [BgpCapabilityInfo.FourOctetAsn(65002)]
+        };
+        var openBuf = new byte[BgpMessageWriter.GetBufferSize(open)];
+        var openLen = BgpMessageWriter.WriteMessage(open, openBuf);
+        client.Send(openBuf, 0, openLen, SocketFlags.None);
+
+        using var hsCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var header = new byte[BgpConstants.MessageHeaderSize];
+        await ReadExactAsync(client, header, hsCts.Token); // session OPEN
+        Assert.Equal(BgpMessageType.Open, (BgpMessageType)header[18]);
+        var replyLen = BgpMessageReader.GetMessageLength(header);
+        if (openLen > BgpConstants.MessageHeaderSize)
+            await ReadExactAsync(client, new byte[replyLen - BgpConstants.MessageHeaderSize], hsCts.Token);
+        await ReadExactAsync(client, header, hsCts.Token); // session KEEPALIVE
+        Assert.Equal(BgpMessageType.Keepalive, (BgpMessageType)header[18]);
+
+        var ka = new byte[BgpMessageWriter.GetBufferSize(BgpKeepaliveMessage.Instance)];
+        BgpMessageWriter.WriteMessage(BgpKeepaliveMessage.Instance, ka);
+        client.Send(ka, 0, ka.Length, SocketFlags.None);
+
+        using var estCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        while (!session.IsEstablished && !estCts.IsCancellationRequested)
+            await Task.Delay(20, estCts.Token);
+        Assert.True(session.IsEstablished);
+        return runTask;
+    }
+
+    private static async Task ReadExactAsync(Socket s, byte[] buf, CancellationToken ct)
+    {
+        var total = 0;
+        while (total < buf.Length)
+        {
+            var n = await s.ReceiveAsync(buf.AsMemory(total), ct);
+            if (n == 0) throw new IOException("closed");
+            total += n;
+        }
+    }
+
+    private static (Socket server, Socket client) ConnectedPair()
+    {
+        using var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        listener.Listen(1);
+        var client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        client.Connect(listener.LocalEndPoint!);
+        return (listener.Accept(), client);
+    }
+
+    private sealed class EmptyPrefixService : IPrefixService
+    {
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default) => Task.FromResult(new List<(uint, byte, uint)>());
+        public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
+        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default) => Task.FromResult(new List<(uint, byte, uint)>());
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private sealed class NopLogger<T> : ILogger<T>
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => false;
+        public void Log<TState>(LogLevel l, EventId e, TState s, Exception? x, Func<TState, Exception?, string> f) { }
+    }
+
+    private static async Task<(BgpSession session, GatedCountingStore store, Socket client, Socket server)> NewEstablishedSessionAsync()
+    {
+        var (server, client) = ConnectedPair();
+        var store = new GatedCountingStore();
+        var cfg = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
+        var session = new BgpSession(
+            new SocketBgpConnection(server),
+            new PeerConfig { Address = "127.0.0.1" },
+            cfg,
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            new NopLogger<BgpSession>(),
+            peerStore: store,
+            prefixService: new EmptyPrefixService(),
+            appConfig: new AppConfig());
+        _ = await EstablishAsync(session, client, cfg);
+        return (session, store, client, server);
+    }
+
+    [Fact]
+    public async Task ConcurrentRefreshes_CoalesceIntoOneCyclePlusOneLap()
+    {
+        var (session, store, client, server) = await NewEstablishedSessionAsync();
+        using var clientSock = client;
+        using var serverSock = server;
+        using var sessionH = session;
+
+        var baseline = store.LoadCalls; // initial dump already ran during establishment
+        store.Armed = true;
+
+        try
+        {
+            // Task.Run is essential: until the gated Load the refresh chain has no incomplete
+            // await (locks free, loopback writes complete synchronously), so running it on the
+            // test thread would self-deadlock inside the gate before anyone can release it.
+            var tasks = Enumerable.Range(0, 5)
+                .Select(_ => Task.Run(() => session.RefreshRoutesAsync(), CancellationToken.None))
+                .ToArray();
+            await Task.Delay(500); // let the runner block inside the gated Load and the rest coalesce
+
+            Assert.Equal(baseline + 1, Volatile.Read(ref store.LoadCalls)); // exactly ONE in-flight cycle
+
+            store.Armed = false;
+            store.Release.Set();
+            await Task.WhenAll(tasks).WaitAsync(TimeSpan.FromSeconds(10));
+
+            var total = Volatile.Read(ref store.LoadCalls) - baseline;
+            Assert.InRange(total, 1, 2); // one in-flight + at most one coalesced lap — never 5
+        }
+        finally
+        {
+            store.Armed = false;
+            store.Release.Set(); // never leak a blocked pool thread on an assertion failure
+        }
+    }
+
+    [Fact]
+    public async Task DefaultToken_IsSessionToken_DisposedSessionCancelsRefresh()
+    {
+        var (session, store, client, server) = await NewEstablishedSessionAsync();
+        using var clientSock = client;
+        using var serverSock = server;
+
+        var baseline = Volatile.Read(ref store.LoadCalls);
+        session.Dispose(); // cancels the session _cts
+
+        // Token-less call: with the #254 normalization this observes the cancelled session token
+        // and no-ops instead of running a full cycle against a disposed session.
+        await session.RefreshRoutesAsync().WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(baseline, Volatile.Read(ref store.LoadCalls));
+    }
+}


### PR DESCRIPTION
Closes #254

## Problem
`RefreshRoutesAsync(CancellationToken ct = default)` treated `default` as "the session's own _cts" (per the comment) — but `default(CancellationToken)` is `CancellationToken.None`. All token-less callers (management API `RefreshPeerAsync`/`RefreshAllEstablishedAsync`, `onSourceChanged`) queued non-cancellable full withdraw+re-announce cycles that outlived the session, and N stacked triggers produced N sequential dumps.

## Fix
- `ct == default` → session token (guarded: a disposed CTS means a disposed session → return).
- Debounce: one runner cycle at a time; concurrent requesters set a pending flag and return; the runner's do/while performs a single coalesced extra lap. Wire worst case: in-flight + one lap. Cycle body moved verbatim into `RefreshCycleAsync`.

## Verification
- `dotnet test` — 599 passed, 0 failed. New tests on a live established session with a gated counting `IPeerStore`: 5 concurrent refreshes → exactly 1 in-flight cycle (asserted mid-flight) + 1 coalesced lap (final count in [1..2]); token-less refresh on a disposed session no-ops. 4× repeat runs stable.
- Found and documented a test-design deadlock along the way: the refresh chain has no incomplete await before the store gate, so it must be Task.Run'd off the test thread (comment in the test).