### PR TITLE
fix(protocol): make the Extended Length flag match the length field the writer emits

### DIFF
--- a/BGPLite.Protocol/BgpMessageWriter.cs
+++ b/BGPLite.Protocol/BgpMessageWriter.cs
@@ -209,6 +209,15 @@ public static class BgpMessageWriter
 
     private static int WriteAttribute(PathAttribute attr, Span<byte> buffer)
     {
+        // RFC 4271 §4.3: flag bit 0x08 is reserved and MUST be zero on the wire. BgpMessageReader
+        // rejects it on the way in (#272); emitting it would make the writer produce a frame its
+        // own reader refuses — the same round-trip break this PR fixes for the Extended Length bit.
+        // Checked BEFORE anything is written so a rejected attribute leaves the caller's span
+        // untouched, matching WriteOpen's RequireFitsByte guard.
+        if ((attr.Flags & BgpConstants.Attribute.FlagReserved) != 0)
+            throw new ArgumentOutOfRangeException(nameof(attr), attr.Flags,
+                $"Path attribute flag bit 0x{BgpConstants.Attribute.FlagReserved:X2} is reserved and must be zero (RFC 4271 §4.3).");
+
         var extended = UsesExtendedLength(attr);
 
         var p = 0;

--- a/BGPLite.Protocol/BgpMessageWriter.cs
+++ b/BGPLite.Protocol/BgpMessageWriter.cs
@@ -179,16 +179,29 @@ public static class BgpMessageWriter
         return len;
     }
 
