### PR TITLE
fix(api): create/update a peer in one transaction, and dedup its collections

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -651,10 +651,13 @@ public sealed class ManagementApi : IHostedService, IDisposable
             }
         }
 
-        var id = _store.CreatePeer(data.Ip, data.Asn, data.Description);
-        _store.SetSubscriptions(id, asnLists);
-        _store.SetCustomPrefixes(id, customPrefixes);
-        _store.SetCustomAsns(id, data.CustomAsns ?? []);
+        // #259: one transaction for the whole create. The previous CreatePeer + three Set* calls
+        // each committed separately, so a duplicate CIDR — which violates the
+        // (PeerId, Prefix, PrefixLength) key — returned 500 over an already-committed peer row and
+        // left the user with a half-configured peer. Duplicates are now deduplicated inside the
+        // store: a set of prefixes means the same thing whether a value appears once or twice.
+        var id = _store.SavePeerConfiguration(
+            data.Ip, data.Asn, data.Description, asnLists, customPrefixes, data.CustomAsns ?? []);
 
         var peer = _store.GetDbPeerById(id);
 
@@ -736,16 +739,10 @@ public sealed class ManagementApi : IHostedService, IDisposable
         _logger.LogInformation("UpdatePeer {Id}: CustomPrefixes={Count}, CustomAsns={AsnCount}",
             SanitizeForLog(peerId), parsedPrefixes?.Count ?? 0, data.CustomAsns?.Count ?? 0);
 
-        if (data.Description is not null)
-            _store.SetDescription(peerId, data.Description);
-
-        if (data.Lists is not null)
-            _store.SetSubscriptions(peerId, data.Lists);
-
-        if (parsedPrefixes is not null)
-            _store.SetCustomPrefixes(peerId, parsedPrefixes);
-        if (data.CustomAsns is not null)
-            _store.SetCustomAsns(peerId, data.CustomAsns);
+        // #259: one transaction for the whole update, same reasoning as the create path. A null
+        // argument means "leave this alone" — the PATCH semantics this endpoint already had, now
+        // expressed once in the store instead of as four conditional calls that each committed.
+        _store.UpdatePeerConfiguration(peerId, data.Description, data.Lists, parsedPrefixes, data.CustomAsns);
 
         _logger.LogInformation("Updated peer {Id}", SanitizeForLog(peerId));
 

--- a/BGPLite.Api/PeerStore.cs
+++ b/BGPLite.Api/PeerStore.cs
@@ -10,6 +10,11 @@ public sealed class PeerStore : IPeerStore
 
     public PeerStore(IDbContextFactory<BgpDbContext> dbFactory) => _dbFactory = dbFactory;
 
+    /// <summary>
+    /// Creates or upserts the peer row alone. Callers configuring a peer in full should use
+    /// <see cref="SavePeerConfiguration"/> instead, so the row and its collections commit together
+    /// (#259).
+    /// </summary>
     public string CreatePeer(string ip, uint asn, string? description)
     {
         using var db = _dbFactory.CreateDbContext();
@@ -317,6 +322,7 @@ public sealed class PeerStore : IPeerStore
     // the composite methods above can put every part of a save inside one transaction. The public
     // Set* methods keep their own DbContext + transaction for single-field callers.
 
+    /// <summary>Stages the subscription set, deduplicated — keyed <c>(PeerId, AsnListName)</c>.</summary>
     private static void ReplaceSubscriptions(BgpDbContext db, string peerId, IReadOnlyList<string> names)
     {
         db.Set<PeerSubscription>().Where(s => s.PeerId == peerId).ExecuteDelete();
@@ -325,6 +331,7 @@ public sealed class PeerStore : IPeerStore
                  .Select(n => new PeerSubscription { PeerId = peerId, AsnListName = n }));
     }
 
