### PR TITLE
refactor(architecture): require the send path's dependencies instead of defaulting them

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -28,9 +28,12 @@ public sealed class ManagementApi : IHostedService, IDisposable
     private ConcurrencyLimiter? _concurrencyLimiter;
     private IReadOnlyList<string>? _corsAllowedOrigins;
     private readonly BgpMetrics _metrics;
-    private readonly IPrefixService? _prefixService;
-    private readonly IPrefixSourceService? _prefixSources;
-    private readonly ISessionManager? _sessionManager;
+    // #263: required, not optional. Each of these was a silent feature switch: without
+    // _sessionManager a peer edited in the UI was persisted but never pushed to its live session,
+    // and without _prefixService the prefix views reported zero instead of failing.
+    private readonly IPrefixService _prefixService;
+    private readonly IPrefixSourceService _prefixSources;
+    private readonly ISessionManager _sessionManager;
     private readonly ILogger<ManagementApi> _logger;
     private readonly int _port;
     private readonly string _listenAddress;  // #90: bind address — loopback by default
@@ -54,9 +57,9 @@ public sealed class ManagementApi : IHostedService, IDisposable
         AppConfig config,
         BgpMetrics metrics,
         ILogger<ManagementApi> logger,
-        IPrefixService? prefixService = null,
-        IPrefixSourceService? prefixSources = null,
-        ISessionManager? sessionManager = null)
+        IPrefixService prefixService,
+        IPrefixSourceService prefixSources,
+        ISessionManager sessionManager)
     {
         _store = store;
         _routeTable = routeTable;
@@ -597,7 +600,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         // #212: actual advertised count from the live session (post-aggregation, post-dedup).
         var advertisedCount = peer.Asn.HasValue
-            ? _sessionManager?.GetAdvertisedPrefixCount(peer.Ip, peer.Asn.Value) ?? 0
+            ? _sessionManager.GetAdvertisedPrefixCount(peer.Ip, peer.Asn.Value)
             : 0;
 
         return new
@@ -679,8 +682,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         _logger.LogInformation("Created peer {Ip} AS{Asn} ({Id}): {Subs} lists, {Prefixes} custom prefixes, {Asns} custom AS",
             normalizedIp, data.Asn, id, asnLists.Count, customPrefixes.Count, data.CustomAsns?.Count ?? 0);
 
-        if (_sessionManager is not null)
-            _ = _sessionManager.RefreshPeerAsync(normalizedIp, data.Asn);
+        _ = _sessionManager.RefreshPeerAsync(normalizedIp, data.Asn);
 
         return ApiResponse.Ok(new
         {
@@ -771,8 +773,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         _logger.LogInformation("Updated peer {Id}", SanitizeForLog(peerId));
 
-        if (_sessionManager is not null)
-            _ = _sessionManager.RefreshPeerAsync(peer.Ip, peer.Asn ?? 0);
+        _ = _sessionManager.RefreshPeerAsync(peer.Ip, peer.Asn ?? 0);
 
         return HandleGetPeer(peerId);
     }
@@ -853,8 +854,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         // Trigger refresh so the peer receives the new source's prefixes immediately —
         // same pattern as CreatePeer/UpdatePeer. Pass ASN so shared-IP peers aren't refreshed (#200).
-        if (_sessionManager is not null)
-            _ = _sessionManager.RefreshPeerAsync(peer.Ip, peer.Asn ?? 0);
+        _ = _sessionManager.RefreshPeerAsync(peer.Ip, peer.Asn ?? 0);
 
         _logger.LogInformation("Added source '{Name}' ({Url}) to peer {PeerId}",
             SanitizeForLog(data.Name), SanitizeForLog(data.Url), SanitizeForLog(peerId));
@@ -871,8 +871,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
             return ApiResponse.Error($"Source '{sourceId}' not found", 404);
 
         // Trigger refresh so the source's prefixes are withdrawn immediately (#200: ASN-scoped).
-        if (_sessionManager is not null)
-            _ = _sessionManager.RefreshPeerAsync(peer.Ip, peer.Asn ?? 0);
+        _ = _sessionManager.RefreshPeerAsync(peer.Ip, peer.Asn ?? 0);
 
         _logger.LogInformation("Deleted source {SourceId} from peer {PeerId}", SanitizeForLog(sourceId), SanitizeForLog(peerId));
         return ApiResponse.Ok(new { id = sourceId, deleted = true });
@@ -895,8 +894,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
             return ApiResponse.Error($"Source '{sourceId}' not found", 404);
 
         // Trigger refresh so toggling active/inactive takes effect immediately (#200: ASN-scoped).
-        if (_sessionManager is not null)
-            _ = _sessionManager.RefreshPeerAsync(peer.Ip, peer.Asn ?? 0);
+        _ = _sessionManager.RefreshPeerAsync(peer.Ip, peer.Asn ?? 0);
 
         _logger.LogInformation("Source {SourceId} active={Active}", SanitizeForLog(sourceId), data.Active.Value);
         return ApiResponse.Ok(new { id = sourceId, active = data.Active.Value });
@@ -928,9 +926,6 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         // Custom prefixes
         prefixes.AddRange(_store.GetCustomPrefixes(peerId));
-
-        if (_prefixService is null)
-            return prefixes.Distinct().OrderBy(p => p).ToList();
 
         var subscriptions = _store.GetSubscriptions(peerId);
         var subscribedLists = _config.RipeStat?.AsnLists
@@ -981,21 +976,18 @@ public sealed class ManagementApi : IHostedService, IDisposable
         foreach (var l in lists)
         {
             int prefixCount = 0;
-            if (_prefixService is not null)
+            if (l.Asns.Count > 0)
             {
-                if (l.Asns.Count > 0)
+                foreach (var asn in l.Asns)
                 {
-                    foreach (var asn in l.Asns)
-                    {
-                        try { prefixCount += await _prefixService.GetPrefixCountAsync(asn); }
-                        catch (Exception ex) { _logger.LogWarning(ex, "Failed to get prefix count for AS{Asn}", asn); }
-                    }
+                    try { prefixCount += await _prefixService.GetPrefixCountAsync(asn); }
+                    catch (Exception ex) { _logger.LogWarning(ex, "Failed to get prefix count for AS{Asn}", asn); }
                 }
-                else if (l.Country is not null)
-                {
-                    try { prefixCount = (await _prefixService.GetRuPrefixesAsync()).Count; }
-                    catch (Exception ex) { _logger.LogWarning(ex, "Failed to get RU prefix count"); }
-                }
+            }
+            else if (l.Country is not null)
+            {
+                try { prefixCount = (await _prefixService.GetRuPrefixesAsync()).Count; }
+                catch (Exception ex) { _logger.LogWarning(ex, "Failed to get RU prefix count"); }
             }
 
             result.Add(new
@@ -1012,23 +1004,20 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         // Append configured PrefixSources (file/http) alongside the legacy RipeStat ASN-lists,
         // reusing the same response shape. "Kind" is intentionally not exposed.
-        if (_prefixSources is not null)
+        var seen = lists.Select(l => l.Name).ToHashSet();
+        foreach (var (source, prefixes) in await _prefixSources.LoadAllAsync())
         {
-            var seen = lists.Select(l => l.Name).ToHashSet();
-            foreach (var (source, prefixes) in await _prefixSources.LoadAllAsync())
+            if (!seen.Add(source.Name)) continue; // skip names already present (e.g. shared "ru")
+            result.Add(new
             {
-                if (!seen.Add(source.Name)) continue; // skip names already present (e.g. shared "ru")
-                result.Add(new
-                {
-                    id = source.Name,
-                    Name = source.Name,
-                    Description = source.Description,
-                    Country = (string?)null,
-                    Community = source.Community,
-                    prefixCount = prefixes.Count,
-                    type = source.Kind == "asn" ? "asn" : "list"
-                });
-            }
+                id = source.Name,
+                Name = source.Name,
+                Description = source.Description,
+                Country = (string?)null,
+                Community = source.Community,
+                prefixCount = prefixes.Count,
+                type = source.Kind == "asn" ? "asn" : "list"
+            });
         }
 
         return ApiResponse.Ok(result);
@@ -1094,9 +1083,6 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         if (countOnly)
         {
-            if (_prefixService is null)
-                return ApiResponse.Error("Prefix service not available", 503);
-
             try
             {
                 var count = await _prefixService.GetPrefixCountAsync(asn);

--- a/BGPLite.Providers/PrefixService.cs
+++ b/BGPLite.Providers/PrefixService.cs
@@ -7,10 +7,10 @@ namespace BGPLite.Providers;
 
 public sealed class PrefixService : IPrefixService
 {
-    private readonly RipeStatProvider? _ripeStat;
+    private readonly RipeStatProvider _ripeStat;
     private readonly IPrefixSourceService _prefixSources;
     private readonly AppConfig _config;
-    private readonly HttpPrefixProvider? _httpProvider;
+    private readonly HttpPrefixProvider _httpProvider;
     // asn → (prefix list, cached at, is negative). Negative entries (failed RIPEstat fetches) use
     // _negativeTtl. The tuple is shaped to mirror PrefixSourceService so the resilience semantics
     // (stale-on-failure, negative cache, bounded sweep) are identical across both caches.
@@ -34,7 +34,7 @@ public sealed class PrefixService : IPrefixService
     // when the TTL elapses. Mirrors the per-ASN gate pattern in GetPrefixesAsync.
     private readonly SemaphoreSlim _ruGate = new(1, 1);
 
-    public PrefixService(AppConfig config, RipeStatProvider? ripeStat, IPrefixSourceService prefixSources, HttpPrefixProvider? httpProvider = null, TimeSpan? cacheTtl = null, ILogger<PrefixService>? logger = null, TimeSpan? negativeTtl = null, int? maxCacheEntries = null, TimeProvider? timeProvider = null)
+    public PrefixService(AppConfig config, RipeStatProvider ripeStat, IPrefixSourceService prefixSources, HttpPrefixProvider httpProvider, TimeSpan? cacheTtl = null, ILogger<PrefixService>? logger = null, TimeSpan? negativeTtl = null, int? maxCacheEntries = null, TimeProvider? timeProvider = null)
     {
         _config = config;
         _ripeStat = ripeStat;
@@ -56,13 +56,12 @@ public sealed class PrefixService : IPrefixService
     /// peer-supplied (not in <c>AppConfig.PrefixSources</c>, so the name-keyed <see cref="PrefixSourceService"/>
     /// cache can't help); instead a URL-keyed TTL cache (<see cref="UserSourceCache"/>) dedupes fetches
     /// across peers and serves a stale copy on transient failure. SSRF defense (#144) is inherited from
-    /// the http provider's named client. Returns empty when no http provider is wired. The <c>Active</c>
+    /// the http provider's named client. The <c>Active</c>
     /// lifecycle is handled by the caller (LoadPeerRoutingView filters Active before this is reached),
     /// so paused sources are never advertised regardless of cache state.
     /// </summary>
     public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
     {
-        if (_httpProvider is null) return [];
         var source = new PrefixSourceConfig
         {
             Kind = "http",
@@ -82,8 +81,6 @@ public sealed class PrefixService : IPrefixService
         // Fast path: fresh entry (positive or negative within its TTL).
         if (TryGetFresh(asn, out var fresh))
             return fresh;
-
-        if (_ripeStat is null) return [];
 
         // Serialize per-ASN so concurrent callers share a single RIPEstat fetch — no thundering herd
         // on a cold or just-expired ASN (#164). Mirrors PrefixSourceService.LoadCachedAsync.

--- a/BGPLite.Server/BgpServer.cs
+++ b/BGPLite.Server/BgpServer.cs
@@ -16,13 +16,10 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
     private readonly RouteTable _routeTable;
     private readonly IRouteFilter _routeFilter;
     private readonly BgpMetrics _metrics;
-    private readonly ILogger<BgpSession> _sessionLogger;
     private readonly ILogger<BgpServer> _logger;
-    private readonly Action<string, uint>? _onPeerIdentified;
-    private readonly IPeerStore? _peerStore;
-    private readonly IPrefixService? _prefixService;
-    private readonly IPrefixAggregator _prefixAggregator;
-    private readonly ICommunityResolver _communityResolver;
+    // #263: the accept loop needs none of the session's dependencies for itself — it only forwarded
+    // them, and every forwarded one was optional. The factory owns them and requires them.
+    private readonly IBgpSessionFactory _sessionFactory;
     // Keyed by the accepted TCP connection (remote IP + remote source port), NOT by remote IP
     // alone: per RFC 4271 §8.2.1 there is one session per TCP connection, so several distinct peers
     // arriving from the same source IP (different ephemeral source ports) must coexist as separate
@@ -46,25 +43,15 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
         RouteTable routeTable,
         IRouteFilter routeFilter,
         BgpMetrics metrics,
-        ILogger<BgpSession> sessionLogger,
-        ILogger<BgpServer> logger,
-        Action<string, uint>? onPeerIdentified = null,
-        IPeerStore? peerStore = null,
-        IPrefixService? prefixService = null,
-        IPrefixAggregator? prefixAggregator = null,
-        ICommunityResolver? communityResolver = null)
+        IBgpSessionFactory sessionFactory,
+        ILogger<BgpServer> logger)
     {
         _config = config;
         _routeTable = routeTable;
         _routeFilter = routeFilter;
         _metrics = metrics;
-        _sessionLogger = sessionLogger;
+        _sessionFactory = sessionFactory;
         _logger = logger;
-        _onPeerIdentified = onPeerIdentified;
-        _peerStore = peerStore;
-        _prefixService = prefixService;
-        _prefixAggregator = prefixAggregator ?? new ExactUnionPrefixAggregator();
-        _communityResolver = communityResolver ?? NullCommunityResolver.Instance;
         _acceptThrottle = new IpAcceptThrottle(config.Bgp.MaxAcceptsPerIpPerMinute);
     }
 
@@ -192,11 +179,7 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
                 // SendTimeout backstop from #160), so BgpSession no longer touches Socket directly.
                 var peerConfig = new PeerConfig { Address = peerAddress, Port = remoteEndpoint.Port };
 
-                var session = new BgpSession(
-                    new SocketBgpConnection(socket), peerConfig, _config.Bgp, _routeTable,
-                    _routeFilter, _metrics, _sessionLogger,
-                    _onPeerIdentified,
-                    _peerStore, _prefixService, _config, _prefixAggregator, _communityResolver);
+                var session = _sessionFactory.Create(new SocketBgpConnection(socket), peerConfig);
 
                 if (Volatile.Read(ref _acceptingConnections) == 0)
                 {

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -32,14 +32,13 @@ public sealed class BgpSession : IDisposable
     private readonly CancellationTokenSource _cts = new();
     private readonly Action<string, uint>? _onPeerIdentified;
     private readonly IPeerStore? _peerStore;
-    private readonly IPrefixService? _prefixService;
-    private readonly AppConfig? _appConfig;
     private readonly IPrefixAggregator _prefixAggregator;
-    private readonly ICommunityResolver _communityResolver;
     // #93 Phase 2: the outbound route-assembly policy lives here, not in the session. The session
     // delegates to BuildOutboundRoutesAsync and keeps the send/withdraw mirror (_advertisedPrefixes)
-    // and the codec glue (SendRoutesAsync).
-    private readonly RouteAssembler _routeAssembler;
+    // and the codec glue (SendRoutesAsync). #263: injected rather than constructed here — the
+    // session no longer carries the assembler's own dependencies (prefix service, AppConfig,
+    // community resolver) just to hand them on.
+    private readonly IRouteAssembler _routeAssembler;
 
     // volatile: read by external threads (BgpServer.RefreshPeerAsync/StopAsync). Guarantees
     // acquire/release so IsEstablished reflects the most recent TransitionTo without JIT caching.
@@ -244,10 +243,8 @@ public sealed class BgpSession : IDisposable
         ILogger<BgpSession> logger,
         Action<string, uint>? onPeerIdentified = null,
         IPeerStore? peerStore = null,
-        IPrefixService? prefixService = null,
-        AppConfig? appConfig = null,
         IPrefixAggregator? prefixAggregator = null,
-        ICommunityResolver? communityResolver = null,
+        IRouteAssembler? routeAssembler = null,
         TimeProvider? timeProvider = null)
     {
         _connection = connection;
@@ -261,13 +258,11 @@ public sealed class BgpSession : IDisposable
         _logger = logger;
         _onPeerIdentified = onPeerIdentified;
         _peerStore = peerStore;
-        _prefixService = prefixService;
-        _appConfig = appConfig;
         _prefixAggregator = prefixAggregator ?? new ExactUnionPrefixAggregator();
-        _communityResolver = communityResolver ?? NullCommunityResolver.Instance;
-        _routeAssembler = new RouteAssembler(
-            prefixService, _peerStore, _communityResolver, _routeFilter,
-            _appConfig, _bgpConfig, _routeTable, logger, _peer);
+        // #263: no assembler supplied means no per-peer configuration is reachable. That is a real
+        // (test-only) composition, so it gets a real, named implementation that says so out loud —
+        // not a RouteAssembler quietly holding nulls.
+        _routeAssembler = routeAssembler ?? new SharedTableRouteAssembler(_routeTable, _routeFilter, logger);
     }
 
     public async Task RunAsync(CancellationToken cancellationToken = default)
@@ -907,16 +902,16 @@ public sealed class BgpSession : IDisposable
     }
 
     /// <summary>
-    /// Thin wrapper over <see cref="RouteAssembler.BuildOutboundRoutesAsync"/> (#93 Phase 2): resolves
+    /// Thin wrapper over <see cref="IRouteAssembler.BuildOutboundRoutesAsync"/> (#93 Phase 2): resolves
     /// the per-peer route set, then delegates the aggregate + batch + send to <see cref="SendRoutesAsync"/>.
     /// The decision tree (RU defaults / subscriptions / custom prefixes / custom AS / user sources) and
-    /// the outgoing filter live in RouteAssembler; the send/withdraw mirror stays here.
+    /// the outgoing filter live in the assembler; the send/withdraw mirror stays here.
     /// </summary>
     private async Task SendAllRoutesAsync()
     {
         var nextHop = BgpConstants.IPAddressToUint(_bgpConfig.GetRouterIdAddress());
         var routes = await _routeAssembler.BuildOutboundRoutesAsync(
-            _peerConfig.Address, _remoteAsn, GetFilterPeerConfig(), _cts.Token);
+            _peerConfig.Address, _remoteAsn, GetFilterPeerConfig(), _peer, _cts.Token);
         if (routes.Count > 0)
             await SendRoutesAsync(nextHop, routes);
     }

--- a/BGPLite.Server/BgpSessionFactory.cs
+++ b/BGPLite.Server/BgpSessionFactory.cs
@@ -1,0 +1,72 @@
+using BGPLite.Configuration;
+using BGPLite.Contracts;
+using BGPLite.Routing;
+using Microsoft.Extensions.Logging;
+
+namespace BGPLite.Server;
+
+/// <summary>
+/// Creates a <see cref="BgpSession"/> for an accepted connection. The seam exists so
+/// <see cref="BgpServer"/> stops carrying the session's dependencies (#263): the accept loop needs
+/// none of the peer store, prefix service, aggregator or community resolver for itself — it only
+/// forwarded them — and every one of them was optional, so a dropped DI registration turned into
+/// wrong route sets at runtime instead of a startup failure.
+/// </summary>
+public interface IBgpSessionFactory
+{
+    /// <summary>Creates a session bound to <paramref name="connection"/> for <paramref name="peerConfig"/>.</summary>
+    BgpSession Create(IBgpConnection connection, PeerConfig peerConfig);
+}
+
+/// <summary>
+/// The production factory. Every dependency is required: resolving it is what makes an incomplete
+/// composition fail at startup (<c>GetRequiredService</c> throws naming the missing service) rather
+/// than at the first route send.
+/// </summary>
+public sealed class BgpSessionFactory : IBgpSessionFactory
+{
+    private readonly BgpConfig _bgpConfig;
+    private readonly RouteTable _routeTable;
+    private readonly IRouteFilter _routeFilter;
+    private readonly BgpMetrics _metrics;
+    private readonly ILogger<BgpSession> _sessionLogger;
+    private readonly IPeerStore _peerStore;
+    private readonly IPrefixAggregator _prefixAggregator;
+    private readonly IRouteAssembler _routeAssembler;
+    private readonly TimeProvider _timeProvider;
+
+    /// <summary>Captures the composition every accepted connection's session is built from.</summary>
+    public BgpSessionFactory(
+        BgpConfig bgpConfig,
+        RouteTable routeTable,
+        IRouteFilter routeFilter,
+        BgpMetrics metrics,
+        ILogger<BgpSession> sessionLogger,
+        IPeerStore peerStore,
+        IPrefixAggregator prefixAggregator,
+        IRouteAssembler routeAssembler,
+        TimeProvider timeProvider)
+    {
+        _bgpConfig = bgpConfig;
+        _routeTable = routeTable;
+        _routeFilter = routeFilter;
+        _metrics = metrics;
+        _sessionLogger = sessionLogger;
+        _peerStore = peerStore;
+        _prefixAggregator = prefixAggregator;
+        _routeAssembler = routeAssembler;
+        _timeProvider = timeProvider;
+    }
+
+    /// <inheritdoc />
+    public BgpSession Create(IBgpConnection connection, PeerConfig peerConfig) =>
+        new(connection, peerConfig, _bgpConfig, _routeTable, _routeFilter, _metrics, _sessionLogger,
+            // The peer row is upserted as soon as OPEN identifies the peer, so a peer that has never
+            // been configured in the UI still shows up there. Previously a lambda hand-wired in
+            // Program.cs and threaded through BgpServer.
+            onPeerIdentified: _peerStore.UpsertPeer,
+            peerStore: _peerStore,
+            prefixAggregator: _prefixAggregator,
+            routeAssembler: _routeAssembler,
+            timeProvider: _timeProvider);
+}

--- a/BGPLite.Server/IRouteAssembler.cs
+++ b/BGPLite.Server/IRouteAssembler.cs
@@ -1,0 +1,30 @@
+using BGPLite.Configuration;
+using BGPLite.Routing;
+
+namespace BGPLite.Server;
+
+/// <summary>
+/// Resolves the outbound route set for one peer — "which prefixes does this peer get" — without
+/// touching the transport. The caller (<see cref="BgpSession"/>) aggregates, batches and sends.
+/// <para>
+/// The seam exists so <see cref="BgpSession"/> stops constructing its own assembler (#263). The
+/// production implementation (<c>RouteAssembler</c>) requires the peer store, prefix service and
+/// <c>AppConfig</c> as non-nullable dependencies, so a composition that cannot serve per-peer
+/// configuration no longer type-checks; the degraded shared-table behavior is a separate, named
+/// implementation (<see cref="SharedTableRouteAssembler"/>) that a caller has to choose on purpose.
+/// </para>
+/// </summary>
+public interface IRouteAssembler
+{
+    /// <summary>
+    /// Resolves the routes to advertise to <paramref name="peerIp"/>/<paramref name="remoteAsn"/>,
+    /// already passed through the outgoing community filter for <paramref name="filterPeerConfig"/>.
+    /// </summary>
+    /// <param name="peerIp">Peer IP, the durable store identity together with <paramref name="remoteAsn"/>.</param>
+    /// <param name="remoteAsn">Peer ASN as negotiated in OPEN.</param>
+    /// <param name="filterPeerConfig">Peer config the outgoing community filter is resolved against.</param>
+    /// <param name="peerLabel">Display form of the peer (<c>ip:port</c>), used only for logging.</param>
+    /// <param name="ct">Cancels the fetches the assembly performs.</param>
+    Task<List<Route>> BuildOutboundRoutesAsync(
+        string peerIp, uint remoteAsn, PeerConfig filterPeerConfig, string peerLabel, CancellationToken ct);
+}

--- a/BGPLite.Server/RouteAssembler.cs
+++ b/BGPLite.Server/RouteAssembler.cs
@@ -18,29 +18,32 @@ namespace BGPLite.Server;
 /// route-shaping helpers that were <c>internal static</c> on BgpSession. The send/withdraw mirror
 /// (<c>_advertisedPrefixes</c>) and the codec glue (<c>SendRoutesAsync</c>) stay in BgpSession.
 /// </para>
+/// <para>
+/// #263: the peer store, prefix service and <c>AppConfig</c> are required. They used to be nullable
+/// and a null in any of them silently switched every peer over to the shared route table, so a
+/// dropped DI registration read as "why is this peer not getting its prefixes" rather than as a
+/// startup error. That degraded mode is now <see cref="SharedTableRouteAssembler"/> — a type a
+/// caller has to pick — and this one cannot be constructed without the configuration it needs.
+/// </para>
 /// </summary>
-internal sealed class RouteAssembler
+public sealed class RouteAssembler : IRouteAssembler
 {
-    private readonly IPrefixService? _prefixService;
-    private readonly IPeerStore? _peerStore;
+    private readonly IPrefixService _prefixService;
+    private readonly IPeerStore _peerStore;
     private readonly ICommunityResolver _communityResolver;
     private readonly IRouteFilter _routeFilter;
-    private readonly AppConfig? _appConfig;
+    private readonly AppConfig _appConfig;
     private readonly BgpConfig _bgpConfig;
-    private readonly RouteTable _routeTable;
-    private readonly ILogger _logger;
-    private readonly string _peer;
+    private readonly ILogger<RouteAssembler> _logger;
 
     public RouteAssembler(
-        IPrefixService? prefixService,
-        IPeerStore? peerStore,
+        IPrefixService prefixService,
+        IPeerStore peerStore,
         ICommunityResolver communityResolver,
         IRouteFilter routeFilter,
-        AppConfig? appConfig,
+        AppConfig appConfig,
         BgpConfig bgpConfig,
-        RouteTable routeTable,
-        ILogger logger,
-        string peer)
+        ILogger<RouteAssembler> logger)
     {
         _prefixService = prefixService;
         _peerStore = peerStore;
@@ -48,248 +51,211 @@ internal sealed class RouteAssembler
         _routeFilter = routeFilter;
         _appConfig = appConfig;
         _bgpConfig = bgpConfig;
-        _routeTable = routeTable;
         _logger = logger;
-        _peer = peer;
     }
 
-    /// <summary>
-    /// Resolves the outbound route set for the given peer: the per-peer decision tree (RU defaults,
-    /// subscriptions, custom prefixes, custom AS, user URL sources) or the shared-table fallback.
-    /// Returns the filtered routes — the caller does aggregate + batch + send. No transport access.
-    /// </summary>
+    /// <inheritdoc />
     public async Task<List<Route>> BuildOutboundRoutesAsync(
-        string peerIp, uint remoteAsn, PeerConfig filterPeerConfig, CancellationToken ct)
+        string peerIp, uint remoteAsn, PeerConfig filterPeerConfig, string peerLabel, CancellationToken ct)
     {
         var nextHop = BgpConstants.IPAddressToUint(_bgpConfig.GetRouterIdAddress());
         var routes = new List<Route>();
         var defaultComms = _communityResolver.Resolve(
-            new CommunitySource(CommunitySourceKind.PrefixSource, _appConfig?.DefaultPrefixSource));
+            new CommunitySource(CommunitySourceKind.PrefixSource, _appConfig.DefaultPrefixSource));
 
-        if (_peerStore is not null && _prefixService is not null && _appConfig is not null)
+        var peer = _peerStore.LoadPeerRoutingView(peerIp, remoteAsn);
+        if (peer is not null)
         {
-            // Capture non-null locals so the compiler tracks the null-guard through the nested
-            // branches without null-forgiving operators (#105 nullable).
-            var peerStore = _peerStore;
-            var prefixService = _prefixService;
-            var appConfig = _appConfig;
-            var peer = peerStore.LoadPeerRoutingView(peerIp, remoteAsn);
-            if (peer is not null)
+            var subscriptionIds = peer.Subscriptions;
+            var customPrefixes = peer.CustomPrefixes;
+            var customAsns = peer.CustomAsns;
+
+            // Unconfigured peer — send RU defaults. A peer whose only configuration is active
+            // user URL sources (#147) is NOT unconfigured — it must not fall through to RU.
+            if (subscriptionIds.Count == 0 && customPrefixes.Count == 0 && customAsns.Count == 0
+                && peer.UserSources.Count == 0)
             {
-                var subscriptionIds = peer.Subscriptions;
-                var customPrefixes = peer.CustomPrefixes;
-                var customAsns = peer.CustomAsns;
-
-                // Unconfigured peer — send RU defaults. A peer whose only configuration is active
-                // user URL sources (#147) is NOT unconfigured — it must not fall through to RU.
-                if (subscriptionIds.Count == 0 && customPrefixes.Count == 0 && customAsns.Count == 0
-                    && peer.UserSources.Count == 0)
+                _logger.LogInformation("Unconfigured peer {Peer}, sending RU defaults", peerLabel);
+                try
                 {
-                    _logger.LogInformation("Unconfigured peer {Peer}, sending RU defaults", _peer);
-                    try
-                    {
-                        var ruPrefixes = await prefixService.GetRuPrefixesAsync(ct);
-                        foreach (var (prefix, length, _) in ruPrefixes)
-                            routes.Add(MakeRoute(prefix, length, nextHop, null, defaultComms));
-                        _logger.LogInformation("Sent {Count} RU prefixes to unconfigured peer {Peer}",
-                            ruPrefixes.Count, _peer);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "Failed to fetch RU prefixes for {Peer}", _peer);
-                    }
-
-                    return FilterAndReturn(routes, filterPeerConfig);
+                    var ruPrefixes = await _prefixService.GetRuPrefixesAsync(ct);
+                    foreach (var (prefix, length, _) in ruPrefixes)
+                        routes.Add(MakeRoute(prefix, length, nextHop, null, defaultComms));
+                    _logger.LogInformation("Sent {Count} RU prefixes to unconfigured peer {Peer}",
+                        ruPrefixes.Count, peerLabel);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to fetch RU prefixes for {Peer}", peerLabel);
                 }
 
-                _logger.LogInformation("Peer {Peer} subscriptions: [{Subs}]", _peer, string.Join(", ", subscriptionIds));
+                return FilterAndReturn(routes, filterPeerConfig);
+            }
 
-                var subscribedLists = appConfig.RipeStat?.AsnLists
-                    .Where(l => subscriptionIds.Contains(l.Name))
-                    .ToList() ?? [];
+            _logger.LogInformation("Peer {Peer} subscriptions: [{Subs}]", peerLabel, string.Join(", ", subscriptionIds));
 
-                // ASN-based lists — resolve per list so each list's community is stamped on its prefixes.
-                var asnLists = subscribedLists.Where(l => l.Asns.Count > 0).ToList();
+            var subscribedLists = _appConfig.RipeStat?.AsnLists
+                .Where(l => subscriptionIds.Contains(l.Name))
+                .ToList() ?? [];
 
-                _logger.LogInformation("Peer {Peer} resolved {Count} ASNs from subscriptions",
-                    _peer, asnLists.SelectMany(l => l.Asns).Count());
+            // ASN-based lists — resolve per list so each list's community is stamped on its prefixes.
+            var asnLists = subscribedLists.Where(l => l.Asns.Count > 0).ToList();
 
-                if (asnLists.Count > 0)
-                {
-                    var before = routes.Count;
-                    foreach (var list in asnLists)
-                    {
-                        try
-                        {
-                            var comms = _communityResolver.Resolve(
-                                new CommunitySource(CommunitySourceKind.AsnList, list.Name));
-                            var prefixes = await prefixService.GetPrefixesForAsns(list.Asns, ct);
-                            foreach (var (prefix, length, _) in prefixes)
-                                // #85: AsPath is overwritten by the local ASN in the outbound codec
-                                // (BuildUpdateAttributes), so the per-prefix asn value is never used
-                                // on the wire — pass null instead of allocating [asn] per prefix.
-                                routes.Add(MakeRoute(prefix, length, nextHop, null, comms));
-                        }
-                        catch (Exception ex)
-                        {
-                            _logger.LogError(ex, "Failed to fetch prefixes for {Peer} (list '{List}')", _peer, list.Name);
-                        }
-                    }
-                    _logger.LogInformation("Fetched {Count} prefixes for {Peer} from ASN subscriptions",
-                        routes.Count - before, _peer);
-                }
+            _logger.LogInformation("Peer {Peer} resolved {Count} ASNs from subscriptions",
+                peerLabel, asnLists.SelectMany(l => l.Asns).Count());
 
-                // Country-based lists (e.g. RU with no ASNs → use local nets.txt).
-                var countryLists = subscribedLists.Where(l => l.Asns.Count == 0 && l.Country is not null).ToList();
-                if (countryLists.Count > 0)
+            if (asnLists.Count > 0)
+            {
+                var before = routes.Count;
+                foreach (var list in asnLists)
                 {
                     try
                     {
                         var comms = _communityResolver.Resolve(
-                            new CommunitySource(CommunitySourceKind.Country, countryLists[0].Name));
-                        var ruPrefixes = await prefixService.GetRuPrefixesAsync(ct);
-                        foreach (var (prefix, length, _) in ruPrefixes)
+                            new CommunitySource(CommunitySourceKind.AsnList, list.Name));
+                        var prefixes = await _prefixService.GetPrefixesForAsns(list.Asns, ct);
+                        foreach (var (prefix, length, _) in prefixes)
+                            // #85: AsPath is overwritten by the local ASN in the outbound codec
+                            // (BuildUpdateAttributes), so the per-prefix asn value is never used
+                            // on the wire — pass null instead of allocating [asn] per prefix.
                             routes.Add(MakeRoute(prefix, length, nextHop, null, comms));
-                        _logger.LogInformation("Fetched {Count} RU prefixes for {Peer}", ruPrefixes.Count, _peer);
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogError(ex, "Failed to fetch RU prefixes for {Peer}", _peer);
+                        _logger.LogError(ex, "Failed to fetch prefixes for {Peer} (list '{List}')", peerLabel, list.Name);
                     }
                 }
-
-                // Prefix-source subscriptions: subscribed names that match a configured PrefixSource.
-                var resolvedAsRipe = subscribedLists.Select(l => l.Name).ToHashSet();
-                var prefixSources = appConfig.PrefixSources;  // safe: we're inside the _appConfig is not null guard
-                var sourceNames = subscriptionIds
-                    .Where(n => !resolvedAsRipe.Contains(n) && prefixSources.Any(s => s.Name == n))
-                    .ToList();
-                foreach (var name in sourceNames)
-                {
-                    try
-                    {
-                        var comms = _communityResolver.Resolve(new CommunitySource(CommunitySourceKind.PrefixSource, name));
-                        var srcPrefixes = await prefixService.GetSourcePrefixesAsync(name, ct);
-                        foreach (var (prefix, length) in srcPrefixes)
-                            routes.Add(MakeRoute(prefix, length, nextHop, null, comms));
-                        _logger.LogInformation("Fetched {Count} prefixes from source '{Source}' for {Peer}",
-                            srcPrefixes.Count, name, _peer);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "Failed to fetch source '{Source}' for {Peer}", name, _peer);
-                    }
-                }
-
-                _logger.LogInformation("Peer {Peer} has {SubRoutes} subscription routes + {CustomCount} custom prefixes",
-                    _peer, routes.Count, customPrefixes.Count);
-
-                // Custom prefixes carry the static "custom prefix" community (<Asn>:100).
-                // #236: parse via the canonical PrefixCidr parser — host-bit masking + range check +
-                // IPv4-only, shared with the API and file sources. Custom prefixes are validated at
-                // write time (ParseCustomPrefix), but a corrupt row or a write path that bypassed the
-                // API must not throw a FormatException out of the BGP send path — skip + log instead.
-                var customPrefixComms = _communityResolver.Resolve(new CommunitySource(CommunitySourceKind.Custom));
-                foreach (var cidr in customPrefixes)
-                {
-                    if (!PrefixCidr.TryParse(cidr, out var prefix, out var length))
-                    {
-                        _logger.LogWarning("Skipping malformed custom prefix '{Cidr}' for {Peer}", cidr, _peer);
-                        continue;
-                    }
-                    routes.Add(MakeRoute(prefix, length, nextHop, null, customPrefixComms));
-                }
-
-                // Add custom AS prefixes. Custom-AS routes carry the static "custom AS" community.
-                if (customAsns.Count > 0)
-                {
-                    try
-                    {
-                        var customAsnComms = _communityResolver.Resolve(new CommunitySource(CommunitySourceKind.CustomAsn));
-                        var asnPrefixes = await prefixService.GetPrefixesForAsns(customAsns, ct);
-                        foreach (var (prefix, length, _) in asnPrefixes)
-                            routes.Add(MakeRoute(prefix, length, nextHop, null, customAsnComms));
-                        _logger.LogInformation("Peer {Peer} custom AS: {Asns} -> {Count} prefixes",
-                            _peer, string.Join(",", customAsns), asnPrefixes.Count);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "Failed to fetch custom AS prefixes for {Peer}", _peer);
-                    }
-                }
-
-                // Per-peer user URL sources (#143/#147): each Active source fetched + community-stamped.
-                foreach (var source in peer.UserSources)
-                {
-                    await AddUserSourceRoutesAsync(
-                        routes, source, nextHop, prefixService, _communityResolver, _logger, _peer, ct);
-                }
-
-                _logger.LogInformation("Sending {Count} total routes to {Peer}", routes.Count, _peer);
-
-                // Configured peer resolved 0 prefixes — fall back to RU.
-                if (routes.Count == 0)
-                {
-                    _logger.LogInformation("Peer {Peer} resolved 0 prefixes, falling back to RU defaults", _peer);
-                    try
-                    {
-                        var ruPrefixes = await prefixService.GetRuPrefixesAsync(ct);
-                        foreach (var (prefix, length, _) in ruPrefixes)
-                            routes.Add(MakeRoute(prefix, length, nextHop, null, defaultComms));
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "Failed to fetch RU fallback for {Peer}", _peer);
-                    }
-                }
-
-                return FilterAndReturn(routes, filterPeerConfig);
+                _logger.LogInformation("Fetched {Count} prefixes for {Peer} from ASN subscriptions",
+                    routes.Count - before, peerLabel);
             }
