### PR TITLE
fix(server): a withdrawal removes only what this peer installed

### DIFF
--- a/BGPLite.Routing/RouteTable.cs
+++ b/BGPLite.Routing/RouteTable.cs
@@ -2,36 +2,98 @@ using System.Collections.Concurrent;
 
 namespace BGPLite.Routing;
 
+/// <summary>
+/// The shared route table. Each entry records which session installed it, so a withdrawal can be a
+/// compare-and-remove against the current owner rather than a delete by prefix (#289).
+/// <para>
+/// This is a minimal stand-in for the per-peer Adj-RIBs-In of RFC 4271 §3.2, not a replacement for
+/// them: there is still one table and one entry per prefix, so a later announcement for a prefix
+/// replaces the earlier one and its owner with it. What the ownership tag buys is that a peer can
+/// only remove an entry it currently owns — it cannot delete the startup seed, another peer's
+/// route, or a route of its own that has since been replaced by someone else.
+/// </para>
+/// </summary>
 public sealed class RouteTable
 {
-    private readonly ConcurrentDictionary<(uint Prefix, byte Length), Route> _routes = new();
+    private readonly ConcurrentDictionary<(uint Prefix, byte Length), Entry> _routes = new();
+
+    /// <summary>
+    /// A stored route plus the object that installed it. A <c>record struct</c> so the generated
+    /// structural equality gives <see cref="RemoveOwnedBy"/> its compare-and-remove: both the
+    /// <see cref="Route"/> instance and the <see cref="Owner"/> reference must still match.
+    /// </summary>
+    private readonly record struct Entry(Route Route, object? Owner);
 
     public int Count => _routes.Count;
 
-    public bool AddOrUpdate(Route route)
+    /// <summary>Installs a route with no owner — startup seeding and tests. Nobody can remove it via <see cref="RemoveOwnedBy"/>.</summary>
+    public bool AddOrUpdate(Route route) => AddOrUpdate(route, owner: null);
+
+    /// <summary>
+    /// Installs a route owned by <paramref name="owner"/>, replacing whatever is at that prefix.
+    /// Returns true when the prefix was new. Replacing transfers ownership: the previous owner can
+    /// no longer remove it, which is the point — its route is gone either way.
+    /// </summary>
+    public bool AddOrUpdate(Route route, object? owner)
     {
         // #85: avoid ConcurrentDictionary.AddOrUpdate's closure allocations (two delegate lambdas
         // per call). The try-pattern is allocation-free and equivalent: TryAdd for the new-key
         // case, indexer for the update case.
-        if (!_routes.TryAdd(route.Key, route))
+        var entry = new Entry(route, owner);
+        if (!_routes.TryAdd(route.Key, entry))
         {
-            _routes[route.Key] = route;
+            _routes[route.Key] = entry;
             return false;
         }
         return true;
     }
 
+    /// <summary>Unconditional removal, regardless of owner — administrative paths only.</summary>
     public bool Remove(uint prefix, byte length) =>
         _routes.TryRemove((prefix, length), out _);
 
-    public Route? Get(uint prefix, byte length) =>
-        _routes.TryGetValue((prefix, length), out var route) ? route : null;
+    /// <summary>
+    /// Removes the route at <paramref name="prefix"/>/<paramref name="length"/> only if
+    /// <paramref name="owner"/> still owns it, and returns whether it did. This is the withdrawal
+    /// path: RFC 4271 §9 removes the route received from that peer, so a peer must not be able to
+    /// delete an entry it never installed — or one it installed but another peer has since replaced.
+    /// <para>
+    /// The removal is a single atomic compare-and-remove via the explicit
+    /// <see cref="ICollection{T}"/> implementation, which removes the pair only when key AND value
+    /// match — the same idiom <c>BgpServer.RemoveSessionIfOwner</c> uses. A plain
+    /// read-then-<c>TryRemove</c> would race with a concurrent replacement and delete the new owner's
+    /// route.
+    /// </para>
+    /// </summary>
+    public bool RemoveOwnedBy(uint prefix, byte length, object owner)
+    {
+        ArgumentNullException.ThrowIfNull(owner);
 
-    public IReadOnlyList<Route> GetAll() =>
-        _routes.Values.ToList();
+        var key = (prefix, length);
+        if (!_routes.TryGetValue(key, out var entry) || !ReferenceEquals(entry.Owner, owner))
+            return false;
+
+        return ((ICollection<KeyValuePair<(uint Prefix, byte Length), Entry>>)_routes)
+            .Remove(new KeyValuePair<(uint Prefix, byte Length), Entry>(key, entry));
+    }
+
+    public Route? Get(uint prefix, byte length) =>
+        _routes.TryGetValue((prefix, length), out var entry) ? entry.Route : null;
+
+    public IReadOnlyList<Route> GetAll()
+    {
+        var routes = new List<Route>(_routes.Count);
+        foreach (var entry in _routes.Values)
+            routes.Add(entry.Route);
+        return routes;
+    }
 
     /// <summary>Enumerates current routes without materializing a snapshot list (one allocation fewer than GetAll).</summary>
-    public IEnumerable<Route> Enumerate() => _routes.Values;
+    public IEnumerable<Route> Enumerate()
+    {
+        foreach (var entry in _routes.Values)
+            yield return entry.Route;
+    }
 
     public void Clear() =>
         _routes.Clear();

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -63,6 +63,12 @@ public sealed class BgpSession : IDisposable
     private bool _localFourByteAsn; // derived from negotiated OPEN capability (RFC 6793)
     private ushort _negotiatedHoldTime;
     private List<IpPrefix> _advertisedPrefixes = [];
+    // #289: the prefixes THIS peer actually installed in the shared RouteTable — a minimal stand-in
+    // for the per-peer Adj-RIB-In of RFC 4271 §3.2. Without it a withdrawal was applied by prefix
+    // alone, so any peer could delete entries seeded by RouteSeedingService or announced by another
+    // peer. Only touched from HandleUpdateAsync, which runs on the single read loop, so no lock is
+    // needed; the shared RouteTable itself is concurrent.
+    private readonly HashSet<(uint Prefix, byte Length)> _installedByPeer = [];
     // #212: actual count sent on the wire (after aggregation + dedup). Updated at the end of
     // SendRoutesAsync. Read via AdvertisedPrefixCount for the management API/UI so operators see
     // the real number their peer's router receives, not the raw pre-aggregation count.
@@ -812,12 +818,13 @@ public sealed class BgpSession : IDisposable
         _logger.LogInformation("UpdateReceived from {Peer}: {Withdrawn} withdrawn, {Nlri} announced",
             _peer, update.WithdrawnRoutes.Count, update.Nlri.Count);
 
-        // Process withdrawals
+        // Process withdrawals. RFC 4271 §3.2/§9: a withdrawal removes the route received FROM THIS
+        // PEER, not whatever happens to sit at that prefix. BGPLite has one shared RouteTable rather
+        // than per-peer Adj-RIBs-In, so ownership is tracked here (#289) — otherwise any peer that
+        // completed a handshake could delete prefixes seeded at startup by RouteSeedingService or
+        // announced by another peer, simply by listing them as withdrawn.
         foreach (var w in update.WithdrawnRoutes)
-        {
-            _routeTable.Remove(w.Address, w.Length);
-            _logger.LogDebug("Route withdrawn: {Prefix}", w);
-        }
+            WithdrawIfOwned(w, "Route withdrawn");
 
         // Process announcements
         if (update.Nlri.Count > 0)
@@ -846,12 +853,10 @@ public sealed class BgpSession : IDisposable
                 //
                 // The withdrawn-routes half of this same UPDATE was already applied above, before
                 // the parse; this closes the asymmetry on the NLRI side.
+                // Same ownership rule as an explicit withdrawal (#289): treat-as-withdraw removes
+                // what this peer installed, not whatever is at that prefix.
                 foreach (var nlri in update.Nlri)
-                {
-                    _routeTable.Remove(nlri.Address, nlri.Length);
-                    if (_logger.IsEnabled(LogLevel.Debug))
-                        _logger.LogDebug("Route withdrawn (treat-as-withdraw): {Prefix}", nlri);
-                }
+                    WithdrawIfOwned(nlri, "Route withdrawn (treat-as-withdraw)");
                 _metrics.SetRouteCount(_routeTable.Count);
                 throw;
             }
