### PR TITLE
fix(server): tear down on an aborted send instead of writing behind a truncated frame

### DIFF
--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -156,6 +156,19 @@ public sealed class BgpSession : IDisposable
             await SendAllRoutesAsync();
         }
         catch (OperationCanceledException) { /* shutdown / caller cancel — best effort */ }
+        catch (IOException ex)
+        {
+            // #285: the outbound byte stream is in an unknown state. A send either failed outright
+            // or was aborted by the per-send budget AFTER the kernel had accepted part of the frame,
+            // leaving the peer mid-frame. Swallowing this (the previous generic catch) kept the
+            // session Established on a stream where every later frame is read by the peer as the
+            // truncated frame's payload — silent route corruption with both sides reporting a
+            // healthy session. Tear down instead, matching HoldTimerLoopAsync's handling of a failed
+            // KEEPALIVE send. No NOTIFICATION is attempted: the peer is either not reading or the
+            // stream is already corrupt, so it would only block for another budget window.
+            _logger.LogWarning(ex, "Route refresh to {Peer} failed on the wire — tearing down the session", _peer);
+            FaultSession();
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to refresh routes for {Peer}", _peer);
@@ -166,6 +179,24 @@ public sealed class BgpSession : IDisposable
             catch (ObjectDisposedException) { /* session disposed — fine */ }
             catch (SemaphoreFullException) { /* double-release guard, shouldn't happen */ }
         }
+    }
+
+    /// <summary>
+    /// Tears the session down after an unrecoverable outbound failure (#285). Latches
+    /// <see cref="TeardownReason.LocalCease"/> so the <c>RunAsync</c> finally-block emits no
+    /// NOTIFICATION — RFC 4271 §8.1 allows exactly one per teardown, and here the right number is
+    /// zero because the wire is not usable — then cancels the session CTS so the read/keepalive
+    /// loops unwind promptly instead of waiting on the peer or the hold timer. Unlike
+    /// <see cref="HoldTimerLoopAsync"/>, which can simply return and let
+    /// <see cref="RunEstablishedAsync"/>'s <c>Task.WhenAny</c> cancel, a refresh runs off the
+    /// session's own loops (background ROUTE_REFRESH task or the management API), so the cancel
+    /// must be explicit.
+    /// </summary>
+    private void FaultSession()
+    {
+        Interlocked.CompareExchange(ref _teardownReason, (int)TeardownReason.LocalCease, (int)TeardownReason.None);
+        try { _cts.Cancel(); }
+        catch (ObjectDisposedException) { /* session already disposed — nothing to unwind */ }
     }
 
     private async Task WithdrawAllAsync()

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -1012,6 +1012,19 @@ public sealed class BgpSession : IDisposable
     // Returns true if the message was fully written; false if the send was cancelled (e.g. the
     // shutdown grace elapsed) or the session was disposed mid-send — callers that need accurate
     // teardown logging (NotifyCeaseAsync) branch on this instead of assuming success.
