### PR TITLE
test(server): make the refresh-debounce test wait on state, not on 500 ms

### DIFF
--- a/BGPLite.Tests/RefreshDebounceTests.cs
+++ b/BGPLite.Tests/RefreshDebounceTests.cs
@@ -44,7 +44,7 @@ public class RefreshDebounceTests
 
         public PeerRoutingView? LoadPeerRoutingView(string ip, uint asn)
         {
-            LoadCalls++;
+            Interlocked.Increment(ref LoadCalls);
             if (Armed)
                 Release.Wait(); // block the refresh cycle mid-flight (sync contract)
             return new PeerRoutingView("peer", [], [], [], []);
@@ -162,13 +162,33 @@ public class RefreshDebounceTests
 
         try
         {
-            // Task.Run is essential: until the gated Load the refresh chain has no incomplete
-            // await (locks free, loopback writes complete synchronously), so running it on the
-            // test thread would self-deadlock inside the gate before anyone can release it.
+            // Off the test thread: until the gated Load the refresh chain has no incomplete await
+            // (locks free, loopback writes complete synchronously), so calling it here would
+            // self-deadlock inside the gate before anyone could release it.
+            //
+            // #302: LongRunning rather than Task.Run. The caller that wins the CAS parks its thread
+            // inside the gated Load, and the thread pool then grows by roughly one thread per 500 ms
+            // — so on a contended 2-core CI runner the remaining callers did not all reach the CAS
+            // within the old 500 ms wall-clock wait. Each straggler arrived after the gate had been
+            // released and _refreshRunning reset, won its own CAS, and ran a FULL cycle: the observed
+            // failures were 3 and 4 loads against an expected 1-2. A dedicated thread per caller
+            // removes the dependency on pool growth entirely.
             var tasks = Enumerable.Range(0, 5)
-                .Select(_ => Task.Run(() => session.RefreshRoutesAsync(), CancellationToken.None))
+                .Select(_ => Task.Factory.StartNew(
+                    () => session.RefreshRoutesAsync(),
+                    CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default).Unwrap())
                 .ToArray();
-            await Task.Delay(500); // let the runner block inside the gated Load and the rest coalesce
+
+            // Wait for the state the assertions are about instead of guessing how long it takes.
+            // Both halves are facts the test can observe rather than hope for:
+            //   - LoadCalls == baseline + 1: the CAS winner is inside the gated Load, mid-cycle;
+            //   - four tasks completed: the other four lost the CAS, set _refreshPending and
+            //     returned — which is precisely "they have been coalesced", the thing the old
+            //     Task.Delay was standing in for.
+            await WaitForAsync(
+                () => Volatile.Read(ref store.LoadCalls) == baseline + 1 && CompletedCount(tasks) == 4,
+                () => $"loads={Volatile.Read(ref store.LoadCalls) - baseline} (want 1), " +
+                      $"callers returned={CompletedCount(tasks)} (want 4)");
 
             Assert.Equal(baseline + 1, Volatile.Read(ref store.LoadCalls)); // exactly ONE in-flight cycle
 
@@ -183,6 +203,33 @@ public class RefreshDebounceTests
         {
             store.Armed = false;
             store.Release.Set(); // never leak a blocked pool thread on an assertion failure
+        }
+    }
+
+    private static int CompletedCount(Task[] tasks)
+    {
+        var completed = 0;
+        foreach (var task in tasks)
+            if (task.IsCompleted) completed++;
+        return completed;
+    }
+
+    /// <summary>
+    /// Polls until <paramref name="condition"/> holds, failing with what was actually observed once
+    /// the deadline passes. A generous deadline is safe here precisely because it is never waited
+    /// out on a healthy run — unlike a fixed delay, which is waited out every time and is still too
+    /// short on the one run that matters (#302).
+    /// </summary>
+    private static async Task WaitForAsync(Func<bool> condition, Func<string> observed,
+        int timeoutMilliseconds = 30_000)
+    {
+        var deadline = Environment.TickCount64 + timeoutMilliseconds;
+        while (!condition())
+        {
+            if (Environment.TickCount64 > deadline)
+                Assert.Fail($"timed out after {timeoutMilliseconds} ms waiting for the refresh " +
+                            $"debounce to settle — {observed()}");
+            await Task.Delay(5);
         }
     }
 


### PR DESCRIPTION
Closes #302

Hit again on [PR #315](https://github.com/ruhex/BGPLite/pull/315) an hour ago, on a change that touches only the prefix aggregator. Two false reds now, on two unrelated PRs.

## What is actually wrong

The test starts five callers with `Task.Run`, sleeps 500 ms, then asserts the debounce coalesced them:

```csharp
var tasks = Enumerable.Range(0, 5)
    .Select(_ => Task.Run(() => session.RefreshRoutesAsync(), CancellationToken.None))
    .ToArray();
await Task.Delay(500); // let the runner block inside the gated Load and the rest coalesce
```

The sleep stands in for *"all five have reached the CAS"*, which a wall clock cannot establish. The caller that wins the CAS parks its thread inside the gated `LoadPeerRoutingView`, so the other four need the thread pool to grow. A straggler that arrives after the gate is released and `_refreshRunning` is back to `0` wins its own CAS and runs a **full cycle** — one more `LoadCalls` each.

Both CI failures fit that signature exactly: the mid-test checkpoint `Assert.Equal(baseline + 1, LoadCalls)` **passed** — one cycle was genuinely in flight, so the debounce did its job — and only the final bound failed.

| | |
|---|---|
| PR #301 | `Assert.InRange() Range (1 - 2), Actual: 4` |
| PR #315 | `Assert.InRange() Range (1 - 2), Actual: 3` |

**The product is not wrong.** `RefreshRoutesAsync` coalesces requests that are genuinely concurrent, which is what the checkpoint verifies. A request arriving after the previous cycle has fully completed *should* start a new one.

## Reproduced, then measured

The flake would not reproduce on this machine as-is, so I emulated the runner: `DOTNET_PROCESSOR_COUNT=2` plus 2–4 blocked pool work items, driving the **real** `BgpSession` and the same gated store — not a model of the debounce. 120 trials of each shape:

| shape | overshoot (`total > 2`) | breakdown |
|---|---:|---|
| old — `Task.Run` + `Task.Delay(500)` | **9 / 120** | 4× `total=3`, 5× `total=5` |
| new — dedicated threads + wait on state | **0 / 120** | all `total=2` |

`total=5` is the one worth looking at: no coalescing at all, every caller running its own withdraw + re-announce. In every failing trial `inFlightAtCheckpoint` was `1`, matching CI.

## The rewrite

Wait for the two facts the assertions are about, instead of guessing how long they take:

```csharp
await WaitForAsync(
    () => Volatile.Read(ref store.LoadCalls) == baseline + 1 && CompletedCount(tasks) == 4,
    () => $"loads={...} (want 1), callers returned={...} (want 4)");
```

- `LoadCalls == baseline + 1` — the CAS winner is inside the gated `Load`, mid-cycle.
- four tasks completed — the other four lost the CAS, set `_refreshPending` and returned. A loser returns immediately, and the winner cannot complete while the gate is held, so this is an observable fact rather than a hope. It is precisely "they have been coalesced", which is what the sleep was approximating.

Callers now get dedicated threads (`TaskCreationOptions.LongRunning`) rather than pool work items, so reaching the CAS does not depend on pool growth at all.

A generous 30 s deadline is safe here exactly because it is never waited out on a healthy run — unlike a fixed delay, which is paid on *every* run and is still too short on the one that matters. On failure it reports what it actually observed rather than just a range violation.

`Assert.InRange(total, 1, 2)` is kept as-is: `1` is still legal, because the winner's `_refreshPending = false` at the top of the do-loop can clear the losers' flag if they CAS before it runs. The bound that matters is the upper one.

Runtime: **~620 ms → ~70 ms**.

Also: `GatedCountingStore.LoadCalls` becomes an `Interlocked.Increment`. The fixture is shared with a second test and the field was read with `Volatile.Read` while being incremented non-atomically — benign in practice here, but it is the kind of thing this test should not be modelling badly.

No product change. The starved-pool probe was scratch scaffolding and is not committed; the numbers above are reproducible with `DOTNET_PROCESSOR_COUNT=2` and a few blocked pool work items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)