@@ -873,6 +878,9 @@ public sealed class BgpSession : IDisposable
                 if (_routeFilter.AcceptIncoming(route, filterPeerConfig))
                 {
                     _routeTable.AddOrUpdate(route);
+                    // Only what actually reached the table is owned — a route the filter dropped was
+                    // never installed, so a later withdrawal for it must remove nothing (#289).
+                    _installedByPeer.Add((nlri.Address, nlri.Length));
                     // #85: guard the UintToIPAddress allocation behind IsEnabled — LogDebug
                     // evaluates the arg eagerly even when Debug is filtered out.
                     if (_logger.IsEnabled(LogLevel.Debug))
@@ -882,6 +890,27 @@ public sealed class BgpSession : IDisposable
         }
 
         _metrics.SetRouteCount(_routeTable.Count);
+    }
+
+    /// <summary>
+    /// Removes <paramref name="prefix"/> from the shared route table only if this session installed
+    /// it (#289). A withdrawal for a prefix this peer never announced is logged and ignored rather
+    /// than applied — RFC 4271 §9 withdraws the route received from that peer, and with one shared
+    /// table the alternative is letting any peer delete another's routes, or the startup seed.
+    /// </summary>
+    private void WithdrawIfOwned(IpPrefix prefix, string reason)
+    {
+        var key = (prefix.Address, prefix.Length);
+        if (!_installedByPeer.Remove(key))
+        {
+            if (_logger.IsEnabled(LogLevel.Debug))
+                _logger.LogDebug("Ignoring withdrawal of {Prefix} from {Peer}: not announced by this session", prefix, _peer);
+            return;
+        }
+
+        _routeTable.Remove(prefix.Address, prefix.Length);
+        if (_logger.IsEnabled(LogLevel.Debug))
+            _logger.LogDebug("{Reason}: {Prefix}", reason, prefix);
     }
 
     /// <summary>

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -63,12 +63,6 @@ public sealed class BgpSession : IDisposable
     private bool _localFourByteAsn; // derived from negotiated OPEN capability (RFC 6793)
     private ushort _negotiatedHoldTime;
     private List<IpPrefix> _advertisedPrefixes = [];
