### PR TITLE
fix(api,server): terminate the deleted peer's live sessions before removing its row (#323)

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -377,7 +377,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (segments.Length == 3 && segments[0] == "api" && segments[1] == "peers" && method == "PUT")
             return await HandleUpdatePeer(segments[2], ctx);
         if (segments.Length == 3 && segments[0] == "api" && segments[1] == "peers" && method == "DELETE")
-            return HandleDeletePeer(segments[2]);
+            return await HandleDeletePeer(segments[2]);
 
         // /api/peers/{id}/prefixes
         if (segments.Length == 4 && segments[0] == "api" && segments[1] == "peers" && segments[3] == "prefixes" && method == "GET")
@@ -778,11 +778,21 @@ public sealed class ManagementApi : IHostedService, IDisposable
         return HandleGetPeer(peerId);
     }
 
-    private ApiResponse HandleDeletePeer(string peerId)
+    internal async Task<ApiResponse> HandleDeletePeer(string peerId)
     {
         var peer = _store.GetDbPeerById(peerId);
         if (peer is null)
             return ApiResponse.Error("Peer not found", 404);
+
+        // #323: terminate the peer's live session(s) BEFORE the row is deleted. Terminating first
+        // stops the advertisement immediately; RouteAssembler's unknown-peer branch refuses to
+        // auto-register once the session token is cancelled (Dispose runs before the row goes
+        // away), so a refresh that straddles the teardown cannot resurrect the deleted peer. The
+        // 10 s bound keeps a slow peer (full TCP receive window — the Cease send can block on the
+        // send-timeout backstop) from pinning the DELETE request; the session is disposed even
+        // when the Cease send is cancelled.
+        using var bound = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await _sessionManager.TerminatePeerAsync(peer.Ip, peer.Asn ?? 0, bound.Token);
 
         _store.DeletePeer(peerId);
         _logger.LogInformation("Deleted peer {Id} ({Ip})", SanitizeForLog(peerId), peer.Ip);

--- a/BGPLite.Contracts/ISessionManager.cs
+++ b/BGPLite.Contracts/ISessionManager.cs
@@ -12,4 +12,16 @@ public interface ISessionManager
     int GetAdvertisedPrefixCount(string peerIp, uint asn);
     /// <summary>#214: Refresh ALL established sessions (unsolicited UPDATE to every peer).</summary>
     Task RefreshAllEstablishedAsync();
+
+    /// <summary>
+    /// Terminates all live BGP sessions for the peer identified by (ip, asn) (#323): established
+    /// sessions are sent exactly one Cease (Administrative Reset) NOTIFICATION, then every matching
+    /// session's connection is disposed — the peer's advertised routes are withdrawn by the normal
+    /// session teardown. Used by the management API when a peer is deleted, so a deleted peer's
+    /// feed stops immediately instead of surviving until the peer disconnects. Sibling sessions
+    /// with a different ASN on the same source IP are untouched (#200 semantics). The token bounds
+    /// the whole Cease phase and is shared across matching sessions — with several sessions, later
+    /// ones may be disposed without their Cease completing; sessions are disposed regardless.
+    /// </summary>
+    Task TerminatePeerAsync(string peerIp, uint asn, CancellationToken ct = default);
 }

--- a/BGPLite.Server/BgpServer.cs
+++ b/BGPLite.Server/BgpServer.cs
@@ -333,6 +333,49 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
             await session.RefreshRoutesAsync();
     }
 
