### PR TITLE
fix(protocol): RFC 4271 §6.1 header subcodes + KEEPALIVE length, and reject AS 0 per RFC 7607

### DIFF
--- a/BGPLite.Protocol/AttributeHelper.cs
+++ b/BGPLite.Protocol/AttributeHelper.cs
@@ -257,12 +257,23 @@ public static class AttributeHelper
 
             for (var i = 0; i < segmentLength; i++)
             {
-                ases.Add(asSize switch
+                var asn = asSize switch
                 {
                     2 => BinaryPrimitives.ReadUInt16BigEndian(data.Slice(offset, asSize)),
                     4 => BinaryPrimitives.ReadUInt32BigEndian(data.Slice(offset, asSize)),
                     _ => throw new ArgumentOutOfRangeException(nameof(asSize))
-                });
+                };
+
+                // RFC 7607 §2: "An UPDATE message that contains the AS number of zero in the AS_PATH
+                // ... MUST be considered as malformed and be handled by the procedures specified in
+                // [RFC7606]" — i.e. treat-as-withdraw via Malformed AS_PATH, the remedy RFC 7606 §7.2
+                // prescribes for a malformed AS_PATH. The same applies to AS4_PATH through this
+                // shared reader (#300). AS 0 is reserved and must never appear in a path.
+                if (asn == 0)
+                    throw new BgpParseException($"Invalid {attributeName}: AS 0 is reserved (RFC 7607)",
+                        BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAsPath);
+
+                ases.Add(asn);
                 offset += asSize;
             }
         }

--- a/BGPLite.Protocol/BgpConstants.cs
+++ b/BGPLite.Protocol/BgpConstants.cs
@@ -41,8 +41,7 @@ public static class BgpConstants
         // The dual naming below (BadBgpIdentifier/MissingWellKnownAttribute both = 3) is intentional.
 
         // Message Header Error subcodes (RFC 4271 §6.1) — used with ErrorCode = MessageHeaderError.
-        // ConnectionNotSynchronized (1) is intentionally absent: the codec surfaces a bad marker as
-        // a generic header failure and never reaches a subcode for it.
+        public const byte ConnectionNotSynchronized = 1;
         public const byte BadMessageLength = 2;
         public const byte BadMessageType = 3;
 

--- a/BGPLite.Protocol/BgpConstants.cs
+++ b/BGPLite.Protocol/BgpConstants.cs
@@ -40,6 +40,12 @@ public static class BgpConstants
         // in the former and Missing Well-known Attribute in the latter (RFC 4271 §6.2/§6.3).
         // The dual naming below (BadBgpIdentifier/MissingWellKnownAttribute both = 3) is intentional.
 
+        // Message Header Error subcodes (RFC 4271 §6.1) — used with ErrorCode = MessageHeaderError.
+        // ConnectionNotSynchronized (1) is intentionally absent: the codec surfaces a bad marker as
+        // a generic header failure and never reaches a subcode for it.
+        public const byte BadMessageLength = 2;
+        public const byte BadMessageType = 3;
+
         // Open Message Error subcodes (RFC 4271 §6.2) — used with ErrorCode = OpenMessageError
         public const byte UnsupportedVersion = 1;
         public const byte BadPeerAs = 2;

--- a/BGPLite.Protocol/BgpMessageReader.cs
+++ b/BGPLite.Protocol/BgpMessageReader.cs
@@ -13,12 +13,35 @@ public static class BgpMessageReader
 
         var length = BinaryPrimitives.ReadUInt16BigEndian(buffer[16..]);
         if (length < BgpConstants.MinMessageSize || length > BgpConstants.MaxMessageSize)
-            throw new BgpParseException($"Invalid message length: {length}");
+            throw BadMessageLength(length);
 
         if (buffer.Length < length)
             throw new BgpParseException($"Incomplete message: have {buffer.Length}, need {length}");
 
         var type = (BgpMessageType)buffer[18];
+
+        // RFC 4271 §6.1: "if the Length field of a KEEPALIVE message is not equal to 19 ... then the
+        // Error Subcode MUST be set to Bad Message Length." Nothing checked this — type 4 mapped
+        // straight to the singleton and any trailing bytes were silently ignored, so a peer could
+        // pad a KEEPALIVE arbitrarily and BGPLite would accept it (#300).
+        //
+        // ONLY KEEPALIVE is validated here, deliberately. §6.1 also gives per-type minimums for
+        // OPEN (29), UPDATE (23) and NOTIFICATION (21), and all three are already rejected today —
+        // but by their body parsers, as Open/Update Message Error rather than as header errors.
+        // Reclassifying them would change behaviour in ways that are not improvements:
+        //   - OPEN: #223 deliberately made a too-short OPEN report Open Message Error (2), with a
+        //     test asserting it. Moving it to Message Header Error would flip that decision, and
+        //     would make ParseOpen's own `payload.Length < 10` guard unreachable.
+        //   - UPDATE: a body error is routed to treat-as-withdraw and the session SURVIVES. A header
+        //     error tears it down — so a 22-byte UPDATE would become a remote session kill, exactly
+        //     the class of defect #222 and #284 closed. RFC 7606 §3 revises UPDATE error handling
+        //     toward keeping the session, and that direction wins here.
+        //   - NOTIFICATION: already a header error, just without the subcode; not worth a special
+        //     case of its own.
+        // Recorded rather than silently skipped; see the PR for the full reasoning.
+        if (type == BgpMessageType.Keepalive && length != BgpConstants.MessageHeaderSize)
+            throw BadMessageLength(length);
+
         var payload = buffer[BgpConstants.MessageHeaderSize..length];
 
         return type switch
@@ -28,9 +51,24 @@ public static class BgpMessageReader
             BgpMessageType.Update => ParseUpdate(payload),
             BgpMessageType.Notification => ParseNotification(payload),
             BgpMessageType.RouteRefresh => ParseRouteRefresh(payload),
