### PR TITLE
fix(protocol): keep the first occurrence of a duplicated path attribute

### DIFF
--- a/BGPLite.Protocol/UpdateCodec.cs
+++ b/BGPLite.Protocol/UpdateCodec.cs
@@ -219,8 +219,24 @@ public static class UpdateCodec
             uint? aggregatorAsn = null;
             uint? as4AggregatorAsn = null;
 
+            // RFC 7606 §3 (revising RFC 4271 §6.3): "If any other attribute (whether recognized or
+            // unrecognized) appears more than once in an UPDATE message, then all the occurrences of
+            // the attribute other than the first one SHALL be discarded and the UPDATE message will
+            // continue to be processed." The switch below assigns unconditionally, so without this
+            // guard the LAST occurrence won — an UPDATE carrying two NEXT_HOPs installed the second
+            // one, so anything reading the first (a collector, a looking glass, an operator's packet
+            // capture) disagreed with what actually landed in the route table (#287).
+            //
+            // The MP_REACH_NLRI/MP_UNREACH_NLRI half of that paragraph — duplicate → NOTIFICATION,
+            // session reset — is deliberately not implemented: BGPLite is IPv4-unicast only and never
+            // parses those attributes. It belongs with MP-BGP support (#14).
+            Span<bool> seenTypes = stackalloc bool[256];
             foreach (var attr in update.PathAttributes)
             {
+                if (seenTypes[attr.TypeCode])
+                    continue;
+                seenTypes[attr.TypeCode] = true;
+
                 switch (attr.TypeCode)
                 {
                     case BgpConstants.Attribute.Origin:

--- a/BGPLite.Protocol/UpdateCodec.cs
+++ b/BGPLite.Protocol/UpdateCodec.cs
@@ -230,7 +230,15 @@ public static class UpdateCodec
             // The MP_REACH_NLRI/MP_UNREACH_NLRI half of that paragraph — duplicate → NOTIFICATION,
             // session reset — is deliberately not implemented: BGPLite is IPv4-unicast only and never
             // parses those attributes. It belongs with MP-BGP support (#14).
+            //
+            // Clear() is not redundant despite `localsinit` zeroing stackalloc by default: adding
+            // [SkipLocalsInit] (or <SkipLocalsInit> in the csproj) is an ordinary perf tweak for a
+            // codec like this one, and it would turn the guard below into garbage — random type
+            // codes reading as "already seen", so the FIRST occurrence of a mandatory attribute
+            // gets skipped and valid UPDATEs are withdrawn. 256 bytes of memset against a silent,
+            // traffic-dependent failure is not a trade worth making.
             Span<bool> seenTypes = stackalloc bool[256];
+            seenTypes.Clear();
             foreach (var attr in update.PathAttributes)
             {
                 if (seenTypes[attr.TypeCode])

--- a/BGPLite.Tests/BgpSessionRfc6793Tests.cs
+++ b/BGPLite.Tests/BgpSessionRfc6793Tests.cs
@@ -294,4 +294,131 @@ public class BgpSessionRfc6793Tests
 
         Assert.Equal([BgpConstants.Capability.FourOctetAsn, 2, 0x01, 0x02], UpdateCodec.GetMalformedFourOctetAsnCapabilityData(open));
     }
+
+    /// <summary>
+    /// RFC 7606 §3, which revises RFC 4271 §6.3: "If any other attribute (whether recognized or
+    /// unrecognized) appears more than once in an UPDATE message, then all the occurrences of the
+    /// attribute other than the first one SHALL be discarded and the UPDATE message will continue
+    /// to be processed." The switch in ParseRouteAttributes assigned unconditionally, so the LAST
+    /// occurrence won (#287).
+    /// </summary>
+    [Fact]
+    public void ParseRouteAttributes_DuplicateNextHop_FirstOccurrenceWins()
+    {
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+                AttributeHelper.WriteAsPath([65001u], fourByteAsn: true),
+                AttributeHelper.WriteNextHop(0xC0000201), // 192.0.2.1 — the one that must win
+                AttributeHelper.WriteNextHop(0x0A0A0A0A), // 10.10.10.10 — discarded
+            ],
+            Nlri = []
+        };
+
+        var attrs = UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: true);
+
+        Assert.Equal(0xC0000201u, attrs.NextHop);
+    }
+
+    [Fact]
+    public void ParseRouteAttributes_DuplicateAsPath_FirstOccurrenceWins()
+    {
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+                AttributeHelper.WriteAsPath([65001u], fourByteAsn: true),
+                AttributeHelper.WriteAsPath([64512u, 65002u], fourByteAsn: true), // discarded
+                AttributeHelper.WriteNextHop(0x0A000001),
+            ],
+            Nlri = []
+        };
+
+        var attrs = UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: true);
+
+        Assert.Equal([65001u], attrs.AsPath);
+    }
+
+    [Fact]
+    public void ParseRouteAttributes_DuplicateCommunity_FirstOccurrenceWins()
+    {
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+                AttributeHelper.WriteAsPath([65001u], fourByteAsn: true),
+                AttributeHelper.WriteNextHop(0x0A000001),
+                AttributeHelper.WriteCommunities([65000u, 100u]),
+                AttributeHelper.WriteCommunities([65000u, 999u]), // discarded
+            ],
+            Nlri = []
+        };
+
+        var attrs = UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: true);
+
+        Assert.Equal([65000u, 100u], attrs.Communities);
+    }
+
+    /// <summary>
+    /// A discarded duplicate must not be validated either — RFC 7606 §3 says the later occurrences
+    /// are discarded, not "discarded but still checked". A valid first ORIGIN followed by an invalid
+    /// second one is accepted; before #287 the second was read and threw Invalid ORIGIN (subcode 6).
+    /// </summary>
+    [Fact]
+    public void ParseRouteAttributes_DuplicateOrigin_SecondIsNotValidated()
+    {
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+                new PathAttribute
+                {
+                    Flags = BgpConstants.Attribute.FlagTransitive,
+                    TypeCode = BgpConstants.Attribute.Origin,
+                    Data = [7], // out of range (RFC 4271 §5.1.2 defines 0/1/2) — must be discarded
+                },
+                AttributeHelper.WriteAsPath([65001u], fourByteAsn: true),
+                AttributeHelper.WriteNextHop(0x0A000001),
+            ],
+            Nlri = []
+        };
+
+        var attrs = UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: true);
+
+        Assert.Equal(0x0A000001u, attrs.NextHop);
+    }
+
+    /// <summary>
+    /// The inverse guard: an invalid FIRST occurrence is still rejected. The duplicate rule must not
+    /// become a way to smuggle a malformed attribute past validation by prefixing a valid one.
+    /// </summary>
+    [Fact]
+    public void ParseRouteAttributes_InvalidFirstOrigin_StillRejected()
+    {
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                new PathAttribute
+                {
+                    Flags = BgpConstants.Attribute.FlagTransitive,
+                    TypeCode = BgpConstants.Attribute.Origin,
+                    Data = [7],
+                },
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+                AttributeHelper.WriteAsPath([65001u], fourByteAsn: true),
+                AttributeHelper.WriteNextHop(0x0A000001),
+            ],
+            Nlri = []
+        };
+
+        var ex = Assert.Throws<BgpNotificationException>(
+            () => UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: true));
+        Assert.Equal(BgpConstants.SubError.InvalidOriginAttribute, ex.SubErrorCode);
+    }
 }

