### PR TITLE
fix(protocol): validate attribute flags against the type code and enforce fixed lengths

### DIFF
--- a/BGPLite.Protocol/UpdateCodec.cs
+++ b/BGPLite.Protocol/UpdateCodec.cs
@@ -245,11 +245,18 @@ public static class UpdateCodec
                     continue;
                 seenTypes[attr.TypeCode] = true;
 
+                // Order matters: the duplicate guard runs FIRST, so a discarded later occurrence is
+                // never shape-checked. RFC 7606 §3 says those occurrences are discarded, not
+                // "discarded but still validated" — checking them would reject an UPDATE over an
+                // attribute that has no effect on the result (#287 + #290).
+                ValidateAttributeShape(attr, fourByteAsnSession);
+
                 switch (attr.TypeCode)
                 {
                     case BgpConstants.Attribute.Origin:
-                        if (attr.Data.Length < 1)
-                            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidOriginAttribute, "Malformed ORIGIN attribute");
+                        // Length is guaranteed to be exactly 1 by ValidateAttributeShape; only the
+                        // value remains to check (RFC 7606 §7.1: "malformed if its length is not 1
+                        // or if it has an undefined value").
                         AttributeHelper.ReadOrigin(attr);
                         originSeen = true;
                         break;
@@ -261,8 +268,8 @@ public static class UpdateCodec
                         as4Path = AttributeHelper.ReadAs4Path(attr);
                         break;
                     case BgpConstants.Attribute.NextHop:
-                        if (attr.Data.Length < 4)
-                            throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNextHopAttribute, "Malformed NEXT_HOP attribute");
+                        // Length is guaranteed to be exactly 4 by ValidateAttributeShape (RFC 7606
+                        // §7.3: "malformed if its length is not 4").
                         nextHop = AttributeHelper.ReadNextHop(attr);
                         nextHopSeen = true;
                         break;
@@ -294,6 +301,73 @@ public static class UpdateCodec
             // of flattening it to Unspecific.
             throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, ex.SubErrorCode ?? BgpConstants.SubError.Unspecific, ex.Message);
         }