-            _ => throw new BgpParseException($"Unknown message type: {type}")
+            // RFC 4271 §6.1: "the Error Subcode MUST be set to Bad Message Type. The Data field
+            // MUST contain the erroneous Message Type field."
+            _ => throw new BgpParseException($"Unknown message type: {(byte)type}",
+                subErrorCode: BgpConstants.SubError.BadMessageType, notificationData: [(byte)type])
         };
     }
+
+    /// <summary>
+    /// RFC 4271 §6.1 Bad Message Length: "The Data field MUST contain the erroneous Length field."
+    /// <c>ErrorCode</c> is deliberately left <c>null</c> — that is how <c>BgpSession.ReadLoopAsync</c>
+    /// tells a fixed-header failure (tear the session down) from a message-body failure
+    /// (treat-as-withdraw), and turning it into a body error here would both violate §6.1 and
+    /// desync the stream, since the payload has not been consumed (#223, #300).
+    /// </summary>
+    private static BgpParseException BadMessageLength(int length) =>
+        new($"Invalid message length: {length}",
+            subErrorCode: BgpConstants.SubError.BadMessageLength,
+            notificationData: [(byte)(length >> 8), (byte)length]);
 
     public static int GetMessageLength(ReadOnlySpan<byte> buffer)
     {
@@ -342,10 +380,13 @@ public static class BgpMessageReader
 /// </summary>
 public sealed class BgpParseException : Exception
 {
-    public BgpParseException(string message, byte? errorCode = null, byte? subErrorCode = null) : base(message)
+    private readonly byte[]? _notificationData;
+
+    public BgpParseException(string message, byte? errorCode = null, byte? subErrorCode = null, byte[]? notificationData = null) : base(message)
     {
         ErrorCode = errorCode;
         SubErrorCode = subErrorCode;
+        _notificationData = notificationData is null ? null : (byte[])notificationData.Clone();
     }
 
     public BgpParseException(string message, Exception inner) : base(message, inner) { }
@@ -355,4 +396,12 @@ public sealed class BgpParseException : Exception
     public byte? ErrorCode { get; }
     /// <summary>RFC 4271 §6 sub-error code, or <c>null</c> for Unspecific (0).</summary>
     public byte? SubErrorCode { get; }
+    /// <summary>
+    /// Contents of the NOTIFICATION Data field, or <c>null</c> when the failure carries none.
+    /// RFC 4271 §6.1 requires the erroneous Length field for Bad Message Length and the erroneous
+    /// Message Type for Bad Message Type, so the peer's operator gets a usable diagnostic instead
+    /// of a bare "unknown error" (#300). Cloned in and out, mirroring
+    /// <see cref="BgpNotificationException.NotificationData"/>.
+    /// </summary>
+    public byte[]? NotificationData => _notificationData is null ? null : (byte[])_notificationData.Clone();
 }

--- a/BGPLite.Protocol/BgpMessageReader.cs
+++ b/BGPLite.Protocol/BgpMessageReader.cs
@@ -81,8 +81,16 @@ public static class BgpMessageReader
     {
         // #105: SequenceEqual over ReadOnlySpan<byte> replaces the hand-rolled byte-by-byte loop —
         // idiomatic, vectorizable by the JIT, and the same semantics.
+        //
+        // RFC 4271 §6.1: "If the Marker field of the message header is not as expected, then a
+        // synchronization error has occurred and the Error Subcode MUST be set to Connection Not
+        // Synchronized." This previously emitted Unspecific, which tells the peer's operator
+        // nothing about the one header failure that actually means "our streams have diverged"
+        // (#300). ErrorCode stays null so it remains a fixed-header failure that tears the session
+        // down, which is exactly right for a desync.
         if (!marker.SequenceEqual(BgpConstants.Marker))
-            throw new BgpParseException("Invalid BGP marker");
+            throw new BgpParseException("Invalid BGP marker",
+                subErrorCode: BgpConstants.SubError.ConnectionNotSynchronized);
     }
 
     #region OPEN

--- a/BGPLite.Protocol/OpenNegotiator.cs
+++ b/BGPLite.Protocol/OpenNegotiator.cs
@@ -61,6 +61,15 @@ public static class OpenNegotiator
         var remoteAsn = CapabilityHelper.GetEffectiveAsn(open);
         var remoteRouteRefresh = open.Capabilities.Any(c => c.Code == BgpConstants.Capability.RouteRefresh);
 
+        // RFC 7607 §2: "If a BGP speaker receives zero as the peer AS in an OPEN message, it MUST
+        // abort the connection and send a NOTIFICATION with Error Code 'OPEN Message Error' and
+        // subcode 'Bad Peer AS'." Both fields are checked: the declared My Autonomous System and
+        // the effective ASN (the 4-octet capability value when present, which takes precedence per
+        // RFC 6793 §4.1). Without this an AS-0 peer was accepted and — since BGPLite auto-registers
+        // unknown peers — persisted in the PeerStore as a real peer (#300).
+        if (open.Asn == 0 || remoteAsn == 0)
+            throw new BgpNotificationException(BgpConstants.Error.OpenMessageError, BgpConstants.SubError.BadPeerAs, "Invalid peer AS: 0 (RFC 7607)");
+
         if (expectedRemoteAsn.HasValue && remoteAsn != expectedRemoteAsn.Value)
             throw new BgpNotificationException(BgpConstants.Error.OpenMessageError, BgpConstants.SubError.BadPeerAs, $"Unexpected ASN: expected {expectedRemoteAsn}, got {remoteAsn}");
 

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -450,7 +450,10 @@ public sealed class BgpSession : IDisposable
             // when the parser did not specify one (e.g. marker/length/type validation in ReadMessage).
             if (Interlocked.CompareExchange(ref _teardownReason, (int)TeardownReason.LocalCease, (int)TeardownReason.None) == (int)TeardownReason.None)
             {
-                try { await SendNotificationAsync(ex.ErrorCode ?? BgpConstants.Error.MessageHeaderError, ex.SubErrorCode ?? BgpConstants.SubError.Unspecific); }
+                // #300: the parser may also supply the NOTIFICATION Data field — RFC 4271 §6.1
+                // requires the erroneous Length for Bad Message Length and the erroneous Message
+                // Type for Bad Message Type, so the peer's operator sees what was wrong.
+                try { await SendNotificationAsync(ex.ErrorCode ?? BgpConstants.Error.MessageHeaderError, ex.SubErrorCode ?? BgpConstants.SubError.Unspecific, ex.NotificationData); }
                 catch { /* best-effort */ }
             }
         }