+    /// <summary>
+    /// Whether an attribute is serialized with the two-octet length field. RFC 4271 §4.3 lets the
+    /// Extended Length bit select the field width independently of the value length — it is only
+    /// <em>required</em> above 255 octets, not forbidden below — so a caller-supplied flag is
+    /// honoured rather than ignored.
+    /// <para>
+    /// The single source of truth for both <see cref="GetAttributesLength"/> and
+    /// <see cref="WriteAttribute"/>: previously they each re-derived it from
+    /// <c>Data.Length &gt; 255</c> while the flags byte was written through verbatim, so an
+    /// attribute arriving with 0x10 already set and a value of 255 octets or fewer produced a TLV
+    /// whose flags declared a two-octet length field followed by a one-octet one (#291).
+    /// </para>
+    /// </summary>
+    private static bool UsesExtendedLength(PathAttribute attr) =>
+        attr.Data.Length > 255 || (attr.Flags & BgpConstants.Attribute.FlagExtendedLength) != 0;
+
     private static int GetAttributesLength(List<PathAttribute> attributes)
     {
         var len = 0;
         foreach (var attr in attributes)
         {
             len += 2; // flags + type code
-            if (attr.Data.Length > 255)
-                len += 2; // extended length
-            else
-                len += 1; // single byte length
+            len += UsesExtendedLength(attr) ? 2 : 1; // length field width
             len += attr.Data.Length;
         }
         return len;
@@ -196,13 +209,16 @@ public static class BgpMessageWriter
 
     private static int WriteAttribute(PathAttribute attr, Span<byte> buffer)
     {
+        var extended = UsesExtendedLength(attr);
+
         var p = 0;
-        buffer[p++] = attr.Flags;
+        // Emit the flag that matches the field actually written. Above 255 octets the bit is
+        // required, so set it even when the caller left it clear.
+        buffer[p++] = extended ? (byte)(attr.Flags | BgpConstants.Attribute.FlagExtendedLength) : attr.Flags;
         buffer[p++] = attr.TypeCode;
 
-        if (attr.Data.Length > 255)
+        if (extended)
         {
-            buffer[p - 2] |= BgpConstants.Attribute.FlagExtendedLength;
             BinaryPrimitives.WriteUInt16BigEndian(buffer[p..], (ushort)attr.Data.Length);
             p += 2;
         }

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -874,4 +874,99 @@ public class BgpMessageTests
         Assert.Throws<ArgumentOutOfRangeException>(() => BgpMessageWriter.WriteMessage(update, buffer));
         Assert.All(buffer, b => Assert.Equal(sentinel, b));
     }
+
+    // ---- #291: Extended Length flag must match the length field actually written ----
+
+    /// <summary>
+    /// RFC 4271 §4.3 lets the Extended Length bit select the length-field width independently of the
+    /// value length — it is required above 255 octets, not forbidden below. The writer emitted the
+    /// caller's flags byte verbatim but derived the field width from <c>Data.Length &gt; 255</c>, so an
+    /// attribute arriving with 0x10 already set and a short value produced a TLV whose flags declared
+    /// a two-octet length followed by a one-octet one — a frame BGPLite's own reader rejects (#291).
+    /// </summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(4)]
+    [InlineData(255)]
+    [InlineData(256)]
+    [InlineData(1000)]
+    public void WriteAttribute_CallerSetExtendedLengthFlag_RoundTrips(int dataLength)
+    {
+        var attr = new PathAttribute
+        {
+            Flags = (byte)(BgpConstants.Attribute.FlagOptional
+                         | BgpConstants.Attribute.FlagTransitive
+                         | BgpConstants.Attribute.FlagExtendedLength),
+            TypeCode = BgpConstants.Attribute.Community,
+            Data = new byte[dataLength],
+        };
+        var update = new BgpUpdateMessage { PathAttributes = [attr] };
+
+        var buffer = new byte[BgpMessageWriter.GetBufferSize(update)];
+        var written = BgpMessageWriter.WriteMessage(update, buffer);
+
+        // GetBufferSize must agree with what WriteMessage actually emitted.
+        Assert.Equal(buffer.Length, written);
+
+        var read = Assert.IsType<BgpUpdateMessage>(BgpMessageReader.ReadMessage(buffer.AsSpan(0, written)));
+        var roundTripped = Assert.Single(read.PathAttributes);
+        Assert.Equal(BgpConstants.Attribute.Community, roundTripped.TypeCode);
+        Assert.Equal(dataLength, roundTripped.Data.Length);
+        Assert.NotEqual(0, roundTripped.Flags & BgpConstants.Attribute.FlagExtendedLength);
+    }
+
+    /// <summary>
+    /// The complementary direction: without the flag a short attribute still uses the one-octet
+    /// field, and above 255 octets the writer sets the bit itself even when the caller left it clear.
+    /// </summary>
+    [Theory]
+    [InlineData(4, false)]
+    [InlineData(255, false)]
+    [InlineData(256, true)]
+    public void WriteAttribute_WithoutCallerFlag_PicksFieldWidthByLength(int dataLength, bool expectExtendedBit)
+    {
+        var attr = new PathAttribute
+        {
+            Flags = (byte)(BgpConstants.Attribute.FlagOptional | BgpConstants.Attribute.FlagTransitive),
+            TypeCode = BgpConstants.Attribute.Community,
+            Data = new byte[dataLength],
+        };
+        var update = new BgpUpdateMessage { PathAttributes = [attr] };
+
+        var buffer = new byte[BgpMessageWriter.GetBufferSize(update)];
+        var written = BgpMessageWriter.WriteMessage(update, buffer);
+        Assert.Equal(buffer.Length, written);
+
+        var read = Assert.IsType<BgpUpdateMessage>(BgpMessageReader.ReadMessage(buffer.AsSpan(0, written)));
+        var roundTripped = Assert.Single(read.PathAttributes);
+        Assert.Equal(dataLength, roundTripped.Data.Length);
+        Assert.Equal(expectExtendedBit, (roundTripped.Flags & BgpConstants.Attribute.FlagExtendedLength) != 0);
+    }
+
+    /// <summary>
+    /// The exact frame from #291: flags 0xD0 with a 4-octet COMMUNITY. The reader used to read the
+    /// length as 0x0400 = 1024 and throw Attribute Length Error on the writer's own output.
+    /// </summary>
+    [Fact]
+    public void WriteAttribute_ExtendedFlagShortValue_EmitsTwoOctetLengthField()
+    {
+        var attr = new PathAttribute
+        {
+            Flags = 0xD0,
+            TypeCode = BgpConstants.Attribute.Community,
+            Data = [0x00, 0x00, 0x00, 0x01],
+        };
+        var update = new BgpUpdateMessage { PathAttributes = [attr] };
+
+        var buffer = new byte[BgpMessageWriter.GetBufferSize(update)];
+        var written = BgpMessageWriter.WriteMessage(update, buffer);
+
+        // header(19) + withdrawn-len(2) + attrs-len(2) + flags(1) + type(1) + length(2) + value(4)
+        Assert.Equal(31, written);
+        var attrStart = BgpConstants.MessageHeaderSize + 4;
+        Assert.Equal(0xD0, buffer[attrStart]);
+        Assert.Equal(BgpConstants.Attribute.Community, buffer[attrStart + 1]);
+        Assert.Equal(0x00, buffer[attrStart + 2]); // two-octet length, high byte
+        Assert.Equal(0x04, buffer[attrStart + 3]); // two-octet length, low byte
+    }
 }

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -969,4 +969,45 @@ public class BgpMessageTests
         Assert.Equal(0x00, buffer[attrStart + 2]); // two-octet length, high byte
         Assert.Equal(0x04, buffer[attrStart + 3]); // two-octet length, low byte
     }