+    /// <summary>Stages the custom-prefix set, deduplicated — keyed <c>(PeerId, Prefix, PrefixLength)</c>.</summary>
     private static void ReplaceCustomPrefixes(BgpDbContext db, string peerId, IReadOnlyList<(string Prefix, byte Length)> prefixes)
     {
         db.Set<PeerCustomPrefix>().Where(c => c.PeerId == peerId).ExecuteDelete();
@@ -333,6 +340,7 @@ public sealed class PeerStore : IPeerStore
                     .Select(p => new PeerCustomPrefix { PeerId = peerId, Prefix = p.Prefix, PrefixLength = p.Length }));
     }
 
+    /// <summary>Stages the custom-ASN set, deduplicated — keyed <c>(PeerId, Asn)</c>.</summary>
     private static void ReplaceCustomAsns(BgpDbContext db, string peerId, IReadOnlyList<uint> asns)
     {
         db.Set<PeerCustomAsn>().Where(c => c.PeerId == peerId).ExecuteDelete();

--- a/BGPLite.Api/PeerStore.cs
+++ b/BGPLite.Api/PeerStore.cs
@@ -13,6 +13,16 @@ public sealed class PeerStore : IPeerStore
     public string CreatePeer(string ip, uint asn, string? description)
     {
         using var db = _dbFactory.CreateDbContext();
+        return UpsertPeerRow(db, ip, asn, description);
+    }
+
+    /// <summary>
+    /// The peer-row upsert, on a caller-supplied <see cref="BgpDbContext"/> so it can participate in
+    /// an enclosing transaction (#259) instead of always committing on its own. Behaviour is
+    /// unchanged from the #227 implementation this was extracted from.
+    /// </summary>
+    private static string UpsertPeerRow(BgpDbContext db, string ip, uint asn, string? description)
+    {
         // #227: atomic SQLite upsert eliminates the read-then-write race on the composite unique
         // index UX_Peers_Ip_Asn. Two concurrent CreatePeer calls for the same (Ip, Asn) previously
         // both observed `existing is null`, both INSERTed, and the second threw DbUpdateException
@@ -237,6 +247,97 @@ public sealed class PeerStore : IPeerStore
                 // Communities stored as long (PeerCommunity.Community); the API formats to "ASN:VAL".
                 p.Communities.Select(c => c.Community).ToList()))
             .FirstOrDefault();
