### PR TITLE
fix(protocol): reject an unrecognized well-known path attribute with subcode 2 (#322)

### DIFF
--- a/BGPLite.Protocol/UpdateCodec.cs
+++ b/BGPLite.Protocol/UpdateCodec.cs
@@ -200,7 +200,7 @@ public static class UpdateCodec
     /// mandatory well-known set (ORIGIN/AS_PATH/NEXT_HOP), AS4_PATH trailing-sequence
     /// reconstruction, and AGGREGATOR/AS4_AGGREGATOR consistency. On a 4-octet session
     /// (<paramref name="fourByteAsnSession"/>) AS4_PATH/AS4_AGGREGATOR are skipped per RFC 6793 §4.1.
-    /// Throws <see cref="BgpNotificationException"/> carrying the RFC subcode (3/6/8/9/11) so the
+    /// Throws <see cref="BgpNotificationException"/> carrying the RFC subcode (2/3/4/5/6/8/9/11) so the
     /// caller can apply treat-as-withdraw (RFC 7606) — the exact pipeline previously inlined in
     /// BgpSession.HandleUpdateAsync, moved verbatim (#270).
     /// </summary>
@@ -249,6 +249,20 @@ public static class UpdateCodec
                 // never shape-checked. RFC 7606 §3 says those occurrences are discarded, not
                 // "discarded but still validated" — checking them would reject an UPDATE over an
                 // attribute that has no effect on the result (#287 + #290).
+                //
+                // RFC 4271 §6.3 (#322): an attribute with the Optional bit clear that this codec
+                // does not recognize has unknown well-known semantics — it MUST be rejected with
+                // Unrecognized Well-known Attribute (subcode 2), never silently ignored. Only
+                // unrecognized OPTIONAL attributes may be discarded (RFC 7606 §2), and those fall
+                // through untouched here. The throw routes through the caller's treat-as-withdraw,
+                // not a session reset. Known-but-unread attributes (LOCAL_PREF,
+                // ATOMIC_AGGREGATE; MED is optional) pass IsKnownAttribute and stay accepted —
+                // over-rejecting those was the #290 lesson.
+                if (!attr.Optional && !AttributeHelper.IsKnownAttribute(attr.TypeCode))
+                    throw new BgpNotificationException(
+                        BgpConstants.Error.UpdateMessageError,
+                        BgpConstants.SubError.UnrecognizedWellKnownAttribute,
+                        $"Unrecognized well-known path attribute type {attr.TypeCode}");
                 ValidateAttributeShape(attr, fourByteAsnSession);
 
                 switch (attr.TypeCode)

--- a/BGPLite.Tests/BgpSessionRfc6793Tests.cs
+++ b/BGPLite.Tests/BgpSessionRfc6793Tests.cs
@@ -107,6 +107,75 @@ public class BgpSessionRfc6793Tests
     }
 
     [Fact]
+    public void ParseRouteAttributes_UnrecognizedWellKnownAttribute_ThrowsSubcode2()
+    {
+        // RFC 4271 §6.3 / #322: an Optional=0 attribute of an unknown type code must be rejected
+        // (subcode 2) — routes must not install with unknown well-known semantics attached.
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+                AttributeHelper.WriteAsPath([65001u], fourByteAsn: true),
+                AttributeHelper.WriteNextHop(0x0A000001),
+                new PathAttribute { Flags = BgpConstants.Attribute.FlagTransitive, TypeCode = 99, Data = [0x01] },
+            ],
+            Nlri = []
+        };
+
+        var ex = Assert.Throws<BgpNotificationException>(() => UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: true));
+
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.UnrecognizedWellKnownAttribute, ex.SubErrorCode);
+    }
+
+    [Fact]
+    public void ParseRouteAttributes_UnrecognizedOptionalAttribute_StillParses()
+    {
+        // RFC 4271 §6.3: only unrecognized WELL-KNOWN attributes are rejected; an unrecognized
+        // optional attribute is ignored (BGPLite re-originates everything it advertises, so there
+        // is nothing to propagate with the Partial bit).
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+                AttributeHelper.WriteAsPath([65001u], fourByteAsn: true),
+                AttributeHelper.WriteNextHop(0x0A000001),
+                new PathAttribute { Flags = BgpConstants.Attribute.FlagOptional | BgpConstants.Attribute.FlagTransitive, TypeCode = 99, Data = [0x01] },
+            ],
+            Nlri = []
+        };
+
+        var attrs = UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: true);
+
+        Assert.Equal([65001u], attrs.AsPath);
+    }
+
+    [Fact]
+    public void ParseRouteAttributes_KnownButUnreadWellKnownAttributes_StillAccepted()
+    {
+        // #290 guard for the #322 check: LOCAL_PREF (type 5) and ATOMIC_AGGREGATE (type 6) are
+        // well-known attributes this codec never reads — they must not start being rejected.
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+                AttributeHelper.WriteAsPath([65001u], fourByteAsn: true),
+                AttributeHelper.WriteNextHop(0x0A000001),
+                new PathAttribute { Flags = BgpConstants.Attribute.FlagTransitive, TypeCode = BgpConstants.Attribute.LocalPref, Data = [0x00, 0x00, 0x00, 0x64] },
+                new PathAttribute { Flags = BgpConstants.Attribute.FlagTransitive, TypeCode = BgpConstants.Attribute.AtomicAggregate, Data = [] },
+            ],
+            Nlri = []
+        };
+
+        var attrs = UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: true);
+
+        Assert.Equal([65001u], attrs.AsPath);
+    }
+
+    [Fact]
     public void ParseRouteAttributes_InvalidOriginValue_ThrowsSubcode6()
     {
         var update = new BgpUpdateMessage
@@ -575,17 +644,19 @@ public class BgpSessionRfc6793Tests
     }
 
     /// <summary>
