### PR TITLE
fix(server): treat-as-withdraw now withdraws the UPDATE's NLRI

### DIFF
--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -574,6 +574,14 @@ public sealed class BgpSession : IDisposable
                 // No NOTIFICATION is sent: RFC 7606 treat-as-withdraw keeps the session up without
                 // notifying (RFC 4271 §6.3 mandates the receiver of a NOTIFICATION tear down, which
                 // would defeat the point of preserving the session).
+                //
+                // Note this branch cannot apply true treat-as-withdraw and does not claim to: the
+                // frame failed to parse, so the NLRI list is not recoverable and there is nothing to
+                // remove (contrast HandleUpdateAsync, where the NLRI IS known — #288). RFC 7606 §3(j)
+                // says that when the NLRI field cannot be parsed, "the 'session reset' approach ...
+                // MUST be followed"; BGPLite deliberately discards and keeps the session instead,
+                // because resetting on a single malformed frame is precisely the remote-DoS lever
+                // #222/#284 closed. Deviation recorded here rather than silently implied.
                 _metrics.UpdateRejected();
                 _logger.LogWarning(
                     "Rejected malformed message from {Peer}: {Error}/{SubError} — {Reason}; session stays up",
@@ -741,8 +749,37 @@ public sealed class BgpSession : IDisposable
             // #270: the inbound attribute pipeline (per-attribute validation, mandatory set,
             // AS4_PATH reconstruction, aggregator consistency — subcodes 3/6/8/9/11) lives in the
             // protocol library. Its BgpNotificationException propagates to the treat-as-withdraw
-            // catch in the dispatch loop exactly as before.
-            var attrs = UpdateCodec.ParseRouteAttributes(update, _remoteFourByteAsn);
+            // catch in the dispatch loop, which logs and counts it.
+            UpdateCodec.RouteAttributes attrs;
+            try
+            {
+                attrs = UpdateCodec.ParseRouteAttributes(update, _remoteFourByteAsn);
+            }
+            catch (BgpNotificationException ex) when (ex.ErrorCode == BgpConstants.Error.UpdateMessageError)
+            {
+                // RFC 7606 §2, "treat-as-withdraw": "the UPDATE message containing the path
+                // attribute in question MUST be treated as though all contained routes had been
+                // withdrawn just as if they had been listed in the WITHDRAWN ROUTES field ... thus
+                // causing them to be removed from the Adj-RIB-In."
+                //
+                // #288: only the "treat" half was implemented. The UPDATE was discarded and the
+                // session kept, but its NLRI stayed installed carrying the attributes of the
+                // PREVIOUS announcement — so a peer whose route changed in a way we cannot parse
+                // kept its stale next hop indefinitely, with no NOTIFICATION (correctly) and no
+                // removal (incorrectly). Nothing on either end could observe it.
+                //
+                // The withdrawn-routes half of this same UPDATE was already applied above, before
+                // the parse; this closes the asymmetry on the NLRI side.
+                foreach (var nlri in update.Nlri)
+                {
+                    _routeTable.Remove(nlri.Address, nlri.Length);
+                    if (_logger.IsEnabled(LogLevel.Debug))
+                        _logger.LogDebug("Route withdrawn (treat-as-withdraw): {Prefix}", nlri);
+                }
+                _metrics.SetRouteCount(_routeTable.Count);
+                throw;
+            }
+
             var filterPeerConfig = GetFilterPeerConfig();
 
             foreach (var nlri in update.Nlri)

--- a/BGPLite.Tests/MalformedUpdateResilienceTests.cs
+++ b/BGPLite.Tests/MalformedUpdateResilienceTests.cs
@@ -112,7 +112,7 @@ public class MalformedUpdateResilienceTests
             0x40, 0x02, 0x06, 0x02, 0x01, 0x00, 0x00, 0x00, 0x64,   // AS_PATH seq [100]
             0x40, 0x03, 0x04, 0xC0, 0x00, 0x02, 0x01,               // NEXT_HOP 192.0.2.1
         };
-        client.Send(AnnounceFrame(good), SocketFlags.None);
+        SendAll(client, AnnounceFrame(good));
 
         for (var i = 0; i < 40 && routeTable.Count == 0; i++)
             await Task.Delay(TimeSpan.FromMilliseconds(50));
@@ -125,7 +125,7 @@ public class MalformedUpdateResilienceTests
             0x40, 0x01, 0x01, 0x00,
             0x40, 0x02, 0x06, 0x02, 0x01, 0x00, 0x00, 0x00, 0x64,
         };
-        client.Send(AnnounceFrame(bad), SocketFlags.None);
+        SendAll(client, AnnounceFrame(bad));
 
         for (var i = 0; i < 40 && metrics.UpdatesRejected == 0; i++)
             await Task.Delay(TimeSpan.FromMilliseconds(50));