@@ -1061,7 +1064,13 @@ public sealed class BgpSession : IDisposable
 
             var length = BgpMessageReader.GetMessageLength(headerBuffer);
             if (length is < BgpConstants.MinMessageSize or > BgpConstants.MaxMessageSize)
-                throw new BgpParseException($"Invalid message length: {length}");
+                // RFC 4271 §6.1: Bad Message Length, with the erroneous Length in the Data field.
+                // ErrorCode stays null so this remains a fixed-header failure — ReadLoopAsync must
+                // NOT treat it as withdraw-able, both per §6.1 and because the payload has not been
+                // read yet, so continuing would desync the stream (#223, #300).
+                throw new BgpParseException($"Invalid message length: {length}",
+                    subErrorCode: BgpConstants.SubError.BadMessageLength,
+                    notificationData: [(byte)(length >> 8), (byte)length]);
 
             var payloadSize = length - BgpConstants.MessageHeaderSize;
             var messageBuffer = ArrayPool<byte>.Shared.Rent(length);

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -924,6 +924,111 @@ public class BgpMessageTests
     [InlineData(255, false)]
     [InlineData(256, true)]
     public void WriteAttribute_WithoutCallerFlag_PicksFieldWidthByLength(int dataLength, bool expectExtendedBit)
+
+    // ---- #300: RFC 4271 §6.1 header validation + RFC 7607 AS 0 ----
+
+    /// <summary>
+    /// RFC 4271 §6.1: "if the Length field of a KEEPALIVE message is not equal to 19 ... then the
+    /// Error Subcode MUST be set to Bad Message Length." Type 4 previously mapped straight to the
+    /// singleton, so a padded KEEPALIVE was accepted with its trailing bytes silently ignored.
+    /// </summary>
+    [Theory]
+    [InlineData(20)]
+    [InlineData(23)]
+    [InlineData(100)]
+    public void ReadMessage_KeepaliveWithWrongLength_BadMessageLength(int totalLength)
+    {
+        var frame = new byte[totalLength];
+        BgpConstants.Marker.CopyTo(frame.AsSpan(0, BgpConstants.MarkerSize));
+        BinaryPrimitives.WriteUInt16BigEndian(frame.AsSpan(16, 2), (ushort)totalLength);
+        frame[18] = (byte)BgpMessageType.Keepalive;
+
+        var ex = Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(frame));
+        Assert.Equal(BgpConstants.SubError.BadMessageLength, ex.SubErrorCode);
+        // ErrorCode stays null: this is a fixed-header failure, which BgpSession.ReadLoopAsync must
+        // propagate (tear down) rather than route to treat-as-withdraw.
+        Assert.Null(ex.ErrorCode);
+        Assert.Equal([(byte)(totalLength >> 8), (byte)totalLength], ex.NotificationData);
+    }
+
+    [Fact]
+    public void ReadMessage_KeepaliveWithExactLength_StillParses()
+    {
+        var frame = new byte[BgpConstants.MessageHeaderSize];
+        BgpConstants.Marker.CopyTo(frame.AsSpan(0, BgpConstants.MarkerSize));
+        BinaryPrimitives.WriteUInt16BigEndian(frame.AsSpan(16, 2), BgpConstants.MessageHeaderSize);
+        frame[18] = (byte)BgpMessageType.Keepalive;
+
+        Assert.IsType<BgpKeepaliveMessage>(BgpMessageReader.ReadMessage(frame));
+    }
+
+    /// <summary>
+    /// RFC 4271 §6.1: an out-of-range Length carries Bad Message Length "and the Data field MUST
+    /// contain the erroneous Length field".
+    /// </summary>
+    [Theory]
+    [InlineData(5)]
+    [InlineData(18)]
+    [InlineData(4097)]
+    [InlineData(65535)]
+    public void ReadMessage_LengthOutOfRange_BadMessageLengthWithData(int declaredLength)
+    {
+        var frame = new byte[BgpConstants.MessageHeaderSize];
+        BgpConstants.Marker.CopyTo(frame.AsSpan(0, BgpConstants.MarkerSize));
+        BinaryPrimitives.WriteUInt16BigEndian(frame.AsSpan(16, 2), (ushort)declaredLength);
+        frame[18] = (byte)BgpMessageType.Keepalive;
+
+        var ex = Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(frame));
+        Assert.Null(ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.BadMessageLength, ex.SubErrorCode);
+        Assert.Equal([(byte)(declaredLength >> 8), (byte)declaredLength], ex.NotificationData);
+    }
+
+    /// <summary>
+    /// RFC 4271 §6.1: "the Error Subcode MUST be set to Bad Message Type. The Data field MUST
+    /// contain the erroneous Message Type field."
+    /// </summary>
+    [Theory]
+    [InlineData((byte)0)]
+    [InlineData((byte)6)]
+    [InlineData((byte)255)]
+    public void ReadMessage_UnknownMessageType_BadMessageTypeWithData(byte type)
+    {
+        var frame = new byte[BgpConstants.MessageHeaderSize];
+        BgpConstants.Marker.CopyTo(frame.AsSpan(0, BgpConstants.MarkerSize));
+        BinaryPrimitives.WriteUInt16BigEndian(frame.AsSpan(16, 2), BgpConstants.MessageHeaderSize);
+        frame[18] = type;
+
+        var ex = Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(frame));
+        Assert.Null(ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.BadMessageType, ex.SubErrorCode);
+        Assert.Equal([type], ex.NotificationData);
+    }
+
+    /// <summary>
+    /// RFC 7607 §2: "An UPDATE message that contains the AS number of zero in the AS_PATH ... MUST
+    /// be considered as malformed and be handled by the procedures specified in [RFC7606]" — i.e.
+    /// treat-as-withdraw via Malformed AS_PATH (RFC 7606 §7.2). Covers AS4_PATH through the same
+    /// shared segment reader.
+    /// </summary>
+    [Fact]
+    public void ReadAsPath_ContainingAsZero_MalformedAsPath()
+    {
+        // AS_SEQUENCE of 2 four-octet ASNs: 100, then 0.
+        var attr = new PathAttribute
+        {
+            Flags = BgpConstants.Attribute.FlagTransitive,
+            TypeCode = BgpConstants.Attribute.AsPath,
+            Data = [0x02, 0x02, 0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00, 0x00],
+        };
+
+        var ex = Assert.Throws<BgpParseException>(() => AttributeHelper.ReadAsPath(attr, fourByteAsn: true));
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.MalformedAsPath, ex.SubErrorCode);
+    }
+
+    [Fact]
+    public void ReadAs4Path_ContainingAsZero_MalformedAsPath()
     {
         var attr = new PathAttribute
         {
@@ -1009,5 +1114,33 @@ public class BgpMessageTests
         // attribute region — everything past the fixed UPDATE header — is untouched.
         var attrRegion = BgpConstants.MessageHeaderSize + 4;
         Assert.Equal(canary.AsSpan(attrRegion).ToArray(), buffer.AsSpan(attrRegion).ToArray());
+            TypeCode = BgpConstants.Attribute.As4Path,
+            Data = [0x02, 0x01, 0x00, 0x00, 0x00, 0x00],
+        };
+
+        var ex = Assert.Throws<BgpParseException>(() => AttributeHelper.ReadAs4Path(attr));
+        Assert.Equal(BgpConstants.SubError.MalformedAsPath, ex.SubErrorCode);
+    }
+
+    [Fact]
+    public void ReadAsPath_TwoOctetAsZero_MalformedAsPath()
+    {
+        // The 2-octet encoding path must reject AS 0 too.
+        var attr = new PathAttribute
+        {
+            Flags = BgpConstants.Attribute.FlagTransitive,
+            TypeCode = BgpConstants.Attribute.AsPath,
+            Data = [0x02, 0x02, 0x00, 0x64, 0x00, 0x00],
+        };
+
+        var ex = Assert.Throws<BgpParseException>(() => AttributeHelper.ReadAsPath(attr, fourByteAsn: false));
+        Assert.Equal(BgpConstants.SubError.MalformedAsPath, ex.SubErrorCode);
+    }
+
+    [Fact]
+    public void ReadAsPath_WithoutAsZero_StillParses()
+    {
+        var attr = AttributeHelper.WriteAsPath([65001u, 200000u], fourByteAsn: true);
+        Assert.Equal([65001u, 200000u], AttributeHelper.ReadAsPath(attr, fourByteAsn: true));
     }
 }

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -924,6 +924,92 @@ public class BgpMessageTests
     [InlineData(255, false)]
     [InlineData(256, true)]
     public void WriteAttribute_WithoutCallerFlag_PicksFieldWidthByLength(int dataLength, bool expectExtendedBit)
