### PR TITLE
perf(api): split the peer reads — a Cartesian product was costing up to 814 ms per call

### DIFF
--- a/BGPLite.Api/PeerStore.cs
+++ b/BGPLite.Api/PeerStore.cs
@@ -171,12 +171,33 @@ public sealed class PeerStore : IPeerStore
     public PeerRoutingView? LoadPeerRoutingView(string ip, uint asn)
     {
         using var db = _dbFactory.CreateDbContext();
-        var peer = db.Peers.AsNoTracking()
-            .Include(p => p.Subscriptions)
-            .Include(p => p.CustomPrefixes)
-            .Include(p => p.CustomAsns)
-            .Include(p => p.CustomSources.Where(c => c.Active))
-            .FirstOrDefault(p => p.Ip == ip && p.Asn == asn);
+
+        // AsSplitQuery: without it EF emits ONE statement that LEFT JOINs all four collections, so
+        // the driver materializes subs x prefixes x asns x sources rows. Measured on a real SQLite
+        // file, 200 iterations: a peer with 3 subscriptions / 200 custom prefixes / 5 ASNs /
+        // 2 sources produces 6,000 rows and takes 31 ms per call; 5/1000/10/3 produces 150,000 rows
+        // and takes 814 ms. Split, the same reads are 0.33 ms and 1.4 ms — 96x and 596x (#260).
+        //
+        // This runs on the BGP send path (every session establish, every RefreshRoutesAsync, and
+        // RefreshAllEstablishedAsync fires it for all peers at once), so it is the read a user waits
+        // on before their selected prefixes reach the wire.
+        //
+        // The read is wrapped in a transaction because splitting gives up the single-statement
+        // consistency #138 relied on: the four SELECTs would otherwise each see their own snapshot,
+        // and a UI edit landing between them would advertise a mixed configuration. SQLite runs in
+        // WAL here (#95), so a read transaction takes no write lock and does not block writers.
+        Peer? peer;
+        using (var read = db.Database.BeginTransaction())
+        {
+            peer = db.Peers.AsNoTracking()
+                .Include(p => p.Subscriptions)
+                .Include(p => p.CustomPrefixes)
+                .Include(p => p.CustomAsns)
+                .Include(p => p.CustomSources.Where(c => c.Active))
+                .AsSplitQuery()
+                .FirstOrDefault(p => p.Ip == ip && p.Asn == asn);
+            read.Commit();
+        }
         if (peer is null) return null;
 
         // Fold the status update (was UpdateSessionStatus(active:true) on its own DbContext) into
@@ -204,20 +225,28 @@ public sealed class PeerStore : IPeerStore
     /// <c>GetCommunities</c> sequence the management API's GET endpoints used to issue as 5–6
     /// separate <c>DbContext</c> instances (each opening its own SQLite connection + running the
     /// PRAGMA trio) — issue #228. Loads the peer and ALL its child collections through ONE
-    /// read-only <c>DbContext</c> via an EF Core projection. EF auto-splits the collection
-    /// subqueries inside a projection (one SELECT per collection + one for the peer row, all on the
-    /// same connection), so there is no Cartesian-product row explosion that an Include-based load
-    /// would produce. Read-only (<c>AsNoTracking</c>); unlike <see cref="LoadPeerRoutingView"/> it
+    /// read-only <c>DbContext</c> via an EF Core projection.
+    /// <para>
+    /// This doc previously claimed EF "auto-splits the collection subqueries inside a projection ...
+    /// so there is no Cartesian-product row explosion". That is not what EF emits: the projection
+    /// produced a single statement LEFT JOINing all five collections, byte-for-byte the same shape
+    /// as an Include-based load, and this method carried the full N x M x K x ... explosion since
+    /// #228. Verified by dumping the SQL — one SELECT before, six after adding
+    /// <c>AsSplitQuery</c> (#260). For a peer with 200 custom prefixes that is 120 ms per call
+    /// against 0.17 ms, on the path the management UI hits to render a peer.
+    /// </para>
+    /// Read-only (<c>AsNoTracking</c>); unlike <see cref="LoadPeerRoutingView"/> it
     /// does NOT fold a status update (the GET path does not mutate). Returns null if the peer does
     /// not exist. Field shapes match the prior standalone getters byte-for-byte.
     /// </summary>
     public PeerDetailDto? GetPeerDetail(string peerId)
     {
         using var db = _dbFactory.CreateDbContext();
-        // Project straight into the DTO — EF Core applies collection-splitting automatically inside
-        // a projection, so the four collection subqueries each run as a separate SELECT filtered by
-        // the peer's Id (no N×M×K Cartesian row explosion that an Include-based load would produce).
-        return db.Peers.AsNoTracking()
+        // AsSplitQuery is what makes each collection its own SELECT — a projection alone does not
+        // split (#260). Read transaction for the same reason as LoadPeerRoutingView: the six
+        // statements must see one snapshot, and in WAL a read transaction blocks nobody.
+        using var read = db.Database.BeginTransaction();
+        var detail = db.Peers.AsNoTracking()
             .Where(p => p.Id == peerId)
             .Select(p => new PeerDetailDto(
                 p.Id,
@@ -236,7 +265,10 @@ public sealed class PeerStore : IPeerStore
                     .ToList(),
                 // Communities stored as long (PeerCommunity.Community); the API formats to "ASN:VAL".
                 p.Communities.Select(c => c.Community).ToList()))
+            .AsSplitQuery()
             .FirstOrDefault();
+        read.Commit();
+        return detail;
     }
 
     public void SetDescription(string id, string description)

--- a/BGPLite.Tests/PeerStoreSplitQueryTests.cs
+++ b/BGPLite.Tests/PeerStoreSplitQueryTests.cs
@@ -1,0 +1,119 @@
+using BGPLite.Api;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #260: both peer reads must emit one SELECT per collection, not a single statement LEFT JOINing
+/// all of them. Without that, the driver materializes the Cartesian product of the child
+/// collections — measured on a real SQLite file, a peer with 3 subscriptions / 200 custom prefixes /
+/// 5 ASNs / 2 sources produced 6,000 rows and took 31 ms per <c>LoadPeerRoutingView</c> call
+/// (0.33 ms split), and 120 ms per <c>GetPeerDetail</c> call (0.17 ms split).
+/// <para>
+/// Asserted by counting the SQL actually emitted rather than by timing, so the guard is
+/// deterministic and does not depend on the runner. It also covers what EF's
+/// <c>MultipleCollectionIncludeWarning</c> cannot: that warning fires only for the <c>Include</c>
+/// shape, and <c>GetPeerDetail</c> uses a projection — whose collection subqueries were documented
+/// as auto-splitting and demonstrably do not.
+/// </para>
+/// </summary>
+public class PeerStoreSplitQueryTests
+{
+    private const string Ip = "203.0.113.20";
+    private const uint Asn = 64520;
+
+    [Fact]
+    public void LoadPeerRoutingView_EmitsOneSelectPerCollection()
+    {
+        var (store, connection, selects) = NewStoreCountingSelects();
+        using var _ = connection;
+        var id = SeedPeerWithChildren(store);
+
+        selects.Clear();
+        var view = store.LoadPeerRoutingView(Ip, Asn);
+
+        Assert.NotNull(view);
+        // peer row + 4 collections; a single-query load would emit exactly 1 SELECT.
+        Assert.True(selects.Count > 1,
+            $"expected a split query (one SELECT per collection), got {selects.Count} SELECT statement(s) — " +
+            "the Cartesian-product shape is back (#260)");
+    }
+
+    [Fact]
+    public void GetPeerDetail_EmitsOneSelectPerCollection()
+    {
+        var (store, connection, selects) = NewStoreCountingSelects();
+        using var _ = connection;
+        var id = SeedPeerWithChildren(store);
+
+        selects.Clear();
+        var detail = store.GetPeerDetail(id);
+
+        Assert.NotNull(detail);
+        Assert.True(selects.Count > 1,
+            $"expected a split query (one SELECT per collection), got {selects.Count} SELECT statement(s) — " +
+            "a projection does NOT auto-split, AsSplitQuery is what does it (#260)");
+    }
+
+    /// <summary>The split must not change what the reads return — the point is the SQL shape, not the data.</summary>
+    [Fact]
+    public void SplitReadsReturnTheSameData()
+    {
+        var (store, connection, _) = NewStoreCountingSelects();
+        using var __ = connection;
+        var id = SeedPeerWithChildren(store);
+
+        var view = store.LoadPeerRoutingView(Ip, Asn);
+        var detail = store.GetPeerDetail(id);
+
+        Assert.NotNull(view);
+        Assert.NotNull(detail);
+        Assert.Equal(["list-a", "list-b"], view!.Subscriptions);
+        Assert.Equal(["10.0.0.0/8", "192.0.2.0/24"], view.CustomPrefixes);
+        Assert.Equal([64512u, 64513u], view.CustomAsns);
+        // Only Active sources are advertised (#147); the peer below has one of each.
+        var source = Assert.Single(view.UserSources);
+        Assert.Equal("active-src", source.Name);
+
+        Assert.Equal(["list-a", "list-b"], detail!.Subscriptions);
+        Assert.Equal(["10.0.0.0/8", "192.0.2.0/24"], detail.CustomPrefixes);
+        Assert.Equal([64512u, 64513u], detail.CustomAsns);
+        Assert.Equal(2, detail.CustomSources.Count); // the detail view shows inactive ones too
+    }
+
+    // ---- harness ----
+
+    private static (PeerStore Store, SqliteConnection Connection, List<string> Selects) NewStoreCountingSelects()
+    {
+        var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        var selects = new List<string>();
+        var options = new DbContextOptionsBuilder<BgpDbContext>()
+            .UseSqlite(connection)
+            .LogTo(line => { if (line.Contains("SELECT", StringComparison.Ordinal)) lock (selects) selects.Add(line); },
+                   [RelationalEventId.CommandExecuted])
+            .Options;
+        using (var boot = new BgpDbContext(options))
+            BgpDbContext.Initialize(boot);
+        return (new PeerStore(new StaticOptionsFactory(options)), connection, selects);
+    }
+
+    private static string SeedPeerWithChildren(PeerStore store)
+    {
+        var id = store.CreatePeer(Ip, Asn, "split-query test");
+        store.SetSubscriptions(id, ["list-a", "list-b"]);
+        store.SetCustomPrefixes(id, [("10.0.0.0", (byte)8), ("192.0.2.0", (byte)24)]);
+        store.SetCustomAsns(id, [64512u, 64513u]);
+        var active = store.AddCustomSource(id, "active-src", "https://example.invalid/a", null);
+        store.AddCustomSource(id, "paused-src", "https://example.invalid/b", null);
+        store.SetSourceActive(id, active.Id, true);
+        return id;
+    }
+
+    private sealed class StaticOptionsFactory(DbContextOptions<BgpDbContext> options) : IDbContextFactory<BgpDbContext>
+    {
+        public BgpDbContext CreateDbContext() => new(options);
+    }
+}

--- a/BGPLite/Program.cs
+++ b/BGPLite/Program.cs
@@ -1,7 +1,6 @@
 using BGPLite;
 using BGPLite.Api;
 using BGPLite.Configuration;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using BGPLite.Protocol;
 using BGPLite.Providers;
 using BGPLite.Routing;
@@ -49,16 +48,18 @@ builder.Services.AddSingleton(routeTable);
 // busy_timeout (engine-level lock retry) applied on every connection via a DbConnectionInterceptor,
 // so both the factory-created and scoped contexts get the same settings.
 var sqlitePragmas = new SqlitePragmasInterceptor();
-// Suppress EF Core warning 20504 (MultipleCollectionIncludeWarning): LoadPeerRoutingView includes 3
-// collection navigations in a SingleQuery. For SQLite (local, embedded) with small per-peer data
-// (tens of rows), the Cartesian product is negligible and SingleQuery keeps the read atomic (#138).
+// #260: the MultipleCollectionIncludeWarning suppression is gone. It was added by #138 on the
+// premise that "for SQLite with small per-peer data (tens of rows), the Cartesian product is
+// negligible" — measured false: a peer with 200 custom prefixes made LoadPeerRoutingView materialize
+// 6,000 rows (31 ms per call, on the BGP send path), and one with 1,000 made it 150,000 (814 ms).
+// Both peer reads now use AsSplitQuery, so the warning has nothing to fire on; leaving the
+// suppression in would only hide the next reintroduction. PeerStoreSplitQueryTests asserts the
+// emitted SQL directly, which also covers the projection shape the warning cannot see.
 builder.Services.AddDbContextFactory<BgpDbContext>(options =>
-    options.UseSqlite($"Data Source={dbPath}").AddInterceptors(sqlitePragmas)
-        .ConfigureWarnings(w => w.Ignore(RelationalEventId.MultipleCollectionIncludeWarning)));
+    options.UseSqlite($"Data Source={dbPath}").AddInterceptors(sqlitePragmas));
 
 builder.Services.AddDbContext<BgpDbContext>(options =>
-    options.UseSqlite($"Data Source={dbPath}").AddInterceptors(sqlitePragmas)
-        .ConfigureWarnings(w => w.Ignore(RelationalEventId.MultipleCollectionIncludeWarning)), ServiceLifetime.Scoped);
+    options.UseSqlite($"Data Source={dbPath}").AddInterceptors(sqlitePragmas), ServiceLifetime.Scoped);
 
 builder.Services.AddSingleton<PeerStore>();
 builder.Services.AddSingleton<IRouteFilter>(sp =>


### PR DESCRIPTION
Closes #260

## Measured, not argued

Both peer reads emitted **one** statement LEFT JOINing every child collection, so the driver materialized their Cartesian product. Real SQLite file, 200 iterations per shape:

| peer shape | cartesian rows | before | after | |
|---|---|---|---|---|
| 1 sub, 5 prefixes, 1 asn, 1 source | 5 | 0.24 ms | 0.27 ms | — |
| 3 subs, **200 prefixes**, 5 asns, 2 sources | 6,000 | **31 ms** | **0.33 ms** | 96× |
| 5 subs, **1000 prefixes**, 10 asns, 3 sources | 150,000 | **814 ms** | **1.4 ms** | 596× |

`LoadPeerRoutingView` is on the BGP send path — every session establish, every `RefreshRoutesAsync`, and `RefreshAllEstablishedAsync` fires it for all peers concurrently. A user with 1,000 custom prefixes waited most of a second on the database before route assembly even began.

`GetPeerDetail` is the read the management UI hits to render a peer: **120 ms → 0.17 ms** at 200 prefixes.

## Two prior conclusions this corrects

Both verified by dumping the SQL EF actually emits, not by reading the code.

**#138's premise is false.** It suppressed `MultipleCollectionIncludeWarning` because *"for SQLite (local, embedded) with small per-peer data (tens of rows), the Cartesian product is negligible and SingleQuery keeps the read atomic"*. The product is `subs × prefixes × asns × sources`, and this deployment lets a user pick prefixes in a UI — 200 is ordinary, and six figures needs nothing unusual. The suppression is removed: with both reads split it has nothing to fire on, and leaving it would only hide the next reintroduction.

**#228's fix did not do what its doc claims.** `GetPeerDetail` was documented as:

> EF auto-splits the collection subqueries inside a projection (one SELECT per collection + one for the peer row, all on the same connection), so there is no Cartesian-product row explosion that an Include-based load would produce.

EF emits a single joined statement for it — byte-for-byte the same shape as the `Include` version:

```sql
SELECT "p4"."Id", "p0"."AsnListName", ... FROM (
    SELECT "p"."Id" FROM "Peers" AS "p" WHERE "p"."Ip" = ... LIMIT 1
) AS "p4"
LEFT JOIN "PeerSubscription" AS "p0" ON "p4"."Id" = "p0"."PeerId"
LEFT JOIN "PeerCustomPrefix" AS "p1" ON "p4"."Id" = "p1"."PeerId"
...
```

**One** SELECT before, **six** after adding `AsSplitQuery`. So the GET path #228 set out to fix has carried the explosion since — with five collections, one more than `LoadPeerRoutingView`. The doc is corrected in place rather than deleted, since the false claim is exactly the thing a future reader would otherwise rely on.

This also means the obvious reading of #260 — "switch the send path to a projection like `GetPeerDetail`" — would have produced a 1.2× improvement and closed the issue as fixed. That is why the measurement came before the change.

## Consistency

Splitting gives up the single-statement read consistency #138 also named — the one thing it got right. Both reads therefore run inside an explicit transaction: the separate SELECTs would otherwise each see their own snapshot, and a UI edit landing between them would advertise a mixed configuration. SQLite runs in WAL here (#95), so a read transaction takes no write lock and blocks no writer.

In `LoadPeerRoutingView` the transaction covers the read only; the folded `ExecuteUpdate` status write stays outside it, so the write lock is held no longer than before.

## Verification

`dotnet build BGPLite.sln` + `dotnet test BGPLite.sln`: **687 passed, 0 failed** (684 before, 3 added). `dotnet format --severity warn` clean.

Confirmed to catch the regression — with `AsSplitQuery()` removed:

```
Failed LoadPeerRoutingView_EmitsOneSelectPerCollection
  expected a split query (one SELECT per collection), got 1 SELECT statement(s)
Failed GetPeerDetail_EmitsOneSelectPerCollection
  expected a split query (one SELECT per collection), got 1 SELECT statement(s)
```

## Tests added

`PeerStoreSplitQueryTests` asserts the **emitted SQL** rather than timings — deterministic, no dependence on the runner, and it covers what EF's own `MultipleCollectionIncludeWarning` cannot: that warning fires only for the `Include` shape, so it would never have caught `GetPeerDetail`'s projection.

- `LoadPeerRoutingView_EmitsOneSelectPerCollection`
- `GetPeerDetail_EmitsOneSelectPerCollection`
- `SplitReadsReturnTheSameData` — the split must not change what the reads return, including that only Active sources reach the advertisement (#147) while the detail view shows both.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved peer detail and routing views to load related information consistently.
  * Prevented duplicate or incomplete peer data when multiple related collections are displayed.
  * Preserved subscriptions, prefixes, ASNs, and source visibility during peer reads.

* **Tests**
  * Added coverage to verify accurate results and reliable loading of related peer information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->