-            else
-            {
-                // Unknown peer — auto-register and send default RU list.
-                _logger.LogInformation("Unknown peer {Ip}, auto-registering with RU defaults", _peer);
-                peerStore.CreatePeer(peerIp, remoteAsn, null);
 
+            // Country-based lists (e.g. RU with no ASNs → use local nets.txt).
+            var countryLists = subscribedLists.Where(l => l.Asns.Count == 0 && l.Country is not null).ToList();
+            if (countryLists.Count > 0)
+            {
                 try
                 {
-                    var ruPrefixes = await prefixService.GetRuPrefixesAsync(ct);
+                    var comms = _communityResolver.Resolve(
+                        new CommunitySource(CommunitySourceKind.Country, countryLists[0].Name));
+                    var ruPrefixes = await _prefixService.GetRuPrefixesAsync(ct);
                     foreach (var (prefix, length, _) in ruPrefixes)
-                        routes.Add(MakeRoute(prefix, length, nextHop, null, defaultComms));
-                    _logger.LogInformation("Fetched {Count} RU prefixes for unknown peer {Peer}",
-                        ruPrefixes.Count, _peer);
+                        routes.Add(MakeRoute(prefix, length, nextHop, null, comms));
+                    _logger.LogInformation("Fetched {Count} RU prefixes for {Peer}", ruPrefixes.Count, peerLabel);
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Failed to fetch RU prefixes for {Peer}", _peer);
+                    _logger.LogError(ex, "Failed to fetch RU prefixes for {Peer}", peerLabel);
                 }
-
-                return FilterAndReturn(routes, filterPeerConfig);
             }
+
+            // Prefix-source subscriptions: subscribed names that match a configured PrefixSource.
+            var resolvedAsRipe = subscribedLists.Select(l => l.Name).ToHashSet();
+            var prefixSources = _appConfig.PrefixSources;
+            var sourceNames = subscriptionIds
+                .Where(n => !resolvedAsRipe.Contains(n) && prefixSources.Any(s => s.Name == n))
+                .ToList();
+            foreach (var name in sourceNames)
+            {
+                try
+                {
+                    var comms = _communityResolver.Resolve(new CommunitySource(CommunitySourceKind.PrefixSource, name));
+                    var srcPrefixes = await _prefixService.GetSourcePrefixesAsync(name, ct);
+                    foreach (var (prefix, length) in srcPrefixes)
+                        routes.Add(MakeRoute(prefix, length, nextHop, null, comms));
+                    _logger.LogInformation("Fetched {Count} prefixes from source '{Source}' for {Peer}",
+                        srcPrefixes.Count, name, peerLabel);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to fetch source '{Source}' for {Peer}", name, peerLabel);
+                }
+            }
+
+            _logger.LogInformation("Peer {Peer} has {SubRoutes} subscription routes + {CustomCount} custom prefixes",
+                peerLabel, routes.Count, customPrefixes.Count);
+
+            // Custom prefixes carry the static "custom prefix" community (<Asn>:100).
+            // #236: parse via the canonical PrefixCidr parser — host-bit masking + range check +
+            // IPv4-only, shared with the API and file sources. Custom prefixes are validated at
+            // write time (ParseCustomPrefix), but a corrupt row or a write path that bypassed the
+            // API must not throw a FormatException out of the BGP send path — skip + log instead.
+            var customPrefixComms = _communityResolver.Resolve(new CommunitySource(CommunitySourceKind.Custom));
+            foreach (var cidr in customPrefixes)
+            {
+                if (!PrefixCidr.TryParse(cidr, out var prefix, out var length))
+                {
+                    _logger.LogWarning("Skipping malformed custom prefix '{Cidr}' for {Peer}", cidr, peerLabel);
+                    continue;
+                }
+                routes.Add(MakeRoute(prefix, length, nextHop, null, customPrefixComms));
+            }
+
+            // Add custom AS prefixes. Custom-AS routes carry the static "custom AS" community.
+            if (customAsns.Count > 0)
+            {
+                try
+                {
+                    var customAsnComms = _communityResolver.Resolve(new CommunitySource(CommunitySourceKind.CustomAsn));
+                    var asnPrefixes = await _prefixService.GetPrefixesForAsns(customAsns, ct);
+                    foreach (var (prefix, length, _) in asnPrefixes)
+                        routes.Add(MakeRoute(prefix, length, nextHop, null, customAsnComms));
+                    _logger.LogInformation("Peer {Peer} custom AS: {Asns} -> {Count} prefixes",
+                        peerLabel, string.Join(",", customAsns), asnPrefixes.Count);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to fetch custom AS prefixes for {Peer}", peerLabel);
+                }
+            }
+
+            // Per-peer user URL sources (#143/#147): each Active source fetched + community-stamped.
+            foreach (var source in peer.UserSources)
+            {
+                await AddUserSourceRoutesAsync(
+                    routes, source, nextHop, _prefixService, _communityResolver, _logger, peerLabel, ct);
+            }
+
+            _logger.LogInformation("Sending {Count} total routes to {Peer}", routes.Count, peerLabel);
+
+            // Configured peer resolved 0 prefixes — fall back to RU.
+            if (routes.Count == 0)
+            {
+                _logger.LogInformation("Peer {Peer} resolved 0 prefixes, falling back to RU defaults", peerLabel);
+                try
+                {
+                    var ruPrefixes = await _prefixService.GetRuPrefixesAsync(ct);
+                    foreach (var (prefix, length, _) in ruPrefixes)
+                        routes.Add(MakeRoute(prefix, length, nextHop, null, defaultComms));
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to fetch RU fallback for {Peer}", peerLabel);
+                }
+            }
+
+            return FilterAndReturn(routes, filterPeerConfig);
         }
