### PR TITLE
fix(config): validate PrefixSources and every config community at startup (#327)

### DIFF
--- a/BGPLite.Configuration/AppConfig.cs
+++ b/BGPLite.Configuration/AppConfig.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Sockets;
+using BGPLite.Protocol;
 using YamlDotNet.Serialization;
 
 namespace BGPLite.Configuration;
@@ -123,6 +124,93 @@ public sealed class AppConfig
                     $"Invalid configuration: Peers[{i}].Address must be a valid IPv4 address " +
                     $"(got '{peer.Address}').");
             }
+        }
+
+        // #327: prefix-source errors used to surface only at load time, where LoadAllAsync absorbs
+        // them into a Warning plus an empty prefix set — a config typo silently served zero prefixes
+        // until restart. Fail loud at startup (and reject the file on hot reload) instead. The
+        // per-kind required fields mirror the providers' own load-time checks
+        // (FilePrefixProvider/HttpPrefixProvider/AsnPrefixProvider); the community rule is
+        // CommunityCodec's, single-sourced via the Protocol leaf. The ?? [] guards keep an explicit
+        // YAML null ("PrefixSources:") meaning "none" — every runtime consumer treats it that way,
+        // and Validate must reject with a message, never with an NRE.
+        var prefixSources = PrefixSources ?? [];
+        var sourceNames = new HashSet<string>(StringComparer.Ordinal);
+        for (var i = 0; i < prefixSources.Count; i++)
+        {
+            var source = prefixSources[i];
+            var at = $"PrefixSources[{i}] ('{source.Name}')";
+
+            if (string.IsNullOrWhiteSpace(source.Name))
+                throw new InvalidOperationException($"Invalid configuration: {at} requires a Name.");
+            if (!sourceNames.Add(source.Name))
+                throw new InvalidOperationException(
+                    $"Invalid configuration: duplicate prefix source name '{source.Name}' — sources are addressed by name (subscriptions, per-source cache).");
+
+            switch (source.Kind)
+            {
+                case "file":
+                    if (string.IsNullOrWhiteSpace(source.Path))
+                        throw new InvalidOperationException($"Invalid configuration: {at}: Kind=file requires a Path.");
+                    break;
+                case "http":
+                    if (string.IsNullOrWhiteSpace(source.Url))
+                        throw new InvalidOperationException($"Invalid configuration: {at}: Kind=http requires a Url.");
+                    // A malformed URL only fails inside HttpClient after startup, and LoadAllAsync
+                    // absorbs that into a Warning plus zero prefixes — the same silent class this
+                    // validation exists to prevent. Deeper checks (SSRF ranges, ports) stay at fetch
+                    // time in PrefixSourceUrlValidator.
+                    if (!Uri.TryCreate(source.Url, UriKind.Absolute, out var url)
+                        || (url.Scheme != Uri.UriSchemeHttp && url.Scheme != Uri.UriSchemeHttps))
+                        throw new InvalidOperationException(
+                            $"Invalid configuration: {at}: Url must be an absolute http(s) URL (got '{source.Url}').");
+                    break;
+                case "asn":
+                    if (!source.Asn.HasValue)
+                        throw new InvalidOperationException($"Invalid configuration: {at}: Kind=asn requires an Asn.");
+                    if (source.Asn.Value == 0)
+                        throw new InvalidOperationException(
+                            $"Invalid configuration: {at}: Asn must be a positive AS number (RFC 7607 rejects AS 0).");
+                    break;
+                default:
+                    throw new InvalidOperationException(
+                        $"Invalid configuration: {at}: unknown Kind '{source.Kind}' (expected file, http or asn).");
+            }
+
+            if (source.Timeout is <= 0)
+                throw new InvalidOperationException(
+                    $"Invalid configuration: {at}: Timeout must be a positive number of seconds (got {source.Timeout}).");
+
+            ValidateCommunity(source.Community, $"{at}: Community");
+        }
+
+        if (!string.IsNullOrEmpty(DefaultPrefixSource) && !sourceNames.Contains(DefaultPrefixSource))
+            throw new InvalidOperationException(
+                $"Invalid configuration: DefaultPrefixSource '{DefaultPrefixSource}' does not match any PrefixSources entry — unconfigured peers would silently get zero prefixes.");
+
+        // Every community string in this file goes through the same rule so a typo cannot silently
+        // fall back at send time (ConfigCommunityResolver) — the runtime half landed with #335.
+        ValidateCommunity(CustomPrefixCommunity, "CustomPrefixCommunity");
+        ValidateCommunity(CustomAsnCommunity, "CustomAsnCommunity");
+        var asnLists = RipeStat?.AsnLists ?? [];
+        for (var i = 0; i < asnLists.Count; i++)
+            ValidateCommunity(asnLists[i].Community, $"RipeStat.AsnLists[{i}] ('{asnLists[i].Name}'): Community");
+    }
+
+    /// <summary>
+    /// Fail-loud variant of the community format check: the runtime layers (ConfigCommunityResolver,
+    /// RouteSeedingService) deliberately never throw and fall back to defaults/untagged, so config
+    /// validation is the only place a malformed community is actually rejected (#327).
+    /// </summary>
+    private void ValidateCommunity(string? community, string field)
+    {
+        if (string.IsNullOrEmpty(community))
+            return;
+        try { CommunityCodec.Parse(community); }
+        catch (FormatException ex)
+        {
+            throw new InvalidOperationException(
+                $"Invalid configuration: {field} is not a valid 'ASN:VALUE' community — {ex.Message}", ex);
         }
     }
 }

