### PR TITLE
fix(routing): the shared-table fallback must not advertise peer-injected routes

### DIFF
--- a/BGPLite.Routing/RouteTable.cs
+++ b/BGPLite.Routing/RouteTable.cs
@@ -95,6 +95,26 @@ public sealed class RouteTable
             yield return entry.Route;
     }
 
+    /// <summary>
+    /// Enumerates only the routes installed with no owner — in practice the startup seed written by
+    /// <c>RouteSeedingService</c>. Excludes everything a peer announced inbound, which
+    /// <c>BgpSession.HandleUpdateAsync</c> installs owned by its session.
+    /// <para>
+    /// This is the advertise-side counterpart to <see cref="RemoveOwnedBy"/>: the owner tag exists so
+    /// a peer can neither remove what it does not own nor have what it injected handed to somebody
+    /// else. Used by <c>RouteAssembler</c>'s shared-table fallback, which would otherwise re-advertise
+    /// one peer's inbound announcements to every other peer (#307).
+    /// </para>
+    /// </summary>
+    public IEnumerable<Route> EnumerateUnowned()
+    {
+        foreach (var entry in _routes.Values)
+        {
+            if (entry.Owner is null)
+                yield return entry.Route;
+        }
+    }
+
     public void Clear() =>
         _routes.Clear();
 }

--- a/BGPLite.Server/RouteAssembler.cs
+++ b/BGPLite.Server/RouteAssembler.cs
@@ -268,10 +268,23 @@ internal sealed class RouteAssembler
             }
         }
 
-        // Final fallback: send from shared route table.
+        // Fallback: no per-peer configuration is reachable, so serve the shared table's SEEDED
+        // routes. This branch means a dependency is missing from the composition — in a correct
+        // production wiring it is unreachable (#263), and reaching it silently changes what every
+        // peer receives rather than merely disabling a feature, so it is logged (#307).
+        _logger.LogWarning(
+            "Route assembly for {Peer} fell back to the shared table — per-peer configuration is unavailable " +
+            "(peerStore={HasPeerStore}, prefixService={HasPrefixService}, appConfig={HasAppConfig}). " +
+            "This peer will NOT receive its configured prefixes.",
+            _peer, _peerStore is not null, _prefixService is not null, _appConfig is not null);
+
+        // EnumerateUnowned, not Enumerate: everything a peer announced inbound is installed in this
+        // same table owned by its session (#289). Advertising those here would hand one peer's
+        // injected routes to every other peer — a tenant-isolation failure, not just a wrong list.
+        // The startup seed is written with no owner and is what this fallback is meant to serve.
         var sharedAllowSet = _routeFilter.ResolveOutgoingAllowSet(filterPeerConfig);
         var filtered = new List<Route>();
-        foreach (var r in _routeTable.Enumerate())
+        foreach (var r in _routeTable.EnumerateUnowned())
         {
             if (_routeFilter.AcceptOutgoing(r, filterPeerConfig, sharedAllowSet))
                 filtered.Add(r);

--- a/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
+++ b/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
@@ -163,6 +163,50 @@ public class BgpSessionRouteOwnershipTests
         await TeardownAsync(b, bRun);
     }
 
+    [Fact]
+    public async Task SharedTableFallback_DoesNotAdvertiseRoutesInjectedByAnotherPeer()
+    {
+        // #307: with no peer store injected, RouteAssembler falls back to the shared table — which
+        // also holds every NLRI any peer announced inbound. Advertising those would hand one peer's
+        // injected routes to every other peer. The owner tag from #289 is what separates the startup
+        // seed (unowned) from peer-injected entries (owned by the installing session).
+        var routeTable = Seeded((TestNetSlash24, 24));   // the "startup seed"
+        var (injector, injectorRun, injectorConn) = await EstablishAsync(routeTable, routerId: 0x0A000002);
+
+        injectorConn.EnqueueFrame(AnnounceFrame(8, 0x0A));
+        await SettleAsync(injectorConn, () => routeTable.Count == 2);
+        Assert.NotNull(routeTable.Get(TenSlashEight, 8)); // it IS in the shared table
+
+        // A second peer connects; its initial dump goes through the fallback.
+        var (victim, victimRun, victimConn) = await EstablishAsync(routeTable, routerId: 0x0A000003);
+        var advertised = await CollectAdvertisedNlriAsync(victimConn);
+
+        Assert.Contains((TestNetSlash24, (byte)24), advertised);      // the seed reaches the peer
+        Assert.DoesNotContain((TenSlashEight, (byte)8), advertised);  // the other peer's injection does not
+
+        await TeardownAsync(injector, injectorRun);
+        await TeardownAsync(victim, victimRun);
+    }
+
+    /// <summary>Waits for the initial dump and returns every NLRI the session put on the wire.</summary>
+    private static async Task<List<(uint Prefix, byte Length)>> CollectAdvertisedNlriAsync(ScriptedConnection conn)
+    {
+        var nlri = new List<(uint, byte)>();
+        for (var i = 0; i < 200; i++)
+        {
+            nlri.Clear();
+            foreach (var frame in conn.Sent)
+            {
+                if (BgpMessageReader.ReadMessage(frame) is not BgpUpdateMessage update) continue;
+                foreach (var p in update.Nlri)
+                    nlri.Add((p.Address, p.Length));
+            }
+            if (nlri.Count > 0) break;
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        }
+        return nlri;
+    }
+
     // ---- frame builders ----
 
     private static byte[] Frame(BgpMessageType type, params byte[] payload)