+
+    /// <summary>
+    /// RFC 4271 §4.3: flag bit 0x08 is reserved and MUST be zero. The reader rejects it (#272), so
+    /// emitting it would make the writer produce a frame its own reader refuses — the same
+    /// round-trip break this PR fixes for the Extended Length bit (#291 review).
+    /// </summary>
+    [Theory]
+    [InlineData((byte)0x08)]                      // reserved alone
+    [InlineData((byte)0xC8)]                      // optional | transitive | reserved
+    [InlineData((byte)0xD8)]                      // ...also extended length
+    public void WriteAttribute_ReservedFlagBitSet_Throws(byte flags)
+    {
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes = [new PathAttribute { Flags = flags, TypeCode = BgpConstants.Attribute.Community, Data = [0, 0, 0, 1] }],
+        };
+        var buffer = new byte[BgpMessageWriter.GetBufferSize(update)];
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => BgpMessageWriter.WriteMessage(update, buffer));
+    }
+
+    [Fact]
+    public void WriteAttribute_ReservedFlagBitSet_LeavesBufferUntouched()
+    {
+        // The guard runs before any byte is written, so a rejected attribute cannot leave a
+        // half-serialized frame in the caller's span.
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes = [new PathAttribute { Flags = 0xC8, TypeCode = BgpConstants.Attribute.Community, Data = [0, 0, 0, 1] }],
+        };
+        var buffer = new byte[BgpMessageWriter.GetBufferSize(update)];
+        var canary = new byte[buffer.Length];
+        Array.Fill(canary, (byte)0xEE);
+        canary.CopyTo(buffer, 0);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => BgpMessageWriter.WriteMessage(update, buffer));
+        // The header is written by WriteUpdate before the attribute loop, so only assert that the
+        // attribute region — everything past the fixed UPDATE header — is untouched.
+        var attrRegion = BgpConstants.MessageHeaderSize + 4;
+        Assert.Equal(canary.AsSpan(attrRegion).ToArray(), buffer.AsSpan(attrRegion).ToArray());
+    }
 }


### PR DESCRIPTION
Closes #291

## Problem

`WriteAttribute` wrote `attr.Flags` through verbatim but derived the length-field width from `Data.Length > 255`:

```csharp
buffer[p++] = attr.Flags;              // <-- caller's flags, 0x10 included
buffer[p++] = attr.TypeCode;

if (attr.Data.Length > 255)
{
    buffer[p - 2] |= BgpConstants.Attribute.FlagExtendedLength;
    BinaryPrimitives.WriteUInt16BigEndian(buffer[p..], (ushort)attr.Data.Length);
    p += 2;
}
else
{
    buffer[p++] = (byte)attr.Data.Length;   // <-- one octet, but the flag may say two
}
```