-
-        // Fallback: no per-peer configuration is reachable, so serve the shared table's SEEDED
-        // routes. This branch means a dependency is missing from the composition — in a correct
-        // production wiring it is unreachable (#263), and reaching it silently changes what every
-        // peer receives rather than merely disabling a feature, so it is logged (#307).
-        _logger.LogWarning(
-            "Route assembly for {Peer} fell back to the shared table — per-peer configuration is unavailable " +
-            "(peerStore={HasPeerStore}, prefixService={HasPrefixService}, appConfig={HasAppConfig}). " +
-            "This peer will NOT receive its configured prefixes.",
-            _peer, _peerStore is not null, _prefixService is not null, _appConfig is not null);
-
-        // EnumerateUnowned, not Enumerate: everything a peer announced inbound is installed in this
-        // same table owned by its session (#289). Advertising those here would hand one peer's
-        // injected routes to every other peer — a tenant-isolation failure, not just a wrong list.
-        // The startup seed is written with no owner and is what this fallback is meant to serve.
-        var sharedAllowSet = _routeFilter.ResolveOutgoingAllowSet(filterPeerConfig);
-        var filtered = new List<Route>();
-        foreach (var r in _routeTable.EnumerateUnowned())
+        else
         {
-            if (_routeFilter.AcceptOutgoing(r, filterPeerConfig, sharedAllowSet))
-                filtered.Add(r);
+            // Unknown peer — auto-register and send default RU list.
+            _logger.LogInformation("Unknown peer {Ip}, auto-registering with RU defaults", peerLabel);
+            _peerStore.CreatePeer(peerIp, remoteAsn, null);
+
+            try
+            {
+                var ruPrefixes = await _prefixService.GetRuPrefixesAsync(ct);
+                foreach (var (prefix, length, _) in ruPrefixes)
+                    routes.Add(MakeRoute(prefix, length, nextHop, null, defaultComms));
+                _logger.LogInformation("Fetched {Count} RU prefixes for unknown peer {Peer}",
+                    ruPrefixes.Count, peerLabel);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to fetch RU prefixes for {Peer}", peerLabel);
+            }
+
+            return FilterAndReturn(routes, filterPeerConfig);
         }