+    public async Task TerminatePeerAsync(string peerIp, uint asn, CancellationToken ct = default)
+    {
+        // Same (ip, asn) matching as RefreshPeerAsync (#200): a NAT/shared-IP sibling session with
+        // a different ASN must survive a peer deletion.
+        if (!IPAddress.TryParse(peerIp, out var ip))
+        {
+            _logger.LogWarning("TerminatePeer: invalid IP {Ip}", peerIp);
+            return;
+        }
+
+        var sessions = _sessions
+            .Where(kvp => kvp.Key.Address.Equals(ip) && kvp.Value.RemoteAsn == asn)
+            .Select(kvp => kvp.Value)
+            .ToList();
+
+        if (sessions.Count == 0)
+            return;
+
+        _logger.LogInformation("Terminating {Count} session(s) for {Ip} AS{Asn} (peer deleted)",
+            sessions.Count, peerIp, asn);
+        await TerminateSessionsAsync(sessions, ct);
+    }
+
+    /// <summary>
+    /// The #323 teardown core, split out so tests can drive real sessions without a live BgpServer
+    /// (sessions enter <see cref="_sessions"/> only through the accept loop, which binds port 179).
+    /// Established sessions get exactly one Cease (Administrative Reset) — NotifyCeaseAsync
+    /// CAS-latches the teardown reason, so the session's own finally-block cannot double-send —
+    /// and then every session is disposed. The dictionary is left alone: RunSessionAsync's
+    /// compare-and-remove unwinds each entry, exactly like session replacement. Unlike StopAsync,
+    /// the Cease is sent even when Graceful Restart is enabled: a deleted peer is a permanent
+    /// removal, not a restart we will return from, and a NOTIFICATION termination is what makes
+    /// the peer flush our routes instead of retaining them (RFC 4724 §4).
+    /// </summary>
+    internal static async Task TerminateSessionsAsync(IReadOnlyList<BgpSession> sessions, CancellationToken ct)
+    {
+        foreach (var session in sessions.Where(s => s.IsEstablished))
+            await session.NotifyCeaseAsync(ct);   // best-effort: swallows send/IO failures internally
+
+        foreach (var session in sessions)
+            session.Dispose();
+    }
+
     public List<string> GetActivePeerIps() =>
         _sessions.Where(kvp => kvp.Value.IsEstablished)
                  .Select(kvp => kvp.Key.Address.ToString())

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -1290,7 +1290,9 @@ public sealed class BgpSession : IDisposable
     /// Best-effort Cease NOTIFICATION for graceful shutdown (RFC 4271 §6.2). The caller (BgpServer)
     /// should only invoke this on an Established session and only when Graceful Restart is disabled —
     /// a NOTIFICATION termination bypasses GR (RFC 4724 §4), so with GR on we drop the TCP connection
-    /// instead to let peers retain our routes. Write/IO errors are swallowed (we are shutting down).
+    /// instead to let peers retain our routes. The one GR-on exception is peer deletion (#323, D16):
+    /// a deleted peer is a permanent removal, not a restart, so the Cease is what tells the peer to
+    /// flush our routes. Write/IO errors are swallowed (we are shutting down).
     /// Accepts a <see cref="CancellationToken"/> so the host's shutdown grace can bound how long a
     /// single Cease send blocks (a slow/stuck peer otherwise pins the send lock indefinitely).
     /// </summary>

--- a/BGPLite.Server/RouteAssembler.cs
+++ b/BGPLite.Server/RouteAssembler.cs
@@ -237,6 +237,16 @@ public sealed class RouteAssembler : IRouteAssembler
         }
         else
         {
+            // A cancelled token here means the session is being torn down (Dispose cancels its
+            // token before a peer deletion removes the row, #323) — a refresh or initial dump that
+            // straddles the Dispose must not auto-register the just-deleted peer back into the
+            // store. Shutdown (StopAsync) cancels the same token, so the gate covers it too.
+            if (ct.IsCancellationRequested)
+            {
+                _logger.LogInformation("Cancelled build for unknown peer {Ip} — not auto-registering", peerLabel);
+                return FilterAndReturn(routes, filterPeerConfig);
+            }
+
             // Unknown peer — auto-register and send default RU list.
             _logger.LogInformation("Unknown peer {Ip}, auto-registering with RU defaults", peerLabel);
             _peerStore.CreatePeer(peerIp, remoteAsn, null);

--- a/BGPLite.Tests/ConfigHotReloadTests.cs
+++ b/BGPLite.Tests/ConfigHotReloadTests.cs
@@ -325,6 +325,7 @@ public class ConfigHotReloadTests
         public List<string> GetActivePeerIps() => [];
         public int GetAdvertisedPrefixCount(string peerIp, uint asn) => 0;
         public Task RefreshAllEstablishedAsync() => Task.CompletedTask;
+        public Task TerminatePeerAsync(string peerIp, uint asn, CancellationToken ct = default) => Task.CompletedTask;
     }
 
     private sealed class ApiHarness : IDisposable