+    }
+
+    /// <summary>
+    /// Creates (or upserts) a peer and applies its whole configuration in ONE transaction (#259).
+    /// <para>
+    /// The management API previously chained <c>CreatePeer</c> → <c>SetSubscriptions</c> →
+    /// <c>SetCustomPrefixes</c> → <c>SetCustomAsns</c>, each opening its own <c>DbContext</c> and
+    /// transaction. #226/#227 made each individual step atomic; the composition was not. A failure
+    /// part-way — a duplicate CIDR violating the <c>(PeerId, Prefix, PrefixLength)</c> key is the
+    /// reported trigger — returned 500 to the client over an already-committed peer row, leaving a
+    /// half-configured peer that the client's retry then had to reconcile. It also opened a window
+    /// where a concurrent BGP session read a <c>LoadPeerRoutingView</c> with the subscriptions
+    /// applied but not the custom prefixes, and advertised the incomplete set.
+    /// </para>
+    /// <para>
+    /// Every child collection is a set, and all four are keyed on <c>(PeerId, …)</c>, so duplicates
+    /// are deduplicated rather than rejected: asking to advertise 10.0.0.0/8 twice means the same
+    /// thing as asking once, and a user assembling a list in the UI produces repeats by pasting.
+    /// </para>
+    /// </summary>
+    public string SavePeerConfiguration(
+        string ip, uint asn, string? description,
+        IReadOnlyList<string> asnListNames,
+        IReadOnlyList<(string Prefix, byte Length)> customPrefixes,
+        IReadOnlyList<uint> customAsns)
+    {
+        using var db = _dbFactory.CreateDbContext();
+        using var tx = db.Database.BeginTransaction();
+
+        var id = UpsertPeerRow(db, ip, asn, description);
+        ReplaceSubscriptions(db, id, asnListNames);
+        ReplaceCustomPrefixes(db, id, customPrefixes);
+        ReplaceCustomAsns(db, id, customAsns);
+        db.SaveChanges();
+
+        tx.Commit();
+        return id;
+    }
+
+    /// <summary>
+    /// Applies a partial peer update in ONE transaction (#259). A <c>null</c> argument means "leave
+    /// this alone", matching the PATCH semantics the management API exposes — an empty list means
+    /// "clear it", which is a different request and is honoured as such.
+    /// </summary>
+    public void UpdatePeerConfiguration(
+        string peerId, string? description,
+        IReadOnlyList<string>? asnListNames,
+        IReadOnlyList<(string Prefix, byte Length)>? customPrefixes,
+        IReadOnlyList<uint>? customAsns)
+    {
+        using var db = _dbFactory.CreateDbContext();
+        using var tx = db.Database.BeginTransaction();
+
+        if (description is not null)
+        {
+            db.Peers.Where(p => p.Id == peerId)
+                .ExecuteUpdate(s => s.SetProperty(p => p.Description, description));
+        }
+        if (asnListNames is not null) ReplaceSubscriptions(db, peerId, asnListNames);
+        if (customPrefixes is not null) ReplaceCustomPrefixes(db, peerId, customPrefixes);
+        if (customAsns is not null) ReplaceCustomAsns(db, peerId, customAsns);
+        db.SaveChanges();
+
+        tx.Commit();
+    }
+
+    // The Replace* helpers stage a delete + insert on the CALLER's DbContext without committing, so
+    // the composite methods above can put every part of a save inside one transaction. The public
+    // Set* methods keep their own DbContext + transaction for single-field callers.
+
+    private static void ReplaceSubscriptions(BgpDbContext db, string peerId, IReadOnlyList<string> names)
+    {
+        db.Set<PeerSubscription>().Where(s => s.PeerId == peerId).ExecuteDelete();
+        db.Set<PeerSubscription>().AddRange(
+            names.Distinct(StringComparer.Ordinal)
+                 .Select(n => new PeerSubscription { PeerId = peerId, AsnListName = n }));
+    }
+
+    private static void ReplaceCustomPrefixes(BgpDbContext db, string peerId, IReadOnlyList<(string Prefix, byte Length)> prefixes)
+    {
+        db.Set<PeerCustomPrefix>().Where(c => c.PeerId == peerId).ExecuteDelete();
+        db.Set<PeerCustomPrefix>().AddRange(
+            prefixes.Distinct()
+                    .Select(p => new PeerCustomPrefix { PeerId = peerId, Prefix = p.Prefix, PrefixLength = p.Length }));
+    }
+
+    private static void ReplaceCustomAsns(BgpDbContext db, string peerId, IReadOnlyList<uint> asns)
+    {
+        db.Set<PeerCustomAsn>().Where(c => c.PeerId == peerId).ExecuteDelete();
+        db.Set<PeerCustomAsn>().AddRange(
+            asns.Distinct().Select(a => new PeerCustomAsn { PeerId = peerId, Asn = a }));
     }
 
     public void SetDescription(string id, string description)