+    //
+    // INVARIANT (#285): every route-carrying send — WithdrawAllAsync, SendUpdateBatchAsync,
+    // SendEndOfRibAsync — and the OPEN/KEEPALIVE sends pass NO token, so `ct` is None for them and
+    // a per-send budget abort can only surface as IOException, which RefreshCycleAsync turns into a
+    // teardown. NotifyCeaseAsync is the ONLY caller that passes a real token (the host's shutdown
+    // grace), and there BgpServer.StopAsync disposes the session immediately afterwards.
+    //
+    // That matters because SocketBgpConnection latches its send-fault on a caller-cancelled write
+    // too: an aborted socket write is not rolled back regardless of which token fired. If a future
+    // caller threads a cancellable token into a route-carrying send, the `return false` below would
+    // let RefreshCycleAsync finish normally on a poisoned transport — the session would stay
+    // Established with the peer mid-frame. Thread a token here only together with a way for that
+    // failure to reach RefreshCycleAsync.
     private async Task<bool> SendMessageAsync(BgpMessage message, CancellationToken ct = default)
     {
         try

--- a/BGPLite.Server/SocketBgpConnection.cs
+++ b/BGPLite.Server/SocketBgpConnection.cs
@@ -15,6 +15,14 @@ namespace BGPLite.Server;
 /// budget itself with a linked CTS: when the budget fires the pending write is aborted and
 /// surfaced as <see cref="IOException"/> (dead connection), regardless of the caller's token.
 /// </para>
+/// <para>
+/// #285: aborting a write does NOT roll it back. A cancelled socket write delivers whatever the
+/// kernel already accepted and abandons the rest, so the peer's parse position is left inside a
+/// truncated BGP frame. Every write after that point is consumed by the peer as payload of that
+/// frame — permanent stream desync. The connection therefore latches a fault on the first aborted
+/// write and fails every subsequent <see cref="WriteAsync"/> fast, so no send path can append a
+/// well-formed frame behind a truncated one.
+/// </para>
 /// </summary>
 internal sealed class SocketBgpConnection : IBgpConnection
 {
@@ -26,6 +34,9 @@ internal sealed class SocketBgpConnection : IBgpConnection
     private readonly Socket _socket;
     private readonly NetworkStream _stream;
     private int _disposed; // 0 = not disposed, 1 = disposed. Atomic CAS (matches BgpSession.Dispose).
+    // 0 = the outbound stream is intact, 1 = a write was aborted and may have been partially
+    // delivered, so the frame boundary is lost and nothing more may be written (#285).
+    private int _sendFaulted;
 
     public SocketBgpConnection(Socket socket) : this(socket, DefaultSendTimeoutMs) { }
 
@@ -53,6 +64,14 @@ internal sealed class SocketBgpConnection : IBgpConnection
 
     public async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
     {
+        // #285: a previous write was aborted after the kernel had already accepted part of it, so
+        // the peer is mid-frame. Appending another frame does not recover the stream — the peer
+        // reads it as the truncated frame's payload. Fail fast so every send path (refresh,
+        // keepalive, the best-effort Cease in RunAsync's catch/finally) sees a dead connection
+        // instead of quietly making the corruption worse.
+        if (Volatile.Read(ref _sendFaulted) == 1)
+            throw new IOException("Connection is unusable — a previous send was aborted mid-frame");
+
         // #252: Socket.SendTimeout does not bound async writes — enforce the budget here so a
         // non-reading peer can never pin the send lock for minutes. The linked CTS also honors the
         // caller's token; distinguishing "budget fired" from "caller cancelled" keeps the benign
@@ -65,13 +84,18 @@ internal sealed class SocketBgpConnection : IBgpConnection
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            throw; // caller-initiated cancel — the send paths treat this as a normal cancelled send
+            // Caller-initiated cancel — the send paths treat this as a normal cancelled send, so
+            // the exception type is preserved. The stream is poisoned all the same: which token
+            // fired does not change that the socket write may have been partially delivered (#285).
+            Volatile.Write(ref _sendFaulted, 1);
+            throw;
         }
         catch (OperationCanceledException)
         {
             // The per-send budget fired: the peer is not reading. Aborting an in-flight socket
             // write leaves the connection unusable — surface it as the dead-connection exception
             // every send path already handles (same as a reset), not as a benign cancellation.
+            Volatile.Write(ref _sendFaulted, 1);
             throw new IOException($"Send timed out after {_sendTimeoutMs} ms — peer is not reading (TCP zero window)");
         }
     }

--- a/BGPLite.Tests/SendTimeoutTests.cs
+++ b/BGPLite.Tests/SendTimeoutTests.cs
@@ -1,7 +1,13 @@
 using System.Diagnostics;
+using System.Threading.Channels;
 using System.Net;
 using System.Net.Sockets;
+using BGPLite.Configuration;
+using BGPLite.Contracts;
+using BGPLite.Protocol;
+using BGPLite.Routing;
 using BGPLite.Server;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace BGPLite.Tests;
 
@@ -41,6 +47,39 @@ public class SendTimeoutTests
     }
 
     [Fact]