+    {
+        var attr = new PathAttribute
+        {
+            Flags = (byte)(BgpConstants.Attribute.FlagOptional | BgpConstants.Attribute.FlagTransitive),
+            TypeCode = BgpConstants.Attribute.Community,
+            Data = new byte[dataLength],
+        };
+        var update = new BgpUpdateMessage { PathAttributes = [attr] };
+
+        var buffer = new byte[BgpMessageWriter.GetBufferSize(update)];
+        var written = BgpMessageWriter.WriteMessage(update, buffer);
+        Assert.Equal(buffer.Length, written);
+
+        var read = Assert.IsType<BgpUpdateMessage>(BgpMessageReader.ReadMessage(buffer.AsSpan(0, written)));
+        var roundTripped = Assert.Single(read.PathAttributes);
+        Assert.Equal(dataLength, roundTripped.Data.Length);
+        Assert.Equal(expectExtendedBit, (roundTripped.Flags & BgpConstants.Attribute.FlagExtendedLength) != 0);
+    }
+
+    /// <summary>
+    /// The exact frame from #291: flags 0xD0 with a 4-octet COMMUNITY. The reader used to read the
+    /// length as 0x0400 = 1024 and throw Attribute Length Error on the writer's own output.
+    /// </summary>
+    [Fact]
+    public void WriteAttribute_ExtendedFlagShortValue_EmitsTwoOctetLengthField()
+    {
+        var attr = new PathAttribute
+        {
+            Flags = 0xD0,
+            TypeCode = BgpConstants.Attribute.Community,
+            Data = [0x00, 0x00, 0x00, 0x01],
+        };
+        var update = new BgpUpdateMessage { PathAttributes = [attr] };
+
+        var buffer = new byte[BgpMessageWriter.GetBufferSize(update)];
+        var written = BgpMessageWriter.WriteMessage(update, buffer);
+
+        // header(19) + withdrawn-len(2) + attrs-len(2) + flags(1) + type(1) + length(2) + value(4)
+        Assert.Equal(31, written);
+        var attrStart = BgpConstants.MessageHeaderSize + 4;
+        Assert.Equal(0xD0, buffer[attrStart]);
+        Assert.Equal(BgpConstants.Attribute.Community, buffer[attrStart + 1]);
+        Assert.Equal(0x00, buffer[attrStart + 2]); // two-octet length, high byte
+        Assert.Equal(0x04, buffer[attrStart + 3]); // two-octet length, low byte
+    }
+
+    /// <summary>
+    /// RFC 4271 §4.3: flag bit 0x08 is reserved and MUST be zero. The reader rejects it (#272), so
+    /// emitting it would make the writer produce a frame its own reader refuses — the same
+    /// round-trip break this PR fixes for the Extended Length bit (#291 review).
+    /// </summary>
+    [Theory]
+    [InlineData((byte)0x08)]                      // reserved alone
+    [InlineData((byte)0xC8)]                      // optional | transitive | reserved
+    [InlineData((byte)0xD8)]                      // ...also extended length
+    public void WriteAttribute_ReservedFlagBitSet_Throws(byte flags)
+    {
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes = [new PathAttribute { Flags = flags, TypeCode = BgpConstants.Attribute.Community, Data = [0, 0, 0, 1] }],
+        };
+        var buffer = new byte[BgpMessageWriter.GetBufferSize(update)];
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => BgpMessageWriter.WriteMessage(update, buffer));
+    }
+
+    [Fact]
+    public void WriteAttribute_ReservedFlagBitSet_LeavesBufferUntouched()
+    {
+        // The guard runs before any byte is written, so a rejected attribute cannot leave a
+        // half-serialized frame in the caller's span.
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes = [new PathAttribute { Flags = 0xC8, TypeCode = BgpConstants.Attribute.Community, Data = [0, 0, 0, 1] }],
+        };
+        var buffer = new byte[BgpMessageWriter.GetBufferSize(update)];
+        var canary = new byte[buffer.Length];
+        Array.Fill(canary, (byte)0xEE);
+        canary.CopyTo(buffer, 0);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => BgpMessageWriter.WriteMessage(update, buffer));
+        // The header is written by WriteUpdate before the attribute loop, so only assert that the
+        // attribute region — everything past the fixed UPDATE header — is untouched.
+        var attrRegion = BgpConstants.MessageHeaderSize + 4;
+        Assert.Equal(canary.AsSpan(attrRegion).ToArray(), buffer.AsSpan(attrRegion).ToArray());
+    }
 
     // ---- #300: RFC 4271 §6.1 header validation + RFC 7607 AS 0 ----
 