--- a/BGPLite.Tests/PeerStoreConfigurationAtomicityTests.cs
+++ b/BGPLite.Tests/PeerStoreConfigurationAtomicityTests.cs
@@ -1,0 +1,167 @@
+using BGPLite.Api;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #259: creating or updating a peer chained CreatePeer → SetSubscriptions → SetCustomPrefixes →
+/// SetCustomAsns, each opening its own DbContext and transaction. #226/#227 made each individual
+/// Set* atomic; the composition of them was not, so a failure part-way left a peer half-configured
+/// and the client saw a 500 over an already-committed peer row.
+/// <para>
+/// The reported trigger is a duplicate CIDR, which violates the (PeerId, Prefix, PrefixLength)
+/// primary key. The same hazard exists on every child collection — subscriptions are keyed
+/// (PeerId, AsnListName) and custom ASNs (PeerId, Asn) — so a repeated list name or ASN throws
+/// just as readily. A user assembling a prefix set in the management UI can produce any of the
+/// three by pasting a list twice.
+/// </para>
+/// </summary>
+public class PeerStoreConfigurationAtomicityTests
+{
+    private const string Ip = "203.0.113.30";
+    private const uint Asn = 64530;
+
+    [Fact]
+    public void SavePeerConfiguration_DuplicatePrefixes_AreAcceptedIdempotently()
+    {
+        var (store, connection) = NewStore();
+        using var _ = connection;
+
+        var id = store.SavePeerConfiguration(Ip, Asn, "dup prefixes",
+            asnListNames: ["ru"],
+            customPrefixes: [("10.0.0.0", 8), ("10.0.0.0", 8), ("192.0.2.0", 24)],
+            customAsns: [64512]);
+
+        // A set of prefixes: announcing 10.0.0.0/8 twice is the same as once, so the duplicate is
+        // dropped rather than rejected.
+        Assert.Equal(["10.0.0.0/8", "192.0.2.0/24"], store.GetCustomPrefixes(id).Order().ToList());
+        Assert.Equal(["ru"], store.GetSubscriptions(id));
+        Assert.Equal([64512u], store.GetCustomAsns(id));
+    }
+
+    [Fact]
+    public void SavePeerConfiguration_DuplicateListNamesAndAsns_AreAcceptedIdempotently()
+    {
+        var (store, connection) = NewStore();
+        using var _ = connection;
+
+        var id = store.SavePeerConfiguration(Ip, Asn, "dup lists and asns",
+            asnListNames: ["ru", "ru", "cdn"],
+            customPrefixes: [],
+            customAsns: [64512, 64512, 64513]);
+
+        Assert.Equal(["cdn", "ru"], store.GetSubscriptions(id).Order().ToList());
+        Assert.Equal([64512u, 64513u], store.GetCustomAsns(id).Order().ToList());
+    }
+
+    [Fact]
+    public void SavePeerConfiguration_AppliesEveryPartOrNothing()
+    {
+        var (store, connection) = NewStore();
+        using var _ = connection;
+
+        var id = store.SavePeerConfiguration(Ip, Asn, "full",
+            asnListNames: ["ru"],
+            customPrefixes: [("10.0.0.0", 8)],
+            customAsns: [64512]);
+
+        // The failure #259 describes is a peer row committed with its child collections missing.
+        // Assert the whole configuration is readable through the same view the send path uses.
+        var view = store.LoadPeerRoutingView(Ip, Asn);
+        Assert.NotNull(view);
+        Assert.Equal(["ru"], view!.Subscriptions);
+        Assert.Equal(["10.0.0.0/8"], view.CustomPrefixes);
+        Assert.Equal([64512u], view.CustomAsns);
+        Assert.Equal(id, view.PeerId);
+    }
+
+    /// <summary>
+    /// The property #259 is actually about: the whole save is ONE transaction, not four DbContexts
+    /// and three commits. Asserted by counting the transactions EF actually opens rather than by
+    /// forcing a failure — no production test hook, and it fails the moment someone re-splits the
+    /// composition into separate Set* calls.
+    /// </summary>
+    [Fact]
+    public void SavePeerConfiguration_RunsInASingleTransaction()
+    {
+        var (store, connection, transactions) = NewStoreCountingTransactions();
+        using var _ = connection;
+
+        transactions.Clear();
+        store.SavePeerConfiguration(Ip, Asn, "one transaction",
+            asnListNames: ["ru", "cdn"],
+            customPrefixes: [("10.0.0.0", 8), ("192.0.2.0", 24)],
+            customAsns: [64512, 64513]);
+
+        Assert.Single(transactions);
+    }
+
+    [Fact]
+    public void UpdatePeerConfiguration_RunsInASingleTransaction()
+    {
+        var (store, connection, transactions) = NewStoreCountingTransactions();
+        using var _ = connection;
+        var id = store.SavePeerConfiguration(Ip, Asn, "initial",
+            asnListNames: ["ru"], customPrefixes: [("10.0.0.0", 8)], customAsns: [64512]);
+
+        transactions.Clear();
+        store.UpdatePeerConfiguration(id, "changed",
+            asnListNames: ["cdn"],
+            customPrefixes: [("192.0.2.0", 24)],
+            customAsns: [64514]);
+
+        Assert.Single(transactions);
+    }
+
+    [Fact]
+    public void UpdatePeerConfiguration_NullsLeaveTheExistingValueAlone()
+    {
+        var (store, connection) = NewStore();
+        using var _ = connection;
+        var id = store.SavePeerConfiguration(Ip, Asn, "initial",
+            asnListNames: ["ru"], customPrefixes: [("10.0.0.0", 8)], customAsns: [64512]);
+
+        // Only the prefixes are supplied; the rest must survive untouched, matching the PATCH
+        // semantics the management API exposes.
+        store.UpdatePeerConfiguration(id, description: null,
+            asnListNames: null,
+            customPrefixes: [("192.0.2.0", 24), ("192.0.2.0", 24)],
+            customAsns: null);
+
+        Assert.Equal(["192.0.2.0/24"], store.GetCustomPrefixes(id));
+        Assert.Equal(["ru"], store.GetSubscriptions(id));
+        Assert.Equal([64512u], store.GetCustomAsns(id));
+        Assert.Equal("initial", store.GetDbPeerById(id)!.Description);
+    }
+
+    private static (PeerStore Store, SqliteConnection Connection, List<string> Transactions) NewStoreCountingTransactions()
+    {
+        var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        var transactions = new List<string>();
+        var options = new DbContextOptionsBuilder<BgpDbContext>()
+            .UseSqlite(connection)
+            .LogTo(line => { lock (transactions) transactions.Add(line); },
+                   [Microsoft.EntityFrameworkCore.Diagnostics.RelationalEventId.TransactionStarted])
+            .Options;
+        using (var boot = new BgpDbContext(options))
+            BgpDbContext.Initialize(boot);
+        return (new PeerStore(new StaticOptionsFactory(options)), connection, transactions);
+    }
+
+    private static (PeerStore Store, SqliteConnection Connection) NewStore()
+    {
+        var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        var options = new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(connection).Options;
+        using (var boot = new BgpDbContext(options))
+            BgpDbContext.Initialize(boot);
+        return (new PeerStore(new StaticOptionsFactory(options)), connection);
+    }
+
+    private sealed class StaticOptionsFactory(DbContextOptions<BgpDbContext> options) : IDbContextFactory<BgpDbContext>
+    {
+        public BgpDbContext CreateDbContext() => new(options);
+    }
+}