--- a/BGPLite.Configuration/AppConfig.cs
+++ b/BGPLite.Configuration/AppConfig.cs
@@ -139,6 +139,11 @@ public sealed class AppConfig
         for (var i = 0; i < prefixSources.Count; i++)
         {
             var source = prefixSources[i];
+            // An empty YAML list item ("- ") deserializes as a null element — reject it with a
+            // message instead of an NRE, like the null-collection case above.
+            if (source is null)
+                throw new InvalidOperationException(
+                    $"Invalid configuration: PrefixSources[{i}] is empty — each item must be a mapping (Kind, Name, ...).");
             var at = $"PrefixSources[{i}] ('{source.Name}')";
 
             if (string.IsNullOrWhiteSpace(source.Name))
@@ -194,7 +199,13 @@ public sealed class AppConfig
         ValidateCommunity(CustomAsnCommunity, "CustomAsnCommunity");
         var asnLists = RipeStat?.AsnLists ?? [];
         for (var i = 0; i < asnLists.Count; i++)
-            ValidateCommunity(asnLists[i].Community, $"RipeStat.AsnLists[{i}] ('{asnLists[i].Name}'): Community");
+        {
+            var list = asnLists[i];
+            if (list is null)
+                throw new InvalidOperationException(
+                    $"Invalid configuration: RipeStat.AsnLists[{i}] is empty — each item must be a mapping (Name, Asns, ...).");
+            ValidateCommunity(list.Community, $"RipeStat.AsnLists[{i}] ('{list.Name}'): Community");
+        }
     }
 
     /// <summary>

--- a/BGPLite.Configuration/BGPLite.Configuration.csproj
+++ b/BGPLite.Configuration/BGPLite.Configuration.csproj
@@ -10,4 +10,10 @@
     <PackageReference Include="YamlDotNet" Version="18.1.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Protocol is the BCL-only leaf (#230 layering): sharing CommunityCodec here single-sources
+         the community-format rule for config validation (#327) instead of duplicating it. -->
+    <ProjectReference Include="..\BGPLite.Protocol\BGPLite.Protocol.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/BGPLite.Tests/ConfigValidationTests.cs
+++ b/BGPLite.Tests/ConfigValidationTests.cs
@@ -229,6 +229,30 @@ public class ConfigValidationTests
     }
 
     [Fact]