+    public async Task WriteAsync_AfterAbortedSend_FailsFastInsteadOfAppending()
+    {
+        // #285: aborting a write does not roll it back — the kernel keeps whatever it already
+        // accepted, so the peer is left mid-frame. A later write would be read by the peer as that
+        // truncated frame's payload, so the connection must refuse it instead.
+        using var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        listener.Listen(1);
+
+        using var client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        client.Connect(listener.LocalEndPoint!);
+        using var server = listener.Accept();
+        server.ReceiveBufferSize = 8 * 1024;
+        client.SendBufferSize = 8 * 1024;
+
+        using var connection = new SocketBgpConnection(client, sendTimeoutMs: 200);
+
+        await Assert.ThrowsAsync<IOException>(
+            () => connection.WriteAsync(new byte[8 * 1024 * 1024], CancellationToken.None).AsTask());
+
+        // The second write must fail immediately — not block for another budget window, and not
+        // reach the socket at all.
+        var sw = Stopwatch.StartNew();
+        var ex = await Assert.ThrowsAsync<IOException>(
+            () => connection.WriteAsync(new byte[19], CancellationToken.None).AsTask());
+        sw.Stop();
+
+        Assert.Contains("unusable", ex.Message);
+        Assert.True(sw.Elapsed < TimeSpan.FromMilliseconds(150),
+            $"a faulted connection must reject writes without touching the socket, took {sw.Elapsed}");
+    }
+
+    [Fact]
     public async Task WriteAsync_HonorsCallerCancellation_WithDifferentException()
     {
         using var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
@@ -60,5 +99,115 @@ public class SendTimeoutTests
         // contract of the send paths — not as the dead-connection IOException.
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
             () => connection.WriteAsync(new byte[8 * 1024 * 1024], cts.Token).AsTask());