-    /// An unrecognized attribute is not shape-checked — RFC 7606 §3 leaves those to the
+    /// An unrecognized OPTIONAL attribute is not shape-checked — RFC 7606 §3 leaves those to the
     /// optional/transitive propagation rules. Validating attributes the codec never reads would
-    /// only create new ways to reject an UPDATE a conformant implementation accepts.
+    /// only create new ways to reject an UPDATE a conformant implementation accepts. The
+    /// well-known half of an unknown type code is different since #322: Optional=0 now rejects
+    /// with subcode 2 (see <see cref="ParseRouteAttributes_UnrecognizedWellKnownAttribute_ThrowsSubcode2"/>).
     /// </summary>
     [Fact]
     public void ParseRouteAttributes_UnrecognizedAttribute_IsNotShapeChecked()
     {
         var update = UpdateWith(new PathAttribute
         {
-            Flags = 0x00,          // neither optional nor transitive — nonsense for an unknown type
-            TypeCode = 200,        // unassigned
+            Flags = BgpConstants.Attribute.FlagOptional | BgpConstants.Attribute.FlagTransitive,
+            TypeCode = 200,        // unassigned, but OPTIONAL — ignored, never shape-checked
             Data = [1, 2, 3],
         });
 

--- a/BGPLite.Tests/MalformedUpdateResilienceTests.cs
+++ b/BGPLite.Tests/MalformedUpdateResilienceTests.cs
@@ -272,6 +272,68 @@ public class MalformedUpdateResilienceTests
         await runTask.WaitAsync(TimeSpan.FromSeconds(5));
     }
 