-    // #289: the prefixes THIS peer actually installed in the shared RouteTable — a minimal stand-in
-    // for the per-peer Adj-RIB-In of RFC 4271 §3.2. Without it a withdrawal was applied by prefix
-    // alone, so any peer could delete entries seeded by RouteSeedingService or announced by another
-    // peer. Only touched from HandleUpdateAsync, which runs on the single read loop, so no lock is
-    // needed; the shared RouteTable itself is concurrent.
-    private readonly HashSet<(uint Prefix, byte Length)> _installedByPeer = [];
     // #212: actual count sent on the wire (after aggregation + dedup). Updated at the end of
     // SendRoutesAsync. Read via AdvertisedPrefixCount for the management API/UI so operators see
     // the real number their peer's router receives, not the raw pre-aggregation count.
@@ -877,10 +871,10 @@ public sealed class BgpSession : IDisposable
 
                 if (_routeFilter.AcceptIncoming(route, filterPeerConfig))
                 {
-                    _routeTable.AddOrUpdate(route);
-                    // Only what actually reached the table is owned — a route the filter dropped was
-                    // never installed, so a later withdrawal for it must remove nothing (#289).
-                    _installedByPeer.Add((nlri.Address, nlri.Length));
+                    // Tagged with this session as the owner, so only this peer's own withdrawal can
+                    // remove it (#289). A route the filter dropped is never installed and therefore
+                    // never owned, so a later withdrawal for it removes nothing.
+                    _routeTable.AddOrUpdate(route, owner: this);
                     // #85: guard the UintToIPAddress allocation behind IsEnabled — LogDebug
                     // evaluates the arg eagerly even when Debug is filtered out.
                     if (_logger.IsEnabled(LogLevel.Debug))
@@ -893,22 +887,21 @@ public sealed class BgpSession : IDisposable
     }
 
     /// <summary>
-    /// Removes <paramref name="prefix"/> from the shared route table only if this session installed
-    /// it (#289). A withdrawal for a prefix this peer never announced is logged and ignored rather
-    /// than applied — RFC 4271 §9 withdraws the route received from that peer, and with one shared
-    /// table the alternative is letting any peer delete another's routes, or the startup seed.
+    /// Removes <paramref name="prefix"/> from the shared route table only if this session still owns
+    /// the entry (#289). RFC 4271 §9 withdraws the route received from that peer; with one shared
+    /// table the alternative is letting any peer delete the startup seed, another peer's route, or
+    /// one of its own that another peer has since replaced. A withdrawal that owns nothing is logged
+    /// and ignored — not a protocol error, since a stale withdrawal after a reconverge is ordinary.
     /// </summary>
     private void WithdrawIfOwned(IpPrefix prefix, string reason)
     {
-        var key = (prefix.Address, prefix.Length);
-        if (!_installedByPeer.Remove(key))
+        if (!_routeTable.RemoveOwnedBy(prefix.Address, prefix.Length, this))
         {
             if (_logger.IsEnabled(LogLevel.Debug))
-                _logger.LogDebug("Ignoring withdrawal of {Prefix} from {Peer}: not announced by this session", prefix, _peer);
+                _logger.LogDebug("Ignoring withdrawal of {Prefix} from {Peer}: not owned by this session", prefix, _peer);
             return;
         }
 
-        _routeTable.Remove(prefix.Address, prefix.Length);
         if (_logger.IsEnabled(LogLevel.Debug))
             _logger.LogDebug("{Reason}: {Prefix}", reason, prefix);
     }

--- a/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
+++ b/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
@@ -128,6 +128,41 @@ public class BgpSessionRouteOwnershipTests
         await TeardownAsync(session, run);
     }
 
