### PR TITLE
fix(routing): delete a peer's routes when its session ends

### DIFF
--- a/BGPLite.Routing/RouteTable.cs
+++ b/BGPLite.Routing/RouteTable.cs
@@ -77,6 +77,36 @@ public sealed class RouteTable
             .Remove(new KeyValuePair<(uint Prefix, byte Length), Entry>(key, entry));
     }
 
+    /// <summary>
+    /// Removes every entry still owned by <paramref name="owner"/> and returns how many went — the
+    /// session-close counterpart to <see cref="RemoveOwnedBy"/>. RFC 4271 §8.2.2 has a speaker
+    /// "delete all routes associated with this connection" on every transition out of Established,
+    /// and without it a peer's announcements outlived its session forever: nothing else in the
+    /// server removes an entry, so a peer could reconnect and add another batch indefinitely (#313).
+    /// <para>
+    /// Each removal is the same atomic compare-and-remove <see cref="RemoveOwnedBy"/> performs, so
+    /// an entry another peer has taken over between the scan and the delete stays put — the losing
+    /// session must not delete the winner's route, exactly as in #289. Enumerating a
+    /// <see cref="ConcurrentDictionary{TKey,TValue}"/> while removing from it is safe and defined:
+    /// the enumerator is a moment-in-time view, not a snapshot, and never throws for concurrent
+    /// modification.
+    /// </para>
+    /// </summary>
+    public int RemoveAllOwnedBy(object owner)
+    {
+        ArgumentNullException.ThrowIfNull(owner);
+
+        var removed = 0;
+        foreach (var pair in _routes)
+        {
+            if (!ReferenceEquals(pair.Value.Owner, owner))
+                continue;
+            if (((ICollection<KeyValuePair<(uint Prefix, byte Length), Entry>>)_routes).Remove(pair))
+                removed++;
+        }
+        return removed;
+    }
+
     public Route? Get(uint prefix, byte length) =>
         _routes.TryGetValue((prefix, length), out var entry) ? entry.Route : null;
 

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -515,6 +515,26 @@ public sealed class BgpSession : IDisposable
                 catch { /* best-effort */ }
             }
             TransitionTo(BgpFsmState.Idle);
+
+            // RFC 4271 §8.2.2: every transition out of Established "deletes all routes associated
+            // with this connection". #313: nothing did. A peer's announcements outlived its session
+            // forever — no other path in the server removes an entry — so a peer could disconnect,
+            // reconnect and add another batch without limit, and both GET /api/routes and the route
+            // count kept reporting peers that were long gone. Unconditional, not gated on
+            // wasEstablished: a session that installed nothing removes nothing, and the guard would
+            // only be a hole if the FSM ever grew another way to install routes.
+            //
+            // Not GR-exempt. RFC 4724 lets a receiver RETAIN a restarting peer's routes as stale for
+            // its advertised Restart Time and flush them when it expires; BGPLite implements no part
+            // of that (HandleOpen only logs the peer's GR capability), and retention without the
+            // timer is not Graceful Restart, it is the leak.
+            var flushed = _routeTable.RemoveAllOwnedBy(this);
+            if (flushed > 0)
+            {
+                _logger.LogInformation("Removed {Count} route(s) learned from {Peer} on session close", flushed, _peer);
+                _metrics.SetRouteCount(_routeTable.Count);
+            }
+
             if (wasEstablished)
             {
                 _metrics.SessionClosed();

--- a/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
+++ b/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
@@ -282,6 +282,108 @@ public class BgpSessionRouteOwnershipTests
         return Frame(BgpMessageType.Update, [.. payload]);
     }
 