@@ -1036,87 +1122,6 @@ public class BgpMessageTests
         var attr = new PathAttribute
         {
             Flags = (byte)(BgpConstants.Attribute.FlagOptional | BgpConstants.Attribute.FlagTransitive),
-            TypeCode = BgpConstants.Attribute.Community,
-            Data = new byte[dataLength],
-        };
-        var update = new BgpUpdateMessage { PathAttributes = [attr] };
-
-        var buffer = new byte[BgpMessageWriter.GetBufferSize(update)];
-        var written = BgpMessageWriter.WriteMessage(update, buffer);
-        Assert.Equal(buffer.Length, written);
-
-        var read = Assert.IsType<BgpUpdateMessage>(BgpMessageReader.ReadMessage(buffer.AsSpan(0, written)));
-        var roundTripped = Assert.Single(read.PathAttributes);
-        Assert.Equal(dataLength, roundTripped.Data.Length);
-        Assert.Equal(expectExtendedBit, (roundTripped.Flags & BgpConstants.Attribute.FlagExtendedLength) != 0);
-    }
-
-    /// <summary>
-    /// The exact frame from #291: flags 0xD0 with a 4-octet COMMUNITY. The reader used to read the
-    /// length as 0x0400 = 1024 and throw Attribute Length Error on the writer's own output.
-    /// </summary>
-    [Fact]
-    public void WriteAttribute_ExtendedFlagShortValue_EmitsTwoOctetLengthField()
-    {
-        var attr = new PathAttribute
-        {
-            Flags = 0xD0,
-            TypeCode = BgpConstants.Attribute.Community,
-            Data = [0x00, 0x00, 0x00, 0x01],
-        };
-        var update = new BgpUpdateMessage { PathAttributes = [attr] };
-
-        var buffer = new byte[BgpMessageWriter.GetBufferSize(update)];
-        var written = BgpMessageWriter.WriteMessage(update, buffer);
-
-        // header(19) + withdrawn-len(2) + attrs-len(2) + flags(1) + type(1) + length(2) + value(4)
-        Assert.Equal(31, written);
-        var attrStart = BgpConstants.MessageHeaderSize + 4;
-        Assert.Equal(0xD0, buffer[attrStart]);
-        Assert.Equal(BgpConstants.Attribute.Community, buffer[attrStart + 1]);
-        Assert.Equal(0x00, buffer[attrStart + 2]); // two-octet length, high byte
-        Assert.Equal(0x04, buffer[attrStart + 3]); // two-octet length, low byte
-    }
-
-    /// <summary>
-    /// RFC 4271 §4.3: flag bit 0x08 is reserved and MUST be zero. The reader rejects it (#272), so
-    /// emitting it would make the writer produce a frame its own reader refuses — the same
-    /// round-trip break this PR fixes for the Extended Length bit (#291 review).
-    /// </summary>
-    [Theory]
-    [InlineData((byte)0x08)]                      // reserved alone
-    [InlineData((byte)0xC8)]                      // optional | transitive | reserved
-    [InlineData((byte)0xD8)]                      // ...also extended length
-    public void WriteAttribute_ReservedFlagBitSet_Throws(byte flags)
-    {
-        var update = new BgpUpdateMessage
-        {
-            PathAttributes = [new PathAttribute { Flags = flags, TypeCode = BgpConstants.Attribute.Community, Data = [0, 0, 0, 1] }],
-        };
-        var buffer = new byte[BgpMessageWriter.GetBufferSize(update)];
-
-        Assert.Throws<ArgumentOutOfRangeException>(() => BgpMessageWriter.WriteMessage(update, buffer));
-    }
-
-    [Fact]
-    public void WriteAttribute_ReservedFlagBitSet_LeavesBufferUntouched()
-    {
-        // The guard runs before any byte is written, so a rejected attribute cannot leave a
-        // half-serialized frame in the caller's span.
-        var update = new BgpUpdateMessage
-        {
-            PathAttributes = [new PathAttribute { Flags = 0xC8, TypeCode = BgpConstants.Attribute.Community, Data = [0, 0, 0, 1] }],
-        };
-        var buffer = new byte[BgpMessageWriter.GetBufferSize(update)];
-        var canary = new byte[buffer.Length];
-        Array.Fill(canary, (byte)0xEE);
-        canary.CopyTo(buffer, 0);
-
-        Assert.Throws<ArgumentOutOfRangeException>(() => BgpMessageWriter.WriteMessage(update, buffer));
-        // The header is written by WriteUpdate before the attribute loop, so only assert that the
-        // attribute region — everything past the fixed UPDATE header — is untouched.
-        var attrRegion = BgpConstants.MessageHeaderSize + 4;
-        Assert.Equal(canary.AsSpan(attrRegion).ToArray(), buffer.AsSpan(attrRegion).ToArray());
             TypeCode = BgpConstants.Attribute.As4Path,
             Data = [0x02, 0x01, 0x00, 0x00, 0x00, 0x00],
         };