@@ -359,7 +403,16 @@ public class BgpSessionRouteOwnershipTests
             }
         }
 
-        public ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken) => default;
+        private readonly List<byte[]> _sent = [];
+
+        /// <summary>Outbound frames, copied because SendMessageAsync returns its buffer to the pool.</summary>
+        public IReadOnlyList<byte[]> Sent { get { lock (_sent) return [.. _sent]; } }
+
+        public ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+        {
+            lock (_sent) _sent.Add(buffer.ToArray());
+            return default;
+        }
 
         public bool IsPeerClosed => false;
 


### PR DESCRIPTION
Closes #307

## Problem

`RouteAssembler.BuildOutboundRoutesAsync` takes the per-peer decision tree only when all three of `IPeerStore`, `IPrefixService` and `AppConfig` are present — each an optional constructor parameter defaulting to `null` (`RouteAssembler.cs:35-39`, reached via `BgpSession.cs:246-248`, `BgpServer.cs:52-53`) — and otherwise advertises the shared `RouteTable` verbatim.

That table is not a per-peer route set. Alongside the startup seed from `RouteSeedingService`, it holds **every NLRI any peer announced inbound**, because `BgpSession.HandleUpdateAsync` installs accepted routes straight into it.

So one missing DI registration silently changes what every session receives, from *"the prefixes this user selected"* to *"one global list including what other users' sessions injected"*. No exception, no distinguishing log line, sessions establish normally.

BGPLite is deployed as a service where each user picks their own prefix set in the management UI and the session exists to hand that user their selection. Under that model this is a **tenant-isolation failure**, not a disabled feature: a peer can place a prefix into another peer's advertisement simply by announcing it inbound.

The branch is unreachable in the current `Program.cs`, which registers all three. Nothing in the type system keeps it that way — that is #263's subject; what this PR addresses is the blast radius when it does happen.

## Fix

**1. `RouteTable.EnumerateUnowned()`** yields only entries installed with no owner — in practice the startup seed. The owner tag added in #289 already separates those from peer-installed routes, so the fallback stops being a cross-tenant path *outright*, rather than depending on the composition being correct:

```csharp
foreach (var r in _routeTable.EnumerateUnowned())   // was: Enumerate()
```

This is the advertise-side counterpart of `RemoveOwnedBy`. The tag now carries one coherent meaning in both directions: a peer can neither delete what it does not own, nor have what it injected handed to somebody else.

**2. Taking the fallback logs a Warning** naming which dependency is missing. Until now the only symptom was "the peer got the wrong prefixes", which is indistinguishable from a configuration mistake on the user's side.

## Deliberately not a throw

Several existing tests construct `BgpSession` without a peer store and legitimately exercise this path (`BgpSessionShutdownTests`, `MalformedUpdateResilienceTests`, `SendTimeoutTests`, `BgpSessionHoldTimerTests`, and the ownership tests here). Turning the fallback into a failure would need those to be given a null-object to inject first — that is #263's fix (1), and it belongs there. This PR closes the isolation hole independently of whether that lands, which seemed the right order given the two have very different sizes.

## Verification

`dotnet build BGPLite.sln` + `dotnet test BGPLite.sln`: **684 passed, 0 failed** (683 before, 1 added). `dotnet format --severity warn` clean. No existing test changed behaviour — the two that seed the table already use the owner-less `AddOrUpdate(route)` overload, which is exactly what the fallback still serves.

Confirmed to catch the regression — reverting `EnumerateUnowned()` to `Enumerate()`:

```
Failed SharedTableFallback_DoesNotAdvertiseRoutesInjectedByAnotherPeer
  Assert.DoesNotContain() Failure: Item found in collection
```

## Test added

`SharedTableFallback_DoesNotAdvertiseRoutesInjectedByAnotherPeer` — seeds `192.0.2.0/24`, has one peer announce `10.0.0.0/8` inbound (asserting it *is* in the shared table, so the test cannot pass by the injection having failed), then connects a second peer and reads the NLRI it actually put on the wire. The seed must be there; the other peer's injection must not.

`ScriptedConnection` now captures outbound frames so that last assertion is against real wire bytes rather than internal state.

## Note

Nothing bounds what a peer may *add* to that table — see #304. This PR stops those additions leaking into other peers' advertisements; it does not stop them accumulating.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected fallback route announcements so peers receive only configured startup routes.
  * Prevented routes learned from other peer sessions from being advertised during an initial dump.
  * Added a warning when peer-specific configuration is unavailable and configured prefixes cannot be served.

* **Tests**
  * Added coverage verifying route ownership and outbound route announcements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->