+    // ---- #313: a session's routes go when the session goes ----
+
+    /// <summary>
+    /// RFC 4271 §8.2.2: every transition out of Established "deletes all routes associated with this
+    /// connection". #313: nothing did. A peer's announcements outlived its session, and since no
+    /// other path in the server removes an entry, a peer could disconnect, reconnect and add another
+    /// batch without limit — which is also why a per-session max-prefix cap (#304) could not have
+    /// contained it on its own.
+    /// </summary>
+    [Fact]
+    public async Task SessionClose_RemovesTheRoutesThatSessionAnnounced()
+    {
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        conn.EnqueueFrame(AnnounceFrame(8, 0x0A));
+        await SettleAsync(conn, () => routeTable.Count == 1);
+
+        await TeardownAsync(session, run);
+
+        Assert.Equal(0, routeTable.Count);
+    }
+
+    /// <summary>
+    /// A reconnect must not accumulate. Two sessions in sequence announcing the same and a further
+    /// prefix leave exactly what the second one announced — the growth-across-reconnects property.
+    /// </summary>
+    [Fact]
+    public async Task Reconnecting_DoesNotAccumulateTheFormerSessionsRoutes()
+    {
+        var routeTable = new RouteTable();
+
+        var (first, firstRun, firstConn) = await EstablishAsync(routeTable);
+        firstConn.EnqueueFrame(AnnounceFrame(8, 0x0A));
+        await SettleAsync(firstConn, () => routeTable.Count == 1);
+        await TeardownAsync(first, firstRun);
+
+        var (second, secondRun, secondConn) = await EstablishAsync(routeTable, routerId: 0x0A000003);
+        secondConn.EnqueueFrame(AnnounceFrame(8, 0x0A));
+        secondConn.EnqueueFrame(AnnounceFrame(24, 0xC0, 0x00, 0x02));
+        await SettleAsync(secondConn, () => routeTable.Count == 2);
+
+        Assert.Equal(2, routeTable.Count);
+
+        await TeardownAsync(second, secondRun);
+        Assert.Equal(0, routeTable.Count);
+    }
+
+    /// <summary>
+    /// The mirror of #307's isolation property at teardown: the flush is scoped by owner, so the
+    /// startup seed (written unowned by <c>RouteSeedingService</c>) survives a peer disconnecting.
+    /// A flush by prefix rather than by owner would empty the table every time any peer left.
+    /// </summary>
+    [Fact]
+    public async Task SessionClose_LeavesTheStartupSeedAndOtherPeersRoutes()
+    {
+        var routeTable = Seeded((TestNetSlash24, 24));
+        var (keeper, keeperRun, keeperConn) = await EstablishAsync(routeTable, routerId: 0x0A000003);
+        keeperConn.EnqueueFrame(AnnounceFrame(16, 0xAC, 0x10));
+        await SettleAsync(keeperConn, () => routeTable.Count == 2);
+
+        var (leaver, leaverRun, leaverConn) = await EstablishAsync(routeTable, routerId: 0x0A000004);
+        leaverConn.EnqueueFrame(AnnounceFrame(8, 0x0A));
+        await SettleAsync(leaverConn, () => routeTable.Count == 3);
+
+        await TeardownAsync(leaver, leaverRun);
+
+        Assert.Null(routeTable.Get(TenSlashEight, 8));                    // the leaver's route is gone
+        Assert.NotNull(routeTable.Get(TestNetSlash24, 24));               // the seed stays
+        Assert.NotNull(routeTable.Get(0xAC100000, 16));                   // the other peer's route stays
+
+        await TeardownAsync(keeper, keeperRun);
+    }
+
+    /// <summary>
+    /// The compare-and-remove rule from #289 applies to the bulk flush too: a route this session
+    /// announced but another peer has since replaced belongs to the replacement, and this session
+    /// closing must not take it with it.
+    /// </summary>
+    [Fact]
+    public async Task SessionClose_DoesNotRemoveARouteAnotherPeerHasSinceReplaced()
+    {
+        var routeTable = new RouteTable();
+        var (a, aRun, aConn) = await EstablishAsync(routeTable, routerId: 0x0A000002);
+        aConn.EnqueueFrame(AnnounceFrame(8, 0x0A));
+        await SettleAsync(aConn, () => routeTable.Count == 1);
+
+        var (b, bRun, bConn) = await EstablishAsync(routeTable, routerId: 0x0A000003);
+        // Same prefix, different next hop, so the installed route is observably B's.
+        bConn.EnqueueFrame(BuildAnnounce(AttributesWithNextHop(0x0A, 0x0A, 0x0A, 0x0A), 8, [0x0A]));
+        await SettleAsync(bConn, () => routeTable.Get(TenSlashEight, 8)?.NextHop == 0x0A0A0A0A);
+
+        await TeardownAsync(a, aRun);
+
+        var route = routeTable.Get(TenSlashEight, 8);
+        Assert.NotNull(route);
+        Assert.Equal(0x0A0A0A0Au, route!.NextHop);   // still B's
+
+        await TeardownAsync(b, bRun);
+        Assert.Equal(0, routeTable.Count);
+    }
+
     // ---- harness ----
 
     private static RouteTable Seeded(params (uint Prefix, byte Length)[] routes)