An attribute arriving with the Extended Length bit already set and a value of 255 octets or fewer therefore produced a TLV whose flags declare a two-octet length field followed by a one-octet one:

```
FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF 001E 02 0000 0007 D0 08 04 00000001
                                                   ^^ ^^ ^^
                                      flags=0xD0 (extended) | type 8 | ONE length byte
```

Feeding that straight back into `BgpMessageReader.ReadMessage` gives

```
BgpParseException 3/5 :: Truncated path attribute value: declared 1024 at offset 4, have 7
```

— the reader read `04 00` as the 16-bit length. Round-trip through the library's own public API was broken.

`GetAttributesLength` made the same length-only decision, so the computed message length agreed with the wrong encoding and no bounds check caught it.

RFC 4271 §4.3 lets the Extended Length bit select the field width **independently** of the value length — it is *required* above 255 octets, not *forbidden* below — so this is a legal input the writer mis-encoded. The reader already accepts the legal inbound form:

```
UPDATE with extended-length ORIGIN (flags 0x50, type 1, len 0x0001, value 0)
  -> accepted: type=1 flags=0x50 len=1
```

## Fix

One `UsesExtendedLength(attr)` predicate — `Data.Length > 255 || (Flags & 0x10) != 0` — used by **both** `GetAttributesLength` and `WriteAttribute`, so the sizing and the encoding can no longer disagree.

The caller's flag is *honoured* rather than normalised away. That is the right choice for a library being packaged for standalone use: a consumer re-emitting a parsed attribute (route reflection, a collector, a test fixture) preserves the sender's encoding. Above 255 octets the writer still sets the bit itself when the caller left it clear, since there the RFC requires it.

## Reachability

**Not reachable from BGPLite's own send path today** — every outbound attribute comes from `AttributeHelper.Write*`, none of which set `0x10`. This is a latent public-API defect, and it matters because `BgpMessageWriter` is public API of `BGPLite.Protocol`, which #271 is preparing for standalone publication. It also undercuts the writer-level guarantee #272 item 2 was added to provide: sorting attributes is a wire-correctness guarantee, and the writer could still emit an unparseable TLV.

## Verification

`dotnet build BGPLite.sln` + `dotnet test BGPLite.sln`: **609 passed, 0 failed** (600 before, 9 added). `dotnet format --severity warn` clean.

Confirmed to catch the regression — reverting to the length-only predicate fails 4 of the 9:

```
reverted to length-only predicate (pre-fix behavior)
  Failed WriteAttribute_CallerSetExtendedLengthFlag_RoundTrips(dataLength: 0)
  Failed WriteAttribute_CallerSetExtendedLengthFlag_RoundTrips(dataLength: 4)
  Failed WriteAttribute_CallerSetExtendedLengthFlag_RoundTrips(dataLength: 255)
  Failed WriteAttribute_ExtendedFlagShortValue_EmitsTwoOctetLengthField
Failed! - Failed: 4, Passed: 5
--- restored ---
```

The five that pass in both states are the negative controls (no caller flag, and the >255 cases the old code already handled).

## Tests added

- `WriteAttribute_CallerSetExtendedLengthFlag_RoundTrips` — 5 lengths (0, 4, 255, 256, 1000) through write → read, also asserting `GetBufferSize` equals what `WriteMessage` actually emitted.
- `WriteAttribute_WithoutCallerFlag_PicksFieldWidthByLength` — the complementary direction, including that the writer sets the bit itself above 255.
- `WriteAttribute_ExtendedFlagShortValue_EmitsTwoOctetLengthField` — byte-level assertion on the exact frame from the issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BGP path-attribute length handling for values of all supported sizes.
  * Preserved explicitly requested extended-length encoding.
  * Automatically selects the appropriate length format for large values.
  * Ensured encoded attribute flags and length fields remain consistent.

* **Tests**
  * Added coverage for short and long attributes, explicit extended-length requests, automatic format selection, and buffer-size accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->