### PR TITLE
fix(protocol): reject a community VALUE above 65535 instead of masking it (#328)

### DIFF
--- a/BGPLite.Protocol/CommunityCodec.cs
+++ b/BGPLite.Protocol/CommunityCodec.cs
@@ -12,13 +12,17 @@ public static class CommunityCodec
         if (colon < 0)
             throw new FormatException($"Invalid community '{community}' (expected 'ASN:VALUE').");
 
-        var asn = uint.Parse(community[..colon]);
-        var value = uint.Parse(community[(colon + 1)..]);
+        // uint.Parse would surface huge/negative parts as OverflowException, which no caller's
+        // FormatException filter catches — TryParse keeps every malformed input a FormatException.
+        if (!uint.TryParse(community[..colon], out var asn) || !uint.TryParse(community[(colon + 1)..], out var value))
+            throw new FormatException($"Invalid community '{community}': ASN and VALUE must be non-negative integers.");
 
         if (asn > 0xFFFF)
             throw new FormatException($"Invalid community '{community}': ASN part must be 0-65535 (got {asn}).");
+        if (value > 0xFFFF)
+            throw new FormatException($"Invalid community '{community}': VALUE part must be 0-65535 (got {value}).");
 
-        return (asn << 16) | (value & 0xFFFF);
+        return (asn << 16) | value;
     }
 
     public static string Format(uint community) => $"{community >> 16}:{community & 0xFFFF}";

--- a/BGPLite.Tests/CommunityCodecTests.cs
+++ b/BGPLite.Tests/CommunityCodecTests.cs
@@ -24,10 +24,28 @@ public class CommunityCodecTests
     }
 
     [Fact]
-    public void Parse_MasksValueTo16Bits()
+    public void Parse_ValueAbove65535_Throws()
     {
-        // 131071 = 0x1FFFF → low 16 bits 0xFFFF
-        Assert.Equal((1u << 16) | 0xFFFFu, CommunityCodec.Parse("1:131071"));
+        // #328: the VALUE half used to be silently masked (131071 = 0x1FFFF → low 16 bits 0xFFFF),
+        // corrupting operator-supplied tags without a trace — symmetric with the ASN check now.
+        var ex = Assert.Throws<FormatException>(() => CommunityCodec.Parse("1:131071"));
+        Assert.Contains("VALUE", ex.Message);
+    }
+
+    [Fact]
+    public void Parse_MaxValue65535_Accepted()
+    {
+        Assert.Equal((65000u << 16) | 0xFFFFu, CommunityCodec.Parse("65000:65535"));
+    }
+
+    [Fact]
+    public void Parse_NonNumericOrHugeParts_ThrowFormatException_NotOverflow()
+    {
+        // uint.Parse used to surface huge/negative parts as OverflowException, which the
+        // FormatException filters in ConfigCommunityResolver do not catch (#328 review).
+        Assert.Throws<FormatException>(() => CommunityCodec.Parse("65000:99999999999999999999"));
+        Assert.Throws<FormatException>(() => CommunityCodec.Parse("-1:1"));
+        Assert.Throws<FormatException>(() => CommunityCodec.Parse("65000:abc"));
     }
 
     [Fact]

--- a/BGPLite.Tests/RouteSeedingServiceTests.cs
+++ b/BGPLite.Tests/RouteSeedingServiceTests.cs
@@ -1,5 +1,6 @@
 using BGPLite.Configuration;
 using BGPLite.Contracts;
+using BGPLite.Protocol;
 using BGPLite.Providers;
 using BGPLite.Routing;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -37,12 +38,17 @@ public class RouteSeedingServiceTests
 
     private sealed class FakeSourceService : IPrefixSourceService
     {
-        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>> LoadAllAsync(CancellationToken ct = default) =>
-            Task.FromResult<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>>(new List<(PrefixSourceConfig, IReadOnlyList<(uint, byte)>)>
-            {
+        private readonly IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)> _sources;
+
+        public FakeSourceService(IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<(uint, byte)>)>? sources = null) =>
+            _sources = sources ??
+            [
                 (new PrefixSourceConfig { Name = "nets", Kind = "file", Url = "nets.txt" },
                     new List<(uint, byte)> { (0xC0A80000u, 24), (0x0A000000u, 8) })
-            });
+            ];
+
+        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>> LoadAllAsync(CancellationToken ct = default) =>
+            Task.FromResult(_sources);
         public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
         public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetDefaultAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
@@ -95,6 +101,37 @@ public class RouteSeedingServiceTests
         for (var i = 0; i < 100 && table.Count < 2; i++)
             await Task.Delay(20);
         Assert.Equal(2, table.Count);
+    }
+
+    [Fact]
+    public async Task BadSourceCommunity_DegradesToUntagged_DoesNotAbortSeeding()
+    {
+        // #328/#327: an out-of-range community VALUE used to be silently masked; now that the codec
+        // rejects it, seeding must degrade that ONE source to untagged instead of aborting the loop
+        // (later sources unseeded, warm-up and the final established-session push skipped).
+        var prefix = new HangingPrefixService();
+        var table = new RouteTable();
+        var sources = new FakeSourceService(
+        [
+            (new PrefixSourceConfig { Name = "bad", Kind = "file", Url = "a.txt", Community = "65444:99999" },
+                new List<(uint, byte)> { (0xAC100000u, 12) }),
+            (new PrefixSourceConfig { Name = "good", Kind = "file", Url = "b.txt", Community = "65000:100" },
+                new List<(uint, byte)> { (0xC0A80000u, 24) }),
+        ]);
+        using var service = NewService(prefix, sources, table, new RecordingSessionManager());
+
+        await service.StartAsync(CancellationToken.None);
+
+        for (var i = 0; i < 100 && table.Count < 2; i++)
+            await Task.Delay(20);
+
+        Assert.Equal(2, table.Count);
+        var bad = table.Get(0xAC100000, 12);
+        Assert.NotNull(bad);
+        Assert.Empty(bad!.Communities);
+        var good = table.Get(0xC0A80000, 24);
+        Assert.NotNull(good);
+        Assert.Equal([CommunityCodec.Parse("65000:100")], good!.Communities);
     }
 
     [Fact]