--- a/BGPLite.Tests/RouteTableTests.cs
+++ b/BGPLite.Tests/RouteTableTests.cs
@@ -65,4 +65,58 @@ public class RouteTableTests
         table.Clear();
         Assert.Equal(0, table.Count);
     }
+
+    // ---- #313: bulk removal by owner (session close) ----
+
+    /// <summary>Scoped by owner: one session's entries go, nobody else's does.</summary>
+    [Fact]
+    public void RemoveAllOwnedBy_RemovesOnlyThatOwnersEntries()
+    {
+        var table = new RouteTable();
+        var leaving = new object();
+        var staying = new object();
+        table.AddOrUpdate(new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 1 }, leaving);
+        table.AddOrUpdate(new Route { Prefix = 0x0A010000, PrefixLength = 16, NextHop = 1 }, leaving);
+        table.AddOrUpdate(new Route { Prefix = 0xC0A80000, PrefixLength = 24, NextHop = 2 }, staying);
+        table.AddOrUpdate(new Route { Prefix = 0xC0000200, PrefixLength = 24, NextHop = 3 });   // the seed
+
+        Assert.Equal(2, table.RemoveAllOwnedBy(leaving));
+
+        Assert.Equal(2, table.Count);
+        Assert.NotNull(table.Get(0xC0A80000, 24));
+        Assert.NotNull(table.Get(0xC0000200, 24));   // unowned entries are nobody's to flush
+    }
+
+    /// <summary>
+    /// The compare-and-remove rule from #289 in bulk form: <c>AddOrUpdate</c> transfers ownership, so
+    /// a prefix the former owner announced but a later announcement replaced belongs to the new owner
+    /// and must survive the former owner's close.
+    /// </summary>
+    [Fact]
+    public void RemoveAllOwnedBy_SkipsEntriesTakenOverByAnotherOwner()
+    {
+        var table = new RouteTable();
+        var first = new object();
+        var second = new object();
+        table.AddOrUpdate(new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 1 }, first);
+        table.AddOrUpdate(new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 2 }, second);
+
+        Assert.Equal(0, table.RemoveAllOwnedBy(first));
+        Assert.Equal(2u, table.Get(0x0A000000, 8)!.NextHop);
+    }
+
+    /// <summary>An owner that installed nothing removes nothing — the close path runs for every session.</summary>
+    [Fact]
+    public void RemoveAllOwnedBy_UnknownOwner_RemovesNothing()
+    {
+        var table = new RouteTable();
+        table.AddOrUpdate(new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 1 });
+
+        Assert.Equal(0, table.RemoveAllOwnedBy(new object()));
+        Assert.Equal(1, table.Count);
+    }
+
+    [Fact]
+    public void RemoveAllOwnedBy_NullOwner_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => new RouteTable().RemoveAllOwnedBy(null!));
 }


### PR DESCRIPTION
Closes #313

## The defect

RFC 4271 §8.2.2 has a speaker *"delete all routes associated with this connection"* on every transition out of Established. Nothing in BGPLite did. `RunAsync`'s `finally` sent the Cease, transitioned to Idle, updated metrics and the peer's session status — and left the entries in the shared table:

