### PR TITLE
fix(api): validate and canonicalize peer input before it is persisted

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -624,6 +624,11 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
     #region /api/peers
 
+    /// <summary>
+    /// <c>POST /api/peers</c> — creates a peer from the request body. Every field is validated and
+    /// the address canonicalized (#255) BEFORE the store is touched, so a rejected request leaves no
+    /// row behind and an accepted one is stored in the form <c>BgpServer</c> keys sessions by.
+    /// </summary>
     private async Task<ApiResponse> HandleCreatePeer(HttpListenerContext ctx)
     {
         var (body, bodyError) = await ReadBodyAsync(ctx);
@@ -716,6 +721,11 @@ public sealed class ManagementApi : IHostedService, IDisposable
         });
     }
 
+    /// <summary>
+    /// <c>PATCH /api/peers/{id}</c> — updates the supplied fields of an existing peer; an omitted
+    /// collection means "leave it alone", an empty one means "clear it". Validation runs before the
+    /// store is touched, matching <see cref="HandleCreatePeer"/> (#255).
+    /// </summary>
     private async Task<ApiResponse> HandleUpdatePeer(string peerId, HttpListenerContext ctx)
     {
         var peer = _store.GetDbPeerById(peerId);

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -633,6 +633,16 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (data is null)
             return ApiResponse.Error("Invalid request body", 400);
 
+        // #255: validate everything BEFORE the store is touched. The peer row and its collections
+        // now commit together (#259), so a rejection here leaves nothing behind at all.
+        var normalizedIp = NormalizePeerIp(data.Ip);
+        if (normalizedIp is null)
+            return ApiResponse.Error($"Invalid peer IP: {SanitizeForLog(data.Ip ?? "(missing)")}", 400);
+        if (!IsConfigurablePeerAsn(data.Asn))
+            return ApiResponse.Error($"Invalid peer AS number: {data.Asn}", 400);
+        if (ValidatePeerFields(data.Description, data.CustomAsns) is { } createError)
+            return createError;
+
         var asnLists = data.AsnLists ?? [];
         var customPrefixes = new List<(string Prefix, byte Length)>();
 
@@ -657,20 +667,20 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // left the user with a half-configured peer. Duplicates are now deduplicated inside the
         // store: a set of prefixes means the same thing whether a value appears once or twice.
         var id = _store.SavePeerConfiguration(
-            data.Ip, data.Asn, data.Description, asnLists, customPrefixes, data.CustomAsns ?? []);
+            normalizedIp, data.Asn, data.Description, asnLists, customPrefixes, data.CustomAsns ?? []);
 
         var peer = _store.GetDbPeerById(id);
 
         _logger.LogInformation("Created peer {Ip} AS{Asn} ({Id}): {Subs} lists, {Prefixes} custom prefixes, {Asns} custom AS",
-            data.Ip, data.Asn, id, asnLists.Count, customPrefixes.Count, data.CustomAsns?.Count ?? 0);
+            normalizedIp, data.Asn, id, asnLists.Count, customPrefixes.Count, data.CustomAsns?.Count ?? 0);
 
         if (_sessionManager is not null)