-        return filtered;
     }
 
     /// <summary>Applies the per-peer outgoing community filter and returns the filtered list.</summary>

--- a/BGPLite.Server/SharedTableRouteAssembler.cs
+++ b/BGPLite.Server/SharedTableRouteAssembler.cs
@@ -1,0 +1,61 @@
+using BGPLite.Configuration;
+using BGPLite.Routing;
+using Microsoft.Extensions.Logging;
+
+namespace BGPLite.Server;
+
+/// <summary>
+/// The explicit degraded assembler (#263): serves every peer the shared route table's SEEDED
+/// routes, with no per-peer configuration at all. This is what a <see cref="BgpSession"/> built
+/// without an <see cref="IRouteAssembler"/> falls back to — previously the same behavior arose
+/// implicitly, from <c>RouteAssembler</c> being handed a null peer store / prefix service /
+/// <c>AppConfig</c>, which made a composition mistake indistinguishable from a deliberate choice.
+/// <para>
+/// It logs its activation ONCE at Warning: reaching it in production means peers receive the seed
+/// instead of what their operator selected, which is a wrong route set rather than a disabled
+/// feature, and the per-send warning #307 added would otherwise repeat on every refresh.
+/// </para>
+/// </summary>
+public sealed class SharedTableRouteAssembler : IRouteAssembler
+{
+    private readonly RouteTable _routeTable;
+    private readonly IRouteFilter _routeFilter;
+    private readonly ILogger _logger;
+    private int _announced;
+
+    /// <summary>Serves <paramref name="routeTable"/>'s unowned entries, filtered per peer.</summary>
+    public SharedTableRouteAssembler(RouteTable routeTable, IRouteFilter routeFilter, ILogger logger)
+    {
+        _routeTable = routeTable;
+        _routeFilter = routeFilter;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task<List<Route>> BuildOutboundRoutesAsync(
+        string peerIp, uint remoteAsn, PeerConfig filterPeerConfig, string peerLabel, CancellationToken ct)
+    {
+        if (Interlocked.Exchange(ref _announced, 1) == 0)
+        {
+            _logger.LogWarning(
+                "Route assembly is running WITHOUT per-peer configuration — every peer, starting with " +
+                "{Peer}, receives the shared table's seeded routes instead of its configured prefixes. " +
+                "In a production composition this is a wiring error (#263).",
+                peerLabel);
+        }
+
+        // EnumerateUnowned, not Enumerate: everything a peer announced inbound is installed in this
+        // same table owned by its session (#289). Advertising those here would hand one peer's
+        // injected routes to every other peer — a tenant-isolation failure, not just a wrong list.
+        // The startup seed is written with no owner and is what this fallback is meant to serve.
+        var allowSet = _routeFilter.ResolveOutgoingAllowSet(filterPeerConfig);
+        var filtered = new List<Route>();
+        foreach (var route in _routeTable.EnumerateUnowned())
+        {
+            if (_routeFilter.AcceptOutgoing(route, filterPeerConfig, allowSet))
+                filtered.Add(route);
+        }
+
+        return Task.FromResult(filtered);
+    }
+}

--- a/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
+++ b/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
@@ -360,65 +360,6 @@ public class BgpSessionRouteOwnershipTests
         session.Dispose();
     }
 
