### PR TITLE
fix(protocol): bound the UPDATE withdrawn-routes section — a 23-byte frame no longer kills the session

### DIFF
--- a/BGPLite.Protocol/BgpMessageReader.cs
+++ b/BGPLite.Protocol/BgpMessageReader.cs
@@ -170,11 +170,27 @@ public static class BgpMessageReader
             var withdrawnEnd = offset + withdrawnLen;
             while (offset < withdrawnEnd)
             {
-                var (prefix, consumed) = PrefixCodec.Decode(payload[offset..]);
+                // Slice to the declared end of the withdrawn-routes section (not payload end), the
+                // same rule the attribute loop below already follows (#245). Decoding against the
+                // payload let a prefix whose declared value crosses withdrawnEnd consume the bytes
+                // of the next field: either desyncing every subsequent field (a prefix the peer
+                // never withdrew was reported as withdrawn) or, when the overrun reached the end of
+                // the payload, throwing ArgumentOutOfRangeException out of the codec — which is not
+                // a BgpParseException, so ReadLoopAsync's treat-as-withdraw filter never saw it and
+                // a 23-byte UPDATE tore down the session (#284, same failure mode as #222).
+                var (prefix, consumed) = PrefixCodec.Decode(payload[offset..withdrawnEnd]);
                 withdrawn.Add(prefix);
                 offset += consumed;
             }
         }
+
+        // The withdrawn-routes section may end exactly at the payload end, leaving no room for the
+        // Total Path Attribute Length field. The `payload.Length < 4` guard above only covers an
+        // UPDATE with no withdrawn routes, so bounds-check here as well (#284).
+        if (offset + 2 > payload.Length)
+            throw new BgpParseException(
+                $"UPDATE truncated before Total Path Attribute Length: have {payload.Length - offset} bytes at offset {offset}, need 2",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList);
 
         var attrsLen = BinaryPrimitives.ReadUInt16BigEndian(payload[offset..]);
         offset += 2;

--- a/BGPLite.Tests/MalformedUpdateResilienceTests.cs
+++ b/BGPLite.Tests/MalformedUpdateResilienceTests.cs
@@ -80,6 +80,86 @@ public class MalformedUpdateResilienceTests
         Assert.Equal(BgpConstants.SubError.MalformedAttributeList, ex.SubErrorCode);
     }
 