-            _ = _sessionManager.RefreshPeerAsync(data.Ip, data.Asn);
+            _ = _sessionManager.RefreshPeerAsync(normalizedIp, data.Asn);
 
         return ApiResponse.Ok(new
         {
             id,
-            ip = data.Ip,
+            ip = normalizedIp,
             asn = data.Asn,
             description = data.Description,
             status = peer?.Status ?? "inactive",
@@ -738,6 +748,11 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         _logger.LogInformation("UpdatePeer {Id}: CustomPrefixes={Count}, CustomAsns={AsnCount}",
             SanitizeForLog(peerId), parsedPrefixes?.Count ?? 0, data.CustomAsns?.Count ?? 0);
+
+        // #255: the address and the peer's own ASN are not updatable through this endpoint, so only
+        // the shared fields need checking — but they need it before anything is written.
+        if (ValidatePeerFields(data.Description, data.CustomAsns) is { } updateError)
+            return updateError;
 
         // #259: one transaction for the whole update, same reasoning as the create path. A null
         // argument means "leave this alone" — the PATCH semantics this endpoint already had, now
@@ -1129,6 +1144,78 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // Return the masked network address in dotted-quad form (matches how it is stored in the DB
         // and re-parsed by the BGP send path, so the round-trip is byte-identical).
         return (BgpConstants.UintToIPAddress(prefix).ToString(), length);
+    }
+
+    /// <summary>
+    /// Validates a peer address and returns it in canonical dotted-quad form, or <c>null</c> if it is
+    /// not a usable IPv4 address (#255).
+    /// <para>
+    /// Canonicalizing is the point, not a nicety. <c>BgpServer</c> keys an accepted session by
+    /// <c>remoteEndpoint.Address.ToString()</c>, so a peer row storing any other spelling of the same
+    /// address never binds to its session — the peer is configured, visible in the UI, and silently
+    /// never comes up. <see cref="IPAddress.TryParse"/> accepts several such spellings and rewrites
+    /// them: <c>01.02.03.04</c> and <c>0x1.2.3.4</c> both become <c>1.2.3.4</c>, and the three-part
+    /// form <c>1.2.3</c> becomes <c>1.2.0.3</c> — a different host than the one typed. Storing
+    /// <c>ToString()</c> collapses all of them onto the form the BGP path will look for.
+    /// </para>
+    /// <para>
+    /// IPv6 is rejected rather than mapped: BGPLite is IPv4-unicast only (#14 tracks the rest), so
+    /// <c>::ffff:1.2.3.4</c> would produce a peer no session can match.
+    /// </para>
+    /// </summary>
+    internal static string? NormalizePeerIp(string? ip)
+    {
+        if (string.IsNullOrWhiteSpace(ip)) return null;
+        if (!IPAddress.TryParse(ip, out var address)) return null;
+        if (address.AddressFamily != AddressFamily.InterNetwork) return null;
+        return address.ToString();
+    }
+
+    /// <summary>
+    /// Whether an AS number may be configured for a peer (#255). Rejects exactly four values:
+    /// <list type="bullet">
+    /// <item><c>0</c> — RFC 7607 §2 requires an OPEN carrying peer AS 0 to be rejected with Bad Peer
+    /// AS, which BGPLite now does (#300). Accepting it here produces a peer that is stored, shown in
+    /// the UI, and can never establish a session.</item>
+    /// <item><c>23456</c> — AS_TRANS is the RFC 6793 placeholder a 4-octet speaker puts in My AS; its
+    /// real AS arrives in the capability, so no peer ever *is* AS_TRANS.</item>
+    /// <item><c>65535</c> and <c>4294967295</c> — the Last ASNs reserved by RFC 7300.</item>
+    /// </list>
+    /// <para>
+    /// The private ranges are deliberately NOT rejected. 64512–65534 (RFC 6996) and 4200000000–
+    /// 4294967294 are exactly what a user of a route server peers with; #255 suggested excluding
+    /// "4200000000+", which is the private 32-bit range and would lock out real peers. RFC 7300
+    /// reserves only the two endpoints above.
+    /// </para>
+    /// </summary>
+    internal static bool IsConfigurablePeerAsn(uint asn) =>
+        asn is not (0 or BgpConstants.AsPath.AsTrans or 65535 or uint.MaxValue);
+
+    /// <summary>Maximum stored length of a peer description — bounds what a client can persist per peer.</summary>
+    internal const int MaxDescriptionLength = 512;
+
+    /// <summary>
+    /// Validates the peer fields shared by create and update, returning the error response to send or
+    /// <c>null</c> when everything checks out. Runs BEFORE anything is persisted, so a rejected
+    /// request leaves no trace (#255, and #259 for why "before" matters).
+    /// </summary>
+    private static ApiResponse? ValidatePeerFields(string? description, IReadOnlyList<uint>? customAsns)
+    {
+        if (description is { Length: > MaxDescriptionLength })
+            return ApiResponse.Error($"Description exceeds {MaxDescriptionLength} characters", 400);
+
+        if (customAsns is not null)
+        {
+            foreach (var asn in customAsns)
+            {
+                // Custom ASNs are handed to RIPEstat to resolve the prefixes that AS originates, so
+                // an unusable value becomes a lookup that can never return anything.
+                if (!IsConfigurablePeerAsn(asn))
+                    return ApiResponse.Error($"Invalid custom AS number: {asn}", 400);
+            }
+        }
+
+        return null;
     }
 
     private string GetClientIp(HttpListenerContext ctx) =>

--- a/BGPLite.Tests/PeerInputValidationTests.cs
+++ b/BGPLite.Tests/PeerInputValidationTests.cs
@@ -1,0 +1,119 @@
+using BGPLite.Api;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #255: the management API accepted whatever a client sent as a peer address or AS number. The
+/// address went to the store verbatim, so any spelling other than the canonical dotted quad produced
+/// a peer that <c>BgpServer</c> — which keys sessions by <c>remoteEndpoint.Address.ToString()</c> —
+/// could never bind to: configured, visible in the UI, and silently never up.
+/// <para>
+/// The AS side gained urgency from #300: the BGP path now rejects an OPEN carrying AS 0 with Bad
+/// Peer AS (RFC 7607), so a peer created with <c>asn: 0</c> was accepted by the API and then
+/// guaranteed never to establish. Validating at the API is what closes that asymmetry.
+/// </para>
+/// </summary>
+public class PeerInputValidationTests
+{
+    // ---- addresses ----
+
+    /// <summary>
+    /// Forms IPAddress.TryParse accepts but rewrites. Storing the input rather than the parse result
+    /// is the phantom-peer bug; the three-part form is the sharpest case, since 1.2.3 resolves to a
+    /// different host than a reader expects.
+    /// </summary>
+    [Theory]
+    [InlineData("1.2.3.4", "1.2.3.4")]
+    [InlineData("01.02.03.04", "1.2.3.4")]
+    [InlineData("0x1.2.3.4", "1.2.3.4")]
+    [InlineData("1.2.3", "1.2.0.3")]
+    [InlineData("192.168.000.001", "192.168.0.1")]
+    public void NormalizePeerIp_CanonicalizesAcceptedForms(string input, string expected)
+    {
+        Assert.Equal(expected, ManagementApi.NormalizePeerIp(input));
+    }
+
+    /// <summary>
+    /// Rejected outright: unparseable input, absent input (which reached the store as null and
+    /// surfaced as a 500 from a NOT NULL violation), and IPv6 — BGPLite is IPv4-unicast only, so an
+    /// IPv6 peer row could never match a session either.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("1.2.3.4 ")]
+    [InlineData(" 1.2.3.4")]
+    [InlineData("banana")]
+    [InlineData("1.2.3.4.5")]
+    [InlineData("2001:db8::1")]
+    [InlineData("::ffff:1.2.3.4")]
+    public void NormalizePeerIp_RejectsUnusableInput(string? input)
+    {
+        Assert.Null(ManagementApi.NormalizePeerIp(input));
+    }
+
+    /// <summary>
+    /// The property that actually matters: whatever spelling a client sends, what gets stored is the
+    /// form BgpServer will look the session up by.
+    /// </summary>
+    [Theory]
+    [InlineData("01.02.03.04")]
+    [InlineData("0x1.2.3.4")]
+    [InlineData("192.168.000.001")]
+    public void NormalizePeerIp_OutputMatchesWhatTheBgpPathWouldStore(string input)
+    {
+        var normalized = ManagementApi.NormalizePeerIp(input);
+        Assert.NotNull(normalized);
+        // BgpServer stores remoteEndpoint.Address.ToString(); the round trip must be a fixed point.
+        Assert.Equal(normalized, System.Net.IPAddress.Parse(normalized!).ToString());
+    }
+
+    // ---- AS numbers ----
+
+    /// <summary>
+    /// Exactly four values are unusable as a peer's AS: 0 (RFC 7607, and the OPEN path rejects it
+    /// since #300), AS_TRANS (RFC 6793 — a placeholder, never a real peer), and the two Last ASNs
+    /// reserved by RFC 7300.
+    /// </summary>
+    [Theory]
+    [InlineData(0u)]
+    [InlineData(23456u)]
+    [InlineData(65535u)]
+    [InlineData(4294967295u)]
+    public void IsConfigurablePeerAsn_RejectsUnusableValues(uint asn)
+    {
+        Assert.False(ManagementApi.IsConfigurablePeerAsn(asn));
+    }
+
+    /// <summary>
+    /// The private ranges must stay usable — they are what a user of a route server peers with.
+    /// #255 proposed excluding "4200000000+", which is the RFC 6996 private 32-bit range; RFC 7300
+    /// reserves only the two endpoints, so that exclusion would have locked out real peers.
+    /// </summary>
+    [Theory]
+    [InlineData(1u)]
+    [InlineData(65001u)]
+    [InlineData(64512u)]      // RFC 6996 private 16-bit, first
+    [InlineData(65534u)]      // RFC 6996 private 16-bit, last
+    [InlineData(4200000000u)] // RFC 6996 private 32-bit, first
+    [InlineData(4294967294u)] // RFC 6996 private 32-bit, last
+    [InlineData(200000u)]
+    public void IsConfigurablePeerAsn_AcceptsEverythingElseIncludingPrivateRanges(uint asn)
+    {
+        Assert.True(ManagementApi.IsConfigurablePeerAsn(asn));
+    }
+
+    /// <summary>The boundaries either side of each reserved value are usable — an off-by-one here
+    /// would silently lock out a legitimate AS.</summary>
+    [Theory]
+    [InlineData(23455u)]
+    [InlineData(23457u)]
+    [InlineData(65534u)]
+    [InlineData(65536u)]
+    [InlineData(4294967294u)]
+    public void IsConfigurablePeerAsn_ReservedValuesDoNotBleedIntoNeighbours(uint asn)
+    {
+        Assert.True(ManagementApi.IsConfigurablePeerAsn(asn));
+    }
+}


### PR DESCRIPTION
Closes #255

## Problem

`HandleCreatePeer` passed `data.Ip` and `data.Asn` straight to the store, and both handlers passed `data.CustomAsns` through untouched. AGENTS.md requires *"API endpoints must validate peer addresses, ASN ranges"*; nothing did.

**Addresses.** The stored value was whatever the client sent. `BgpServer` keys an accepted session by `remoteEndpoint.Address.ToString()`, so any other spelling of the same address produces a peer that can never bind to its session — configured, listed in the UI, and silently never up.

Measured what `IPAddress.TryParse` actually does with the forms a client can send:

| input | parses | `ToString()` | |
|---|---|---|---|
| `1.2.3.4` | ✅ | `1.2.3.4` | canonical |
| `01.02.03.04` | ✅ | `1.2.3.4` | **rewritten** |
| `0x1.2.3.4` | ✅ | `1.2.3.4` | **rewritten** |
| `1.2.3` | ✅ | **`1.2.0.3`** | **a different host than typed** |
| `1.2.3.4 ` | ❌ | — | |
| `::ffff:1.2.3.4` | ✅ | `::ffff:1.2.3.4` | IPv6 family |
| `banana`, `""`, `1.2.3.4.5` | ❌ | — | |

The three-part form is the sharpest: a user typing an incomplete address gets a peer for `1.2.0.3` and no indication anything was reinterpreted.

`NormalizePeerIp` parses, requires `AddressFamily.InterNetwork`, and returns `ToString()` — which collapses every accepted spelling onto the form the BGP path will look for. A missing or unparseable address is now **400**, not a 500 out of a NOT NULL violation.

Note this corrects one detail of the issue: it lists `"1.2.3.4 "` (trailing space) as *"accepted with 200"*. It is accepted by the API today because nothing validates, but `TryParse` rejects it, so the check handles it without special-casing. The forms that genuinely slip through validation-by-TryParse are the rewritten ones above, which is why canonicalizing matters more than rejecting.

**AS numbers.** Exactly four values are rejected:

- `0` — RFC 7607 §2. This one gained urgency from #300: the BGP path now answers an OPEN carrying peer AS 0 with Bad Peer AS, so a peer created with `asn: 0` was accepted, stored, rendered in the UI, and **guaranteed never to establish**, with nothing explaining why. That asymmetry did not exist before the protocol side was tightened.
- `23456` — AS_TRANS is the RFC 6793 placeholder a 4-octet speaker puts in My AS; its real AS arrives in the capability, so no peer ever *is* AS_TRANS.
- `65535` and `4294967295` — the Last ASNs reserved by RFC 7300.

## Departure from the issue: private ranges stay usable

#255 proposes rejecting "optionally 23456 / 65535 / **4200000000+**". That last one is the **RFC 6996 private 32-bit range** (4200000000–4294967294), whose 16-bit counterpart is 64512–65534. Both are exactly what a user of a route server peers with, so excluding them would lock out real peers.

Verified against RFC 7300, which reserves only the two endpoints:

> Operators SHOULD NOT use these Last ASNs for any other purpose or as Private Use ASNs.

— referring to 65535 and 4294967295 specifically, and noting the private range is RFC 6996's, not its own. Tests pin both private ranges as accepted, and the neighbours of every rejected value, so an off-by-one cannot silently lock out a legitimate AS.

## `CustomAsns`

Validated with the same rule on both handlers. Those values are handed to RIPEstat to resolve the prefixes an AS originates, so an unusable one becomes a lookup that can never return anything. The issue is written entirely about the peer's own ASN; this was raised in review of #310 and [recorded on #255](https://github.com/ruhex/BGPLite/issues/255#issuecomment-5440137452) before being fixed here.

## Ordering

All validation runs **before** the store is touched. Combined with #259 making the save a single transaction, a rejected request now leaves nothing behind at all — which is the pair of properties that together make a failed save safe.

Descriptions are capped at 512 characters.

## Verification

`dotnet build BGPLite.sln` + `dotnet test BGPLite.sln`: **726 passed, 0 failed** (693 before, 33 added). `dotnet format --severity warn` clean.

Confirmed to catch the regression — with canonicalization and the ASN filter neutered, 8 of the 33 fail, covering both halves:

```
validation neutered
  Failed NormalizePeerIp_OutputMatchesWhatTheBgpPathWouldStore  x3
  Failed IsConfigurablePeerAsn_RejectsUnusableValues            x4
  Failed NormalizePeerIp_CanonicalizesAcceptedForms(1.2.3 → 1.2.0.3)
```

## Not in scope

Subscription and community name validation is #266's, and the request-body size cap is already handled by `MaxRequestBodyBytes` (#156).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Peer creation and updates now reject invalid IP addresses, ASNs, custom ASNs, and overly long descriptions before saving.
  * Peer IP addresses are consistently normalized to standard dotted-quad format.
  * Invalid or reserved ASN values now return a clear bad-request response.
  * Improved consistency between saved peer addresses, BGP sessions, logs, and API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->