-    /// <summary>Scripts inbound frames and discards outbound bytes; reads block until a frame arrives.</summary>
-    private sealed class ScriptedConnection : IBgpConnection
-    {
-        private readonly Channel<byte[]> _inbound = Channel.CreateUnbounded<byte[]>();
-        private readonly Queue<byte> _readBuffer = new();
-        private int _pending;
-
-        /// <summary>True once every enqueued frame has been fully handed to the read loop.</summary>
-        public bool Drained => Volatile.Read(ref _pending) == 0 && _readBuffer.Count == 0;
-
-        public void EnqueueFrame(byte[] frame)
-        {
-            Interlocked.Increment(ref _pending);
-            _inbound.Writer.TryWrite(frame);
-        }
-
-        public void EnqueueMessage(BgpMessage message)
-        {
-            var buf = new byte[BgpMessageWriter.GetBufferSize(message)];
-            var n = BgpMessageWriter.WriteMessage(message, buf);
-            EnqueueFrame(buf[..n]);
-        }
-
-        public async ValueTask ReadExactAsync(Memory<byte> buffer, CancellationToken cancellationToken)
-        {
-            var offset = 0;
-            while (offset < buffer.Length)
-            {
-                while (_readBuffer.Count > 0 && offset < buffer.Length)
-                    buffer.Span[offset++] = _readBuffer.Dequeue();
-                if (offset >= buffer.Length) break;
-
-                byte[] chunk;
-                try { chunk = await _inbound.Reader.ReadAsync(cancellationToken); }
-                catch (ChannelClosedException) { throw new IOException("Connection closed by peer"); }
-
-                var toCopy = Math.Min(chunk.Length, buffer.Length - offset);
-                for (var i = 0; i < toCopy; i++) buffer.Span[offset++] = chunk[i];
-                for (var i = toCopy; i < chunk.Length; i++) _readBuffer.Enqueue(chunk[i]);
-                Interlocked.Decrement(ref _pending);
-            }
-        }
-
-        private readonly List<byte[]> _sent = [];
-
-        /// <summary>Outbound frames, copied because SendMessageAsync returns its buffer to the pool.</summary>
-        public IReadOnlyList<byte[]> Sent { get { lock (_sent) return [.. _sent]; } }
-
-        public ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
-        {
-            lock (_sent) _sent.Add(buffer.ToArray());
-            return default;
-        }
-
-        public bool IsPeerClosed => false;
-
-        public void Dispose() => _inbound.Writer.TryComplete();
-    }
-
     /// <summary>Rejects every inbound route, so nothing this peer announces reaches the table.</summary>
     private sealed class RejectAllIncomingFilter : IRouteFilter
     {

--- a/BGPLite.Tests/CompositionContractTests.cs
+++ b/BGPLite.Tests/CompositionContractTests.cs
@@ -1,0 +1,291 @@
+using System.Reflection;
+using BGPLite.Api;
+using BGPLite.Configuration;
+using BGPLite.Contracts;
+using BGPLite.Protocol;
+using BGPLite.Providers;
+using BGPLite.Routing;
+using BGPLite.Server;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #263: the send path's dependencies were nullable-optional the whole way down —
+/// <c>BgpServer</c> → <c>BgpSession</c> → <c>RouteAssembler</c> — with each layer supplying a silent
+/// fallback for the missing one. Dropping a single DI registration therefore produced no error at
+/// all: peers kept their sessions and simply received the shared table's seeded routes instead of
+/// the prefixes their operator had selected, which is a wrong route set rather than a disabled
+/// feature.
+/// <para>
+/// These tests pin the two properties that make that unreachable: production collaborators cannot
+/// be constructed without their dependencies, and the degraded behavior is a separate named type a
+/// caller has to choose on purpose.
+/// </para>
+/// </summary>
+public class CompositionContractTests
+{
+    /// <summary>
+    /// Every dependency #263 lists as "nullable-optional" must now be required — no default value
+    /// and not a nullable reference type — so an incomplete composition fails to compile, or fails
+    /// at container build with the service named, instead of degrading at the first route send.
+    /// </summary>
+    [Theory]
+    // RouteAssembler.cs:22-24 — the three whose absence silently switched the whole peer over to
+    // the shared table.
+    [InlineData(typeof(RouteAssembler), "prefixService")]
+    [InlineData(typeof(RouteAssembler), "peerStore")]
+    [InlineData(typeof(RouteAssembler), "appConfig")]
+    // The collaborators BgpServer used to forward, now owned by the factory.
+    [InlineData(typeof(BgpSessionFactory), "peerStore")]
+    [InlineData(typeof(BgpSessionFactory), "prefixAggregator")]
+    [InlineData(typeof(BgpSessionFactory), "routeAssembler")]
+    // ManagementApi.cs:57-59 — without sessionManager a peer edited in the UI was persisted and
+    // never pushed to its live session.
+    [InlineData(typeof(ManagementApi), "prefixService")]
+    [InlineData(typeof(ManagementApi), "prefixSources")]
+    [InlineData(typeof(ManagementApi), "sessionManager")]
+    // PrefixService.cs:14-15 — a null http provider made every per-peer user URL source resolve to
+    // zero prefixes, and a null RIPEstat did the same for custom ASNs.
+    [InlineData(typeof(PrefixService), "ripeStat")]
+    [InlineData(typeof(PrefixService), "httpProvider")]
+    public void ProductionDependency_IsRequired(Type type, string parameterName)
+    {
+        var ctor = Assert.Single(type.GetConstructors());
+        var parameter = ctor.GetParameters().SingleOrDefault(p => p.Name == parameterName);
+
+        Assert.True(parameter is not null,
+            $"{type.Name} has no constructor parameter '{parameterName}' — if it was renamed, update this list; " +
+            "if it was dropped, #263 needs re-checking rather than the test deleting.");
+        Assert.False(parameter!.HasDefaultValue,
+            $"{type.Name}.{parameterName} has a default value again — an omitted dependency is silent by construction (#263)");
+        Assert.Equal(NullabilityState.NotNull, new NullabilityInfoContext().Create(parameter).WriteState);
+    }
+
+    /// <summary>
+    /// The other half of #263's acceptance: the accept loop does not build sessions itself, so it
+    /// no longer carries — or can silently drop — any of the session's dependencies.
+    /// </summary>
+    [Fact]
+    public void BgpServer_DoesNotCarryTheSessionsDependencies()
+    {
+        var parameters = Assert.Single(typeof(BgpServer).GetConstructors()).GetParameters();
+
+        Assert.Contains(parameters, p => p.ParameterType == typeof(IBgpSessionFactory));
+        foreach (var forwarded in new[]
+                 {
+                     typeof(IPeerStore), typeof(IPrefixService), typeof(ICommunityResolver),
+                     typeof(IPrefixAggregator), typeof(Action<string, uint>)
+                 })
+        {
+            Assert.DoesNotContain(parameters, p => p.ParameterType == forwarded);
+        }
+    }
+
+    // ---- the degraded assembler is explicit, and behaves as #289/#307 established ----
+
+    /// <summary>
+    /// Tenant isolation, carried over from #307 into the type that now owns the behavior: the
+    /// shared table also holds every NLRI peers announced inbound, and handing those to a different
+    /// peer leaks one tenant's routes to another.
+    /// </summary>
+    [Fact]
+    public async Task SharedTableAssembler_ServesTheSeedButNotRoutesOwnedByAPeer()
+    {
+        var table = new RouteTable();
+        table.AddOrUpdate(new Route { Prefix = 0xC0000200, PrefixLength = 24, NextHop = 0x7F000001 });
+        var otherPeer = new object();
+        table.AddOrUpdate(new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 0x0A0A0A0A }, owner: otherPeer);
+
+        var routes = await NewSharedTableAssembler(table, NullLogger.Instance)
+            .BuildOutboundRoutesAsync("127.0.0.1", 65002, new PeerConfig { Address = "127.0.0.1" }, "127.0.0.1", default);
+
+        Assert.Equal(0xC0000200u, Assert.Single(routes).Prefix);
+    }
+
+    /// <summary>
+    /// Reaching this assembler in production means a wiring error, so it says so — once, not on
+    /// every refresh, which is what a per-send warning would have done.
+    /// </summary>
+    [Fact]
+    public async Task SharedTableAssembler_AnnouncesItselfExactlyOnce()
+    {
+        var log = new CountingLogger();
+        var assembler = NewSharedTableAssembler(new RouteTable(), log);
+        var peer = new PeerConfig { Address = "127.0.0.1" };
+
+        for (var i = 0; i < 3; i++)
+            await assembler.BuildOutboundRoutesAsync("127.0.0.1", 65002, peer, "127.0.0.1", default);
+
+        Assert.Equal(1, log.Warnings);
+    }
+
+    /// <summary>The outgoing community filter still applies — the fallback is degraded, not unfiltered.</summary>
+    [Fact]
+    public async Task SharedTableAssembler_AppliesTheOutgoingFilter()
+    {
+        var table = new RouteTable();
+        table.AddOrUpdate(new Route { Prefix = 0xC0000200, PrefixLength = 24, NextHop = 0x7F000001 });
+
+        var routes = await new SharedTableRouteAssembler(table, new RejectAllOutgoingFilter(), NullLogger.Instance)
+            .BuildOutboundRoutesAsync("127.0.0.1", 65002, new PeerConfig { Address = "127.0.0.1" }, "127.0.0.1", default);
+
+        Assert.Empty(routes);
+    }
+
+    // ---- the factory actually wires what it was given ----
+
+    /// <summary>
+    /// The session built by the factory asks the INJECTED assembler for its route set, with the
+    /// peer identity resolved from the OPEN. Before #263 the session constructed its own assembler
+    /// from arguments threaded through BgpServer, so this wiring had no seam to assert on.
+    /// </summary>
+    [Fact]
+    public async Task Factory_BuildsSessionsThatUseTheInjectedAssembler()
+    {
+        var assembler = new RecordingAssembler();
+        var store = new RecordingPeerStore();
+        var (session, run, conn) = await EstablishThroughFactoryAsync(assembler, store);
+
+        Assert.Equal(("127.0.0.1", 65002u), assembler.Asked);
+        // The label is the peer's display form, which is what every assembler log line carries.
+        Assert.Contains("127.0.0.1", assembler.Label);
+
+        await TeardownAsync(session, run, conn);
+    }
+
+    /// <summary>
+    /// The peer row is upserted as soon as OPEN identifies the peer. That used to be a lambda in
+    /// Program.cs threaded through BgpServer as an optional <c>Action</c>; the factory owns it now,
+    /// and dropping it would otherwise be invisible until a peer failed to appear in the UI.
+    /// </summary>
+    [Fact]
+    public async Task Factory_BuildsSessionsThatRegisterThePeerOnOpen()
+    {
+        var store = new RecordingPeerStore();
+        var (session, run, conn) = await EstablishThroughFactoryAsync(new RecordingAssembler(), store);
+
+        Assert.Equal(("127.0.0.1", 65002u), store.Upserted);
+
+        await TeardownAsync(session, run, conn);
+    }
+
+    // ---- harness ----
+
+    /// <summary>The degraded assembler over <paramref name="table"/> with no outgoing filtering.</summary>
+    private static SharedTableRouteAssembler NewSharedTableAssembler(RouteTable table, ILogger logger) =>
+        new(table, AllowAllFilter.Instance, logger);
+
+    /// <summary>
+    /// Drives a factory-built session to Established over the <c>IBgpConnection</c> seam, so the
+    /// assertions observe what the factory actually wired rather than a hand-assembled session.
+    /// </summary>
+    private static async Task<(BgpSession Session, Task Run, ScriptedConnection Conn)> EstablishThroughFactoryAsync(
+        IRouteAssembler assembler, IPeerStore store)
+    {
+        var factory = new BgpSessionFactory(
+            new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 },
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            NullLogger<BgpSession>.Instance,
+            store,
+            new ExactUnionPrefixAggregator(),
+            assembler,
+            TimeProvider.System);
+
+        var conn = new ScriptedConnection();
+        var session = factory.Create(conn, new PeerConfig { Address = "127.0.0.1" });
+        var run = session.RunAsync();
+
+        conn.EnqueueMessage(new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = 0,
+            RouterId = 0x0A000002,
+            Capabilities = [BgpCapabilityInfo.FourOctetAsn(65002)],
+        });
+        conn.EnqueueMessage(BgpKeepaliveMessage.Instance);
+
+        for (var i = 0; i < 200 && !session.IsEstablished; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        Assert.True(session.IsEstablished, "session must reach Established");
+        return (session, run, conn);
+    }
+
+    /// <summary>Closes the session without emitting a NOTIFICATION and waits for its loops to unwind.</summary>
+    private static async Task TeardownAsync(BgpSession session, Task run, ScriptedConnection conn)
+    {
+        session.MarkSilentClose();
+        try { await run.WaitAsync(TimeSpan.FromSeconds(5)); }
+        catch (OperationCanceledException) { /* expected */ }
+        catch (IOException) { /* expected */ }
+        session.Dispose();
+        conn.Dispose();
+    }
+
+    /// <summary>Records the one call the session makes and returns nothing to send.</summary>
+    private sealed class RecordingAssembler : IRouteAssembler
+    {
+        public (string Ip, uint Asn) Asked { get; private set; }
+        public string Label { get; private set; } = "";
+
+        public Task<List<Route>> BuildOutboundRoutesAsync(
+            string peerIp, uint remoteAsn, PeerConfig filterPeerConfig, string peerLabel, CancellationToken ct)
+        {
+            Asked = (peerIp, remoteAsn);
+            Label = peerLabel;
+            return Task.FromResult(new List<Route>());
+        }
+    }
+
+    /// <summary>Records the identity callback; every other member throws to catch unexpected use.</summary>
+    private sealed class RecordingPeerStore : IPeerStore
+    {
+        public (string Ip, uint Asn) Upserted { get; private set; }
+
+        public void UpsertPeer(string ip, uint asn) => Upserted = (ip, asn);
+        public void UpdateSessionStatus(string ip, uint asn, bool active) { }
+
+        public string CreatePeer(string ip, uint asn, string? description) => throw new NotSupportedException();
+        public void DeletePeer(string id) => throw new NotSupportedException();
+        public PeerInfo? GetPeerByIp(string ip) => throw new NotSupportedException();
+        public PeerInfo? GetPeer(string ip, uint asn) => throw new NotSupportedException();
+        public PeerInfo? GetPeerById(string id) => throw new NotSupportedException();
+        public List<string> GetSubscriptions(string peerId) => throw new NotSupportedException();
+        public List<string> GetCustomPrefixes(string peerId) => throw new NotSupportedException();
+        public List<uint> GetCustomAsns(string peerId) => throw new NotSupportedException();
+        public HashSet<uint> GetCommunities(string peerId) => throw new NotSupportedException();
+        public HashSet<uint> GetCommunities(string ip, uint asn) => throw new NotSupportedException();
+        public void SetCommunities(string peerId, HashSet<uint> communities) => throw new NotSupportedException();
+        public void ClearCommunities(string peerId) => throw new NotSupportedException();
+        public void SetDescription(string id, string description) => throw new NotSupportedException();
+        public PeerRoutingView? LoadPeerRoutingView(string ip, uint asn) => throw new NotSupportedException();
+    }
+
+    /// <summary>Drops every outbound route, so the filter's effect is unambiguous.</summary>
+    private sealed class RejectAllOutgoingFilter : IRouteFilter
+    {
+        private static readonly IReadOnlySet<uint> Empty = new HashSet<uint>();
+        public bool AcceptIncoming(Route route, PeerConfig peer) => true;
+        public IReadOnlySet<uint> ResolveOutgoingAllowSet(PeerConfig peer) => Empty;
+        public bool AcceptOutgoing(Route route, PeerConfig peer, IReadOnlySet<uint> allowSet) => false;
+    }
+
+    /// <summary>Counts Warning-level entries.</summary>
+    private sealed class CountingLogger : ILogger
+    {
+        private int _warnings;
+        public int Warnings => Volatile.Read(ref _warnings);
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Warning) Interlocked.Increment(ref _warnings);
+        }
+    }
+}