+    }
+
+    /// <summary>
+    /// The RFC-mandated shape of a recognized path attribute: the required Optional/Transitive flag
+    /// bits and, where the type code fixes it, the exact value length. Returns <c>null</c> for a
+    /// type code this codec does not parse — RFC 7606 §3 leaves unrecognized attributes to the
+    /// optional/transitive propagation rules rather than validating them.
+    /// <para>
+    /// Scoped deliberately to the attributes <see cref="ParseRouteAttributes"/> actually consumes.
+    /// MED/LOCAL_PREF/ATOMIC_AGGREGATE are "known" to <see cref="AttributeHelper.IsKnownAttribute"/>
+    /// but are never read here, and validating attributes the codec ignores would only create new
+    /// ways to reject an UPDATE a conformant implementation accepts.
+    /// </para>
+    /// </summary>
+    private static (bool Optional, bool Transitive, int? FixedLength)? ExpectedAttributeShape(
+        byte typeCode, bool fourByteAsnSession) => typeCode switch
+        {
+            // Well-known mandatory (RFC 4271 §4.3 / §5.1): optional=0, transitive=1.
+            BgpConstants.Attribute.Origin => (false, true, 1),
+            BgpConstants.Attribute.AsPath => (false, true, (int?)null),
+            BgpConstants.Attribute.NextHop => (false, true, 4),
+            // Optional transitive (RFC 4271 §5.1.7, RFC 1997, RFC 6793 §3, RFC 8092 §2).
+            BgpConstants.Attribute.Aggregator => (true, true, (int?)null),
+            BgpConstants.Attribute.Community => (true, true, (int?)null),
+            // AS4_PATH / AS4_AGGREGATOR exist only to tunnel 4-octet ASNs across a 2-octet session
+            // (RFC 6793 §3). On a 4-octet session the switch below ignores them entirely
+            // (`case ... when !fourByteAsnSession`), so validating their shape there would withdraw an
+            // UPDATE's routes over an attribute this codec does not even read — the same over-rejection
+            // the type list above avoids by excluding MED/LOCAL_PREF/ATOMIC_AGGREGATE (#290 review).
+            BgpConstants.Attribute.As4Path when !fourByteAsnSession => (true, true, (int?)null),
+            BgpConstants.Attribute.As4Aggregator when !fourByteAsnSession => (true, true, (int?)null),
+            BgpConstants.Attribute.LargeCommunity => (true, true, (int?)null),
+            _ => null,
+        };
+
+    /// <summary>
+    /// Validates a recognized attribute's flags and fixed length against its type code (#290).
+    /// Throws <see cref="BgpNotificationException"/> with Attribute Flags Error (4) or Attribute
+    /// Length Error (5) so the caller's treat-as-withdraw path applies (RFC 7606 §4).
+    /// </summary>
+    private static void ValidateAttributeShape(PathAttribute attr, bool fourByteAsnSession)
+    {
+        if (ExpectedAttributeShape(attr.TypeCode, fourByteAsnSession) is not { } expected)
+            return;
+
+        // RFC 7606 §3: "If the value of either the Optional or Transitive bits in the Attribute
+        // Flags is in conflict with their specified values, then the attribute MUST be treated as
+        // malformed and the 'treat-as-withdraw' approach used."
+        //
+        // ONLY those two bits. The Partial bit is deliberately not checked: RFC 7606 narrows the
+        // RFC 4271 §5 "MUST be 0 for well-known attributes" rule to Optional/Transitive, and
+        // rejecting on Partial would drop routes that conformant implementations accept. Bit 0x08
+        // (reserved) is already rejected at the wire level by BgpMessageReader.ParseAttribute (#272).
+        if (attr.Optional != expected.Optional || attr.Transitive != expected.Transitive)
+            throw new BgpNotificationException(
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.AttributeFlagsError,
+                $"Attribute type {attr.TypeCode} has flags 0x{attr.Flags:X2} conflicting with its type code " +
+                $"(expected optional={expected.Optional}, transitive={expected.Transitive})");
+
+        // RFC 4271 §6.3: "If any recognized attribute has an Attribute Length that conflicts with
+        // the expected length (based on the attribute type code), then the Error Subcode MUST be
+        // set to Attribute Length Error." RFC 7606 §7.1/§7.3 fix ORIGIN at 1 octet and NEXT_HOP at
+        // 4, both handled as treat-as-withdraw.
+        if (expected.FixedLength is { } fixedLength && attr.Data.Length != fixedLength)
+            throw new BgpNotificationException(
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.AttributeLengthError,
+                $"Attribute type {attr.TypeCode} has length {attr.Data.Length}, which conflicts with its type code (expected {fixedLength})");
     }
 
     public static byte[] GetMalformedFourOctetAsnCapabilityData(BgpOpenMessage open)

--- a/BGPLite.Tests/BgpSessionRfc6793Tests.cs
+++ b/BGPLite.Tests/BgpSessionRfc6793Tests.cs
@@ -421,4 +421,264 @@ public class BgpSessionRfc6793Tests
             () => UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: true));
         Assert.Equal(BgpConstants.SubError.InvalidOriginAttribute, ex.SubErrorCode);
     }