```csharp
TransitionTo(BgpFsmState.Idle);
if (wasEstablished)
{
    _metrics.SessionClosed();
    _peerStore?.UpdateSessionStatus(_peerConfig.Address, _remoteAsn, false);
}
```

`WithdrawIfOwned` — reached only from an explicit WITHDRAWN ROUTES field or a treat-as-withdraw — was the **only** removal path in the entire server.

Confirmed on `main` before writing the fix: establish a session, announce `10.0.0.0/8`, tear it down, and `routeTable.Count` is still `1`. Every teardown reason behaves identically, because none of them touches the table.

## Why it is not just tidiness

Because the entries outlive the session, a peer disconnects, reconnects with a fresh session, and adds another batch — indefinitely. BGPLite auto-registers unknown peers, so completing a handshake is the whole prerequisite. That is also why this is filed and fixed **separately from #304** rather than folded into it: a per-session max-prefix cap that a reconnect resets is not a cap, so this had to land first.

`GET /api/routes` (`_routeTable.GetAll()`) and `_metrics.SetRouteCount(_routeTable.Count)` both read the shared table, so both kept counting peers that were long gone.

## The fix

`RouteTable.RemoveAllOwnedBy(object owner)` — the session-close counterpart to `RemoveOwnedBy`, called from `RunAsync`'s `finally`.

Two decisions worth stating rather than leaving to be inferred:

**It uses the same atomic compare-and-remove, per entry.** A bulk clear-by-prefix would delete routes another peer has taken over in the meantime; `AddOrUpdate` transfers ownership, so the losing session must not take the winner's route with it when it closes. Same rule as #289, in bulk form, and there is a test for exactly that.

**It is not gated on `wasEstablished`.** A session that installed nothing removes nothing, so the call is cheap; the guard would only become a hole if the FSM ever grew another way to install routes.

**It is deliberately not GR-exempt.** RFC 4724 lets a receiver retain a restarting peer's routes as *stale* for its advertised Restart Time and flush them when the timer expires. BGPLite implements no part of the receiving half — `HandleOpen` reads the peer's GR capability and only logs it:

```csharp
var peerGr = CapabilityHelper.GetGracefulRestart(open);
_logger.LogInformation("Peer {Peer} Graceful Restart: {State}", ...);
```

Retention without the timer is not Graceful Restart, it is the leak. Implementing the receiving half (stale marking + Restart Time + flush) is a separate feature; until it exists, flushing unconditionally is the RFC 4271 behavior. Recorded in a comment at the call site so the next reader does not have to re-derive it.

## Tests

8 new tests, 701 total.

`BgpSessionRouteOwnershipTests` — the fixture that already owns this machinery, driven through the `IBgpConnection` seam:
- `SessionClose_RemovesTheRoutesThatSessionAnnounced` — the reproduction from the issue.
- `Reconnecting_DoesNotAccumulateTheFormerSessionsRoutes` — the growth-across-reconnects property, which is the actual impact.
- `SessionClose_LeavesTheStartupSeedAndOtherPeersRoutes` — the flush is scoped by owner: the unowned seed and another peer's routes survive. A flush by prefix would empty the table whenever any peer left.
- `SessionClose_DoesNotRemoveARouteAnotherPeerHasSinceReplaced` — the #289 rule at teardown.

`RouteTableTests` — `RemoveAllOwnedBy` in isolation: scoped by owner, skips entries taken over by another owner, an owner that installed nothing removes nothing, null owner throws.

Verified they fail without the fix: replacing `RemoveAllOwnedBy(this)` with `0` turns all four session tests red (7 passed / 4 failed in that fixture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for removing all routes associated with a specific session or owner in one operation.

* **Bug Fixes**
  * Routes announced by a session are now automatically withdrawn when the session closes.
  * Cleanup preserves unowned routes, routes from other sessions, and routes whose ownership has changed.
  * Reconnecting sessions no longer accumulate stale routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->