--- a/BGPLite.Tests/ConfigHotReloadTests.cs
+++ b/BGPLite.Tests/ConfigHotReloadTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using BGPLite;
 using BGPLite.Api;
 using BGPLite.Configuration;
+using BGPLite.Providers;
 using BGPLite.Routing;
 using BGPLite.Server;
 using Microsoft.Data.Sqlite;
@@ -276,8 +277,54 @@ public class ConfigHotReloadTests
             new RouteTable(),
             config,
             new BgpMetrics(),
-            new CapturingLogger<ManagementApi>());
+            new CapturingLogger<ManagementApi>(),
+            // #263: these are required now. This fixture exercises only the hot-reload path
+            // (trusted proxies / CORS / rate limits), so inert stubs are supplied rather than
+            // omitted — the API can no longer be built in a half-wired state by accident.
+            new InertPrefixService(),
+            new InertPrefixSourceService(),
+            new InertSessionManager());
         return new ApiHarness(api, connection);
+    }
+
+    /// <summary>Answers every prefix query with an empty set; the hot-reload path never calls it.</summary>
+    private sealed class InertPrefixService : IPrefixService
+    {
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
+            => Task.FromResult(new List<(uint Prefix, byte Length, uint Asn)>());
+        public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
+        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
+            => Task.FromResult(new List<(uint Prefix, byte Length, uint Asn)>());
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    /// <summary>Reports no configured prefix sources; the hot-reload path never calls it.</summary>
+    private sealed class InertPrefixSourceService : IPrefixSourceService
+    {
+        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<(uint, byte)>)>>([]);
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetDefaultAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);
+        public bool SourceSupportsConditional(string sourceName) => false;
+    }
+
+    /// <summary>Holds no sessions; the hot-reload path never calls it.</summary>
+    private sealed class InertSessionManager : ISessionManager
+    {
+        public Task RefreshPeerAsync(string peerIp, uint asn) => Task.CompletedTask;
+        public List<string> GetActivePeerIps() => [];
+        public int GetAdvertisedPrefixCount(string peerIp, uint asn) => 0;
+        public Task RefreshAllEstablishedAsync() => Task.CompletedTask;
     }
 
     private sealed class ApiHarness : IDisposable