+
+    // ---- #290: attribute flags vs type code, and fixed lengths ----
+
+    /// <summary>
+    /// Builds a minimal valid announcing UPDATE (ORIGIN + AS_PATH + NEXT_HOP) with
+    /// <paramref name="replacement"/> substituted for the attribute sharing its type code, or
+    /// appended when it is a new type.
+    /// </summary>
+    private static BgpUpdateMessage UpdateWith(PathAttribute replacement, bool fourByteAsn = true)
+    {
+        // The base AS_PATH must match the session encoding the caller will parse with, or it throws
+        // Malformed AS_PATH before the loop ever reaches the attribute under test.
+        var attrs = new List<PathAttribute>
+        {
+            AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+            AttributeHelper.WriteAsPath([65001u], fourByteAsn),
+            AttributeHelper.WriteNextHop(0x0A000001),
+        };
+        var i = attrs.FindIndex(a => a.TypeCode == replacement.TypeCode);
+        if (i >= 0) attrs[i] = replacement; else attrs.Add(replacement);
+        return new BgpUpdateMessage { PathAttributes = attrs, Nlri = [] };
+    }
+
+    /// <summary>
+    /// RFC 7606 §3: "If the value of either the Optional or Transitive bits in the Attribute Flags
+    /// is in conflict with their specified values, then the attribute MUST be treated as malformed
+    /// and the 'treat-as-withdraw' approach used." Nothing checked this before #290.
+    /// </summary>
+    [Theory]
+    [InlineData(BgpConstants.Attribute.Origin, (byte)0x80)]          // well-known marked Optional
+    [InlineData(BgpConstants.Attribute.Origin, (byte)0x00)]          // Transitive cleared
+    [InlineData(BgpConstants.Attribute.AsPath, (byte)0x00)]          // well-known non-transitive
+    [InlineData(BgpConstants.Attribute.AsPath, (byte)0xC0)]          // marked Optional
+    [InlineData(BgpConstants.Attribute.NextHop, (byte)0x80)]
+    [InlineData(BgpConstants.Attribute.Community, (byte)0x40)]       // optional marked well-known
+    [InlineData(BgpConstants.Attribute.Community, (byte)0x80)]       // Transitive cleared
+    [InlineData(BgpConstants.Attribute.LargeCommunity, (byte)0x40)]
+    public void ParseRouteAttributes_FlagsConflictWithTypeCode_AttributeFlagsError(byte typeCode, byte flags)
+    {
+        var data = typeCode switch
+        {
+            BgpConstants.Attribute.Origin => new byte[] { 0x00 },
+            BgpConstants.Attribute.AsPath => [0x02, 0x01, 0x00, 0x00, 0xFD, 0xE9],
+            BgpConstants.Attribute.NextHop => [0x0A, 0x00, 0x00, 0x01],
+            BgpConstants.Attribute.Community => [0x00, 0x00, 0x00, 0x01],
+            BgpConstants.Attribute.LargeCommunity => new byte[12],
+            BgpConstants.Attribute.As4Path => [0x02, 0x01, 0x00, 0x03, 0x0D, 0x40],
+            _ => throw new InvalidOperationException(),
+        };
+        var update = UpdateWith(new PathAttribute { Flags = flags, TypeCode = typeCode, Data = data });
+
+        var ex = Assert.Throws<BgpNotificationException>(
+            () => UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: true));
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.AttributeFlagsError, ex.SubErrorCode);
+    }
+
+    /// <summary>
+    /// AS4_PATH / AS4_AGGREGATOR exist only to tunnel 4-octet ASNs across a 2-octet session
+    /// (RFC 6793 §3), so their shape IS validated on a 2-octet session — where the parser reads
+    /// them.
+    /// </summary>
+    [Theory]
+    [InlineData(BgpConstants.Attribute.As4Path, (byte)0x40)]   // marked well-known
+    [InlineData(BgpConstants.Attribute.As4Path, (byte)0x80)]   // Transitive cleared
+    public void ParseRouteAttributes_As4FlagsConflict_OnTwoOctetSession_AttributeFlagsError(byte typeCode, byte flags)
+    {
+        var update = UpdateWith(new PathAttribute
+        {
+            Flags = flags,
+            TypeCode = typeCode,
+            Data = [0x02, 0x01, 0x00, 0x03, 0x0D, 0x40], // AS_SEQUENCE [200000]
+        }, fourByteAsn: false);
+
+        var ex = Assert.Throws<BgpNotificationException>(
+            () => UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: false));
+        Assert.Equal(BgpConstants.SubError.AttributeFlagsError, ex.SubErrorCode);
+    }
+
+    /// <summary>
+    /// ...and is NOT validated on a 4-octet session, where the parser ignores those attributes
+    /// outright (`case ... when !fourByteAsnSession`). Validating an attribute the codec never
+    /// reads would withdraw an UPDATE's routes over something that has no effect on the result —
+    /// the same over-rejection the shape table avoids for MED/LOCAL_PREF/ATOMIC_AGGREGATE (#290 review).
+    /// </summary>
+    [Theory]
+    [InlineData(BgpConstants.Attribute.As4Path, (byte)0x40)]
+    [InlineData(BgpConstants.Attribute.As4Path, (byte)0x00)]
+    [InlineData(BgpConstants.Attribute.As4Aggregator, (byte)0x40)]
+    public void ParseRouteAttributes_As4FlagsConflict_OnFourOctetSession_IsIgnored(byte typeCode, byte flags)
+    {
+        var update = UpdateWith(new PathAttribute
+        {
+            Flags = flags,
+            TypeCode = typeCode,
+            Data = [0x02, 0x01, 0x00, 0x03, 0x0D, 0x40],
+        });
+
+        var attrs = UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: true);
+
+        Assert.Equal(0x0A000001u, attrs.NextHop);
+        Assert.Equal([65001u], attrs.AsPath); // the ignored AS4_PATH did not affect the result
+    }
+
+    /// <summary>
+    /// The Partial bit is deliberately NOT checked. RFC 7606 §3 narrows the flags check to the
+    /// Optional and Transitive bits; RFC 4271 §5's "Partial MUST be 0 for well-known attributes"
+    /// is not re-stated as an error condition, and rejecting on it would drop routes that
+    /// conformant implementations accept.
+    /// </summary>
+    [Theory]
+    [InlineData(BgpConstants.Attribute.Origin, (byte)0x60)]          // Transitive | Partial
+    [InlineData(BgpConstants.Attribute.Community, (byte)0xE0)]       // Optional | Transitive | Partial
+    public void ParseRouteAttributes_PartialBitSet_IsAccepted(byte typeCode, byte flags)
+    {
+        var data = typeCode == BgpConstants.Attribute.Origin
+            ? new byte[] { 0x00 }
+            : [0x00, 0x00, 0x00, 0x01];
+        var update = UpdateWith(new PathAttribute { Flags = flags, TypeCode = typeCode, Data = data });
+
+        var attrs = UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: true);
+
+        Assert.Equal(0x0A000001u, attrs.NextHop);
+    }
+
+    /// <summary>
+    /// RFC 7606 §7.1 (ORIGIN) and §7.3 (NEXT_HOP): "considered malformed if its length is not 1"
+    /// / "not 4". The previous checks were lower bounds (&lt; 1 / &lt; 4), so an over-long ORIGIN was
+    /// accepted and an 8-octet NEXT_HOP was silently truncated to its first four octets.
+    /// </summary>
+    [Theory]
+    [InlineData(BgpConstants.Attribute.Origin, 0)]
+    [InlineData(BgpConstants.Attribute.Origin, 2)]
+    [InlineData(BgpConstants.Attribute.Origin, 4)]
+    [InlineData(BgpConstants.Attribute.NextHop, 0)]
+    [InlineData(BgpConstants.Attribute.NextHop, 3)]
+    [InlineData(BgpConstants.Attribute.NextHop, 8)]  // an IPv6-shaped value must not be truncated
+    [InlineData(BgpConstants.Attribute.NextHop, 16)]
+    public void ParseRouteAttributes_FixedLengthMismatch_AttributeLengthError(byte typeCode, int length)
+    {
+        var update = UpdateWith(new PathAttribute
+        {
+            Flags = BgpConstants.Attribute.FlagTransitive,
+            TypeCode = typeCode,
+            Data = new byte[length],
+        });
+
+        var ex = Assert.Throws<BgpNotificationException>(
+            () => UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: true));
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.AttributeLengthError, ex.SubErrorCode);
+    }
+
+    /// <summary>
+    /// An unrecognized attribute is not shape-checked — RFC 7606 §3 leaves those to the
+    /// optional/transitive propagation rules. Validating attributes the codec never reads would
+    /// only create new ways to reject an UPDATE a conformant implementation accepts.
+    /// </summary>
+    [Fact]
+    public void ParseRouteAttributes_UnrecognizedAttribute_IsNotShapeChecked()
+    {
+        var update = UpdateWith(new PathAttribute
+        {
+            Flags = 0x00,          // neither optional nor transitive — nonsense for an unknown type
+            TypeCode = 200,        // unassigned
+            Data = [1, 2, 3],
+        });
+
+        var attrs = UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: true);
+
+        Assert.Equal(0x0A000001u, attrs.NextHop);
+    }
+
+    /// <summary>Correct flags and lengths still parse — guards against over-rejecting.</summary>
+    [Fact]
+    public void ParseRouteAttributes_CanonicalFlagsAndLengths_StillParse()
+    {
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+                AttributeHelper.WriteAsPath([65001u], fourByteAsn: true),
+                AttributeHelper.WriteNextHop(0x0A000001),
+                AttributeHelper.WriteCommunities([65000u, 100u]),
+                AttributeHelper.WriteLargeCommunities([(64512u, 1u, 2u)]),
+            ],
+            Nlri = []
+        };
+
+        var attrs = UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: true);
+
+        Assert.Equal(0x0A000001u, attrs.NextHop);
+        Assert.Equal([65000u, 100u], attrs.Communities);
+        Assert.Equal([(64512u, 1u, 2u)], attrs.LargeCommunities);
+    }
+
+    /// <summary>
+    /// The interaction between the duplicate rule (#287) and shape validation (#290), which only
+    /// exists once both are in place: the guard runs FIRST, so a discarded later occurrence is never
+    /// shape-checked. RFC 7606 §3 says those occurrences are discarded, not "discarded but still
+    /// validated" — rejecting on the flags of an attribute that has no effect on the result would
+    /// drop an UPDATE a conformant implementation accepts.
+    /// </summary>
+    [Fact]
+    public void ParseRouteAttributes_DuplicateWithConflictingFlags_IsDiscardedNotRejected()
+    {
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+                AttributeHelper.WriteAsPath([65001u], fourByteAsn: true),
+                AttributeHelper.WriteNextHop(0x0A000001),
+                AttributeHelper.WriteCommunities([65000u, 100u]),   // first — wins
+                new PathAttribute
+                {
+                    Flags = BgpConstants.Attribute.FlagTransitive,  // well-known: conflicts with COMMUNITY
+                    TypeCode = BgpConstants.Attribute.Community,
+                    Data = [0x00, 0x00, 0x03, 0xE7],
+                },
+            ],
+            Nlri = []
+        };
+
+        var attrs = UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: true);
+
+        Assert.Equal([65000u, 100u], attrs.Communities);
+        Assert.Equal(0x0A000001u, attrs.NextHop);
+    }
+
+    /// <summary>
+    /// The inverse: a conflicting-flags attribute in FIRST position is still rejected, so the
+    /// duplicate rule cannot be used to smuggle a malformed attribute past shape validation.
+    /// </summary>
+    [Fact]
+    public void ParseRouteAttributes_ConflictingFlagsOnFirstOccurrence_StillRejected()
+    {
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+                AttributeHelper.WriteAsPath([65001u], fourByteAsn: true),
+                AttributeHelper.WriteNextHop(0x0A000001),
+                new PathAttribute
+                {
+                    Flags = BgpConstants.Attribute.FlagTransitive,  // conflicting — and first
+                    TypeCode = BgpConstants.Attribute.Community,
+                    Data = [0x00, 0x00, 0x03, 0xE7],
+                },
+                AttributeHelper.WriteCommunities([65000u, 100u]),
+            ],
+            Nlri = []
+        };
+
+        var ex = Assert.Throws<BgpNotificationException>(
+            () => UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: true));
+        Assert.Equal(BgpConstants.SubError.AttributeFlagsError, ex.SubErrorCode);
+    }
 }