+    [Fact]
+    public async Task UnknownWellKnownAttribute_TreatedAsWithdraw_KeepsSessionAlive()
+    {
+        // #322 / RFC 4271 §6.3: an UPDATE carrying an unrecognized WELL-KNOWN attribute (Optional
+        // bit clear, unknown type code) must be rejected with subcode 2 and handled by
+        // treat-as-withdraw: the UPDATE's NLRI leaves the table, the session survives, no
+        // NOTIFICATION. Previously the attribute was silently ignored and the route installed.
+        var (server, client) = ConnectedPair();
+        using var clientSock = client;
+        var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
+        var metrics = new BgpMetrics();
+        var routeTable = new RouteTable();
+        using var session = new BgpSession(
+            new SocketBgpConnection(server),
+            new PeerConfig { Address = "127.0.0.1" },
+            bgpConfig,
+            routeTable,
+            AllowAllFilter.Instance,
+            metrics,
+            new NopLogger<BgpSession>());
+
+        var runTask = await EstablishSessionAsync(session, client, bgpConfig);
+
+        // 1) A well-formed announcement of 10.0.0.0/8 via 192.0.2.1 (4-octet session → AS_PATH
+        //    is 4-octet encoded).
+        var good = new List<byte>
+        {
+            0x40, 0x01, 0x01, 0x00,                                 // ORIGIN igp
+            0x40, 0x02, 0x06, 0x02, 0x01, 0x00, 0x00, 0x00, 0x64,   // AS_PATH seq [100]
+            0x40, 0x03, 0x04, 0xC0, 0x00, 0x02, 0x01,               // NEXT_HOP 192.0.2.1
+        };
+        SendAll(client, AnnounceFrame(good));
+
+        for (var i = 0; i < 40 && routeTable.Count == 0; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(50));
+        Assert.NotNull(routeTable.Get(0x0A000000, 8));
+
+        // 2) The same NLRI re-announced with an unrecognized well-known attribute (type 99,
+        //    flags 0x40) attached — the UPDATE is rejected and treat-as-withdraw removes the prefix.
+        var bad = new List<byte>
+        {
+            0x40, 0x01, 0x01, 0x00,
+            0x40, 0x02, 0x06, 0x02, 0x01, 0x00, 0x00, 0x00, 0x64,
+            0x40, 0x03, 0x04, 0xC0, 0x00, 0x02, 0x01,
+            0x40, 0x63, 0x01, 0x00,                                 // type 99, well-known (Optional=0), 1 data byte
+        };
+        SendAll(client, AnnounceFrame(bad));
+
+        for (var i = 0; i < 40 && metrics.UpdatesRejected == 0; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(50));
+
+        Assert.Null(routeTable.Get(0x0A000000, 8));  // the re-announced NLRI was withdrawn, not installed
+        Assert.True(session.IsEstablished, "an unrecognized well-known attribute must not reset the session");
+        Assert.Equal(1, metrics.UpdatesRejected);
+
+        var sent = await DrainAsync(client, TimeSpan.FromSeconds(2));
+        Assert.DoesNotContain(sent, m => m is BgpNotificationMessage);
+
+        session.MarkSilentClose();
+        await runTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
     /// <summary>
     /// Writes the whole frame. <see cref="Socket.Send(byte[], SocketFlags)"/> may accept fewer bytes
     /// than requested, which would deliver a truncated UPDATE and fail the test somewhere other than


### PR DESCRIPTION
Closes #322

## Problem

`ParseRouteAttributes` silently skipped any type code it did not know: `ExpectedAttributeShape` returned `null` (`UpdateCodec.cs` `_ => null`), `ValidateAttributeShape` early-returned, and the attribute switch had no default branch. An UPDATE carrying a **well-known** attribute (Optional bit = 0) of an unknown type installed its NLRI with the attribute's semantics ignored — no log, no NOTIFICATION. RFC 4271 §6.3 mandates the Unrecognized Well-known Attribute error (subcode 2); RFC 7606 lowers the remedy to treat-as-withdraw. `BgpConstants.SubError.UnrecognizedWellKnownAttribute` was declared but never used — the check was planned, not implemented.

## Fix

One guard in `ParseRouteAttributes`, after the #287 duplicate guard and before #290 shape validation:

```csharp
if (!attr.Optional && !AttributeHelper.IsKnownAttribute(attr.TypeCode))
    throw new BgpNotificationException(UpdateMessageError, UnrecognizedWellKnownAttribute, ...);
```

It lands in the **existing** RFC 7606 treat-as-withdraw path (same as Missing Well-known / Attribute Flags Error): the UPDATE's NLRI is withdrawn, `UpdatesRejected` increments, the session stays up, no NOTIFICATION.

Deliberate scope split (the over-rejection lesson of #290):
- unrecognized **optional** attribute → still ignored (RFC 7606 §2);
- known-but-unread well-known attributes (**LOCAL_PREF, ATOMIC_AGGREGATE**; MED is optional) → still accepted — guarded by a dedicated test;
- the #290 fixture `ParseRouteAttributes_UnrecognizedAttribute_IsNotShapeChecked` used `Flags = 0x00` (i.e. well-known) for its unknown attribute — updated to optional flags so it guards the surviving #290 invariant, with the doc comment linking to the new well-known test.

## Verification

- `dotnet build BGPLite.sln` — 0 errors; `dotnet test BGPLite.sln` — **764/764**.
- Red on old code is proven by the #290 fixture itself: before this change an UPDATE with `Flags=0x00, TypeCode=200` parsed successfully (that fixture failed red the moment the guard landed).
- New tests: direct `ParseRouteAttributes` → 3/2; unrecognized optional still parses; LOCAL_PREF + ATOMIC_AGGREGATE still accepted; wire-level (`MalformedUpdateResilienceTests`) — established session, good announcement installed, then the same NLRI re-announced with a type-99/0x40 attribute → prefix withdrawn, session Established, `UpdatesRejected == 1`, zero NOTIFICATIONs on the wire.
- Reviewer: PRISTINE (one MINOR — stale subcode list in the method's XML doc — fixed before the push).

## Notes

- Duplicate unknown well-known attribute: the later occurrence is discarded by the #287 guard before this check — consistent with RFC 7606 §3 (discarded ≠ validated); the first occurrence rejects.
- MP_REACH/UNREACH (14/15), EXTENDED_COMMUNITIES (16) etc. are optional by their RFCs, so the guard cannot fire on them unless the peer also missets the Optional flag — in which case rejection is correct (`IsKnownAttribute` covers every IANA well-known type: 1,2,3,5,6).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unrecognized BGP path attributes according to RFC 4271.
  * Unrecognized mandatory attributes are now rejected with the appropriate parse error.
  * Unrecognized optional attributes continue to be ignored safely.
  * Known attributes that are not fully processed remain accepted.
  * Malformed updates are withdrawn without terminating the established session or sending a notification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->