--- a/BGPLite.Tests/PrefixCacheRaceTests.cs
+++ b/BGPLite.Tests/PrefixCacheRaceTests.cs
@@ -108,8 +108,12 @@ public class PrefixCacheRaceTests
 
     private static PrefixService Service(CountingPrefixSource source, TimeSpan? cacheTtl = null, TimeProvider? timeProvider = null) =>
         new(new AppConfig(),
-            ripeStat: null,
-            source,
+            // #263 made both required in production; neither is on the GetRuPrefixesAsync path this
+            // fixture exercises, so the fake composition states that explicitly rather than relying
+            // on a nullable parameter that production code could also leave unset.
+            ripeStat: null!,
+            prefixSources: source,
+            httpProvider: null!,
             cacheTtl: cacheTtl ?? TimeSpan.FromHours(1),
             logger: NullLogger<PrefixService>.Instance,
             timeProvider: timeProvider);

--- a/BGPLite.Tests/PrefixServiceTests.cs
+++ b/BGPLite.Tests/PrefixServiceTests.cs
@@ -76,6 +76,7 @@ public class PrefixServiceTests
                 NullLogger<RipeStatProvider>.Instance,
                 new RipeStatConfig { RetryAttempts = retryAttempts, RetryDelaySeconds = 0 }),
             null!, // IPrefixSourceService is not on the GetPrefixesForAsns path
+            null!, // HttpPrefixProvider is only on the per-peer user-source path (#263)
             cacheTtl: cacheTtl ?? TimeSpan.FromHours(1),
             negativeTtl: negativeTtl,
             maxCacheEntries: maxCacheEntries);

--- a/BGPLite.Tests/RefreshDebounceTests.cs
+++ b/BGPLite.Tests/RefreshDebounceTests.cs
@@ -7,6 +7,7 @@ using BGPLite.Protocol;
 using BGPLite.Routing;
 using BGPLite.Server;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace BGPLite.Tests;
 
@@ -139,8 +140,11 @@ public class RefreshDebounceTests
             new BgpMetrics(),
             new NopLogger<BgpSession>(),
             peerStore: store,
-            prefixService: new EmptyPrefixService(),
-            appConfig: new AppConfig());
+            // #263: the assembler is injected now, so the test supplies the same store it asserts on.
+            routeAssembler: new RouteAssembler(
+                new EmptyPrefixService(), store, NullCommunityResolver.Instance,
+                AllowAllFilter.Instance, new AppConfig(), cfg,
+                NullLogger<RouteAssembler>.Instance));
         _ = await EstablishAsync(session, client, cfg);
         return (session, store, client, server);
     }

--- a/BGPLite.Tests/RouteRefreshHoldTimerTests.cs
+++ b/BGPLite.Tests/RouteRefreshHoldTimerTests.cs
@@ -7,6 +7,7 @@ using BGPLite.Protocol;
 using BGPLite.Routing;
 using BGPLite.Server;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace BGPLite.Tests;
 
@@ -104,8 +105,11 @@ public class RouteRefreshHoldTimerTests
             new BgpMetrics(),
             new NopLogger<BgpSession>(),
             peerStore: store,
-            prefixService: new EmptyPrefixService(),
-            appConfig: new AppConfig());
+            // #263: the assembler is injected now, so the test supplies the same store it asserts on.
+            routeAssembler: new RouteAssembler(
+                new EmptyPrefixService(), store, NullCommunityResolver.Instance,
+                AllowAllFilter.Instance, new AppConfig(), cfg,
+                NullLogger<RouteAssembler>.Instance));
         var runTask = Task.Run(() => session.RunAsync(CancellationToken.None));
 
         // Handshake with the RouteRefresh capability negotiated (otherwise the message is ignored).

--- a/BGPLite.Tests/ScriptedConnection.cs
+++ b/BGPLite.Tests/ScriptedConnection.cs
@@ -1,0 +1,75 @@
+using System.Threading.Channels;
+using BGPLite.Protocol;
+using BGPLite.Server;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// Scripts inbound frames and discards outbound bytes; reads block until a frame arrives. Driving a
+/// <see cref="BgpSession"/> through the <c>IBgpConnection</c> seam (#96) instead of loopback sockets
+/// makes frame delivery deterministic and sidesteps the timing flakiness #302 documents. Shared by
+/// the fixtures that need a session established without a real socket.
+/// </summary>
+internal sealed class ScriptedConnection : IBgpConnection
+{
+    private readonly Channel<byte[]> _inbound = Channel.CreateUnbounded<byte[]>();
+    private readonly Queue<byte> _readBuffer = new();
+    private int _pending;
+
+    /// <summary>True once every enqueued frame has been fully handed to the read loop.</summary>
+    public bool Drained => Volatile.Read(ref _pending) == 0 && _readBuffer.Count == 0;
+
+    /// <summary>Queues raw bytes for the read loop to consume as one delivery.</summary>
+    public void EnqueueFrame(byte[] frame)
+    {
+        Interlocked.Increment(ref _pending);
+        _inbound.Writer.TryWrite(frame);
+    }
+
+    /// <summary>Encodes <paramref name="message"/> with the production writer and queues the frame.</summary>
+    public void EnqueueMessage(BgpMessage message)
+    {
+        var buf = new byte[BgpMessageWriter.GetBufferSize(message)];
+        var n = BgpMessageWriter.WriteMessage(message, buf);
+        EnqueueFrame(buf[..n]);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask ReadExactAsync(Memory<byte> buffer, CancellationToken cancellationToken)
+    {
+        var offset = 0;
+        while (offset < buffer.Length)
+        {
+            while (_readBuffer.Count > 0 && offset < buffer.Length)
+                buffer.Span[offset++] = _readBuffer.Dequeue();
+            if (offset >= buffer.Length) break;
+
+            byte[] chunk;
+            try { chunk = await _inbound.Reader.ReadAsync(cancellationToken); }
+            catch (ChannelClosedException) { throw new IOException("Connection closed by peer"); }
+
+            var toCopy = Math.Min(chunk.Length, buffer.Length - offset);
+            for (var i = 0; i < toCopy; i++) buffer.Span[offset++] = chunk[i];
+            for (var i = toCopy; i < chunk.Length; i++) _readBuffer.Enqueue(chunk[i]);
+            Interlocked.Decrement(ref _pending);
+        }
+    }
+
+    private readonly List<byte[]> _sent = [];
+
+    /// <summary>Outbound frames, copied because SendMessageAsync returns its buffer to the pool.</summary>
+    public IReadOnlyList<byte[]> Sent { get { lock (_sent) return [.. _sent]; } }
+
+    /// <inheritdoc />
+    public ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+    {
+        lock (_sent) _sent.Add(buffer.ToArray());
+        return default;
+    }
+
+    /// <summary>Never reports a half-closed peer: teardown is driven explicitly by the fixtures.</summary>
+    public bool IsPeerClosed => false;
+
+    /// <summary>Completes the inbound channel so a blocked read unwinds as a closed connection.</summary>
+    public void Dispose() => _inbound.Writer.TryComplete();
+}

--- a/BGPLite/Program.cs
+++ b/BGPLite/Program.cs
@@ -15,6 +15,19 @@ using BGPLite.Contracts;
 
 var builder = Host.CreateApplicationBuilder(args);
 
+// #263: validate the whole composition when the container is built, not when a service is first
+// used. ValidateOnBuild walks every constructor-injected registration and throws — naming the
+// service and the parameter — if a dependency is unregistered, so a missing registration is a
+// startup failure instead of a feature that quietly does nothing.
+// ValidateScopes stays off: EF Core's own AddDbContext plumbing resolves the scoped
+// IDbContextOptionsConfiguration<BgpDbContext> while building the singleton DbContextOptions, which
+// the root-scope check rejects. That is EF's internal wiring, not this composition — the app's own
+// singletons already take IDbContextFactory rather than a scoped DbContext.
+builder.ConfigureContainer(new DefaultServiceProviderFactory(new ServiceProviderOptions
+{
+    ValidateOnBuild = true
+}));
+
 // EF Core logs every SQL statement at Information by default; with no appsettings.json the host
 // uses Information for everything → EF SQL is ~85% of log volume. Silence EF SQL (warnings/errors
 // still surface) without muting startup/host logs. (appsettings.yml Logging:LogLevel is NOT read
@@ -155,29 +168,40 @@ builder.Services.AddSingleton<IPrefixService>(sp =>
     return new PrefixService(config, ripe, sources, sp.GetRequiredService<HttpPrefixProvider>(), logger: sp.GetRequiredService<ILogger<PrefixService>>());
 });
 
