### PR TITLE
fix(api): cancel in-flight handlers on shutdown and bound the drain (#326)

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -50,6 +50,12 @@ public sealed class ManagementApi : IHostedService, IDisposable
     private HttpListener? _listener;
     private Task? _listenTask;
     private readonly CancellationTokenSource _cts = new();
+    // #326: cancelled at the top of StopAsync so in-flight handlers stop provider work (RIPEstat
+    // fetches) instead of pinning the drain — the host stops services in reverse registration
+    // order, and BgpServer.StopAsync (the Cease + socket teardown) waits behind this drain.
+    // Deliberately never disposed: handlers abandoned by the bounded drain may still hold its
+    // token, and a disposed source's Token getter would throw ODE at them.
+    private readonly CancellationTokenSource _shutdownCts = new();
 
     public ManagementApi(
         PeerStore store,
@@ -180,6 +186,13 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
     public async Task StopAsync(CancellationToken cancellationToken)
     {
+        // #326: cancel in-flight handlers FIRST — they observe this token on provider calls, so a
+        // cold-cache RIPEstat fetch (per-attempt timeout 180 s × retries, /api/asn-lists sequential
+        // per ASN) unwinds immediately instead of pinning the drain. The host stops services in
+        // reverse registration order, so BgpServer.StopAsync (the Cease teardown) waits behind this
+        // method; an unbounded drain got the process SIGKILLed in Docker (default 10 s stop grace)
+        // — peers saw a TCP RST instead of the promised Cease.
+        _shutdownCts.Cancel();
         _cts.Cancel();
         _listener?.Stop();
         if (_listenTask is not null)
@@ -187,13 +200,14 @@ public sealed class ManagementApi : IHostedService, IDisposable
             try { await _listenTask; } catch { }
         }
 
-        // Drain in-flight handlers before the host disposes this service: a handler reaching
-        // _inflightCap.Release() after Dispose would hit ObjectDisposedException (#248 review).
+        // Drain in-flight handlers, but bounded: 10 s after cancellation is enough for a response
+        // write or an orderly OCE unwind, and short of the host's 30 s shutdown grace.
         Task[] pending;
         lock (_inflightHandlers) pending = _inflightHandlers.ToArray();
         if (pending.Length > 0)
         {
-            try { await Task.WhenAll(pending); } catch { }
+            try { await Task.WhenAny(Task.WhenAll(pending), Task.Delay(TimeSpan.FromSeconds(10), cancellationToken)); }
+            catch { /* host grace elapsed — proceed */ }
         }
     }
 
@@ -240,6 +254,11 @@ public sealed class ManagementApi : IHostedService, IDisposable
         try
         {
             await HandleAsync(ctx);
+        }
+        catch (OperationCanceledException) when (_shutdownCts.IsCancellationRequested)
+        {
+            // #326/#114: shutdown cancelled an in-flight provider fetch — a normal unwind, not a
+            // fault. The response is closed by the listener teardown; the drain observes this task.
         }
         catch (Exception ex)
         {
@@ -920,7 +939,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (peer is null)
             return ApiResponse.Error("Peer not found", 404);
 
-        var prefixes = await CollectPeerPrefixes(peerId);
+        var prefixes = await CollectPeerPrefixes(peerId, _shutdownCts.Token);
 
         var format = ctx.Request.QueryString["format"] ?? "txt";
         if (format == "json")
@@ -930,7 +949,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         return ApiResponse.Ok(string.Join("\n", prefixes));
     }
 
-    private async Task<List<string>> CollectPeerPrefixes(string peerId)
+    private async Task<List<string>> CollectPeerPrefixes(string peerId, CancellationToken ct)
     {
         var prefixes = new List<string>();
 
@@ -948,10 +967,11 @@ public sealed class ManagementApi : IHostedService, IDisposable
         {
             try
             {
-                var fetched = await _prefixService.GetPrefixesForAsns(asns);
+                var fetched = await _prefixService.GetPrefixesForAsns(asns, ct);
                 foreach (var (prefix, length, _) in fetched)
                     prefixes.Add($"{BgpConstants.UintToIPAddress(prefix)}/{length}");
             }
+            catch (OperationCanceledException) { throw; }  // #114: shutdown is not a fetch failure
             catch (Exception ex) { _logger.LogWarning(ex, "CollectPeerPrefixes: ASN fetch failed"); }
         }
 
@@ -960,10 +980,11 @@ public sealed class ManagementApi : IHostedService, IDisposable
         {
             try
             {
-                var ruPrefixes = await _prefixService.GetRuPrefixesAsync();
+                var ruPrefixes = await _prefixService.GetRuPrefixesAsync(ct);
                 foreach (var (prefix, length, _) in ruPrefixes)
                     prefixes.Add($"{BgpConstants.UintToIPAddress(prefix)}/{length}");
             }
+            catch (OperationCanceledException) { throw; }  // #114: shutdown is not a fetch failure
             catch (Exception ex) { _logger.LogWarning(ex, "CollectPeerPrefixes: RU prefix fetch failed"); }
         }
 
@@ -980,6 +1001,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
     private async Task<ApiResponse> HandleGetAsnListsAsync()
     {
+        var ct = _shutdownCts.Token;
         var lists = _config.RipeStat?.AsnLists ?? [];
         var result = new List<object>();
 
@@ -990,13 +1012,15 @@ public sealed class ManagementApi : IHostedService, IDisposable
             {
                 foreach (var asn in l.Asns)
                 {
-                    try { prefixCount += await _prefixService.GetPrefixCountAsync(asn); }
+                    try { prefixCount += await _prefixService.GetPrefixCountAsync(asn, ct); }
+                    catch (OperationCanceledException) { throw; }  // #114: shutdown is not a fetch failure
                     catch (Exception ex) { _logger.LogWarning(ex, "Failed to get prefix count for AS{Asn}", asn); }
                 }
             }
             else if (l.Country is not null)
             {
-                try { prefixCount = (await _prefixService.GetRuPrefixesAsync()).Count; }
+                try { prefixCount = (await _prefixService.GetRuPrefixesAsync(ct)).Count; }
+                catch (OperationCanceledException) { throw; }  // #114: shutdown is not a fetch failure
                 catch (Exception ex) { _logger.LogWarning(ex, "Failed to get RU prefix count"); }
             }
 
@@ -1015,7 +1039,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // Append configured PrefixSources (file/http) alongside the legacy RipeStat ASN-lists,
         // reusing the same response shape. "Kind" is intentionally not exposed.
         var seen = lists.Select(l => l.Name).ToHashSet();
-        foreach (var (source, prefixes) in await _prefixSources.LoadAllAsync())
+        foreach (var (source, prefixes) in await _prefixSources.LoadAllAsync(ct))
         {
             if (!seen.Add(source.Name)) continue; // skip names already present (e.g. shared "ru")
             result.Add(new
@@ -1095,7 +1119,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         {
             try
             {
-                var count = await _prefixService.GetPrefixCountAsync(asn);
+                var count = await _prefixService.GetPrefixCountAsync(asn, _shutdownCts.Token);
                 return ApiResponse.Ok(new { asn, prefixCount = count });
             }
             catch (Exception ex) when (ex is not OperationCanceledException)

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -971,7 +971,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
                 foreach (var (prefix, length, _) in fetched)
                     prefixes.Add($"{BgpConstants.UintToIPAddress(prefix)}/{length}");
             }
-            catch (OperationCanceledException) { throw; }  // #114: shutdown is not a fetch failure
+            catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#337: only shutdown cancellation — a provider-timeout OCE (live token) is a fetch failure below
             catch (Exception ex) { _logger.LogWarning(ex, "CollectPeerPrefixes: ASN fetch failed"); }
         }
 
@@ -984,7 +984,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
                 foreach (var (prefix, length, _) in ruPrefixes)
                     prefixes.Add($"{BgpConstants.UintToIPAddress(prefix)}/{length}");
             }
-            catch (OperationCanceledException) { throw; }  // #114: shutdown is not a fetch failure
+            catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#337: only shutdown cancellation — a provider-timeout OCE (live token) is a fetch failure below
             catch (Exception ex) { _logger.LogWarning(ex, "CollectPeerPrefixes: RU prefix fetch failed"); }
         }
 
@@ -1013,14 +1013,14 @@ public sealed class ManagementApi : IHostedService, IDisposable
                 foreach (var asn in l.Asns)
                 {
                     try { prefixCount += await _prefixService.GetPrefixCountAsync(asn, ct); }
-                    catch (OperationCanceledException) { throw; }  // #114: shutdown is not a fetch failure
+                    catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#337: only shutdown cancellation — a provider-timeout OCE (live token) is a fetch failure below
                     catch (Exception ex) { _logger.LogWarning(ex, "Failed to get prefix count for AS{Asn}", asn); }
                 }
             }
             else if (l.Country is not null)
             {
                 try { prefixCount = (await _prefixService.GetRuPrefixesAsync(ct)).Count; }
-                catch (OperationCanceledException) { throw; }  // #114: shutdown is not a fetch failure
+                catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#337: only shutdown cancellation — a provider-timeout OCE (live token) is a fetch failure below
                 catch (Exception ex) { _logger.LogWarning(ex, "Failed to get RU prefix count"); }
             }
 
@@ -1427,6 +1427,10 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (_disposed) return;
         _disposed = true;
 
+        // #337 review: direct Dispose (embedded use, tests) skips StopAsync — cancel the shutdown
+        // token here too so in-flight provider work observes shutdown. Still never disposed:
+        // abandoned handlers may hold its token (a disposed source's Token getter throws ODE).
+        _shutdownCts.Cancel();
         _cts.Cancel();
         _cts.Dispose();
         // At shutdown no requests are in-flight, so disposing the current limiters is safe

--- a/BGPLite.Tests/ManagementApiShutdownTests.cs
+++ b/BGPLite.Tests/ManagementApiShutdownTests.cs
@@ -1,0 +1,199 @@
+using System.Net;
+using System.Net.Sockets;
+using BGPLite.Api;
+using BGPLite.Configuration;
+using BGPLite.Contracts;
+using BGPLite.Providers;
+using BGPLite.Routing;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #326: StopAsync must not hang behind in-flight handlers. Handlers observe a shutdown token on
+/// provider calls and the drain is bounded — the host stops services in reverse registration
+/// order, so an unbounded ManagementApi drain held back BgpServer.StopAsync's Cease teardown
+/// (in Docker the process was SIGKILLed after the 10 s grace: peers saw TCP RST, not Cease).
+/// </summary>
+public sealed class ManagementApiShutdownTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private ManagementApi? _api;
+    private HttpClient? _client;
+    private int _port;
+
+    public ManagementApiShutdownTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        using (var boot = new BgpDbContext(new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(_connection).Options))
+            BgpDbContext.Initialize(boot);
+    }
+
+    public void Dispose()
+    {
+        // StopAsync cancels the shutdown token, so a handler parked in the provider (e.g. when the
+        // test failed before reaching its own StopAsync) unwinds here instead of leaking the
+        // connection and its in-flight slot for the rest of the test run.
+        try { _api?.StopAsync(CancellationToken.None).Wait(TimeSpan.FromSeconds(5)); }
+        catch { /* best-effort cleanup */ }
+        _api?.Dispose();
+        _client?.Dispose();
+        _connection.Dispose();
+    }
+
+    [Fact]
+    public async Task StopAsync_CancelsInFlightProviderFetch_AndDrainsWithinBound()
+    {
+        var provider = new BlockingRuPrefixService();
+        // FreeTcpPort has an inherent TOCTOU window — retry on a fresh port if something races us
+        // to the bind (bounded; each failed attempt disposes its listener).
+        for (var attempt = 0; ; attempt++)
+        {
+            var port = FreeTcpPort();
+            var config = new AppConfig
+            {
+                ApiListen = "127.0.0.1",
+                ApiPort = port,
+                Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" },
+                RipeStat = new RipeStatConfig { AsnLists = [new AsnList { Name = "ru", Country = "RU" }] }
+            };
+            _api = new ManagementApi(
+                new PeerStore(new StaticOptionsFactory(new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(_connection).Options)),
+                new RouteTable(),
+                config,
+                new BgpMetrics(),
+                NullLogger<ManagementApi>.Instance,
+                provider,
+                new InertPrefixSourceService(),
+                new InertSessionManager());
+            try
+            {
+                await _api.StartAsync(CancellationToken.None);
+                _port = port;
+                break;
+            }
+            catch (HttpListenerException) when (attempt < 2)
+            {
+                _api.Dispose();
+                _api = null;
+            }
+        }
+        _client = new HttpClient();
+
+        // /api/asn-lists hits the provider for the country list — the handler parks inside
+        // GetRuPrefixesAsync until the shutdown token fires.
+        var request = _client.GetAsync($"http://127.0.0.1:{_port}/api/asn-lists");
+        await provider.Entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var stop = _api.StopAsync(CancellationToken.None);
+
+        // Old behavior: the drain awaited Task.WhenAll(pending) with no cancellation and the
+        // provider never completed on its own — StopAsync hung (RIPEstat worst case: minutes),
+        // starving BgpServer.StopAsync's Cease teardown behind it.
+        await stop.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(stop.IsCompleted);
+
+        // The abandoned request unwinds as OCE → the handler completes; the response is closed by
+        // the listener teardown, so the client sees an error — bounded, never the 100 s default.
+        try { await request.WaitAsync(TimeSpan.FromSeconds(5)); }
+        catch { /* expected — the server is shutting down */ }
+    }
+
+    [Fact]
+    public async Task StartAsync_Retries_WhenThePortIsTaken()
+    {
+        // FreeTcpPort has an inherent TOCTOU window — a concurrent bind between the probe and
+        // HttpListener.Start must surface as a clear HttpListenerException, not a hang.
+        var port = FreeTcpPort();
+        var blocker = new TcpListener(IPAddress.Loopback, port);
+        blocker.Start();
+        var config = new AppConfig
+        {
+            ApiListen = "127.0.0.1",
+            ApiPort = port,
+            Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" }
+        };
+        _api = new ManagementApi(
+            new PeerStore(new StaticOptionsFactory(new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(_connection).Options)),
+            new RouteTable(),
+            config,
+            new BgpMetrics(),
+            NullLogger<ManagementApi>.Instance,
+            new BlockingRuPrefixService(),
+            new InertPrefixSourceService(),
+            new InertSessionManager());
+
+        await Assert.ThrowsAnyAsync<HttpListenerException>(() => _api.StartAsync(CancellationToken.None));
+
+        blocker.Stop();
+    }
+
+    private static int FreeTcpPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    /// <summary>Parks inside GetRuPrefixesAsync until the caller's token fires; every other member is inert.</summary>
+    private sealed class BlockingRuPrefixService : IPrefixService
+    {
+        public TaskCompletionSource Entered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
+            => Task.FromResult(new List<(uint Prefix, byte Length, uint Asn)>());
+        public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
+        public async Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
+        {
+            // Yield BEFORE signalling: the whole chain from the accept loop into this provider is
+            // synchronous up to the first await, so without this the Entered signal could fire
+            // before ListenAsync has even added the handler task to _inflightHandlers — and
+            // StopAsync would observe an empty drain without testing anything.
+            await Task.Yield();
+            Entered.TrySetResult();
+            await Task.Delay(Timeout.Infinite, ct);   // never completes on its own; honors the token
+            return [];
+        }
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    /// <summary>Reports no configured prefix sources; the shutdown path never calls it.</summary>
+    private sealed class InertPrefixSourceService : IPrefixSourceService
+    {
+        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<(uint Prefix, byte Length)>)>>([]);
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetDefaultAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);
+        public bool SourceSupportsConditional(string sourceName) => false;
+    }
+
+    /// <summary>Holds no sessions; the shutdown path never calls it.</summary>
+    private sealed class InertSessionManager : ISessionManager
+    {
+        public Task RefreshPeerAsync(string peerIp, uint asn) => Task.CompletedTask;
+        public List<string> GetActivePeerIps() => [];
+        public int GetAdvertisedPrefixCount(string peerIp, uint asn) => 0;
+        public Task RefreshAllEstablishedAsync() => Task.CompletedTask;
+        public Task TerminatePeerAsync(string peerIp, uint asn, CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private sealed class StaticOptionsFactory(DbContextOptions<BgpDbContext> options) : IDbContextFactory<BgpDbContext>
+    {
+        public BgpDbContext CreateDbContext() => new(options);
+    }
+}


### PR DESCRIPTION
Closes #326

## Problem

`StopAsync` ignored its `CancellationToken` and awaited in-flight handlers via an unbounded `Task.WhenAll`. Handlers made provider calls with no token — `CollectPeerPrefixes` (`/api/peers/{id}/prefixes`), `HandleGetAsnListsAsync` (`/api/asn-lists`, sequential RIPEstat per ASN), `HandleGetAsnPrefixes` (`?count=true`), and `LoadAllAsync` in asn-lists (cold http prefix sources, 5 s x 3 attempts each). Worst case: minutes. The host stops services in reverse registration order, so `BgpServer.StopAsync` (Cease + socket teardown) waited behind the drain; in Docker (10 s stop grace) the process was SIGKILLed — peers saw TCP RST instead of Cease.

## Fix

- `_shutdownCts`, cancelled at the very top of `StopAsync` (deliberately never disposed: handlers abandoned by the bounded drain may still hold its token — a disposed source's `Token` getter would throw ODE at them).
- Every provider-calling handler observes the token (`ct` signatures already existed on `IPrefixService`/`IPrefixSourceService`); OCE is rethrown per the #114 policy — shutdown is not a fetch failure — and `HandleWithInflightReleaseAsync` no longer logs the shutdown unwind as `Management API request handling faulted`.
- Bounded drain: `WhenAny(WhenAll(pending), Task.Delay(10 s, hostToken))` — 10 s after cancellation, short of the host's 30 s grace.

## Verification

- `dotnet test` — **770/770**.
- Regression test drives a REAL HttpListener on a probed free port (with a TOCTOU retry): `GET /api/asn-lists` parks inside a provider that honors the token (`Task.Delay(Timeout.Infinite, ct)`); `StopAsync` completes in well under 5 s. Verified **red** on the old behavior (temporarily reverted: `TimeoutException` — StopAsync hung behind the uncancelled provider). A `Task.Yield` barrier before the provider signals guarantees the handler is registered in the in-flight list before the test proceeds.
- Internal reviewer found two provider calls the first pass missed (asn-count, LoadAllAsync), the OCE-as-fault log noise, and three test robustness issues — all fixed in this commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved API shutdown behavior by canceling in-progress operations and allowing active requests to finish within a bounded time.
  - Prevented expected shutdown cancellations from being reported as fetch failures.
  - Ensured prefix-related requests stop promptly when the service is shutting down.

- **Tests**
  - Added coverage for graceful shutdown during active provider requests.
  - Added coverage for startup behavior when the selected port is already in use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->