+    [Theory]
+    // withdrawn-routes section ends exactly at the payload end, so the 2 bytes the sender meant as
+    // the Total Path Attribute Length were consumed as prefix data.
+    [InlineData(new byte[] { 0x00, 0x02, 0x08, 0x0A }, BgpConstants.SubError.MalformedAttributeList)]
+    // a /24 inside a 2-byte section: the declared 3 value bytes cross withdrawnEnd.
+    [InlineData(new byte[] { 0x00, 0x02, 0x18, 0x0A, 0x00, 0x00 }, BgpConstants.SubError.InvalidNetworkField)]
+    // a /32 inside a 2-byte section, with a well-formed attribute section behind it: previously
+    // parsed as "withdraw 10.0.0.1/32" — a prefix the peer never sent — with no error at all.
+    [InlineData(new byte[] { 0x00, 0x02, 0x20, 0x0A, 0x00, 0x00, 0x01, 0x00, 0x04, 0x40, 0x01, 0x01, 0x00 }, BgpConstants.SubError.InvalidNetworkField)]
+    // a 1-byte withdrawn section leaves a single byte where the attribute-length field must be.
+    [InlineData(new byte[] { 0x00, 0x01, 0x00, 0x00 }, BgpConstants.SubError.MalformedAttributeList)]
+    public void ParseUpdate_WithdrawnSectionOverrun_ThrowsBgpParseException_NotAOORE(byte[] payload, byte expectedSubError)
+    {
+        // #284: the withdrawn-routes loop decoded against the payload end instead of the declared
+        // end of its own section, and nothing bounds-checked the Total Path Attribute Length read.
+        // Both escaped as ArgumentOutOfRangeException — not a BgpParseException, so ReadLoopAsync's
+        // treat-as-withdraw filter never caught them and the session was torn down (cf. #222).
+        var ex = Assert.Throws<BgpParseException>(
+            () => BgpMessageReader.ReadMessage(BuildMessage(BgpMessageType.Update, payload)));
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(expectedSubError, ex.SubErrorCode);
+    }
+
+    [Fact]
+    public void ParseUpdate_WithdrawnSectionExactlyConsumed_StillParses()
+    {
+        // Guard the fix from over-rejecting: a well-formed withdrawn section that ends exactly on
+        // its declared boundary must keep parsing (this is the shape the overrun cases mimic).
+        var payload = new byte[] { 0x00, 0x02, 0x08, 0x0A, 0x00, 0x00 };
+
+        var update = Assert.IsType<BgpUpdateMessage>(
+            BgpMessageReader.ReadMessage(BuildMessage(BgpMessageType.Update, payload)));
+
+        var prefix = Assert.Single(update.WithdrawnRoutes);
+        Assert.Equal(0x0A000000u, prefix.Address);
+        Assert.Equal(8, prefix.Length);
+        Assert.Empty(update.PathAttributes);
+        Assert.Empty(update.Nlri);
+    }
+
+    [Fact]
+    public async Task WithdrawnSectionOverrun_OnWire_KeepsSessionEstablished()
+    {
+        // #284 end-to-end: the smallest frame that used to kill an Established session — a 23-byte
+        // UPDATE, the RFC minimum. It must now take the treat-as-withdraw path like any other
+        // malformed-body UPDATE (#222) and leave the session up.
+        var (server, client) = ConnectedPair();
+        using var clientSock = client;
+        var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
+        var metrics = new BgpMetrics();
+        using var session = new BgpSession(
+            new SocketBgpConnection(server),
+            new PeerConfig { Address = "127.0.0.1" },
+            bgpConfig,
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            metrics,
+            new NopLogger<BgpSession>());
+
+        var runTask = await EstablishSessionAsync(session, client, bgpConfig);
+
+        // withdrawn_len=2, then a /8 prefix that consumes both remaining bytes — the attribute
+        // length field is gone.
+        var malformedFrame = BuildMessage(BgpMessageType.Update, [0x00, 0x02, 0x08, 0x0A]);
+        Assert.Equal(BgpConstants.MinMessageSize + 4, malformedFrame.Length);
+        client.Send(malformedFrame, 0, malformedFrame.Length, SocketFlags.None);
+
+        for (var i = 0; i < 20 && metrics.UpdatesRejected == 0; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(50));
+
+        Assert.True(session.IsEstablished, "session must survive a truncated withdrawn-routes section (#284)");
+        Assert.True(metrics.UpdatesRejected >= 1, "the malformed UPDATE must be counted as rejected");
+
+        var sent = await DrainAsync(client, TimeSpan.FromSeconds(2));
+        Assert.DoesNotContain(sent, m => m is BgpNotificationMessage);
+
+        session.MarkSilentClose();
+        await runTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
     [Fact]
     public void ParseUpdate_AttributeValueCrossingAttrsEnd_Rejected()
     {


### PR DESCRIPTION
Closes #284

## Problem

`BgpMessageReader.ParseUpdate` had two missing guards in the withdrawn-routes section:

1. `PrefixCodec.Decode` was given the slice to the **payload** end, not to `withdrawnEnd`. A prefix whose declared value crosses the section boundary silently consumed the bytes of the next field. (The attribute loop directly below has sliced to `attrsEnd` since the #245 review; the withdrawn loop was never updated to match.)
2. Nothing bounds-checked the read of the Total Path Attribute Length. The `payload.Length < 4` guard at entry only covers an UPDATE with no withdrawn routes.

Both escape as `ArgumentOutOfRangeException`, which is **not** a `BgpParseException`, so `ReadLoopAsync`'s `catch (BgpParseException ex) when (ex.ErrorCode is not null)` treat-as-withdraw filter never saw them. The exception escaped the read loop and `RunAsync` tore the session down with a generic `Cease(6/0)`.

The RFC-minimum 23-byte UPDATE was enough, from any peer that completed a handshake (BGPLite auto-registers unknown peers by default):

```
FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF 0017 02 0002 08 0A
```

Same failure mode as #222, in the one section that fix did not cover.

## Fix

- Slice the withdrawn loop to `withdrawnEnd`. A crossing prefix now surfaces from `PrefixCodec.Decode` as Update Message Error / **Invalid Network Field (10)** — the Withdrawn Routes field is NLRI-formatted, so it gets the same subcode as the NLRI field (RFC 4271 §6.3).
- Bounds-check before reading Total Path Attribute Length → Update Message Error / **Malformed Attribute List (1)**, matching the adjacent "length exceeds payload" checks in the same method.

With the loop sliced to `withdrawnEnd`, `offset` lands exactly on `withdrawnEnd` after the loop, so the field boundaries can no longer drift.

No behavior change for well-formed UPDATEs.

## Verification

`dotnet build BGPLite.sln` + `dotnet test BGPLite.sln`: **606 passed, 0 failed** (600 before, 6 added). `dotnet format --severity warn` clean.

Codec level — the frames that previously escaped as AOORE:

| payload | before | after |
|---|---|---|
| `0002 08 0A` | `ArgumentOutOfRangeException` | `BgpParseException 3/1` |
| `0002 18 0A 0000` | `ArgumentOutOfRangeException` | `BgpParseException 3/10` |
| `0001 00 00` | `ArgumentOutOfRangeException` | `BgpParseException 3/1` |
| `0002 20 0A000001 0004 40 01 01 00` | silently parsed as `withdrawn=[10.0.0.1/32]` | `BgpParseException 3/10` |
| `0000 0000` (control) | OK, empty | OK, empty |
| `0002 08 0A 0000` (control) | OK, `withdrawn=[10.0.0.0/8]` | OK, `withdrawn=[10.0.0.0/8]` |

End-to-end against a live `BgpSession` over a loopback socket pair, both hold-time paths:

```
before:  holdTime=0   established_after=False  updatesRejected=0  wire=[NOTIFICATION(6/0)]
         holdTime=60  established_after=False  updatesRejected=0  wire=[NOTIFICATION(6/0)]

after:   holdTime=0   established_after=True   updatesRejected=1  wire=[]
         holdTime=60  established_after=True   updatesRejected=1  wire=[]
```

`updatesRejected` going 0 → 1 is the load-bearing part: the frame now reaches the treat-as-withdraw path instead of bypassing it, and no NOTIFICATION is emitted (RFC 7606 §2).

## Tests added

- `ParseUpdate_WithdrawnSectionOverrun_ThrowsBgpParseException_NotAOORE` — Theory over the four malformed payloads above, asserting the exact RFC subcode for each.
- `ParseUpdate_WithdrawnSectionExactlyConsumed_StillParses` — guards against over-rejecting: a well-formed section ending exactly on its declared boundary (the shape the overrun cases mimic) must still parse.
- `WithdrawnSectionOverrun_OnWire_KeepsSessionEstablished` — the end-to-end counterpart of the existing `MalformedUpdate_OnWire_KeepsSessionEstablished`, asserting the session stays Established, the UPDATE is counted rejected, and no NOTIFICATION goes on the wire.

## Note

This fixes the parse only. Two adjacent defects found in the same audit are deliberately **not** in scope here (one issue : one PR):

- #288 — treat-as-withdraw discards the UPDATE but never withdraws its NLRI (RFC 7606 §2).
- #289 — any peer can withdraw routes it never announced; no Adj-RIB-In.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed BGP UPDATE messages with truncated or oversized withdrawn-route sections.
  * Prevented parsing from reading beyond the declared withdrawn-routes data.
  * Added clear parse errors for messages missing required path-attribute length data.
  * Ensured malformed updates are rejected without disrupting established sessions or sending unnecessary notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->