+// #263: the BGP send path's dependencies are registered explicitly and resolved with
+// GetRequiredService, so an incomplete composition throws at startup naming the missing service.
+// They used to be optional constructor arguments threaded BgpServer -> BgpSession -> RouteAssembler,
+// where dropping one produced no error at all — just peers receiving the seeded shared table
+// instead of the prefixes their operator selected.
+builder.Services.AddSingleton<IPeerStore>(sp => sp.GetRequiredService<PeerStore>());
+builder.Services.AddSingleton(TimeProvider.System);
+// Summarization policy for what goes on the wire. Was hard-coded as a `?? new ExactUnion...()`
+// fallback in two constructors and never passed by this file; naming it here is what makes it
+// swappable at all.
+builder.Services.AddSingleton<IPrefixAggregator, ExactUnionPrefixAggregator>();
+builder.Services.AddSingleton<IRouteAssembler>(sp => new RouteAssembler(
+    sp.GetRequiredService<IPrefixService>(),
+    sp.GetRequiredService<IPeerStore>(),
+    sp.GetRequiredService<ICommunityResolver>(),
+    sp.GetRequiredService<IRouteFilter>(),
+    sp.GetRequiredService<AppConfig>(),
+    sp.GetRequiredService<BgpConfig>(),
+    sp.GetRequiredService<ILogger<RouteAssembler>>()));
+builder.Services.AddSingleton<IBgpSessionFactory, BgpSessionFactory>();
+
 // BgpServer is registered as a singleton FIRST (same pattern as ManagementApi below): the old
 // wiring created it inside the AddHostedService factory while writing a captured local that the
 // ISessionManager factory read back with `!` — resolution-order-dependent and NRE-prone, since
 // ISessionManager consumers (PrefixAutoRefreshService, PrefixSourceService) can resolve it
 // before the hosted service starts. Now the container owns exactly one instance and every
 // consumer resolves it regardless of order (#231).
-builder.Services.AddSingleton(sp =>
-{
-    var store = sp.GetRequiredService<PeerStore>();
-    var prefixService = sp.GetRequiredService<IPrefixService>();
-
-    return new BgpServer(
-        sp.GetRequiredService<AppConfig>(),
-        sp.GetRequiredService<RouteTable>(),
-        sp.GetRequiredService<IRouteFilter>(),
-        sp.GetRequiredService<BgpMetrics>(),
-        sp.GetRequiredService<ILogger<BgpSession>>(),
-        sp.GetRequiredService<ILogger<BgpServer>>(),
-        (ip, asn) => store.UpsertPeer(ip, asn),
-        store,
-        prefixService,
-        communityResolver: sp.GetRequiredService<ICommunityResolver>());
-});
+builder.Services.AddSingleton(sp => new BgpServer(
+    sp.GetRequiredService<AppConfig>(),
+    sp.GetRequiredService<RouteTable>(),
+    sp.GetRequiredService<IRouteFilter>(),
+    sp.GetRequiredService<BgpMetrics>(),
+    sp.GetRequiredService<IBgpSessionFactory>(),
+    sp.GetRequiredService<ILogger<BgpServer>>()));
 // #251: route seeding (sources + RIPEstat warm-up) runs as a BACKGROUND task — the listeners
 // start immediately, the local nets.txt fallback seeds in milliseconds, and established sessions
 // get the full set pushed once warm-up completes. Registered before the BGP server so seeding


### PR DESCRIPTION
Closes #263

## The problem, verified

Every collaborator on the outbound path was a nullable-optional constructor argument threaded `BgpServer` → `BgpSession` → `RouteAssembler`, and each layer supplied a silent fallback for the one below:

```csharp
_prefixAggregator = prefixAggregator ?? new ExactUnionPrefixAggregator();
_communityResolver = communityResolver ?? NullCommunityResolver.Instance;
if (_peerStore is not null && _prefixService is not null && _appConfig is not null) { ... }
```

Dropping one DI registration produced no error at all. Sessions still established; peers just received the shared route table's **seeded** routes instead of the prefixes their operator selected in the UI. That is a wrong route set, not a disabled feature, and #307 could only make it log a warning after the fact.

Worth noting what the old wiring already got wrong without anyone failing: `Program.cs` never passed `prefixAggregator`, so the `?? new ExactUnionPrefixAggregator()` fallback *was* production. The summarization policy for everything on the wire was reachable only as a default argument.

## What changed

**`RouteAssembler`** requires `IPrefixService`, `IPeerStore` and `AppConfig`. The tri-null guard and the shared-table branch under it are gone, along with the `_routeTable` field only that branch used and the null-forgiveness dance around `_appConfig`. It no longer carries a per-session peer label (that is a method parameter now), so it is a plain singleton.

**`SharedTableRouteAssembler`** is the degraded behavior, kept as a named `IRouteAssembler` a caller chooses on purpose. It preserves #289's owner check — the shared table also holds every NLRI peers announced inbound, and serving those to a different peer leaks one tenant's routes — and announces its activation **once** instead of on every refresh.

**`BgpSessionFactory`** owns the session composition. The accept loop needed none of those dependencies for itself, it only forwarded them: `BgpServer` loses five constructor parameters and four fields, and `new BgpSession(…12 args…)` becomes `_sessionFactory.Create(connection, peerConfig)`. The peer-identity callback that `Program.cs` hand-wired as `(ip, asn) => store.UpsertPeer(ip, asn)` is now just `IPeerStore.UpsertPeer` inside the factory.

`BgpSession` drops `_prefixService`, `_appConfig` and `_communityResolver` entirely — it held all three only to hand them to the assembler it built.

**`ManagementApi`** (`IPrefixService`, `IPrefixSourceService`, `ISessionManager`) and **`PrefixService`** (`RipeStatProvider`, `HttpPrefixProvider`) are required too. A null session manager meant a peer edited in the UI was persisted and never pushed to its live session — six `if (_sessionManager is not null)` guards around exactly that. A null http provider meant `GetUserSourcePrefixesAsync` returned `[]`, so a user's URL source silently produced nothing.

**`Program.cs`** registers `IPeerStore`, `IPrefixAggregator`, `IRouteAssembler`, `IBgpSessionFactory` and `TimeProvider` explicitly, and builds the container with `ValidateOnBuild`.

## Acceptance, checked against a running host

> Removing any single DI registration fails loudly at startup

Deleted the `IPrefixAggregator` registration and started the app:

```
Unhandled exception. System.AggregateException: Some services are not able to be constructed
(Error while validating the service descriptor 'ServiceType: BGPLite.Server.IBgpSessionFactory
 Lifetime: Singleton ImplementationType: BGPLite.Server.BgpSessionFactory':
 Unable to resolve service for type 'BGPLite.Routing.IPrefixAggregator'
 while attempting to activate 'BGPLite.Server.BgpSessionFactory'.)
```

Restored, the host starts clean through to `Application started`.

`ValidateScopes` is deliberately **off**, and this is not a judgment call I made blind — with it on the host dies before reaching any of this project's code:

```
Cannot resolve scoped service
'IEnumerable<IDbContextOptionsConfiguration<BgpDbContext>>' from root provider.
   at EntityFrameworkServiceCollectionExtensions.CreateDbContextOptions<TContext>
```

That is EF's own `AddDbContext` plumbing resolving a scoped option-configuration service while constructing the singleton `DbContextOptions`. The app's own singletons already take `IDbContextFactory` rather than a scoped `DbContext`.

> `BgpServer`/`BgpSession` no longer `new` up their collaborators

`BgpServer` still constructs `new SocketBgpConnection(socket)` — that is the transport adapter for the socket it just accepted, has no configuration of its own, and passing a `Socket` into the factory would only couple the seam to `System.Net.Sockets`.

## Tests

`CompositionContractTests` — 17 new tests, 710 total.

- `ProductionDependency_IsRequired` — a `[Theory]` naming each dependency #263 listed (`RouteAssembler.peerStore`, `ManagementApi.sessionManager`, `PrefixService.httpProvider`, …) and asserting it has no default value and `NullabilityState.NotNull`. Re-adding `= null` to any of them fails here rather than silently at the next route send.
- `BgpServer_DoesNotCarryTheSessionsDependencies` — the second acceptance bullet, as a compile-independent assertion.
- Three `SharedTableRouteAssembler` behavior tests: serves the seed but not a route owned by another peer, applies the outgoing filter, warns exactly once across three calls.
- Two factory tests that establish a real session over the `IBgpConnection` seam and assert it asked the **injected** assembler, and that OPEN upserted the peer.

Verified they fail without the fix. Neutering four things independently — `EnumerateUnowned()` → `Enumerate()`, the once-guard, the factory's `routeAssembler:` argument, and `IPeerStore` back to nullable — produces exactly 4 failures out of 17.

`ScriptedConnection` moved out of `BgpSessionRouteOwnershipTests` into a shared fixture so the factory tests can establish a session without a real socket; `ConfigHotReloadTests` gained three inert stubs now that `ManagementApi` cannot be half-wired.

## Not in scope

`PrefixService`'s optional `ILogger`/`TimeSpan?`/`TimeProvider?` parameters are left alone — those are test seams and tuning knobs, not services whose absence changes what a peer receives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-peer route assembly for more targeted outbound route announcements.
  * Added a fallback mode that shares only seeded routes while preventing peer-owned routes from being exposed to others.
  * Improved session creation and peer registration consistency.

* **Bug Fixes**
  * Outgoing routes now consistently honor peer-specific filtering.
  * Application startup now detects incomplete configuration immediately instead of failing later.

* **Tests**
  * Added coverage for route isolation, filtering, session setup, and startup composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->