### PR TITLE
fix(server): run the hold timer in OpenConfirm — a silent peer no longer pins a session

### DIFF
--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -73,6 +73,12 @@ public sealed class BgpSession : IDisposable
     // DoS where a peer spams type-5 and forces a full re-advertise. Initial 0 = never refreshed.
     // Read/written via Interlocked so RefreshRoutesAsync and ReadLoopAsync can't race.
     private long _lastRouteRefreshTicks;
+    // OpenConfirm bound when the negotiated hold time is 0 (#286). RFC 4271 §4.2 disables the Hold
+    // Timer at 0, but §8.2.2 also gives OpenSent a "large value" initial Hold Time with a suggested
+    // 4 minutes — a handshake that never completes is not the same thing as an established session
+    // that deliberately runs without timers, and leaving it unbounded is the resource hole this
+    // constant closes. The Established phase still honors hold time 0 as "no timer".
+    private static readonly TimeSpan OpenConfirmFallbackHoldTime = TimeSpan.FromMinutes(4);
     // Minimum gap between peer-triggered route refreshes. 1s is a reasonable default:
     // long enough to make flood-DoS impractical, short enough that a legitimate peer retry
     // after a lost UPDATE still gets a fresh advertisement promptly.
@@ -307,8 +313,44 @@ public sealed class BgpSession : IDisposable
 
             TransitionTo(BgpFsmState.OpenConfirm);
 
-            // Receive KEEPALIVE
-            var response = await ReceiveMessageAsync(linkedCts.Token);
+            // Receive KEEPALIVE, bounded by the OpenConfirm hold timer (#286). RFC 4271 §8.2.2 runs
+            // the Hold Timer in OpenSent/OpenConfirm as well, with the negotiated value once the
+            // OPEN exchange has happened. Without it this read was unbounded: #115's
+            // OpenTimeoutSeconds only covers the read that RECEIVES the OPEN, and the keepalive/hold
+            // loop does not start until RunEstablishedAsync — so a peer that sent a well-formed OPEN
+            // and then went silent pinned a session, a socket FD and a task indefinitely, walking
+            // straight past the Slowloris defence (it is not slow; it completes the OPEN and stops).
+            var confirmHoldTime = _negotiatedHoldTime > 0
+                ? TimeSpan.FromSeconds(_negotiatedHoldTime)
+                : OpenConfirmFallbackHoldTime;
+
+            BgpMessage response;
+            using (var confirmTimeoutCts = new CancellationTokenSource(confirmHoldTime, _timeProvider))
+            using (var confirmCts = CancellationTokenSource.CreateLinkedTokenSource(linkedCts.Token, confirmTimeoutCts.Token))
+            {
+                try
+                {
+                    response = await ReceiveMessageAsync(confirmCts.Token);
+                }
+                catch (OperationCanceledException) when (!linkedCts.IsCancellationRequested)
+                {
+                    // Only the OpenConfirm hold timer fired (the external/session token is still
+                    // alive). RFC 4271 §8.2.2, OpenConfirm + HoldTimer_Expires: send a NOTIFICATION
+                    // with Hold Timer Expired, release resources, go to Idle. Unlike the OPEN
+                    // timeout above we DO notify — the peer completed the OPEN exchange, so it is
+                    // reading the socket and the diagnostic reaches its operator.
+                    _logger.LogWarning(
+                        "Hold timer expired for {Peer} in OpenConfirm (no KEEPALIVE within {Hold}s) — closing (#286)",
+                        _peer, confirmHoldTime.TotalSeconds);
+                    if (Interlocked.CompareExchange(ref _teardownReason, (int)TeardownReason.HoldTimerExpired, (int)TeardownReason.None) == (int)TeardownReason.None)
+                    {
+                        try { await SendNotificationAsync(BgpConstants.Error.HoldTimerExpired, BgpConstants.SubError.Unspecific); }
+                        catch { /* best-effort — partial write counts, see RFC 4271 §8.1 */ }
+                    }
+                    return;
+                }
+            }
+
             _logger.LogInformation("Received {Type} from {Peer} in OpenConfirm", response.Type, _peer);
 
             switch (response)

--- a/BGPLite.Tests/BgpSessionHoldTimerTests.cs
+++ b/BGPLite.Tests/BgpSessionHoldTimerTests.cs
@@ -233,6 +233,133 @@ public class BgpSessionHoldTimerTests
     }
 
     /// <summary>
