### PR TITLE
fix(protocol): reject unsupported OPEN optional parameters with 2/4 (#329)

### DIFF
--- a/BGPLite.Protocol/BgpConstants.cs
+++ b/BGPLite.Protocol/BgpConstants.cs
@@ -49,6 +49,7 @@ public static class BgpConstants
         public const byte UnsupportedVersion = 1;
         public const byte BadPeerAs = 2;
         public const byte BadBgpIdentifier = 3;
+        public const byte UnsupportedOptionalParameter = 4;
         public const byte UnacceptableHoldTime = 6;
         public const byte UnsupportedCapability = 7;
 

--- a/BGPLite.Protocol/BgpMessageReader.cs
+++ b/BGPLite.Protocol/BgpMessageReader.cs
@@ -156,7 +156,19 @@ public static class BgpMessageReader
                     BgpConstants.Error.OpenMessageError, BgpConstants.SubError.Unspecific);
 
             if (paramType == 2) // Capability
+            {
                 ParseCapabilities(data[offset..][..paramLen], capabilities);
+            }
+            else
+            {
+                // RFC 4271 §6.2 (#329): an optional parameter type this speaker does not recognize
+                // must be answered with Unsupported Optional Parameter (2/4) — the sender otherwise
+                // believes the parameter was accepted (e.g. RFC 9072 Extended Optional Parameters,
+                // type 255). Unrecognized CAPABILITIES inside type 2 stay ignored per RFC 5492 §4.2.
+                throw new BgpParseException(
+                    $"Unsupported OPEN optional parameter type {paramType} (length {paramLen})",
+                    BgpConstants.Error.OpenMessageError, BgpConstants.SubError.UnsupportedOptionalParameter);
+            }
 
             offset += paramLen;
         }

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -135,6 +135,33 @@ public class BgpMessageTests
     }
 
     [Fact]
+    public void Open_UnrecognizedOptionalParameterType_RejectedWithSubcode4()
+    {
+        // RFC 4271 §6.2 / #329: only type 2 (Capabilities) is supported; any other optional
+        // parameter type must yield Open Message Error / Unsupported Optional Parameter (2/4),
+        // not silent acceptance — the sender otherwise assumes the parameter was honored.
+        // Well-formed TLV (type 1, the deprecated Authentication parameter), so the rejection is
+        // about the type, not framing.
+        var message = BuildRawOpen(4, [0x01, 0x02, 0xAA, 0xBB]);
+
+        var ex = Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(message));
+        Assert.Equal(BgpConstants.Error.OpenMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.UnsupportedOptionalParameter, ex.SubErrorCode);
+    }
+
+    [Fact]
+    public void Open_ExtendedOptionalParametersType255_RejectedWithSubcode4()
+    {
+        // RFC 9072 Extended Optional Parameters (type 255) — the realistic modern trigger for
+        // the same rule: an extended-message speaker must learn we do not support the parameter.
+        var message = BuildRawOpen(3, [0xFF, 0x01, 0x06]);
+
+        var ex = Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(message));
+        Assert.Equal(BgpConstants.Error.OpenMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.UnsupportedOptionalParameter, ex.SubErrorCode);
+    }
+
+    [Fact]
     public void Open_TruncatedCapabilityHeader_Rejected()
     {
         // Capability parameter whose payload is a single stray byte (a TLV header needs 2).

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -154,7 +154,9 @@ public class BgpMessageTests
     {
         // RFC 9072 Extended Optional Parameters (type 255) — the realistic modern trigger for
         // the same rule: an extended-message speaker must learn we do not support the parameter.
-        var message = BuildRawOpen(3, [0xFF, 0x01, 0x06]);
+        // A valid Route Refresh capability precedes it, proving the rejection fires mid-list
+        // after well-formed parameters were consumed (CodeRabbit suggestion).
+        var message = BuildRawOpen(6, [0x02, 0x02, 0x02, 0x00, 0xFF, 0x00]);
 
         var ex = Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(message));
         Assert.Equal(BgpConstants.Error.OpenMessageError, ex.ErrorCode);


### PR DESCRIPTION
Closes #329

## Problem

`ParseOptParameters` handled only `paramType == 2` (Capabilities) and silently skipped every other type — a peer sending RFC 9072 Extended Optional Parameters (type 255) or the deprecated Authentication parameter (type 1) got silent acceptance instead of the RFC 4271 §6.2-mandated NOTIFICATION Open Message Error / Unsupported Optional Parameter (subcode 4). The subcode constant did not exist at all (`SubError` jumped 3 → 6).

## Fix

A well-formed TLV of an unknown parameter type now throws `BgpParseException(OpenMessageError, UnsupportedOptionalParameter)`. The session's OPEN receive path routes it to a NOTIFICATION and teardown — the exact path `UnsupportedVersion` already takes. Scope guards: unrecognized *capabilities* inside type 2 stay ignored (RFC 5492 §4.2, untouched); truncated TLV framing still reports 2/0 (bounds checks run before the type dispatch); the production writer only ever emits type 2, so no legitimate sender is broken.

## Verification

- `dotnet test` — **791/791** (2 new: type-1 and type-255 well-formed TLVs → 2/4; built with the existing `BuildRawOpen` raw-frame helper so framing is exercised, not the object model).
- Red is mechanical: before the change a non-type-2 TLV was skipped and `ReadMessage` succeeded, so `Assert.Throws` failed.
- Internal reviewer: PRISTINE (session routing to NOTIFICATION verified against the UnsupportedVersion path; no test or writer emits type ≠ 2).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OPEN messages containing unsupported optional parameter types are now rejected with the appropriate BGP error and subcode.
  * Supported capability parameters continue to be processed normally.

* **Tests**
  * Added coverage for unsupported authentication and extended optional parameter types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->