@@ -1145,5 +1150,28 @@ public class BgpMessageTests
     {
         var attr = AttributeHelper.WriteAsPath([65001u, 200000u], fourByteAsn: true);
         Assert.Equal([65001u, 200000u], AttributeHelper.ReadAsPath(attr, fourByteAsn: true));
+    }
+
+    /// <summary>
+    /// RFC 4271 §6.1: "If the Marker field of the message header is not as expected, then a
+    /// synchronization error has occurred and the Error Subcode MUST be set to Connection Not
+    /// Synchronized." Previously emitted Unspecific (#300 review).
+    /// </summary>
+    [Theory]
+    [InlineData(0)]   // first marker octet corrupted
+    [InlineData(8)]   // middle
+    [InlineData(15)]  // last
+    public void ReadMessage_InvalidMarker_ConnectionNotSynchronized(int corruptIndex)
+    {
+        var frame = new byte[BgpConstants.MessageHeaderSize];
+        BgpConstants.Marker.CopyTo(frame.AsSpan(0, BgpConstants.MarkerSize));
+        frame[corruptIndex] = 0x00;
+        BinaryPrimitives.WriteUInt16BigEndian(frame.AsSpan(16, 2), BgpConstants.MessageHeaderSize);
+        frame[18] = (byte)BgpMessageType.Keepalive;
+
+        var ex = Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(frame));
+        Assert.Equal(BgpConstants.SubError.ConnectionNotSynchronized, ex.SubErrorCode);
+        // Still a fixed-header failure: BgpSession must tear the session down, not treat-as-withdraw.
+        Assert.Null(ex.ErrorCode);
     }
 }

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -948,7 +948,8 @@ public class BgpMessageTests
         // ErrorCode stays null: this is a fixed-header failure, which BgpSession.ReadLoopAsync must
         // propagate (tear down) rather than route to treat-as-withdraw.
         Assert.Null(ex.ErrorCode);
-        Assert.Equal([(byte)(totalLength >> 8), (byte)totalLength], ex.NotificationData);
+        Assert.NotNull(ex.NotificationData);
+        Assert.Equal([(byte)(totalLength >> 8), (byte)totalLength], ex.NotificationData!);
     }
 
     [Fact]
@@ -981,7 +982,8 @@ public class BgpMessageTests
         var ex = Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(frame));
         Assert.Null(ex.ErrorCode);
         Assert.Equal(BgpConstants.SubError.BadMessageLength, ex.SubErrorCode);
-        Assert.Equal([(byte)(declaredLength >> 8), (byte)declaredLength], ex.NotificationData);
+        Assert.NotNull(ex.NotificationData);
+        Assert.Equal([(byte)(declaredLength >> 8), (byte)declaredLength], ex.NotificationData!);
     }
 
     /// <summary>
@@ -1002,7 +1004,8 @@ public class BgpMessageTests
         var ex = Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(frame));
         Assert.Null(ex.ErrorCode);
         Assert.Equal(BgpConstants.SubError.BadMessageType, ex.SubErrorCode);
-        Assert.Equal([type], ex.NotificationData);
+        Assert.NotNull(ex.NotificationData);
+        Assert.Equal([type], ex.NotificationData!);
     }
 
     /// <summary>

--- a/BGPLite.Tests/MalformedUpdateResilienceTests.cs
+++ b/BGPLite.Tests/MalformedUpdateResilienceTests.cs
@@ -457,7 +457,8 @@ public class MalformedUpdateResilienceTests
         // MUST be set to Bad Message Length ... The Data field MUST contain the erroneous Length
         // field." Previously this emitted 1/0 with no Data, giving the peer's operator nothing.
         Assert.Equal(BgpConstants.SubError.BadMessageLength, notif.SubErrorCode);
-        Assert.Equal([0x00, 0x05], notif.Data); // the declared length that was rejected
+        Assert.NotNull(notif.Data);
+        Assert.Equal([0x00, 0x05], notif.Data!); // the declared length that was rejected
 
         try { await runTask.WaitAsync(TimeSpan.FromSeconds(5)); }
         catch (OperationCanceledException) { /* session torn down */ }

--- a/BGPLite.Tests/MalformedUpdateResilienceTests.cs
+++ b/BGPLite.Tests/MalformedUpdateResilienceTests.cs
@@ -453,6 +453,11 @@ public class MalformedUpdateResilienceTests
         var notif = sent.OfType<BgpNotificationMessage>().SingleOrDefault();
         Assert.NotNull(notif);
         Assert.Equal(BgpConstants.Error.MessageHeaderError, notif!.ErrorCode);
+        // #300: RFC 4271 §6.1 also mandates the subcode and the Data field — "the Error Subcode
+        // MUST be set to Bad Message Length ... The Data field MUST contain the erroneous Length
+        // field." Previously this emitted 1/0 with no Data, giving the peer's operator nothing.
+        Assert.Equal(BgpConstants.SubError.BadMessageLength, notif.SubErrorCode);
+        Assert.Equal([0x00, 0x05], notif.Data); // the declared length that was rejected
 
         try { await runTask.WaitAsync(TimeSpan.FromSeconds(5)); }
         catch (OperationCanceledException) { /* session torn down */ }