+    /// #286: a peer that sends a well-formed OPEN and then goes silent must NOT pin the session.
+    /// OpenTimeoutSeconds (#115) bounds only the read that receives the OPEN; the KEEPALIVE read
+    /// that follows was unbounded, and the keepalive/hold loop does not start until
+    /// RunEstablishedAsync — so the session sat in OpenConfirm forever, holding a socket FD and a
+    /// task. RFC 4271 §8.2.2 runs the Hold Timer in OpenConfirm; on expiry it must send
+    /// NOTIFICATION(Hold Timer Expired) and go to Idle.
+    /// </summary>
+    [Fact]
+    public async Task OpenConfirm_PeerNeverSendsKeepalive_TearsDownOnHoldTimer()
+    {
+        var time = new FakeTimeProvider();
+        var conn = new FakeBgpConnection();
+        var bgpConfig = new BgpConfig
+        {
+            Asn = 65001,
+            RouterId = "127.0.0.1",
+            HoldTime = 9,
+            KeepAlive = 3,
+            OpenTimeoutSeconds = 30, // deliberately longer than HoldTime: it must not be what saves us
+        };
+        using var session = new BgpSession(
+            conn,
+            new PeerConfig { Address = "127.0.0.1" },
+            bgpConfig,
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            new NopLogger<BgpSession>(),
+            timeProvider: time);
+
+        var runTask = Task.Run(() => session.RunAsync(CancellationToken.None));
+
+        // The peer sends a valid OPEN...
+        conn.Enqueue(Serialize(new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = (ushort)bgpConfig.HoldTime,
+            RouterId = 0x7F000002,
+            Capabilities = [BgpCapabilityInfo.FourOctetAsn(65002)]
+        }));
+
+        // ...the session answers with OPEN + KEEPALIVE and enters OpenConfirm...
+        for (var i = 0; i < 200 && session.State != BgpFsmState.OpenConfirm; i++)
+            await Task.Delay(5);
+        Assert.Equal(BgpFsmState.OpenConfirm, session.State);
+
+        // ...and then the peer never sends its KEEPALIVE. Advance past the negotiated hold time.
+        var sentBefore = conn.Sent.Count;
+        for (var i = 0; i < 20 && !runTask.IsCompleted; i++)
+        {
+            time.Advance(TimeSpan.FromSeconds(2));
+            await Task.Delay(5);
+        }
+
+        await runTask.WaitAsync(TimeSpan.FromSeconds(5)); // must not hang
+        Assert.Equal(BgpFsmState.Idle, session.State);
+
+        var notifs = conn.Sent.Skip(sentBefore)
+            .Select(b => BgpMessageReader.ReadMessage(b.AsSpan()))
+            .OfType<BgpNotificationMessage>()
+            .ToList();
+        var notif = Assert.Single(notifs);
+        Assert.Equal(BgpConstants.Error.HoldTimerExpired, notif.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.Unspecific, notif.SubErrorCode);
+    }
+
+    /// <summary>
+    /// #286, hold time 0: RFC 4271 §4.2 disables the Hold Timer at 0, but that is a rule for an
+    /// ESTABLISHED session. A handshake that never completes must still be bounded, so OpenConfirm
+    /// falls back to the §8.2.2 initial Hold Time (4 minutes) rather than waiting forever.
+    /// </summary>
+    [Fact]
+    public async Task OpenConfirm_HoldTimeZero_StillBoundedByFallback()
+    {
+        var time = new FakeTimeProvider();
+        var conn = new FakeBgpConnection();
+        var bgpConfig = new BgpConfig
+        {
+            Asn = 65001,
+            RouterId = "127.0.0.1",
+            HoldTime = 0,
+            KeepAlive = 0,
+            OpenTimeoutSeconds = 30,
+        };
+        using var session = new BgpSession(
+            conn,
+            new PeerConfig { Address = "127.0.0.1" },
+            bgpConfig,
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            new NopLogger<BgpSession>(),
+            timeProvider: time);
+
+        var runTask = Task.Run(() => session.RunAsync(CancellationToken.None));
+        conn.Enqueue(Serialize(new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = 0,
+            RouterId = 0x7F000002,
+            Capabilities = [BgpCapabilityInfo.FourOctetAsn(65002)]
+        }));
+
+        for (var i = 0; i < 200 && session.State != BgpFsmState.OpenConfirm; i++)
+            await Task.Delay(5);
+        Assert.Equal(BgpFsmState.OpenConfirm, session.State);
+
+        // Well inside the 4-minute fallback: still waiting, exactly as before this change.
+        time.Advance(TimeSpan.FromMinutes(3));
+        await Task.Delay(20);
+        Assert.False(runTask.IsCompleted, "must still be waiting inside the fallback window");
+        Assert.Equal(BgpFsmState.OpenConfirm, session.State);
+
+        // Past it: bounded.
+        for (var i = 0; i < 20 && !runTask.IsCompleted; i++)
+        {
+            time.Advance(TimeSpan.FromSeconds(30));
+            await Task.Delay(5);
+        }
+
+        await runTask.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(BgpFsmState.Idle, session.State);
+    }
+
+    /// <summary>
     /// Proof of concept: a peer that connects but never sends OPEN is dropped when the OPEN timeout
     /// fires — the timer CTS uses the TimeProvider, so the fake clock advances instantly instead of
     /// waiting wall-clock seconds. No real socket, no multi-second wait.


### PR DESCRIPTION
Closes #286

## Problem