+    public void Validate_NullSourceElement_ThrowsWithIndex()
+    {
+        // An empty YAML list item ("- ") deserializes as a null element — message, not NRE
+        // (CodeRabbit review of #336).
+        var config = Config(sources: [null!]);
+
+        var ex = Assert.Throws<InvalidOperationException>(config.Validate);
+        Assert.Contains("PrefixSources[0] is empty", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_NullAsnListElement_ThrowsWithIndex()
+    {
+        var config = new AppConfig
+        {
+            Bgp = Bgp(),
+            RipeStat = new RipeStatConfig { AsnLists = [null!] }
+        };
+
+        var ex = Assert.Throws<InvalidOperationException>(config.Validate);
+        Assert.Contains("RipeStat.AsnLists[0] is empty", ex.Message);
+    }
+
+    [Fact]
     public void Validate_AcceptsZeroHoldTime_KeepAliveSkipped()
     {
         // RFC 4271 §4.2: HoldTime=0 disables keepalive processing; KeepAlive is then irrelevant.

--- a/BGPLite.Tests/ConfigValidationTests.cs
+++ b/BGPLite.Tests/ConfigValidationTests.cs
@@ -19,8 +19,16 @@ public class ConfigValidationTests
             MaxAcceptsPerIpPerMinute = maxAcceptsPerIpPerMinute
         };
 
-    private static AppConfig Config(BgpConfig? bgp = null, int apiPort = 5001, List<PeerConfig>? peers = null)
-        => new() { Bgp = bgp ?? Bgp(), ApiPort = apiPort, Peers = peers ?? [] };
+    private static AppConfig Config(BgpConfig? bgp = null, int apiPort = 5001, List<PeerConfig>? peers = null,
+        List<PrefixSourceConfig>? sources = null, string? defaultSource = null)
+        => new()
+        {
+            Bgp = bgp ?? Bgp(),
+            ApiPort = apiPort,
+            Peers = peers ?? [],
+            PrefixSources = sources ?? [],
+            DefaultPrefixSource = defaultSource
+        };
 
     [Fact]
     public void Validate_AcceptsValidConfig()
@@ -30,6 +38,194 @@ public class ConfigValidationTests
         var act = () => config.Validate();
 
         act();
+    }
+
+    // ---- PrefixSources (#327: fail loud at startup instead of a silent empty source at load) ----
+
+    [Fact]
+    public void Validate_AcceptsValidPrefixSources()
+    {
+        var config = Config(defaultSource: "nets", sources:
+        [
+            new PrefixSourceConfig { Name = "nets", Kind = "file", Path = "nets.txt" },
+            new PrefixSourceConfig { Name = "ext", Kind = "http", Url = "https://example.net/list.txt", Community = "65000:100", Timeout = 30 },
+            new PrefixSourceConfig { Name = "as65444", Kind = "asn", Asn = 65444 },
+        ]);
+
+        config.Validate();
+    }
+
+    [Fact]
+    public void Validate_FileSourceWithoutPath_Throws()
+    {
+        var config = Config(sources: [new PrefixSourceConfig { Name = "nets", Kind = "file" }]);
+
+        var ex = Assert.Throws<InvalidOperationException>(config.Validate);
+        Assert.Contains("Kind=file requires a Path", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_HttpSourceWithoutUrl_Throws()
+    {
+        var config = Config(sources: [new PrefixSourceConfig { Name = "ext", Kind = "http" }]);
+
+        var ex = Assert.Throws<InvalidOperationException>(config.Validate);
+        Assert.Contains("Kind=http requires a Url", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("raw.githubusercontent.com/org/repo/main/ru.txt")] // no scheme
+    [InlineData("ftp://example.net/list.txt")]                     // wrong scheme
+    [InlineData("https://exa mple.net/list.txt")]                  // space — not a valid absolute URI
+    public void Validate_HttpSourceWithNonHttpAbsoluteUrl_Throws(string url)
+    {
+        var config = Config(sources: [new PrefixSourceConfig { Name = "ext", Kind = "http", Url = url }]);
+
+        var ex = Assert.Throws<InvalidOperationException>(config.Validate);
+        Assert.Contains("absolute http(s) URL", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_AsnSourceWithoutAsn_Throws()
+    {
+        var config = Config(sources: [new PrefixSourceConfig { Name = "as65444", Kind = "asn" }]);
+
+        var ex = Assert.Throws<InvalidOperationException>(config.Validate);
+        Assert.Contains("Kind=asn requires an Asn", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_AsnSourceWithZeroAsn_Throws()
+    {
+        var config = Config(sources: [new PrefixSourceConfig { Name = "as0", Kind = "asn", Asn = 0 }]);
+
+        var ex = Assert.Throws<InvalidOperationException>(config.Validate);
+        Assert.Contains("positive AS number", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("File")]
+    [InlineData("HTTP")]
+    public void Validate_SourceKindIsCaseSensitive_Throws(string kind)
+    {
+        var config = Config(sources: [new PrefixSourceConfig { Name = "x", Kind = kind, Path = "x.txt" }]);
+
+        var ex = Assert.Throws<InvalidOperationException>(config.Validate);
+        Assert.Contains("unknown Kind", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_UnknownSourceKind_Throws()
+    {
+        var config = Config(sources: [new PrefixSourceConfig { Name = "x", Kind = "ftp", Path = "x.txt" }]);
+
+        var ex = Assert.Throws<InvalidOperationException>(config.Validate);
+        Assert.Contains("unknown Kind 'ftp'", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_BadSourceCommunity_Throws()
+    {
+        // "65000:70000" is exactly the case #328 made a FormatException (VALUE masked before).
+        var config = Config(sources:
+        [
+            new PrefixSourceConfig { Name = "ext", Kind = "http", Url = "https://example.net/l.txt", Community = "65000:70000" },
+        ]);
+
+        var ex = Assert.Throws<InvalidOperationException>(config.Validate);
+        Assert.Contains("Community", ex.Message);
+        Assert.NotNull(ex.InnerException);
+    }
+
+    [Fact]
+    public void Validate_NonPositiveSourceTimeout_Throws()
+    {
+        var config = Config(sources:
+        [
+            new PrefixSourceConfig { Name = "ext", Kind = "http", Url = "https://example.net/l.txt", Timeout = 0 },
+        ]);
+
+        Assert.Contains("Timeout must be a positive",
+            Assert.Throws<InvalidOperationException>(config.Validate).Message);
+
+        var negative = Config(sources:
+        [
+            new PrefixSourceConfig { Name = "ext", Kind = "http", Url = "https://example.net/l.txt", Timeout = -1 },
+        ]);
+
+        Assert.Contains("Timeout must be a positive",
+            Assert.Throws<InvalidOperationException>(negative.Validate).Message);
+    }
+
+    [Fact]
+    public void Validate_EmptySourceName_Throws()
+    {
+        var config = Config(sources: [new PrefixSourceConfig { Name = "", Kind = "file", Path = "nets.txt" }]);
+
+        var ex = Assert.Throws<InvalidOperationException>(config.Validate);
+        Assert.Contains("requires a Name", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_DuplicateSourceNames_Throws()
+    {
+        var config = Config(sources:
+        [
+            new PrefixSourceConfig { Name = "dup", Kind = "file", Path = "a.txt" },
+            new PrefixSourceConfig { Name = "dup", Kind = "file", Path = "b.txt" },
+        ]);
+
+        var ex = Assert.Throws<InvalidOperationException>(config.Validate);
+        Assert.Contains("duplicate prefix source name 'dup'", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_DefaultPrefixSourceWithoutMatchingSource_Throws()
+    {
+        var config = Config(defaultSource: "ruu", sources:
+        [
+            new PrefixSourceConfig { Name = "ru", Kind = "file", Path = "nets.txt" },
+        ]);
+
+        var ex = Assert.Throws<InvalidOperationException>(config.Validate);
+        Assert.Contains("DefaultPrefixSource 'ruu'", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_CustomPrefixCommunity_Throws()
+    {
+        var config = new AppConfig { Bgp = Bgp(), CustomPrefixCommunity = "65000:70000" };
+
+        var ex = Assert.Throws<InvalidOperationException>(config.Validate);
+        Assert.Contains("CustomPrefixCommunity", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_RipeStatAsnListCommunity_Throws()
+    {
+        var config = new AppConfig
+        {
+            Bgp = Bgp(),
+            RipeStat = new RipeStatConfig
+            {
+                AsnLists = [new AsnList { Name = "ru", Country = "RU", Community = "65000:abc" }]
+            }
+        };
+
+        var ex = Assert.Throws<InvalidOperationException>(config.Validate);
+        Assert.Contains("RipeStat.AsnLists[0]", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_ExplicitYamlNullCollections_AreTreatedAsEmpty()
+    {
+        // "PrefixSources:" / "AsnLists:" with no value deserialize as null collections — every
+        // runtime consumer treats them as "none", and Validate must reject config with a message,
+        // never with a NullReferenceException (#327 review).
+        var config = ConfigLoader.LoadFromText(
+            "Bgp:\n  Asn: 65001\n  RouterId: 10.0.0.1\nPrefixSources:\nRipeStat:\n  AsnLists:\n");
+
+        config.Validate();
     }
 
     [Fact]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,9 +19,9 @@ No cycles. The boundaries are enforced by tests, not by convention alone (see "E
      ▼           ▼           ▼            ▼             ▼
 ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌──────────┐ ┌────────────┐
 │ Server  │ │   Api   │ │Providers│ │ Routing  │ │Configuration│
-└────┬────┘ └────┬────┘ └────┬────┘ └────┬─────┘ └─────────────┘
-     │           │           │           │              (YamlDotNet only)
-     ▼           │           ▼           ▼
+└────┬────┘ └────┬────┘ └────┬────┘ └────┬─────┘ └──────┬──────┘
+     │           │           │           │        (YamlDotNet; → Protocol
+     ▼           │           ▼           ▼         for CommunityCodec, #327)
 ┌─────────┐     │      ┌──────────────────────┐
 │Protocol │     │      │ Contracts (pure leaf)│
 │(BCL-only│     │      │ no dependencies      │
@@ -36,10 +36,10 @@ Direct references (from the `.csproj` files):
 |---|---|---|
 | `BGPLite.Contracts` | — (dependency-free leaf) | — |
 | `BGPLite.Protocol` | — (BCL-only leaf) | — |
-| `BGPLite.Configuration` | — | YamlDotNet |
+| `BGPLite.Configuration` | Protocol (CommunityCodec for config validation, #327) | YamlDotNet |
 | `BGPLite.Routing` | Configuration, Protocol | — |
 | `BGPLite.Providers` | Contracts, Configuration, Protocol | M.E.Hosting.Abstractions, M.E.Http(+Resilience), Logging.Abstractions |
-| `BGPLite.Server` | Contracts, Configuration, Protocol, Routing | — |
+| `BGPLite.Server` | Contracts, Configuration, Protocol, Routing | M.E.Hosting.Abstractions, Logging.Abstractions |
 | `BGPLite.Api` | Contracts, Configuration, Providers, Routing | EF Core Sqlite, System.Threading.RateLimiting |
 | `BGPLite` (app) | all of the above | M.E.Hosting, EF Design (build-time) |
 


### PR DESCRIPTION
Closes #327

## Problem

`AppConfig.Validate()` never looked at `PrefixSources`. A bad community, an unknown `Kind`, a missing `Path`/`Url`/`Asn`, a non-positive `Timeout`, or an empty/duplicate name surfaced only at load time — where `LoadAllAsync` absorbs the failure into a Warning plus an empty prefix set. A config typo silently served zero prefixes until restart, and `DefaultPrefixSource` typos ("ruu" vs "ru") emptied the default set for every unconfigured peer the same way. This violates the fail-loud policy (#89/#8) and is the fail-loud half of #327; the runtime half (per-source degrade to untagged in seeding) landed in #335.

## Fix — `Validate()` now checks

- **Per-kind required fields** (file→`Path`, http→`Url`, asn→`Asn`) — mirroring the providers' own load-time checks;
- **`Kind` ∈ {file, http, asn}** (case-sensitive, exactly as the factory resolves it) and **absolute http(s) URLs** for http sources (a malformed URL previously died inside HttpClient post-startup → silent zero prefixes; SSRF depth stays at fetch time in `PrefixSourceUrlValidator`);
- **AS 0 rejected** for asn sources (RFC 7607);
- **`Timeout` null or positive** (the provider silently ignores ≤ 0);
- **Non-empty, unique names** (sources are addressed by name — subscriptions, per-source cache);
- **`DefaultPrefixSource` must name a configured source**;
- **Every community string in the file** — `PrefixSources[].Community`, `CustomPrefixCommunity`, `CustomAsnCommunity`, `RipeStat.AsnLists[].Community` — through one rule via `CommunityCodec` (with the inner `FormatException` preserved). For that single-sourcing, `BGPLite.Configuration` now references the `BGPLite.Protocol` leaf — an edge the #230 layering matrix allows (only Configuration→{Api,Server,Routing,Providers,Contracts} is forbidden); `LayeringTests` stay green, `docs/ARCHITECTURE.md` updated to match (plus a pre-existing Server-row package inaccuracy fixed).
- Explicit YAML null collections (`PrefixSources:`, `AsnLists:` with no value) keep meaning "none" instead of NRE-ing the validator — regression-tested through the real `ConfigLoader`.

Hot-reload semantics are unchanged in shape: `ConfigReloader` validates before applying, so a bad edit is rejected and the previous config keeps running — same as every other invalid field.

## Verification

- `dotnet test` — **787/787** (16 new cases incl. theories).
- Internal reviewer: two passes — first found the missing `DefaultPrefixSource` check, the URL-format gap, the stale `ARCHITECTURE.md` table, AS 0, community fragmentation across the file, and the missing inner exception; second pass confirmed all closed and flagged YAML-null collections + the Server row — both fixed (the null-scalar behavior is pinned by a `ConfigLoader`-level test).
- `appsettings.yml` / `appsettings.Example.yml` pass the new validation (checked source-by-source by the reviewer).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added comprehensive configuration validation for prefix sources, including source types, required values, timeouts, unique names, and default source references.
  - Added validation for community values across custom and RipeStat settings.
  - Invalid or unsupported configuration values now produce clear validation failures.

- **Documentation**
  - Updated architecture documentation to reflect configuration validation dependencies and project relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->