### PR DESCRIPTION
Closes #290

> **Was briefly stacked on #296; now rebased directly onto `main`.** Both PRs edit the same `foreach` in
> `ParseRouteAttributes`, but #290 does not *need* #287's code — only the same few lines of context — so
> stacking was the wrong call: a PR based on a non-`main` branch gets **no CI at all** here
> (`ci.yml`/`codeql.yml`/`format.yml` all trigger on `pull_request: branches: [main]`) and CodeRabbit
> reports `Review skipped: reviews are disabled for this base branch`. This PR now carries exactly one
> commit against `main` and is verified like any other.
>
> **Merge-order note:** whichever of #296 / #297 merges second needs a trivial conflict resolution —
> both insert lines at the top of that loop. Correct combined order is the duplicate guard first, then
> `ValidateAttributeShape(attr)`, so a discarded duplicate is not shape-checked.

## Problem

`ParseRouteAttributes` validated attribute **values** but never checked the **flags** against the type code, and lower-bounded rather than fixed the two fixed-width well-known attributes:

```csharp
case BgpConstants.Attribute.Origin:
    if (attr.Data.Length < 1)            // RFC: ORIGIN length is exactly 1
...
case BgpConstants.Attribute.NextHop:
    if (attr.Data.Length < 4)            // RFC: NEXT_HOP length is exactly 4
```