+    }
+
+    [Fact]
+    public async Task RefreshRoutes_SendFailure_TearsDownTheSession()
+    {
+        // #285: RefreshCycleAsync used to swallow the send IOException in its generic
+        // catch (Exception) and leave the session Established. After a budget abort the peer sits
+        // inside a truncated frame (see WriteAsync_AfterAbortedSend_FailsFastInsteadOfAppending),
+        // so every later frame is read as that frame's payload — silent route corruption with both
+        // sides reporting a healthy session.
+        //
+        // The failure is injected through the IBgpConnection seam rather than by stalling a real
+        // peer: kernel socket buffers are auto-tuned (macOS loopback absorbed a 50 000-route dump
+        // whole despite SO_RCVBUF=8K), so a socket-driven version of this test asserts on the
+        // host's buffering, not on the session's behaviour. The transport half — that an aborted
+        // write raises IOException and poisons the connection — is covered by the two
+        // SocketBgpConnection tests above.
+        var connection = new FailableConnection();
+        var routeTable = new RouteTable();
+        var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
+        using var session = new BgpSession(
+            connection,
+            new PeerConfig { Address = "127.0.0.1" },
+            bgpConfig,
+            routeTable,
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            NullLogger<BgpSession>.Instance);
+
+        var runTask = session.RunAsync();
+        connection.EnqueueMessage(new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = 0,
+            RouterId = 0x0A000002,
+            Capabilities = [BgpCapabilityInfo.FourOctetAsn(65002)]
+        });
+        connection.EnqueueMessage(BgpKeepaliveMessage.Instance);
+
+        for (var i = 0; i < 200 && !session.IsEstablished; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        Assert.True(session.IsEstablished, "session must reach Established before the refresh");
+
+        routeTable.AddOrUpdate(new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 0x7F000001 });
+        connection.FailNextWrites = true;
+
+        await session.RefreshRoutesAsync();
+
+        // FaultSession cancels the session CTS; RunAsync unwinds its loops and transitions to Idle
+        // on another task, so allow a bounded window rather than asserting on the instant
+        // RefreshRoutesAsync returns.
+        for (var i = 0; i < 200 && session.IsEstablished; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+
+        Assert.False(session.IsEstablished,
+            "a refresh whose send failed must tear the session down, not leave it Established (#285)");
+
+        try { await runTask.WaitAsync(TimeSpan.FromSeconds(10)); }
+        catch (OperationCanceledException) { /* session torn down */ }
+    }
+
+    /// <summary>
+    /// An <see cref="IBgpConnection"/> that scripts inbound messages and can be switched to fail
+    /// every subsequent write with <see cref="IOException"/> — the exception
+    /// <see cref="SocketBgpConnection.WriteAsync"/> raises when the per-send budget aborts a write.
+    /// </summary>
+    private sealed class FailableConnection : IBgpConnection
+    {
+        private readonly Channel<byte[]> _inbound = Channel.CreateUnbounded<byte[]>();
+        private readonly Queue<byte> _readBuffer = new();
+
+        public volatile bool FailNextWrites;
+
+        public void EnqueueMessage(BgpMessage message)
+        {
+            var buf = new byte[BgpMessageWriter.GetBufferSize(message)];
+            var n = BgpMessageWriter.WriteMessage(message, buf);
+            _inbound.Writer.TryWrite(buf[..n]);
+        }
+
+        public async ValueTask ReadExactAsync(Memory<byte> buffer, CancellationToken cancellationToken)
+        {
+            var offset = 0;
+            while (offset < buffer.Length)
+            {
+                while (_readBuffer.Count > 0 && offset < buffer.Length)
+                    buffer.Span[offset++] = _readBuffer.Dequeue();
+                if (offset >= buffer.Length) break;
+
+                byte[] chunk;
+                try { chunk = await _inbound.Reader.ReadAsync(cancellationToken); }
+                catch (ChannelClosedException) { throw new IOException("Connection closed by peer"); }
+
+                var toCopy = Math.Min(chunk.Length, buffer.Length - offset);
+                for (var i = 0; i < toCopy; i++) buffer.Span[offset++] = chunk[i];
+                for (var i = toCopy; i < chunk.Length; i++) _readBuffer.Enqueue(chunk[i]);
+            }
+        }
+
+        public ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+        {
+            if (FailNextWrites)
+                throw new IOException("Send timed out — peer is not reading (TCP zero window)");
+            return default;
+        }
+
+        public bool IsPeerClosed => false;
+
+        public void Dispose() => _inbound.Writer.TryComplete();
     }
 }


### PR DESCRIPTION
Closes #285

## Problem