--- a/BGPLite.Tests/PeerStoreConfigurationAtomicityTests.cs
+++ b/BGPLite.Tests/PeerStoreConfigurationAtomicityTests.cs
@@ -22,6 +22,10 @@ public class PeerStoreConfigurationAtomicityTests
     private const string Ip = "203.0.113.30";
     private const uint Asn = 64530;
 
+    /// <summary>
+    /// The reported trigger: a repeated CIDR violates the <c>(PeerId, Prefix, PrefixLength)</c> key.
+    /// Deduplicated rather than rejected — a set of prefixes means the same thing either way.
+    /// </summary>
     [Fact]
     public void SavePeerConfiguration_DuplicatePrefixes_AreAcceptedIdempotently()
     {
@@ -40,6 +44,10 @@ public class PeerStoreConfigurationAtomicityTests
         Assert.Equal([64512u], store.GetCustomAsns(id));
     }
 
+    /// <summary>
+    /// The collections the issue does not mention. Subscriptions and custom ASNs carry the same
+    /// composite keys, so a pasted-twice list name or ASN threw exactly as a repeated CIDR did.
+    /// </summary>
     [Fact]
     public void SavePeerConfiguration_DuplicateListNamesAndAsns_AreAcceptedIdempotently()
     {
@@ -55,6 +63,10 @@ public class PeerStoreConfigurationAtomicityTests
         Assert.Equal([64512u, 64513u], store.GetCustomAsns(id).Order().ToList());
     }
 