+    [Fact]
+    public async Task Withdrawal_AfterAnotherPeerReplacedTheRoute_RemovesNothing()
+    {
+        // The residual hole in the first version of this fix, caught in review: ownership was tracked
+        // per session, but RouteTable.AddOrUpdate replaces by prefix. Peer A announces, peer B
+        // announces the SAME prefix (replacing A's route), then A withdraws — and A's set still said
+        // it owned that prefix, so it deleted B's route. Two peers announcing one prefix is ordinary
+        // for a route server, so this was reachable without anything adversarial.
+        var routeTable = new RouteTable();
+        var (a, aRun, aConn) = await EstablishAsync(routeTable, routerId: 0x0A000002);
+        var (b, bRun, bConn) = await EstablishAsync(routeTable, routerId: 0x0A000003);
+
+        aConn.EnqueueFrame(AnnounceFrame(8, 0x0A));
+        await SettleAsync(aConn, () => routeTable.Count == 1);
+
+        // B replaces it — same prefix, different next hop, so the installed route is observably B's.
+        bConn.EnqueueFrame(BuildAnnounce(AttributesWithNextHop(0x0A, 0x0A, 0x0A, 0x0A), 8, [0x0A]));
+        await SettleAsync(bConn, () => routeTable.Get(TenSlashEight, 8)?.NextHop == 0x0A0A0A0A);
+
+        // A withdraws the prefix it no longer owns.
+        aConn.EnqueueFrame(WithdrawFrame([8, 0x0A]));
+        await SettleAsync(aConn);
+
+        var route = routeTable.Get(TenSlashEight, 8);
+        Assert.NotNull(route);
+        Assert.Equal(0x0A0A0A0Au, route!.NextHop); // still B's route
+
+        // B, the current owner, can still withdraw it.
+        bConn.EnqueueFrame(WithdrawFrame([8, 0x0A]));
+        await SettleAsync(bConn, () => routeTable.Count == 0);
+
+        await TeardownAsync(a, aRun);
+        await TeardownAsync(b, bRun);
+    }
+
     // ---- frame builders ----
 
     private static byte[] Frame(BgpMessageType type, params byte[] payload)
@@ -163,6 +198,19 @@ public class BgpSessionRouteOwnershipTests
         0x40, 0x02, 0x06, 0x02, 0x01, 0x00, 0x00, 0x00, 0x64,   // AS_PATH seq [100]
         0x40, 0x03, 0x04, 0xC0, 0x00, 0x02, 0x01,               // NEXT_HOP 192.0.2.1
     ];
+
+    /// <summary>Well-formed ORIGIN + AS_PATH + NEXT_HOP, with the next hop supplied by the caller.</summary>
+    private static byte[] AttributesWithNextHop(params byte[] nextHop)
+    {
+        var attrs = new List<byte>
+        {
+            0x40, 0x01, 0x01, 0x00,
+            0x40, 0x02, 0x06, 0x02, 0x01, 0x00, 0x00, 0x00, 0x64,
+            0x40, 0x03, 0x04,
+        };
+        attrs.AddRange(nextHop);
+        return [.. attrs];
+    }
 
     // ORIGIN + AS_PATH but no NEXT_HOP — Missing Well-known Attribute, so treat-as-withdraw applies.
     private static readonly byte[] AttributesMissingNextHop =
@@ -239,13 +287,24 @@ public class BgpSessionRouteOwnershipTests
     /// </summary>
     private static async Task SettleAsync(ScriptedConnection conn, Func<bool>? until = null)
     {
+        var reached = false;
         for (var i = 0; i < 200; i++)
         {
-            if (conn.Drained && (until?.Invoke() ?? false)) return;
-            if (conn.Drained && until is null && i > 5) return;
+            if (conn.Drained)
+            {
+                reached = until?.Invoke() ?? true;
+                // A "nothing happened" assertion needs the read loop to have actually processed the
+                // frame, not merely to have consumed its bytes — give it a few more ticks to settle.
+                if (reached && (until is not null || i > 5)) break;
+            }
             await Task.Delay(TimeSpan.FromMilliseconds(10));
         }
-        Assert.True(until is null, "the expected route-table state was not reached in time");
+
+        // Asserted unconditionally: without it a negative test passes when the frame was never
+        // delivered at all, which is exactly the failure mode it is supposed to rule out (#289 review).
+        Assert.True(conn.Drained, "the scripted frame was never consumed by the read loop");
+        if (until is not null)
+            Assert.True(reached, "the expected route-table state was not reached in time");
     }
 
     private static async Task TeardownAsync(BgpSession session, Task run)