Aborting a write does not roll it back. When the per-send budget in `SocketBgpConnection.WriteAsync` (#252/#279) fires, `NetworkStream.WriteAsync` delivers whatever the kernel already accepted and abandons the rest, so the peer's parse position is left inside a truncated BGP frame.

`BgpSession.RefreshCycleAsync` then caught the resulting `IOException` in its generic `catch (Exception ex)`, logged it, and left the session **Established**. Every frame written afterwards is consumed by the peer as that truncated frame's payload — permanent stream desync on a session both sides report as healthy, with no route-level error logged anywhere.

The transport's own XML doc already stated the invariant that was being violated — *"Aborting an in-flight socket write leaves the connection unusable"* — but nothing acted on it. `HoldTimerLoopAsync` already handles a failed KEEPALIVE send correctly (latch teardown + return); the refresh path did not.

## Fix

Two halves, because the hazard has two halves.

**Transport — stop the corruption at its source.** `SocketBgpConnection` latches a fault on the first aborted write and fails every later `WriteAsync` fast. This covers *all* send paths at once rather than patching each caller — including the best-effort `Cease` in `RunAsync`'s `catch (IOException)` / `finally`, which would otherwise append a NOTIFICATION frame directly behind the truncated one.

The fault is latched for a caller-initiated cancel too. Which token fired does not change that the socket write may have been partially delivered; the `OperationCanceledException` type is still preserved so the benign-cancel contract of the send paths is unchanged. In practice that path is only the shutdown `Cease` under the host grace token, where the session is being disposed anyway.

**Session — stop surviving it.** `RefreshCycleAsync` catches `IOException` ahead of the generic handler and calls a new `FaultSession()`, which latches `LocalCease` (so the `RunAsync` finally-block emits no NOTIFICATION — RFC 4271 §8.1 allows exactly one per teardown, and here the right number is zero because the wire is unusable) and cancels the session CTS.

The explicit cancel is needed because a refresh runs *off* the session's own loops — a background ROUTE_REFRESH task (#253) or the management API — so unlike `HoldTimerLoopAsync` it cannot just return and let `RunEstablishedAsync`'s `Task.WhenAny` unwind things.

`IOException` is the right scope: every prefix-fetch call inside `RouteAssembler.BuildOutboundRoutesAsync` is already individually try/caught, so an `IOException` reaching this handler comes from the send path.

## Behavior change

A refresh that cannot complete a frame now **ends the session** instead of logging and continuing. That is the point — the alternative is serving a peer over a stream neither side can parse. Peers reconnect and get a clean dump.

## Verification

`dotnet build BGPLite.sln` + `dotnet test BGPLite.sln`: **602 passed, 0 failed** (600 before, 2 added). `dotnet format --severity warn` clean.

The regression test was confirmed to actually catch the regression — with the `catch (IOException)` block removed it fails, with it restored it passes:

```
IOException catch temporarily removed
  Failed BGPLite.Tests.SendTimeoutTests.RefreshRoutes_SendFailure_TearsDownTheSession [2 s]
--- fix restored ---
  Passed!  - Failed: 0, Passed: 1
```

Measurements behind the diagnosis (socket pair, 512-byte buffers, 4 MiB payload, 300 ms budget):

```
attempt 1: cancelled=True  bytes_delivered_to_peer=24576 of 4194304   <-- PARTIAL
attempt 2/3: identical
```

End to end through `BgpSession` before the fix (60 000 routes, peer stops reading, 400 ms budget):

```
RefreshRoutesAsync returned after 8178 ms
session still Established = True
peer received 331061 bytes = 611 well-formed frames + 512 trailing bytes of a truncated frame
```

## Tests added

- `WriteAsync_AfterAbortedSend_FailsFastInsteadOfAppending` — real socket pair: after a budget abort, the next `WriteAsync` throws immediately (<150 ms, i.e. without touching the socket or waiting another budget window).
- `RefreshRoutes_SendFailure_TearsDownTheSession` — drives a full session through the `IBgpConnection` seam and asserts it leaves Established when a refresh send fails.

### Note on the second test

I first wrote it against a real stalled socket, matching the existing tests in this file. It does not work: kernel socket buffers are auto-tuned and macOS loopback absorbed a **50 000-route dump whole** despite `SO_RCVBUF = 8K` (`DIAG RefreshRoutesAsync took 1778 ms; state=Established; advertised=50000`) — the budget never fired, so the test was asserting on the host's buffering rather than on the session's behaviour, and would be flaky across CI runners.

The failure is now injected through the `IBgpConnection` seam (#96) instead. The transport half — that an aborted write raises `IOException` and poisons the connection — is covered by the two `SocketBgpConnection` tests against real sockets. Deterministic, and 655 ms instead of 7 s.

## Note

This does not change *whether* the budget aborts the write. Ending a partially-written frame without corrupting the stream would need `Socket.Shutdown(SocketShutdown.Send)` / dispose rather than a cancel; the fail-fast latch makes the current behaviour safe, and the stronger change is worth its own issue if the 60 s budget ever proves too eager.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sessions now automatically tear down when route-refresh messages fail to send.
  * Prevented further data from being sent after an interrupted write, avoiding corrupted communication.
  * Improved handling of aborted or timed-out network sends to fail quickly and safely.

* **Tests**
  * Added coverage for failed sends and proper session shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->