--- a/BGPLite.Tests/OpenNegotiatorTests.cs
+++ b/BGPLite.Tests/OpenNegotiatorTests.cs
@@ -240,10 +240,12 @@ public class OpenNegotiatorTests
     [Fact]
     public void Validate_FourOctetCapabilityCarryingZero_BadPeerAs()
     {
+        // Asn is deliberately NON-zero: with Asn = 0 the `open.Asn == 0` half short-circuits and
+        // this test would still pass if the capability-derived check were deleted (#300 review).
         var open = new BgpOpenMessage
         {
             Version = 4,
-            Asn = 0,
+            Asn = 65002,
             HoldTime = 180,
             RouterId = 0x0A000002,
             Capabilities = [BgpCapabilityInfo.FourOctetAsn(0)],

--- a/BGPLite.Tests/OpenNegotiatorTests.cs
+++ b/BGPLite.Tests/OpenNegotiatorTests.cs
@@ -217,4 +217,64 @@ public class OpenNegotiatorTests
         Assert.Equal(0, n.NegotiatedHoldTime);
         Assert.Equal(TimeSpan.Zero, n.KeepAliveInterval);
     }
+
+    /// <summary>
+    /// RFC 7607 §2: "If a BGP speaker receives zero as the peer AS in an OPEN message, it MUST abort
+    /// the connection and send a NOTIFICATION with Error Code 'OPEN Message Error' and subcode
+    /// 'Bad Peer AS'." Both the declared My Autonomous System field and the effective ASN (the
+    /// 4-octet capability value, which takes precedence per RFC 6793 §4.1) are checked. Because
+    /// BGPLite auto-registers unknown peers, an AS-0 peer previously landed in the PeerStore as a
+    /// real peer (#300).
+    /// </summary>
+    [Fact]
+    public void Validate_MyAsZero_BadPeerAs()
+    {
+        var open = new BgpOpenMessage { Version = 4, Asn = 0, HoldTime = 180, RouterId = 0x0A000002 };
+
+        var ex = Assert.Throws<BgpNotificationException>(
+            () => OpenNegotiator.Validate(open, expectedRemoteAsn: null, localRouterId: 0x0A0A0A0A, localHoldTime: 180));
+        Assert.Equal(BgpConstants.Error.OpenMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.BadPeerAs, ex.SubErrorCode);
+    }
+
+    [Fact]
+    public void Validate_FourOctetCapabilityCarryingZero_BadPeerAs()
+    {
+        var open = new BgpOpenMessage
+        {
+            Version = 4,
+            Asn = 0,
+            HoldTime = 180,
+            RouterId = 0x0A000002,
+            Capabilities = [BgpCapabilityInfo.FourOctetAsn(0)],
+        };
+
+        var ex = Assert.Throws<BgpNotificationException>(
+            () => OpenNegotiator.Validate(open, expectedRemoteAsn: null, localRouterId: 0x0A0A0A0A, localHoldTime: 180));
+        Assert.Equal(BgpConstants.SubError.BadPeerAs, ex.SubErrorCode);
+    }
+
+    /// <summary>
+    /// The My-AS field disagreeing with the 4-octet capability is NOT an error: RFC 6793 §4.1 says
+    /// the capability value is used "in lieu of" the My Autonomous System field and mandates no
+    /// error handling for a disagreement. Guards against re-adding a check that would reject peers
+    /// the RFC says to accept.
+    /// </summary>
+    [Fact]
+    public void Validate_MyAsDisagreesWithCapability_UsesCapabilityValue()
+    {
+        var open = new BgpOpenMessage
+        {
+            Version = 4,
+            Asn = 65000, // not AS_TRANS, though the capability carries a 4-octet AS
+            HoldTime = 180,
+            RouterId = 0x0A000002,
+            Capabilities = [BgpCapabilityInfo.FourOctetAsn(131072)],
+        };
+
+        var negotiation = OpenNegotiator.Validate(open, expectedRemoteAsn: null, localRouterId: 0x0A0A0A0A, localHoldTime: 180);
+
+        Assert.Equal(131072u, negotiation.RemoteAsn);
+        Assert.True(negotiation.RemoteFourByteAsn);
+    }
 }


### PR DESCRIPTION
Closes #300

Three message-validation gaps, split out of #292 because they form one coherent change across `BgpMessageReader` / `OpenNegotiator` / `AttributeHelper`.

## 1. KEEPALIVE with a length other than 19 was accepted

`ReadMessage` mapped type 4 straight to `BgpKeepaliveMessage.Instance` with no length check:

```
FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF 0017 04 DEADBEEF   -> parsed as Keepalive, payload ignored
```

RFC 4271 §6.1: *"if the Length field of a KEEPALIVE message is not equal to 19 ... then the Error Subcode MUST be set to Bad Message Length."*

## 2. Header errors carried Unspecific and no Data field

An out-of-range Length and an unknown Message Type both emitted `MessageHeaderError/Unspecific` with no Data, so the peer's operator got "unknown error" and nothing to act on. RFC 4271 §6.1 mandates **Bad Message Length (2)** with *"the erroneous Length field"* in Data, and **Bad Message Type (3)** with *"the erroneous Message Type field"* in Data.

`BgpParseException` gains an optional `NotificationData` (additive — `BgpNotificationException` already had one, and this mirrors its clone-in/clone-out); `BgpSession` passes it through to `SendNotificationAsync`, which already had a data-carrying overload.