`BgpConfig.OpenTimeoutSeconds` (#115) bounds only the **first** read — the one that receives the peer's OPEN. The KEEPALIVE read that follows it was unbounded:

```csharp
TransitionTo(BgpFsmState.OpenConfirm);
var response = await ReceiveMessageAsync(linkedCts.Token);   // no timer of any kind
```

`linkedCts` carries only the host shutdown token and the session's own `_cts`; neither fires on peer inactivity. `_negotiatedHoldTime` is assigned in `ValidateOpen`, but `HoldTimerLoopAsync` does not start until `RunEstablishedAsync` — i.e. after this read has already returned.

So a peer that sends a well-formed OPEN and then goes silent pins a `BgpSession`, a socket FD, a `NetworkStream` and a `Task` in `OpenConfirm` **forever**. Measured on `main` with `OpenTimeoutSeconds = 2`, `HoldTime = 3`:

```
after 20.0s: session state=OpenConfirm, RunAsync completed=False
-> UNBOUNDED: session + socket FD + task pinned in OpenConfirm forever
```

Both timers that should have fired are more than six windows past.

This walks straight past the #115 Slowloris defence — the attacker is not slow, it completes a legitimate OPEN exchange and stops. `MaxAcceptsPerIpPerMinute` (default 60) caps the accept *rate*, not the number of pinned sessions, so one source IP accumulates 60 per minute with no ceiling.

RFC 4271 §8.2.2 runs the Hold Timer in `OpenSent`/`OpenConfirm` as well; BGPLite ran no timer in either.

## Fix

Bound the KEEPALIVE read with the negotiated hold time, via a `CancellationTokenSource(TimeSpan, TimeProvider)` linked to `linkedCts` — the same pattern the OPEN timeout directly above already uses.

On expiry: `NOTIFICATION(Hold Timer Expired, 0)` and Idle, per RFC 4271 §8.2.2 (`OpenConfirm` + `HoldTimer_Expires`). Unlike the OPEN timeout — which deliberately drops the peer silently because a Slowloris socket would not read it — here we **do** notify: the peer completed the OPEN exchange, so it is reading the socket and the diagnostic reaches its operator.

The `when (!linkedCts.IsCancellationRequested)` filter distinguishes "the hold timer fired" from "we are shutting down", mirroring the OPEN-timeout handler.

### Hold time 0 — a deliberate deviation, flagged

RFC 4271 §4.2 disables the Hold Timer at 0. That is a rule for an **established** session; a handshake that never completes is not that, and leaving it unbounded would reopen exactly the hole this PR closes for any peer that proposes 0.

`OpenConfirm` therefore falls back to §8.2.2's initial Hold Time (suggested 4 minutes) when the negotiated value is 0. The Established phase still honors 0 as "no timer" — unchanged. A peer needing more than four minutes to send the KEEPALIVE that answers our own is not a case worth preserving.

No new config knob: the negotiated hold time is the RFC-correct source, and reusing `OpenTimeoutSeconds` (semantically "connect-to-OPEN") would be misleading.

## Verification

`dotnet build BGPLite.sln` + `dotnet test BGPLite.sln`: **602 passed, 0 failed** (600 before, 2 added). `dotnet format --severity warn` clean.

Both new tests were confirmed to catch the regression — with the bound removed they fail, with it restored they pass:

```
OpenConfirm bound temporarily removed
  Failed BgpSessionHoldTimerTests.OpenConfirm_HoldTimeZero_StillBoundedByFallback [5 s]
  Failed BgpSessionHoldTimerTests.OpenConfirm_PeerNeverSendsKeepalive_TearsDownOnHoldTimer [5 s]
--- restored ---
  Passed! - Failed: 0, Passed: 8
```

## Tests added

Both in `BgpSessionHoldTimerTests`, using the existing `FakeBgpConnection` + `FakeTimeProvider` seam (#96) — the timeout CTS is built on `_timeProvider`, so the clock advances instantly instead of waiting wall-clock minutes (248 ms for the whole file).

- `OpenConfirm_PeerNeverSendsKeepalive_TearsDownOnHoldTimer` — peer sends OPEN and nothing else; asserts `RunAsync` completes, state is `Idle`, and exactly one NOTIFICATION with `HoldTimerExpired`/`Unspecific` went out. `OpenTimeoutSeconds` is set to 30 — deliberately longer than `HoldTime` — so the test cannot pass by accident on the #115 timeout.
- `OpenConfirm_HoldTimeZero_StillBoundedByFallback` — asserts both halves of the fallback: still waiting at 3 minutes (behaviour unchanged inside the window), bounded past 4.

## Note

The companion gap — no cap on the number of concurrently active sessions — is a line item in #265 and is not addressed here (one issue : one PR). The two together are what actually bounds the FD budget: this PR stops a session being pinned forever, #265 would bound how many can exist at once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented BGP sessions from remaining indefinitely in the OpenConfirm phase when a peer does not send a KEEPALIVE.
  - Added a four-minute fallback timeout when the negotiated hold time is zero.
  - Sessions now close cleanly and report a hold-timer expiration when the timeout is reached.

- **Tests**
  - Added coverage for missing KEEPALIVE messages and zero hold-time fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->