--- a/BGPLite.Tests/MalformedUpdateResilienceTests.cs
+++ b/BGPLite.Tests/MalformedUpdateResilienceTests.cs
@@ -81,6 +81,57 @@ public class MalformedUpdateResilienceTests
     }
 
     [Fact]
+    public async Task DuplicateNextHop_OnWire_InstallsTheFirstOccurrence()
+    {
+        // #287 / RFC 7606 §3: a duplicated attribute is not an error — all occurrences after the
+        // first are discarded and the UPDATE is still processed. Before the fix the switch in
+        // ParseRouteAttributes assigned unconditionally, so the SECOND next hop landed in the route
+        // table while anything reading the first (collector, looking glass, packet capture) saw the
+        // other one.
+        var (server, client) = ConnectedPair();
+        using var clientSock = client;
+        var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
+        var metrics = new BgpMetrics();
+        var routeTable = new RouteTable();
+        using var session = new BgpSession(
+            new SocketBgpConnection(server),
+            new PeerConfig { Address = "127.0.0.1" },
+            bgpConfig,
+            routeTable,
+            AllowAllFilter.Instance,
+            metrics,
+            new NopLogger<BgpSession>());
+
+        var runTask = await EstablishSessionAsync(session, client, bgpConfig);
+
+        // EstablishSessionAsync negotiates the 4-octet-ASN capability, so AS_PATH is 4-octet encoded.
+        var attrs = new List<byte>
+        {
+            0x40, 0x01, 0x01, 0x00,                                     // ORIGIN igp
+            0x40, 0x02, 0x06, 0x02, 0x01, 0x00, 0x00, 0x00, 0x64,       // AS_PATH seq [100]
+            0x40, 0x03, 0x04, 0xC0, 0x00, 0x02, 0x01,                   // NEXT_HOP 192.0.2.1  <- wins
+            0x40, 0x03, 0x04, 0x0A, 0x0A, 0x0A, 0x0A,                   // NEXT_HOP 10.10.10.10 <- discarded
+        };
+        var payload = new List<byte> { 0x00, 0x00, (byte)(attrs.Count >> 8), (byte)attrs.Count };
+        payload.AddRange(attrs);
+        payload.AddRange([8, 0x0A]); // NLRI 10.0.0.0/8
+        var frame = BuildMessage(BgpMessageType.Update, [.. payload]);
+        client.Send(frame, 0, frame.Length, SocketFlags.None);
+
+        for (var i = 0; i < 40 && routeTable.Count == 0; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(50));
+
+        var route = routeTable.Get(0x0A000000, 8);
+        Assert.NotNull(route);
+        Assert.Equal(0xC0000201u, route!.NextHop); // 192.0.2.1 — the FIRST occurrence
+        Assert.True(session.IsEstablished, "a duplicated attribute must not tear the session down");
+        Assert.Equal(0, metrics.UpdatesRejected); // RFC 7606 §3: processed, not rejected
+
+        session.MarkSilentClose();
+        await runTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
     public void ParseUpdate_AttributeValueCrossingAttrsEnd_Rejected()
     {
         // #245 review finding: an attribute TLV whose declared value length reaches past the


### PR DESCRIPTION
Closes #287

## ⚠️ This is not the fix the issue proposed

#287 asked for rejection with Malformed Attribute List, citing RFC 4271 §6.3. I verified that against RFC 7606 before implementing, and **it is wrong**. RFC 7606 §3 explicitly revises the rule:

> If the MP_REACH_NLRI attribute or the MP_UNREACH_NLRI [RFC4760] attribute appears more than once in the UPDATE message, then a NOTIFICATION message MUST be sent with the Error Subcode "Malformed Attribute List". **If any other attribute (whether recognized or unrecognized) appears more than once in an UPDATE message, then all the occurrences of the attribute other than the first one SHALL be discarded and the UPDATE message will continue to be processed.**

For every attribute BGPLite parses, the correct behaviour is **keep the first, discard the rest, keep processing**. Rejecting would drop UPDATEs a conformant implementation accepts. Corrected [in a comment on the issue](https://github.com/ruhex/BGPLite/issues/287#issuecomment-5432114583) before writing any code; the defect itself and its security framing are unchanged.

## Problem

`UpdateCodec.ParseRouteAttributes` walks `update.PathAttributes` with a plain `switch` and assigns unconditionally, so a repeated attribute overwrites the previous one — **last occurrence wins**:

```
UPDATE attrs = ORIGIN AS_PATH NEXT_HOP 192.0.2.1 NEXT_HOP 10.10.10.10, NLRI 10.0.0.0/8
  -> installed nextHop = 10.10.10.10   established=True  rejected=0
```

RFC 7606 says `192.0.2.1` must be installed. Anything reading the first occurrence — a collector, a looking glass, an operator's packet capture, a policy middlebox — disagreed with what actually landed in the route table, silently. The same divergence applied to ORIGIN, AS_PATH, COMMUNITY, LARGE_COMMUNITY, AGGREGATOR and AS4_AGGREGATOR; duplicating COMMUNITY is a way to defeat `PeerCommunityFilter`'s allow-set (the benign first set is what a reviewer sees, the second is what is stored).

The `*Seen` flags existed only to feed `ValidateMandatoryAttributes` (presence), never to detect a second occurrence.

## Fix

```csharp
Span<bool> seenTypes = stackalloc bool[256];
foreach (var attr in update.PathAttributes)
{
    if (seenTypes[attr.TypeCode])
        continue;
    seenTypes[attr.TypeCode] = true;
    switch (attr.TypeCode) { ... }
}
```

Covers **every** type code, not only the ones the switch handles — a duplicated unrecognized optional attribute is covered by the same RFC sentence. `stackalloc`, so no per-UPDATE allocation on the inbound path.

A discarded duplicate is **not validated** either: RFC 7606 says later occurrences are discarded, not "discarded but still checked". A valid first ORIGIN followed by an out-of-range second one is now accepted, where previously the second was read and threw Invalid ORIGIN (subcode 6).

The inverse is guarded by a test: an invalid **first** occurrence is still rejected, so the rule cannot be used to smuggle a malformed attribute past validation by prefixing a valid one.

## Behavior change

An UPDATE with a duplicated attribute is now **accepted and installed** using the first occurrence, where before it was accepted and installed using the last. Nothing newly rejects; `metrics.UpdatesRejected` is unaffected. The ORIGIN case above is the one place where something previously rejected now passes — which is what the RFC requires.

## Out of scope

The MP_REACH_NLRI / MP_UNREACH_NLRI half of that RFC paragraph (duplicate → NOTIFICATION, session reset) is deliberately not implemented. BGPLite is IPv4-unicast only and never parses those attributes, and `ReadLoopAsync` routes every `BgpNotificationException` carrying `UpdateMessageError` to treat-as-withdraw, so a session reset would need a separate mechanism. That belongs with MP-BGP support (#14).

## Verification

`dotnet build BGPLite.sln` + `dotnet test BGPLite.sln`: **606 passed, 0 failed** (601 before, 5 added). `dotnet format --severity warn` clean.

All five new tests were confirmed to catch the regression — with the guard removed they fail, with it restored they pass:

```
first-wins guard temporarily removed
  Failed ParseRouteAttributes_DuplicateCommunity_FirstOccurrenceWins
  Failed ParseRouteAttributes_DuplicateAsPath_FirstOccurrenceWins
  Failed ParseRouteAttributes_DuplicateNextHop_FirstOccurrenceWins
  Failed ParseRouteAttributes_DuplicateOrigin_SecondIsNotValidated
  Failed DuplicateNextHop_OnWire_InstallsTheFirstOccurrence
--- restored ---
```

## Tests added

Codec level (`BgpSessionRfc6793Tests`):
- `ParseRouteAttributes_DuplicateNextHop_FirstOccurrenceWins`
- `ParseRouteAttributes_DuplicateAsPath_FirstOccurrenceWins`
- `ParseRouteAttributes_DuplicateCommunity_FirstOccurrenceWins`
- `ParseRouteAttributes_DuplicateOrigin_SecondIsNotValidated` — the discarded duplicate is not validated
- `ParseRouteAttributes_InvalidFirstOrigin_StillRejected` — the inverse guard

On the wire (`MalformedUpdateResilienceTests`):
- `DuplicateNextHop_OnWire_InstallsTheFirstOccurrence` — drives a live session over a loopback socket pair and asserts `RouteTable.Get(10.0.0.0/8).NextHop == 192.0.2.1`, the session stays Established, and `UpdatesRejected == 0` (processed, not rejected).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated BGP UPDATE processing to handle duplicate route attributes according to RFC 7606.
  - The first occurrence of duplicated NEXT_HOP, AS_PATH, and COMMUNITY attributes is retained; later duplicates are ignored.
  - Invalid duplicate ORIGIN attributes are discarded without affecting valid updates, while invalid first ORIGIN attributes remain rejected.

- **Tests**
  - Added coverage for duplicate attributes in session and end-to-end update processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->