**`ErrorCode` is deliberately left `null` in both cases.** That null is how `ReadLoopAsync` tells a fixed-header failure (propagate → tear down) from a message-body failure (treat-as-withdraw). Setting it would route header errors into treat-as-withdraw and desync the stream, since the payload has not been consumed at that point (#223). The subcode rides along without disturbing that split, because `RunAsync` already does `SendNotificationAsync(ex.ErrorCode ?? MessageHeaderError, ex.SubErrorCode ?? Unspecific)`. There is an explicit `Assert.Null(ex.ErrorCode)` in the tests so this cannot regress silently.

## 3. AS 0 accepted in OPEN and in AS_PATH / AS4_PATH (RFC 7607)

```
OPEN My-AS=0, 4-octet capability AS=0   -> ACCEPTED, remoteAsn=0
UPDATE AS_PATH = [100, 0]               -> ACCEPTED, asPath=[100,0]
```

> If a BGP speaker receives zero as the peer AS in an OPEN message, it MUST abort the connection and send a NOTIFICATION with Error Code "OPEN Message Error" and subcode "Bad Peer AS".

> An UPDATE message that contains the AS number of zero in the AS_PATH or AGGREGATOR attribute MUST be considered as malformed and be handled by the procedures specified in [RFC7606].

`OpenNegotiator` now rejects a peer whose My Autonomous System **or** effective ASN is 0; `ReadPathData` rejects AS 0 with Malformed AS_PATH (treat-as-withdraw — the remedy RFC 7606 §7.2 prescribes), covering AS_PATH and AS4_PATH in both 2- and 4-octet encodings through the shared segment reader.

Because BGPLite auto-registers unknown peers (`expectedRemoteAsn == null` accepts any declared ASN), an AS-0 peer previously persisted in the `PeerStore` as a real peer.

## Deliberately NOT done — each recorded in a code comment

**The per-type minimum lengths for OPEN / UPDATE / NOTIFICATION.** #300 lists these, and I implemented them first — then backed them out when an existing test went red, which turned out to be the right signal:

- **OPEN**: #223 deliberately made a too-short OPEN report Open Message Error (2), with `ParseOpen_TooShort_PropagatesOpenMessageErrorCode` asserting it. Reclassifying would flip that decision and make `ParseOpen`'s own `payload.Length < 10` guard unreachable.
- **UPDATE**: a body error is routed to treat-as-withdraw and the session **survives**; a header error tears it down. So a 22-byte UPDATE would become a *remote session kill* — exactly the class of defect #222 and #284 closed. RFC 7606 §3 revises UPDATE error handling toward keeping the session, and that direction wins over the letter of RFC 4271 §6.1 here.
- **NOTIFICATION**: already a header error, just without the subcode; not worth a special case.

**AS 0 in AGGREGATOR / AS4_AGGREGATOR**, also required by RFC 7607. RFC 7606 §7.7 prescribes *"attribute discard"* for a malformed AGGREGATOR, a mechanism BGPLite does not have — `ReadAggregatorAsn` throws `OptionalAttributeError`, which lands in treat-as-withdraw. Adding a rejection there would deepen an existing deviation rather than fix it. Recorded on #292 as a separate finding (item 11).

**The My-AS vs 4-octet-capability check** that #292 item 3 asked for. RFC 6793 §4.1 says the capability value is used *"in lieu of"* the My Autonomous System field and mandates **no** error handling for a disagreement — so the current behaviour is correct and the proposed check would reject peers the RFC says to accept. Item withdrawn on #292; a test now pins the correct behaviour so it is not "fixed" later by mistake.

## Verification

`dotnet build BGPLite.sln` + `dotnet test BGPLite.sln`: **618 passed, 0 failed** (600 before, 18 added). `dotnet format --severity warn` clean. No pre-existing test changed behaviour.

15 of the 20 touched tests confirmed to catch the regression — with all three fixes reverted they fail, with them restored they pass:

```
all #300 changes temporarily reverted
  Failed ReadMessage_KeepaliveWithWrongLength_BadMessageLength        x3
  Failed ReadMessage_LengthOutOfRange_BadMessageLengthWithData        x4
  Failed ReadMessage_UnknownMessageType_BadMessageTypeWithData        x3
  Failed ReadAsPath_ContainingAsZero / ReadAs4Path / TwoOctetAsZero   x3
  Failed Validate_MyAsZero_BadPeerAs / Validate_FourOctetCapability…  x2
Failed! - Failed: 15, Passed: 5
--- restored ---
```

The 5 that pass in both states are the negative controls: KEEPALIVE at exactly 19, AS_PATH without a zero, the My-AS-disagreement case, and the on-wire teardown test (which exercises `BgpSession.ReceiveMessageAsync`'s own length check rather than `ReadMessage`'s).

## Tests

Added:
- `ReadMessage_KeepaliveWithWrongLength_BadMessageLength` (3 lengths) + `ReadMessage_KeepaliveWithExactLength_StillParses`
- `ReadMessage_LengthOutOfRange_BadMessageLengthWithData` (4 lengths, incl. 65535)
- `ReadMessage_UnknownMessageType_BadMessageTypeWithData` (types 0, 6, 255)
- `ReadAsPath_ContainingAsZero` / `ReadAs4Path_ContainingAsZero` / `ReadAsPath_TwoOctetAsZero` / `ReadAsPath_WithoutAsZero_StillParses`
- `Validate_MyAsZero_BadPeerAs`, `Validate_FourOctetCapabilityCarryingZero_BadPeerAs`, `Validate_MyAsDisagreesWithCapability_UsesCapabilityValue`

Strengthened:
- `InvalidHeaderLength_OnWire_TearsDownSession_With_MessageHeaderError` now also asserts the NOTIFICATION carries subcode 2 and `Data == [0x00, 0x05]` — the declared length that was rejected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Rejects invalid AS 0 values in BGP paths and peer OPEN messages.
  - Validates KEEPALIVE and other message lengths according to protocol requirements.
  - Reports unknown message types with the correct error details.
  - Includes rejected length or type information in protocol notifications.

- **Tests**
  - Added coverage for malformed headers, invalid message types, AS 0 paths, and valid path parsing.
  - Verified correct peer validation and notification data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->