--- a/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
+++ b/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
@@ -1,0 +1,318 @@
+using System.Threading.Channels;
+using BGPLite.Configuration;
+using BGPLite.Contracts;
+using BGPLite.Protocol;
+using BGPLite.Routing;
+using BGPLite.Server;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #289: a withdrawal must remove the route received FROM THAT PEER (RFC 4271 §3.2/§9), not
+/// whatever happens to sit at the prefix. BGPLite keeps one shared <see cref="RouteTable"/> rather
+/// than per-peer Adj-RIBs-In, so <c>BgpSession</c> tracks what it installed and gates removals on
+/// it. Without that, any peer that completed a handshake could delete prefixes seeded at startup by
+/// <c>RouteSeedingService</c>, or routes announced by another peer, just by listing them as
+/// withdrawn — verified on <c>main</c> before the fix: a peer that announced nothing emptied a
+/// two-route table.
+/// <para>
+/// Driven through the <c>IBgpConnection</c> seam (#96) rather than loopback sockets: the assertions
+/// are about route-table state, so scripting frames deterministically is both faster and immune to
+/// the timing flakiness that #302 documents.
+/// </para>
+/// </summary>
+public class BgpSessionRouteOwnershipTests
+{
+    private const uint TenSlashEight = 0x0A000000;
+    private const uint TestNetSlash24 = 0xC0000200;
+
+    [Fact]
+    public async Task Withdrawal_ForPrefixNeverAnnounced_IsIgnored()
+    {
+        var routeTable = Seeded((TenSlashEight, 8), (TestNetSlash24, 24));
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        // The peer has announced nothing at all, and withdraws both seeded prefixes.
+        conn.EnqueueFrame(WithdrawFrame([8, 0x0A], [24, 0xC0, 0x00, 0x02]));
+        await SettleAsync(conn);
+
+        Assert.Equal(2, routeTable.Count);
+        Assert.NotNull(routeTable.Get(TenSlashEight, 8));
+        Assert.NotNull(routeTable.Get(TestNetSlash24, 24));
+        Assert.True(session.IsEstablished, "an ignored withdrawal is not a protocol error");
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task Withdrawal_ForItsOwnAnnouncement_RemovesTheRoute()
+    {
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        conn.EnqueueFrame(AnnounceFrame(8, 0x0A));
+        await SettleAsync(conn, () => routeTable.Count == 1);
+        Assert.NotNull(routeTable.Get(TenSlashEight, 8));
+
+        conn.EnqueueFrame(WithdrawFrame([8, 0x0A]));
+        await SettleAsync(conn, () => routeTable.Count == 0);
+
+        Assert.Null(routeTable.Get(TenSlashEight, 8));
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task Withdrawal_DoesNotRemoveAnotherPeersRoute()
+    {
+        var routeTable = new RouteTable();
+        var (owner, ownerRun, ownerConn) = await EstablishAsync(routeTable, routerId: 0x0A000002);
+        var (other, otherRun, otherConn) = await EstablishAsync(routeTable, routerId: 0x0A000003);
+
+        ownerConn.EnqueueFrame(AnnounceFrame(8, 0x0A));
+        await SettleAsync(ownerConn, () => routeTable.Count == 1);
+
+        // The second peer withdraws a prefix the FIRST one announced.
+        otherConn.EnqueueFrame(WithdrawFrame([8, 0x0A]));
+        await SettleAsync(otherConn);
+        Assert.NotNull(routeTable.Get(TenSlashEight, 8));
+
+        // The peer that announced it can still withdraw it.
+        ownerConn.EnqueueFrame(WithdrawFrame([8, 0x0A]));
+        await SettleAsync(ownerConn, () => routeTable.Count == 0);
+        Assert.Null(routeTable.Get(TenSlashEight, 8));
+
+        await TeardownAsync(owner, ownerRun);
+        await TeardownAsync(other, otherRun);
+    }
+
+    [Fact]
+    public async Task FilteredAnnouncement_IsNotOwned_SoItsWithdrawalRemovesNothing()
+    {
+        // Ownership follows what actually reached the table, not what was announced: a route the
+        // incoming filter dropped was never installed, so a later withdrawal for it must not remove
+        // a same-prefix route that came from somewhere else.
+        var routeTable = Seeded((TenSlashEight, 8));
+        var (session, run, conn) = await EstablishAsync(routeTable, filter: new RejectAllIncomingFilter());
+
+        conn.EnqueueFrame(AnnounceFrame(8, 0x0A));
+        await SettleAsync(conn);
+        Assert.Equal(1, routeTable.Count); // the announce was filtered out, the seed still stands
+
+        conn.EnqueueFrame(WithdrawFrame([8, 0x0A]));
+        await SettleAsync(conn);
+
+        Assert.NotNull(routeTable.Get(TenSlashEight, 8));
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task TreatAsWithdraw_OnlyRemovesRoutesThisPeerInstalled()
+    {
+        // The interaction with #288: treat-as-withdraw removes the UPDATE's NLRI, but it is still a
+        // withdrawal and obeys the same ownership rule. Otherwise a malformed UPDATE becomes a way
+        // to delete any prefix — strictly worse than the plain withdrawal this fix closes.
+        var routeTable = Seeded((TenSlashEight, 8));
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        // Announcing UPDATE for the seeded prefix with NEXT_HOP omitted: the pipeline rejects it and
+        // treat-as-withdraw applies to 10.0.0.0/8 — which this peer never installed.
+        conn.EnqueueFrame(MalformedAnnounceFrame(8, 0x0A));
+        await SettleAsync(conn);
+
+        Assert.NotNull(routeTable.Get(TenSlashEight, 8));
+        Assert.True(session.IsEstablished, "treat-as-withdraw keeps the session up");
+
+        await TeardownAsync(session, run);
+    }
+
+    // ---- frame builders ----
+
+    private static byte[] Frame(BgpMessageType type, params byte[] payload)
+    {
+        var frame = new byte[BgpConstants.MessageHeaderSize + payload.Length];
+        BgpConstants.Marker.CopyTo(frame.AsSpan(0, BgpConstants.MarkerSize));
+        frame[16] = (byte)(frame.Length >> 8);
+        frame[17] = (byte)frame.Length;
+        frame[18] = (byte)type;
+        payload.CopyTo(frame, BgpConstants.MessageHeaderSize);
+        return frame;
+    }
+
+    /// <summary>
+    /// UPDATE carrying only withdrawn routes. Each argument is one NLRI already in wire form —
+    /// the prefix-length byte followed by its significant address bytes, e.g. <c>[8, 0x0A]</c>.
+    /// </summary>
+    private static byte[] WithdrawFrame(params byte[][] prefixes)
+    {
+        var withdrawn = new List<byte>();
+        foreach (var nlri in prefixes)
+            withdrawn.AddRange(nlri);
+        var payload = new List<byte> { (byte)(withdrawn.Count >> 8), (byte)withdrawn.Count };
+        payload.AddRange(withdrawn);
+        payload.AddRange([0x00, 0x00]); // no path attributes
+        return Frame(BgpMessageType.Update, [.. payload]);
+    }
+
+    // The handshake below negotiates the 4-octet-ASN capability, so AS_PATH is 4-octet encoded.
+    private static readonly byte[] WellFormedAttributes =
+    [
+        0x40, 0x01, 0x01, 0x00,                                 // ORIGIN igp
+        0x40, 0x02, 0x06, 0x02, 0x01, 0x00, 0x00, 0x00, 0x64,   // AS_PATH seq [100]
+        0x40, 0x03, 0x04, 0xC0, 0x00, 0x02, 0x01,               // NEXT_HOP 192.0.2.1
+    ];
+
+    // ORIGIN + AS_PATH but no NEXT_HOP — Missing Well-known Attribute, so treat-as-withdraw applies.
+    private static readonly byte[] AttributesMissingNextHop =
+    [
+        0x40, 0x01, 0x01, 0x00,
+        0x40, 0x02, 0x06, 0x02, 0x01, 0x00, 0x00, 0x00, 0x64,
+    ];
+
+    private static byte[] AnnounceFrame(byte prefixLength, params byte[] addressBytes) =>
+        BuildAnnounce(WellFormedAttributes, prefixLength, addressBytes);
+
+    private static byte[] MalformedAnnounceFrame(byte prefixLength, params byte[] addressBytes) =>
+        BuildAnnounce(AttributesMissingNextHop, prefixLength, addressBytes);
+
+    private static byte[] BuildAnnounce(byte[] attributes, byte prefixLength, byte[] addressBytes)
+    {
+        var payload = new List<byte>
+        {
+            0x00, 0x00,                                                    // no withdrawn routes
+            (byte)(attributes.Length >> 8), (byte)attributes.Length,
+        };
+        payload.AddRange(attributes);
+        payload.Add(prefixLength);
+        payload.AddRange(addressBytes);
+        return Frame(BgpMessageType.Update, [.. payload]);
+    }
+
+    // ---- harness ----
+
+    private static RouteTable Seeded(params (uint Prefix, byte Length)[] routes)
+    {
+        var table = new RouteTable();
+        foreach (var (prefix, length) in routes)
+            table.AddOrUpdate(new Route { Prefix = prefix, PrefixLength = length, NextHop = 0x7F000001 });
+        return table;
+    }
+
+    private static async Task<(BgpSession Session, Task Run, ScriptedConnection Conn)> EstablishAsync(
+        RouteTable routeTable, uint routerId = 0x0A000002, IRouteFilter? filter = null)
+    {
+        var conn = new ScriptedConnection();
+        var config = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
+        var session = new BgpSession(
+            conn,
+            new PeerConfig { Address = "127.0.0.1" },
+            config,
+            routeTable,
+            filter ?? AllowAllFilter.Instance,
+            new BgpMetrics(),
+            NullLogger<BgpSession>.Instance);
+
+        var run = session.RunAsync();
+        conn.EnqueueMessage(new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = 0,
+            RouterId = routerId,
+            Capabilities = [BgpCapabilityInfo.FourOctetAsn(65002)],
+        });
+        conn.EnqueueMessage(BgpKeepaliveMessage.Instance);
+
+        for (var i = 0; i < 200 && !session.IsEstablished; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        Assert.True(session.IsEstablished, "session must reach Established");
+        return (session, run, conn);
+    }
+
+    /// <summary>
+    /// Waits until the scripted frames have been consumed, and — when <paramref name="until"/> is
+    /// given — until the expected route-table state is reached. The frameless wait is bounded and
+    /// deliberately followed by a short settle, since the assertions here are of the form "nothing
+    /// happened" and need the read loop to have actually processed the frame.
+    /// </summary>
+    private static async Task SettleAsync(ScriptedConnection conn, Func<bool>? until = null)
+    {
+        for (var i = 0; i < 200; i++)
+        {
+            if (conn.Drained && (until?.Invoke() ?? false)) return;
+            if (conn.Drained && until is null && i > 5) return;
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        }
+        Assert.True(until is null, "the expected route-table state was not reached in time");
+    }
+
+    private static async Task TeardownAsync(BgpSession session, Task run)
+    {
+        session.MarkSilentClose();
+        try { await run.WaitAsync(TimeSpan.FromSeconds(5)); }
+        catch (OperationCanceledException) { /* expected */ }
+        catch (IOException) { /* expected */ }
+        session.Dispose();
+    }
+
+    /// <summary>Scripts inbound frames and discards outbound bytes; reads block until a frame arrives.</summary>
+    private sealed class ScriptedConnection : IBgpConnection
+    {
+        private readonly Channel<byte[]> _inbound = Channel.CreateUnbounded<byte[]>();
+        private readonly Queue<byte> _readBuffer = new();
+        private int _pending;
+
+        /// <summary>True once every enqueued frame has been fully handed to the read loop.</summary>
+        public bool Drained => Volatile.Read(ref _pending) == 0 && _readBuffer.Count == 0;
+
+        public void EnqueueFrame(byte[] frame)
+        {
+            Interlocked.Increment(ref _pending);
+            _inbound.Writer.TryWrite(frame);
+        }
+
+        public void EnqueueMessage(BgpMessage message)
+        {
+            var buf = new byte[BgpMessageWriter.GetBufferSize(message)];
+            var n = BgpMessageWriter.WriteMessage(message, buf);
+            EnqueueFrame(buf[..n]);
+        }
+
+        public async ValueTask ReadExactAsync(Memory<byte> buffer, CancellationToken cancellationToken)
+        {
+            var offset = 0;
+            while (offset < buffer.Length)
+            {
+                while (_readBuffer.Count > 0 && offset < buffer.Length)
+                    buffer.Span[offset++] = _readBuffer.Dequeue();
+                if (offset >= buffer.Length) break;
+
+                byte[] chunk;
+                try { chunk = await _inbound.Reader.ReadAsync(cancellationToken); }
+                catch (ChannelClosedException) { throw new IOException("Connection closed by peer"); }
+
+                var toCopy = Math.Min(chunk.Length, buffer.Length - offset);
+                for (var i = 0; i < toCopy; i++) buffer.Span[offset++] = chunk[i];
+                for (var i = toCopy; i < chunk.Length; i++) _readBuffer.Enqueue(chunk[i]);
+                Interlocked.Decrement(ref _pending);
+            }
+        }
+
+        public ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken) => default;
+
+        public bool IsPeerClosed => false;
+
+        public void Dispose() => _inbound.Writer.TryComplete();
+    }
+
+    /// <summary>Rejects every inbound route, so nothing this peer announces reaches the table.</summary>
+    private sealed class RejectAllIncomingFilter : IRouteFilter
+    {
+        private static readonly IReadOnlySet<uint> Empty = new HashSet<uint>();
+        public bool AcceptIncoming(Route route, PeerConfig peer) => false;
+        public IReadOnlySet<uint> ResolveOutgoingAllowSet(PeerConfig peer) => Empty;
+        public bool AcceptOutgoing(Route route, PeerConfig peer, IReadOnlySet<uint> allowSet) => true;
+    }
+}


### PR DESCRIPTION
Closes #289

## Problem

`HandleUpdateAsync` applied withdrawals to the shared `RouteTable` by prefix alone:

```csharp
foreach (var w in update.WithdrawnRoutes)
{
    _routeTable.Remove(w.Address, w.Length);
    _logger.LogDebug("Route withdrawn: {Prefix}", w);
}
```

No check that the withdrawing peer had ever announced it. RFC 4271 §3.2 models Adj-RIBs-In as **per peer**, and §9 defines a withdrawal as removing the route received *from that peer*. BGPLite keeps one shared table instead, so any peer that completed a handshake — and unknown peers are auto-registered by default — could delete prefixes seeded at startup by `RouteSeedingService`, or routes announced by another peer, simply by listing them as withdrawn.

Reproduced on `main` with a peer that announced **nothing**, sending one UPDATE with two withdrawn prefixes and no NLRI:

```
routeTable before=2 after=0 established=True
```

After this change, the same frame:

```
routeTable before=2 after=2 established=True
```

## Fix

`BgpSession` tracks the prefixes it actually installed and gates every removal on that set:

```csharp
private readonly HashSet<(uint Prefix, byte Length)> _installedByPeer = [];
```

Ownership follows **what reached the table**, not what was announced — a route the incoming filter dropped was never installed, so a later withdrawal for it removes nothing. That matters because the filter is per-peer policy: without this distinction, announcing a prefix that gets filtered would still buy the right to delete someone else's route at that prefix.

The set is touched only from `HandleUpdateAsync`, which runs on the session's single read loop, so it needs no lock of its own; the shared `RouteTable` remains concurrent.

The treat-as-withdraw removal added in #288 goes through the same gate. Without that, a malformed UPDATE would become a way to delete any prefix — strictly worse than the plain withdrawal this closes, since it needs no valid attributes at all.

An ignored withdrawal is logged at Debug and is **not** a protocol error: the session stays up, which is what a peer sending a stale withdrawal after a reconverge should get.

## Deliberately not included

**Removing a peer's routes when its session ends.** With one shared table, a peer's announcement may have *overwritten* a seeded route at the same prefix — `RouteTable.AddOrUpdate` replaces by key. Deleting "this peer's contributions" on teardown would then delete the startup seed, trading a cross-peer deletion hole for a route-loss one. Doing it safely needs the real per-peer Adj-RIB-In of #7 / #10, where the Loc-RIB can be recomputed from the surviving peers' RIBs. So today a departed peer's routes still linger in the shared table — pre-existing behaviour, unchanged here, and worth its own issue once the RIB shape is decided.

This is the minimal change that closes the hole without opening a different one.

## Verification

`dotnet build BGPLite.sln` + `dotnet test BGPLite.sln`: **682 passed, 0 failed** (677 before, 5 added). `dotnet format --severity warn` clean.

Confirmed to catch the regression — with the gate removed, 4 of the 5 fail:

```
ownership gate temporarily removed
  Failed TreatAsWithdraw_OnlyRemovesRoutesThisPeerInstalled
  Failed Withdrawal_DoesNotRemoveAnotherPeersRoute
  Failed Withdrawal_ForPrefixNeverAnnounced_IsIgnored
  Failed FilteredAnnouncement_IsNotOwned_SoItsWithdrawalRemovesNothing
Failed! - Failed: 4, Passed: 1
--- restored ---
```

The one that passes either way is `Withdrawal_ForItsOwnAnnouncement_RemovesTheRoute` — the negative control that guards against over-correcting into "withdrawals never work".

End to end on a real socket pair, the two probes that matter both behave:

```
PROBE 3 (peer withdraws what it never announced):  before=2 after=2   [was: after=0]
PROBE 4 (RFC 7606 treat-as-withdraw, own route):   routeTable=0        [unchanged — still removed]
```

## Tests added

New `BgpSessionRouteOwnershipTests`, driven through the `IBgpConnection` seam (#96) rather than loopback sockets — the assertions are about route-table state, so scripted frames are both faster and immune to the timing flakiness #302 documents.

- `Withdrawal_ForPrefixNeverAnnounced_IsIgnored` — the headline case, two seeded prefixes.
- `Withdrawal_ForItsOwnAnnouncement_RemovesTheRoute` — negative control.
- `Withdrawal_DoesNotRemoveAnotherPeersRoute` — two sessions on one table; B cannot withdraw A's route, and A still can.
- `FilteredAnnouncement_IsNotOwned_SoItsWithdrawalRemovesNothing` — ownership follows installation, not announcement.
- `TreatAsWithdraw_OnlyRemovesRoutesThisPeerInstalled` — the #288 interaction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route withdrawal handling so peers can remove only routes they previously installed.
  * Prevented withdrawals from deleting routes announced by other peers, filtered routes, malformed announcements, or pre-existing routes.
  * Applied the same ownership safeguards when invalid updates are treated as withdrawals.

* **Tests**
  * Added coverage for route ownership, announcements, withdrawals, filtering, and invalid updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->