`PathAttribute` exposes `Optional`/`Transitive`/`Partial`, but nothing on the inbound path read them. `BgpConstants.SubError.AttributeFlagsError` (4) and `AttributeLengthError` (5) have existed since #235 and were never raised for these cases.

All of the following were accepted and the route installed:

| Attribute | On the wire | Correct | |
|---|---|---|---|
| ORIGIN | flags `0x80` (Optional) | `0x40` | accepted |
| AS_PATH | flags `0x00` (non-transitive) | `0x40` | accepted |
| NEXT_HOP | flags `0x80` | `0x40` | accepted |
| COMMUNITY | flags `0x40` (well-known) | `0xC0` | accepted |
| ORIGIN | length 2, length 4 | 1 | accepted |
| NEXT_HOP | length 8, length 16 | 4 | accepted, **first 4 octets installed** |

The NEXT_HOP length case is the sharp one: an IPv6-shaped value was silently truncated to its first four octets and installed as an IPv4 next hop — the same shape of defect #13 fixed elsewhere.

## Fix

A shape table consulted before the switch, raising `BgpNotificationException(UpdateMessageError, …)` so the existing treat-as-withdraw path applies unchanged (RFC 7606 §4 — a flags error on a well-known attribute is treat-as-withdraw, not a session reset).