@@ -139,6 +139,20 @@ public class MalformedUpdateResilienceTests
 
         session.MarkSilentClose();
         await runTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    /// <summary>
+    /// Writes the whole frame. <see cref="Socket.Send(byte[], SocketFlags)"/> may accept fewer bytes
+    /// than requested, which would deliver a truncated UPDATE and fail the test somewhere other than
+    /// the behaviour under test (#288 review). Loopback frames of this size never actually short-write,
+    /// but a test that can fail for a reason unrelated to its subject is worth two lines to prevent —
+    /// #302 is what that costs when it happens.
+    /// </summary>
+    private static void SendAll(Socket socket, byte[] frame)
+    {
+        var sent = 0;
+        while (sent < frame.Length)
+            sent += socket.Send(frame, sent, frame.Length - sent, SocketFlags.None);
     }
 
     /// <summary>Wraps path-attribute bytes into an UPDATE announcing 10.0.0.0/8.</summary>

--- a/BGPLite.Tests/MalformedUpdateResilienceTests.cs
+++ b/BGPLite.Tests/MalformedUpdateResilienceTests.cs
@@ -81,6 +81,76 @@ public class MalformedUpdateResilienceTests
     }
 
     [Fact]
+    public async Task TreatAsWithdraw_RemovesTheNlriFromTheRouteTable()
+    {
+        // #288 / RFC 7606 §2: "the UPDATE message containing the path attribute in question MUST be
+        // treated as though all contained routes had been withdrawn ... thus causing them to be
+        // removed from the Adj-RIB-In." Only the "treat" half was implemented: the UPDATE was
+        // discarded and the session kept, but its NLRI stayed installed carrying the attributes of
+        // the PREVIOUS announcement.
+        var (server, client) = ConnectedPair();
+        using var clientSock = client;
+        var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
+        var metrics = new BgpMetrics();
+        var routeTable = new RouteTable();
+        using var session = new BgpSession(
+            new SocketBgpConnection(server),
+            new PeerConfig { Address = "127.0.0.1" },
+            bgpConfig,
+            routeTable,
+            AllowAllFilter.Instance,
+            metrics,
+            new NopLogger<BgpSession>());
+
+        var runTask = await EstablishSessionAsync(session, client, bgpConfig);
+
+        // 1) A well-formed announcement of 10.0.0.0/8 via 192.0.2.1. EstablishSessionAsync
+        //    negotiates the 4-octet-ASN capability, so AS_PATH is 4-octet encoded.
+        var good = new List<byte>
+        {
+            0x40, 0x01, 0x01, 0x00,                                 // ORIGIN igp
+            0x40, 0x02, 0x06, 0x02, 0x01, 0x00, 0x00, 0x00, 0x64,   // AS_PATH seq [100]
+            0x40, 0x03, 0x04, 0xC0, 0x00, 0x02, 0x01,               // NEXT_HOP 192.0.2.1
+        };
+        client.Send(AnnounceFrame(good), SocketFlags.None);
+
+        for (var i = 0; i < 40 && routeTable.Count == 0; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(50));
+        Assert.Equal(0xC0000201u, routeTable.Get(0x0A000000, 8)?.NextHop);
+
+        // 2) The same NLRI re-announced with NEXT_HOP omitted — a missing mandatory attribute, so
+        //    the pipeline rejects it and treat-as-withdraw applies.
+        var bad = new List<byte>
+        {
+            0x40, 0x01, 0x01, 0x00,
+            0x40, 0x02, 0x06, 0x02, 0x01, 0x00, 0x00, 0x00, 0x64,
+        };
+        client.Send(AnnounceFrame(bad), SocketFlags.None);
+
+        for (var i = 0; i < 40 && metrics.UpdatesRejected == 0; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(50));
+
+        Assert.Null(routeTable.Get(0x0A000000, 8));  // RFC 7606 §2 — must be gone, not stale
+        Assert.True(session.IsEstablished, "treat-as-withdraw keeps the session up");
+        Assert.Equal(1, metrics.UpdatesRejected);
+
+        var sent = await DrainAsync(client, TimeSpan.FromSeconds(2));
+        Assert.DoesNotContain(sent, m => m is BgpNotificationMessage);
+
+        session.MarkSilentClose();
+        await runTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    /// <summary>Wraps path-attribute bytes into an UPDATE announcing 10.0.0.0/8.</summary>
+    private static byte[] AnnounceFrame(List<byte> attributeBytes)
+    {
+        var payload = new List<byte> { 0x00, 0x00, (byte)(attributeBytes.Count >> 8), (byte)attributeBytes.Count };
+        payload.AddRange(attributeBytes);
+        payload.AddRange([8, 0x0A]); // NLRI 10.0.0.0/8
+        return BuildMessage(BgpMessageType.Update, [.. payload]);
+    }
+
+    [Fact]
     public void ParseUpdate_AttributeValueCrossingAttrsEnd_Rejected()
     {
         // #245 review finding: an attribute TLV whose declared value length reaches past the


### PR DESCRIPTION
Closes #288

## Problem

Only the "treat" half of RFC 7606 treat-as-withdraw was implemented. When the inbound attribute pipeline rejects an announcing UPDATE, the message is discarded and the session kept — correct — but its NLRI stayed installed in the route table, carrying the attributes of the **previous** announcement.

RFC 7606 §2:

> In this approach, the UPDATE message containing the path attribute in question MUST be treated as though all contained routes had been withdrawn just as if they had been listed in the WITHDRAWN ROUTES field (or in the MP_UNREACH_NLRI attribute if appropriate) of the UPDATE message, **thus causing them to be removed from the Adj-RIB-In**.

Reproduced on `main`:

```
1. UPDATE: ORIGIN=igp, AS_PATH=[100], NEXT_HOP=192.0.2.1, NLRI=10.0.0.0/8
   -> routeTable=1  nextHop=192.0.2.1

2. UPDATE: ORIGIN=igp, AS_PATH=[100],  (NEXT_HOP omitted), NLRI=10.0.0.0/8
   -> Missing mandatory NEXT_HOP -> BgpNotificationException(3/3) -> treat-as-withdraw
   -> routeTable=1  rejected=1        <-- still installed, still 192.0.2.1
```

A peer whose route changed in a way BGPLite cannot parse keeps its stale next hop indefinitely, and **neither end can observe it**: no NOTIFICATION is sent (correctly) and nothing is removed (incorrectly). Under a partial outage this is exactly the "routes point at a dead next hop" case.

The withdrawn-routes half of the same UPDATE was already applied before the parse, so the asymmetry was only on the NLRI side.

## Fix

`HandleUpdateAsync` removes the UPDATE's NLRI before rethrowing, so the existing catch in `ReadLoopAsync` still logs it and increments `UpdatesRejected` exactly as before:

```csharp
catch (BgpNotificationException ex) when (ex.ErrorCode == BgpConstants.Error.UpdateMessageError)
{
    foreach (var nlri in update.Nlri)
        _routeTable.Remove(nlri.Address, nlri.Length);
    _metrics.SetRouteCount(_routeTable.Count);
    throw;
}
```

The filter (`AcceptIncoming`) is deliberately not consulted — a withdrawal removes whatever is installed regardless of whether the route would be accepted today.

## A deviation now recorded rather than silently implied

RFC 7606 §3(j) adds a condition I checked while verifying this:

> [applying treat-as-withdraw] requires successfully parsing the entire NLRI field. If this is not possible, the procedures of [RFC4271] and/or [RFC4760] continue to apply, meaning that the "session reset" approach (or the "AFI/SAFI disable" approach) MUST be followed.

That applies to the **other** treat-as-withdraw branch — the codec-level `BgpParseException` catch in `ReadLoopAsync`, where the frame failed to parse and the NLRI list is not recoverable. Strictly, §3(j) requires a session reset there. BGPLite deliberately discards and keeps the session instead, because resetting on a single malformed frame is precisely the remote-DoS lever #222 and #284 closed.

I did **not** change that — it would undo #284 — but the deviation is now stated in a comment at that catch rather than left as an unmarked gap. This PR only covers the branch where the NLRI *is* known.

Note also that BGPLite has no per-peer Adj-RIB-In (#289); removing from the shared `RouteTable` is the closest available analogue. #289 tracks the real fix.

## Verification

`dotnet build BGPLite.sln` + `dotnet test BGPLite.sln`: **601 passed, 0 failed** (600 before, 1 added). `dotnet format --severity warn` clean.

The test was confirmed to catch the regression — with the withdraw removed it fails, with it restored it passes:

```
withdraw-on-reject temporarily removed
  Failed MalformedUpdateResilienceTests.TreatAsWithdraw_RemovesTheNlriFromTheRouteTable [5 s]
--- restored ---
```

## Test added

`TreatAsWithdraw_RemovesTheNlriFromTheRouteTable` — drives a live session over a loopback socket pair through the exact two-step sequence above and asserts all four properties that matter together: the route is **gone** (not stale), the session stays Established, `UpdatesRejected == 1`, and **no NOTIFICATION** goes on the wire.

## Note

Independent of #296/#297 (`ParseRouteAttributes`) — this touches `BgpSession.HandleUpdateAsync` only, no overlapping lines, so it can merge in any order relative to them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Malformed route updates now correctly withdraw affected routes instead of leaving stale routes installed.
  * Sessions remain active after recoverable malformed updates, without sending unnecessary notifications.
  * Route rejection metrics are updated accurately.

* **Tests**
  * Added coverage verifying route withdrawal, session preservation, metrics, and notification behavior for malformed updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->