--- a/BGPLite.Tests/PeerDeleteTeardownTests.cs
+++ b/BGPLite.Tests/PeerDeleteTeardownTests.cs
@@ -165,7 +165,8 @@ public sealed class PeerDeleteTeardownTests
     private static BgpOpenMessage PeerOpen(uint asn) => new()
     {
         Version = BgpConstants.BgpVersion,
-        Asn = (ushort)asn,
+        // RFC 6793 §4.1: the 2-octet My-AS field carries AS_TRANS when the ASN needs 4 octets.
+        Asn = (ushort)(asn > ushort.MaxValue ? BgpConstants.AsPath.AsTrans : asn),
         HoldTime = 0,
         RouterId = 0x0A000002,
         Capabilities = [BgpCapabilityInfo.FourOctetAsn(asn)],

--- a/BGPLite.Tests/PeerDeleteTeardownTests.cs
+++ b/BGPLite.Tests/PeerDeleteTeardownTests.cs
@@ -1,0 +1,271 @@
+using BGPLite.Api;
+using BGPLite.Configuration;
+using BGPLite.Contracts;
+using BGPLite.Protocol;
+using BGPLite.Providers;
+using BGPLite.Routing;
+using BGPLite.Server;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #323: deleting a peer through the management API must terminate its live BGP session(s) before
+/// the row is deleted — otherwise the session keeps advertising, and the next refresh lands in
+/// RouteAssembler's unknown-peer branch and re-creates the just-deleted row (auto-register).
+/// </summary>
+public sealed class PeerDeleteTeardownTests
+{
+    // ---- management API: terminate-before-delete ordering ----
+
+    [Fact]
+    public async Task DeletePeer_TerminatesSession_BeforeDeletingRow()
+    {
+        using var connection = NewOpenConnection();
+        var store = NewStore(connection);
+        var peerId = store.CreatePeer("203.0.113.7", 65002, null);
+        // At terminate time the row must still exist — that ordering is what keeps a dying
+        // session's in-flight refresh away from the auto-register branch.
+        var manager = new RecordingSessionManager((_, _) => Assert.NotNull(store.GetDbPeerById(peerId)));
+        using var api = NewApi(store, manager);
+
+        var response = await api.HandleDeletePeer(peerId);
+
+        Assert.Equal(200, response.StatusCode);
+        var terminated = Assert.Single(manager.Terminated);
+        Assert.Equal("203.0.113.7", terminated.Ip);
+        Assert.Equal(65002u, terminated.Asn);
+        Assert.Null(store.GetDbPeerById(peerId));
+    }
+
+    [Fact]
+    public async Task DeletePeer_UnknownPeer_Returns404_AndDoesNotTerminate()
+    {
+        using var connection = NewOpenConnection();
+        var manager = new RecordingSessionManager();
+        using var api = NewApi(NewStore(connection), manager);
+
+        var response = await api.HandleDeletePeer("00000000-0000-0000-0000-000000000000");
+
+        Assert.Equal(404, response.StatusCode);
+        Assert.Empty(manager.Terminated);
+    }
+
+    // ---- server: the teardown core over real scripted sessions ----
+
+    [Fact]
+    public async Task TerminateSessions_Established_SendsExactlyOneCease_AndUnwinds()
+    {
+        var (session, run, conn) = await EstablishScriptedSessionAsync();
+        try
+        {
+            await BgpServer.TerminateSessionsAsync([session], CancellationToken.None);
+
+            // Exactly one NOTIFICATION beyond the handshake frames: Cease / Administrative Reset.
+            var notification = conn.Sent
+                .Select(f => BgpMessageReader.ReadMessage(f))
+                .OfType<BgpNotificationMessage>()
+                .Single();
+            Assert.Equal(BgpConstants.Error.Cease, notification.ErrorCode);
+            Assert.Equal(BgpConstants.SubError.CeaseAdministrativeReset, notification.SubErrorCode);
+
+            await WaitUntilRunCompletesAsync(run);
+        }
+        finally
+        {
+            session.Dispose();
+            conn.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task TerminateSessions_NonEstablished_UnwindsWithoutNotification()
+    {
+        var conn = new ScriptedConnection();
+        var session = NewSession(conn);
+        var run = session.RunAsync();
+        try
+        {
+            // Peer OPEN only — no KEEPALIVE, so the session parks in OpenConfirm, never Established.
+            conn.EnqueueMessage(PeerOpen(65003));
+            for (var i = 0; i < 200 && session.State != BgpFsmState.OpenConfirm; i++)
+                await Task.Delay(TimeSpan.FromMilliseconds(10));
+            Assert.Equal(BgpFsmState.OpenConfirm, session.State);
+
+            await BgpServer.TerminateSessionsAsync([session], CancellationToken.None);
+
+            // wasEstablished is false, so teardown must not emit any NOTIFICATION.
+            Assert.DoesNotContain(conn.Sent, f => BgpMessageReader.ReadMessage(f) is BgpNotificationMessage);
+            await WaitUntilRunCompletesAsync(run);
+        }
+        finally
+        {
+            session.Dispose();
+            conn.Dispose();
+        }
+    }
+
+    // ---- RouteAssembler: no auto-register for a dying session (#323 resurrection guard) ----
+
+    [Fact]
+    public async Task BuildOutboundRoutes_CancelledToken_UnknownPeer_DoesNotAutoRegister()
+    {
+        using var connection = NewOpenConnection();
+        var store = NewStore(connection);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var routes = await NewAssembler(store).BuildOutboundRoutesAsync(
+            "203.0.113.9", 65002, new PeerConfig { Address = "203.0.113.9" }, "203.0.113.9", cts.Token);
+
+        Assert.Empty(routes);
+        Assert.Empty(store.GetPeersByIp("203.0.113.9"));   // no resurrection of a deleted peer
+    }
+
+    [Fact]
+    public async Task BuildOutboundRoutes_LiveToken_UnknownPeer_StillAutoRegisters()
+    {
+        using var connection = NewOpenConnection();
+        var store = NewStore(connection);
+
+        await NewAssembler(store).BuildOutboundRoutesAsync(
+            "203.0.113.9", 65002, new PeerConfig { Address = "203.0.113.9" }, "203.0.113.9", CancellationToken.None);
+
+        // Control (D11 behavior): a live unknown peer is still auto-registered.
+        Assert.Single(store.GetPeersByIp("203.0.113.9"));
+    }
+
+    // ---- harness ----
+
+    /// <summary>RunAsync may unwind via cancellation or via the scripted closed connection — both are completions; only a hang fails the test.</summary>
+    private static async Task WaitUntilRunCompletesAsync(Task run)
+    {
+        try { await run.WaitAsync(TimeSpan.FromSeconds(5)); }
+        catch (OperationCanceledException) { /* unwound via cancellation */ }
+        catch (IOException) { /* unwound via the scripted closed connection */ }
+    }
+
+    private static async Task<(BgpSession Session, Task Run, ScriptedConnection Conn)> EstablishScriptedSessionAsync()
+    {
+        var conn = new ScriptedConnection();
+        var session = NewSession(conn);
+        var run = session.RunAsync();
+
+        conn.EnqueueMessage(PeerOpen(65002));
+        conn.EnqueueMessage(BgpKeepaliveMessage.Instance);
+
+        for (var i = 0; i < 200 && !session.IsEstablished; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        Assert.True(session.IsEstablished, "session must reach Established");
+        return (session, run, conn);
+    }
+
+    private static BgpOpenMessage PeerOpen(uint asn) => new()
+    {
+        Version = BgpConstants.BgpVersion,
+        Asn = (ushort)asn,
+        HoldTime = 0,
+        RouterId = 0x0A000002,
+        Capabilities = [BgpCapabilityInfo.FourOctetAsn(asn)],
+    };
+
+    private static BgpSession NewSession(ScriptedConnection conn) => new(
+        conn,
+        new PeerConfig { Address = "127.0.0.1" },
+        new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 },
+        new RouteTable(),
+        AllowAllFilter.Instance,
+        new BgpMetrics(),
+        NullLogger<BgpSession>.Instance);
+
+    private static SqliteConnection NewOpenConnection()
+    {
+        var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        using (var boot = new BgpDbContext(new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(connection).Options))
+            BgpDbContext.Initialize(boot);
+        return connection;
+    }
+
+    private static PeerStore NewStore(SqliteConnection connection) =>
+        new(new StaticOptionsFactory(new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(connection).Options));
+
+    private static ManagementApi NewApi(PeerStore store, ISessionManager sessionManager) => new(
+        store,
+        new RouteTable(),
+        new AppConfig(),
+        new BgpMetrics(),
+        NullLogger<ManagementApi>.Instance,
+        new InertPrefixService(),
+        new InertPrefixSourceService(),
+        sessionManager);
+
+    private static RouteAssembler NewAssembler(PeerStore store)
+    {
+        var config = new AppConfig { Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" } };
+        return new RouteAssembler(
+            new InertPrefixService(),
+            store,
+            new ConfigCommunityResolver(config, config.Bgp),
+            AllowAllFilter.Instance,
+            config,
+            config.Bgp,
+            NullLogger<RouteAssembler>.Instance);
+    }
+
+    /// <summary>Records TerminatePeerAsync calls; the optional hook runs at call time (row-state assertions).</summary>
+    private sealed class RecordingSessionManager(Action<string, uint>? onTerminate = null) : ISessionManager
+    {
+        public List<(string Ip, uint Asn)> Terminated { get; } = [];
+
+        public Task RefreshPeerAsync(string peerIp, uint asn) => Task.CompletedTask;
+        public List<string> GetActivePeerIps() => [];
+        public int GetAdvertisedPrefixCount(string peerIp, uint asn) => 0;
+        public Task RefreshAllEstablishedAsync() => Task.CompletedTask;
+
+        public Task TerminatePeerAsync(string peerIp, uint asn, CancellationToken ct = default)
+        {
+            Terminated.Add((peerIp, asn));
+            onTerminate?.Invoke(peerIp, asn);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class StaticOptionsFactory(DbContextOptions<BgpDbContext> options) : IDbContextFactory<BgpDbContext>
+    {
+        public BgpDbContext CreateDbContext() => new(options);
+    }
+
+    /// <summary>Answers every prefix query with an empty set; the delete path never calls it.</summary>
+    private sealed class InertPrefixService : IPrefixService
+    {
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
+            => Task.FromResult(new List<(uint Prefix, byte Length, uint Asn)>());
+        public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
+        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
+            => Task.FromResult(new List<(uint Prefix, byte Length, uint Asn)>());
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    /// <summary>Reports no configured prefix sources; the delete path never calls it.</summary>
+    private sealed class InertPrefixSourceService : IPrefixSourceService
+    {
+        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<(uint Prefix, byte Length)>)>>([]);
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetDefaultAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);
+        public bool SourceSupportsConditional(string sourceName) => false;
+    }
+}

--- a/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
+++ b/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
@@ -51,6 +51,7 @@ public class PrefixAutoRefreshServiceTests
         public List<string> GetActivePeerIps() => [];
         public int GetAdvertisedPrefixCount(string peerIp, uint asn) => 0;
         public Task RefreshAllEstablishedAsync() { RefreshAllCalls++; return Task.CompletedTask; }
+        public Task TerminatePeerAsync(string peerIp, uint asn, CancellationToken ct = default) => Task.CompletedTask;
     }
 
     private static AppConfig ConfigWith(AutoRefreshConfig autoRefresh, params (string Name, string Kind)[] sources)

--- a/BGPLite.Tests/RouteSeedingServiceTests.cs
+++ b/BGPLite.Tests/RouteSeedingServiceTests.cs
@@ -57,6 +57,7 @@ public class RouteSeedingServiceTests
         public List<string> GetActivePeerIps() => [];
         public int GetAdvertisedPrefixCount(string peerIp, uint asn) => 0;
         public Task RefreshAllEstablishedAsync() { RefreshAllCalls++; return Task.CompletedTask; }
+        public Task TerminatePeerAsync(string peerIp, uint asn, CancellationToken ct = default) => Task.CompletedTask;
     }
 
     private static RouteSeedingService NewService(

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -146,3 +146,17 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
   stably to guarantee it for any producer (#272).
 - **Consequence:** attribute order is a convention, not a wire requirement — parsers must not rely on it.
 - **Tracker:** #87, #272 (closed).
+
+### D16. Peer deletion sends Cease even with Graceful Restart enabled
+- **Decision:** `ISessionManager.TerminatePeerAsync` (management-API peer deletion) sends a Cease
+  (Administrative Reset) to the peer's established sessions even when Graceful Restart is enabled —
+  unlike `StopAsync`, which silent-closes under GR.
+- **Context:** GR retention exists so peers keep our routes across a restart we will return from
+  (RFC 4724 §4). Deleting a peer is a permanent removal, not a restart — retention would leave stale
+  routes at the peer until its restart timer expired, so the NOTIFICATION termination (which bypasses
+  GR and makes the peer flush) is the correct signal (#323).
+- **Consequence:** deletion is not a revocation: nothing stops the peer from reconnecting, and D11
+  auto-registration serves it again on the next OPEN (a deny-list is a separate product decision).
+  Pre-OPEN connections (remote ASN not yet known) are not matched by the (ip, asn) termination and
+  may re-register the row once their OPEN arrives.
+- **Tracker:** #323.


### PR DESCRIPTION
Closes #323

## Problem

`DELETE /api/peers/{id}` was a pure DB operation. The peer's live BGP session kept advertising, already-advertised prefixes were never withdrawn, and the next refresh (peer ROUTE_REFRESH, auto-refresh tick, `onSourceChanged`, or the `RefreshPeerAsync` fired by a PATCH on any peer) hit RouteAssembler's unknown-peer auto-register branch (`LoadPeerRoutingView == null` → `CreatePeer`) — the deleted peer came back with default config and a full RU dump.

## Fix

1. **`ISessionManager.TerminatePeerAsync(ip, asn, ct)`** (Contracts; implemented in `BgpServer`): sends exactly one Cease (Administrative Reset) to each matching **established** session (`NotifyCeaseAsync` CAS-latches the teardown reason, so the session's finally-block cannot double-send), then disposes every matching session — the peer's routes are withdrawn by the normal session teardown (`RemoveAllOwnedBy`), and the dictionary entry unwinds via `RunSessionAsync`'s compare-and-remove, exactly like session replacement. Same (ip, asn) matching as `RefreshPeerAsync` (#200: a NAT sibling with a different ASN survives).
2. **`HandleDeletePeer`** terminates **before** deleting the row, with a 10 s bound on the Cease phase so a slow peer (full TCP window → send-timeout backstop) cannot pin the DELETE request; sessions are disposed even when the Cease send is cancelled. If termination throws, the row is not deleted (fail-safe 500).
3. **RouteAssembler guard**: the unknown-peer auto-register branch refuses to `CreatePeer` once the caller's token is cancelled. This closes the straddle window found in review — a refresh that already holds `_advertisedPrefixesLock` reaches `LoadPeerRoutingView` after the row is gone; since Dispose (which cancels the session token) runs strictly before the row delete, the gate sees the cancelled token and bails. Covers the initial-send path the same way. D11 auto-registration for live sessions is unchanged (control test).
4. **D16** (docs/DESIGN_DECISIONS.md): Cease is sent even with Graceful Restart enabled — deletion is a permanent removal, not a restart we return from; RFC 4724 §4 requires normal procedures (route flush) for NOTIFICATION-terminated sessions. `NotifyCeaseAsync`'s XML doc now records the exception.

## Known residual (deliberate, D16)

Deletion is **not a revocation**: nothing stops the peer from reconnecting, and D11 auto-registration serves it again on the next OPEN (deny-list = separate product decision). Pre-OPEN connections (remote ASN not yet learned) are not matched by (ip, asn) termination. The issue's part-2 "soft-delete / DeletedAt" suggestion is superseded by the assembler guard for the live-session race and would only matter for the reconnect case, which is a D11 product decision.

## Verification

- `dotnet build BGPLite.sln` — 0 errors.
- `dotnet test BGPLite.sln` — **760/760** passed (758 pre-existing + 6 new).
- New `PeerDeleteTeardownTests`: terminate-before-delete ordering (row still present at terminate time — verified **red** on the old behavior by temporarily reverting the handler change), 404 path does not terminate, established session receives exactly one Cease (Administrative Reset) and unwinds, non-established session unwinds without any NOTIFICATION, cancelled token does not auto-register / live token still auto-registers (D11 control).
- Red/green: `DeletePeer_TerminatesSession_BeforeDeletingRow` fails on old code (terminate never called); the assembler pair proves the gate is what prevents resurrection (control test shows the same store observation detects an insert).
- Reviewer: PRISTINE (second pass; the first-pass MAJOR — the straddle race — is fixed by the assembler guard above, MINORs fixed: shared 10 s budget documented, `NotifyCeaseAsync` doc + D16, RFC 4724 §4 citation verified against the RFC text).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting a peer now immediately terminates its active BGP sessions and withdraws advertised routes.
  * Established sessions receive a single administrative reset notification before disconnecting.
  * Prevented cancelled refresh operations from recreating deleted peers.
  * Sessions belonging to other peers at the same IP remain unaffected.

* **Documentation**
  * Clarified peer deletion behavior when graceful restart is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->