- **Flags** — RFC 7606 §3: *"If the value of either the Optional or Transitive bits in the Attribute Flags is in conflict with their specified values, then the attribute MUST be treated as malformed and the 'treat-as-withdraw' approach used."* → Attribute Flags Error (4).
- **Fixed length** — RFC 7606 §7.1: ORIGIN *"is considered malformed if its length is not 1"*; §7.3: NEXT_HOP *"if its length is not 4"* → Attribute Length Error (5), which is also what RFC 4271 §6.3 mandates for a length conflict.

## Two deliberate narrowings vs. what the issue proposed

Both verified against the RFC text before implementing, same as #287.

**1. The Partial bit is NOT checked.** #290 asked to reject `ORIGIN with PARTIAL bit set (0x60)`. RFC 7606 §3 narrows the flags check to *"either the Optional or Transitive bits"* and does not restate RFC 4271 §5's "Partial MUST be 0 for well-known attributes" as an error condition. Rejecting on Partial would drop routes conformant implementations accept. There is an explicit test asserting `0x60` and `0xE0` are accepted, so this stays a decision rather than an oversight.

Bit `0x08` (reserved) is already rejected at the wire level by `BgpMessageReader.ParseAttribute` (#272), so it needs nothing here.

**2. The table covers only the attributes this codec consumes** — ORIGIN, AS_PATH, NEXT_HOP, AGGREGATOR, COMMUNITY, AS4_PATH, AS4_AGGREGATOR, LARGE_COMMUNITY. MED / LOCAL_PREF / ATOMIC_AGGREGATE are "known" to `AttributeHelper.IsKnownAttribute` but are never read by `ParseRouteAttributes`; validating attributes the codec ignores would only create new ways to reject an UPDATE a conformant implementation accepts. Unrecognized attributes are left to RFC 7606 §3's optional/transitive propagation rules — also covered by a test.

## Behavior change

The per-case ORIGIN/NEXT_HOP length guards are removed as redundant (the shape check runs first and is strictly stronger). Their subcodes change from Invalid ORIGIN (6) / Invalid NEXT_HOP (8) to **Attribute Length Error (5)** — what RFC 4271 §6.3 mandates for a length conflict. This is diagnostic only: treat-as-withdraw suppresses the NOTIFICATION, so the subcode appears in the log line and nowhere else. An undefined ORIGIN **value** still reports subcode 6.

Otherwise this only rejects UPDATEs that were previously accepted with malformed attributes — that is the point.

## Verification

`dotnet build BGPLite.sln` + `dotnet test BGPLite.sln`: **626 passed, 0 failed** (606 on the base branch, 20 added). `dotnet format --severity warn` clean. No pre-existing test changed behaviour.

All 16 positive cases confirmed to catch the regression — with `ValidateAttributeShape` removed they fail, with it restored they pass:

```
shape check temporarily removed
  Failed ParseRouteAttributes_FixedLengthMismatch_AttributeLengthError  x7
  Failed ParseRouteAttributes_FlagsConflictWithTypeCode_AttributeFlagsError  x9
Failed! - Failed: 16, Passed: 39
--- restored ---
```

The three negative controls pass in **both** states, which is what makes them controls.

## Tests added

- `ParseRouteAttributes_FlagsConflictWithTypeCode_AttributeFlagsError` — 9 cases across ORIGIN / AS_PATH / NEXT_HOP / COMMUNITY / LARGE_COMMUNITY / AS4_PATH, both directions of each bit.
- `ParseRouteAttributes_FixedLengthMismatch_AttributeLengthError` — 7 cases, including the 8- and 16-octet NEXT_HOP truncation.
- `ParseRouteAttributes_PartialBitSet_IsAccepted` — locks in narrowing (1).
- `ParseRouteAttributes_UnrecognizedAttribute_IsNotShapeChecked` — locks in narrowing (2).
- `ParseRouteAttributes_CanonicalFlagsAndLengths_StillParse` — guards against over-rejecting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for recognized route attributes.
  - Detects conflicting flags and incorrect fixed lengths.
  - Preserves support for valid partial attributes and unknown types.
  - Maintains parsing of canonical route attributes and safely handles duplicates.

- **Tests**
  - Added coverage for flag conflicts, length mismatches, partial-bit handling, unknown attributes, duplicates, and valid combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->