+    /// <summary>
+    /// Read back through <c>LoadPeerRoutingView</c> — the same view the BGP send path uses, so this
+    /// asserts the peer is complete where it actually matters, not merely in the store.
+    /// </summary>
     [Fact]
     public void SavePeerConfiguration_AppliesEveryPartOrNothing()
     {
@@ -97,6 +109,9 @@ public class PeerStoreConfigurationAtomicityTests
         Assert.Single(transactions);
     }
 
+    /// <summary>
+    /// The update path carries the same guarantee as the create path.
+    /// </summary>
     [Fact]
     public void UpdatePeerConfiguration_RunsInASingleTransaction()
     {
@@ -114,6 +129,9 @@ public class PeerStoreConfigurationAtomicityTests
         Assert.Single(transactions);
     }
 
+    /// <summary>
+    /// PATCH semantics: <c>null</c> means "leave this alone", while an empty list means "clear it".
+    /// </summary>
     [Fact]
     public void UpdatePeerConfiguration_NullsLeaveTheExistingValueAlone()
     {
@@ -135,6 +153,7 @@ public class PeerStoreConfigurationAtomicityTests
         Assert.Equal("initial", store.GetDbPeerById(id)!.Description);
     }
 
+    /// <summary>A store over an in-memory SQLite DB that records every transaction EF opens.</summary>
     private static (PeerStore Store, SqliteConnection Connection, List<string> Transactions) NewStoreCountingTransactions()
     {
         var connection = new SqliteConnection("DataSource=:memory:");
@@ -150,6 +169,7 @@ public class PeerStoreConfigurationAtomicityTests
         return (new PeerStore(new StaticOptionsFactory(options)), connection, transactions);
     }
 
+    /// <summary>A store over an in-memory SQLite DB, so composite keys and transactions are real.</summary>
     private static (PeerStore Store, SqliteConnection Connection) NewStore()
     {
         var connection = new SqliteConnection("DataSource=:memory:");
@@ -162,6 +182,7 @@ public class PeerStoreConfigurationAtomicityTests
 
     private sealed class StaticOptionsFactory(DbContextOptions<BgpDbContext> options) : IDbContextFactory<BgpDbContext>
     {
+        /// <summary>Hands out contexts over the one open connection, so the in-memory DB survives.</summary>
         public BgpDbContext CreateDbContext() => new(options);
     }
 }


### PR DESCRIPTION
Closes #259

## Problem

`HandleCreatePeer` chained `CreatePeer` → `SetSubscriptions` → `SetCustomPrefixes` → `SetCustomAsns`, and `HandleUpdatePeer` did the same conditionally. #226/#227 made each individual step atomic; the *composition* of them was not — four `DbContext`s, three commits.

Two consequences, both user-visible in a product where the peer's configuration is what the user assembled in the UI:

- A duplicate CIDR violates the `(PeerId, Prefix, PrefixLength)` key, so the request returned **500 with the peer row and its subscriptions already committed**. The user saw an error over a half-saved peer, and a retry had to reconcile it.
- Between two commits, a concurrent BGP session could read a `LoadPeerRoutingView` carrying the subscriptions but not the custom prefixes, and advertise the incomplete set.

## The duplicate hazard is wider than the issue reports

The issue names custom prefixes. All four child collections are keyed on `(PeerId, …)`:

```
e.HasKey(c => new { c.PeerId, c.Community });          // PeerCommunity
e.HasKey(s => new { s.PeerId, s.AsnListName });        // PeerSubscription
e.HasKey(c => new { c.PeerId, c.Prefix, c.PrefixLength });
e.HasKey(c => new { c.PeerId, c.Asn });                // PeerCustomAsn
```

So a repeated list name or ASN throws exactly as a repeated CIDR does, and pasting a list twice in the UI produces any of them. All are deduplicated.

**Deduplicated rather than rejected**, which the issue's acceptance allows either way. These are sets: asking to advertise `10.0.0.0/8` twice means what asking once means, so a 400 would be pedantry aimed at a user who pasted.

## Fix

`SavePeerConfiguration` and `UpdatePeerConfiguration` apply the whole thing on one `DbContext` inside one transaction. `UpdatePeerConfiguration` treats `null` as "leave this alone", preserving the endpoint's PATCH semantics; an empty list still means "clear it", which is a different request and is honoured as such.

The peer-row upsert is extracted from `CreatePeer` into `UpsertPeerRow` so it can join an enclosing transaction — its #227 atomic `INSERT … ON CONFLICT … RETURNING` behaviour is unchanged, and `CreatePeer` now delegates to it, so there is one implementation rather than two.

The `Replace*` helpers stage delete+insert on the caller's context without committing, which is what lets every part of a save share the transaction.

## What is deliberately left alone

The single-field `SetSubscriptions` / `SetCustomPrefixes` / `SetCustomAsns` / `SetDescription` keep their own `DbContext` and transaction, and their #226 coverage. They are no longer on the create/update path, so their only remaining callers are tests — left in place as a legitimate API surface (`SetDescription` is on the `IPeerStore` contract) rather than removed as drive-by cleanup.

## Verification

`dotnet build BGPLite.sln` + `dotnet test BGPLite.sln`: **690 passed, 0 failed** (687 before, 6 added, 3 pre-existing ones re-exercised). `dotnet format --severity warn` clean.

Both properties confirmed to catch their regression:

```
dedup removed
  Failed SavePeerConfiguration_DuplicateListNamesAndAsns_AreAcceptedIdempotently
  Failed SavePeerConfiguration_DuplicatePrefixes_AreAcceptedIdempotently
  Failed UpdatePeerConfiguration_NullsLeaveTheExistingValueAlone

composition re-split into separate transactions
  Failed SavePeerConfiguration_RunsInASingleTransaction
    Actual:   4
```

## Tests added

`PeerStoreConfigurationAtomicityTests`, against a real in-memory SQLite database so the composite keys and transactions are actually exercised:

- `SavePeerConfiguration_DuplicatePrefixes_AreAcceptedIdempotently`
- `SavePeerConfiguration_DuplicateListNamesAndAsns_AreAcceptedIdempotently` — the collections the issue does not mention
- `SavePeerConfiguration_AppliesEveryPartOrNothing` — read back through `LoadPeerRoutingView`, the same view the send path uses
- `SavePeerConfiguration_RunsInASingleTransaction` / `UpdatePeerConfiguration_RunsInASingleTransaction`
- `UpdatePeerConfiguration_NullsLeaveTheExistingValueAlone` — PATCH semantics

Atomicity is asserted by **counting the transactions EF opens** (1, was 4) rather than by forcing a failure. My first draft added a `failAfterPeerRowForTesting` parameter to the production signature to trigger a rollback; counting transactions proves the same property without putting a test hook in shipped API, and it fails the moment someone re-splits the composition.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Peer creation and updates now save configuration changes as a single transaction.
  * Peer configurations support subscriptions, custom prefixes, custom ASNs, and descriptions.
  * Partial updates preserve fields that are omitted, while supplied or empty values replace existing entries.
  * Duplicate configuration entries are handled idempotently.

* **Bug Fixes**
  * Prevented partially applied peer configuration changes when an operation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->