--- a/BGPLite/RouteSeedingService.cs
+++ b/BGPLite/RouteSeedingService.cs
@@ -63,9 +63,20 @@ internal sealed class RouteSeedingService(
         {
             foreach (var (source, prefixes) in await sources.LoadAllAsync(ct))
             {
-                var communities = string.IsNullOrEmpty(source.Community)
-                    ? Array.Empty<uint>()
-                    : new[] { CommunityCodec.Parse(source.Community!) };
+                // Never throw during seeding (the ConfigCommunityResolver contract): a malformed
+                // community degrades THIS source to untagged instead of aborting the loop — the
+                // outer catch-all would otherwise skip every later source, WarmUpAsync, and the
+                // final push. #328 made out-of-range communities throw instead of silently masking.
+                var communities = Array.Empty<uint>();
+                if (!string.IsNullOrEmpty(source.Community))
+                {
+                    try { communities = [CommunityCodec.Parse(source.Community!)]; }
+                    catch (FormatException ex)
+                    {
+                        logger.LogWarning(ex, "Source '{Name}': invalid community '{Community}' — seeding untagged",
+                            source.Name, source.Community);
+                    }
+                }
 
                 foreach (var (prefix, length) in prefixes)
                 {
@@ -78,9 +89,11 @@ internal sealed class RouteSeedingService(
                     });
                 }
 
+                // The suffix reflects the APPLIED tag, not the configured one — after a degrade
+                // (Warning above) the configured string was invalid and the source went out untagged.
                 logger.LogInformation("Source '{Name}': {Count} prefixes{Community}",
                     source.Name, prefixes.Count,
-                    source.Community is null ? "" : $" community={source.Community}");
+                    communities.Length == 0 ? "" : $" community={source.Community}");
             }
 
             logger.LogInformation("Loaded routes: {RouteCount} — warming RIPEstat cache", routeTable.Count);
@@ -98,7 +111,8 @@ internal sealed class RouteSeedingService(
         catch (Exception ex)
         {
             // The server keeps serving whatever seeded (local fallback / stale-on-failure caches);
-            // per-source failures were already absorbed by LoadAllAsync.
+            // per-source load failures are absorbed by LoadAllAsync and community errors degrade
+            // to untagged in the loop above — reaching here means seeding itself failed.
             logger.LogError(ex, "Route seeding failed — serving with {RouteCount} routes", routeTable.Count);
         }
     }


### PR DESCRIPTION
Closes #328

## Problem

`CommunityCodec.Parse` validated the ASN half of `"ASN:VALUE"` but silently masked the VALUE half (`value & 0xFFFF`): `"65000:70000"` became `65000:4464` with no error. Operator-supplied tags from config sources and peer custom sources went to the wire silently wrong, and nothing on either side said why. The existing fixture `Parse_MasksValueTo16Bits` legitimized the truncation.

## Fix

1. **Symmetric rejection** in `Parse`: `value > 0xFFFF` → `FormatException`, mirroring the ASN branch; the mask is gone (value is already ≤ 0xFFFF). The legitimizing fixture is inverted into the regression test for the throw (that inversion is the red proof).
2. **`uint.Parse` → `uint.TryParse`** (review finding): huge/negative/non-numeric parts used to surface as `OverflowException`, which no caller's `FormatException` filter catches — the ctor path of `ConfigCommunityResolver` could crash host build on `"65000:99999999999999999999"`. Every malformed input is now a `FormatException`.
3. **Seeding companion** (`RouteSeedingService`, the runtime half of #327): the bare `Parse` in the per-source loop meant the new throw (and the pre-existing ASN-half throw) would abort the whole seeding run — later sources unseeded, warm-up and the established-session push skipped. The parse now degrades that one source to **untagged** with a Warning (the `ConfigCommunityResolver` never-throw contract), and the summary log reflects the *applied* tag, not the configured one. Fail-loud `Validate()` for `PrefixSources` stays in #327.

Callers: `ConfigCommunityResolver` (both sites catch `FormatException` → Warning + fallback — now also correctly rejecting 65536+ values they previously mistagged); `RouteSeedingService` (guarded, see above). `HandleAddSource` stores the raw string — its API-side 400 validation is #266 item 3 and now gets the reject for free once it delegates to the codec.

## Verification

- `dotnet test` — **768/768**.
- New tests: `Parse_ValueAbove65535_Throws` (+ boundary `Parse_MaxValue65535_Accepted`), `Parse_NonNumericOrHugeParts_ThrowFormatException_NotOverflow`, and `BadSourceCommunity_DegradesToUntagged_DoesNotAbortSeeding` (two sources, first with `65444:99999` → both seeded, first untagged, second correctly tagged).
- Internal reviewer: two passes — first found the seeding regression the strict codec would introduce (fixed in this PR as companion 3) and the OverflowException asymmetry (fixed as companion 2); second pass confirmed everything closed except one MINOR (summary-log lie after degrade — fixed as well).

## Notes

- Until #327's `Validate()` half lands, a bad community in config is still accepted at startup and only degrades at seeding with a Warning — startup fail-loud is tracked there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid community values are now rejected with consistent format errors.
  - Values above the valid 16-bit range are no longer silently truncated.
  - Route seeding continues when a source has an invalid community; that source is seeded without tags while valid sources continue processing.
  - Community status and logging now accurately reflect the applied result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->