### PR TITLE
chore: cross-layer audit minors — guarded OCE rethrows, retired-limiter disposal, response close, RIPEstat failure logging, doc drift (#330)

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -26,6 +26,10 @@ public sealed class ManagementApi : IHostedService, IDisposable
     private IReadOnlyList<IPNetwork> _trustedProxyNetworks;
     private PartitionedRateLimiter<string>? _rateLimiter;
     private ConcurrencyLimiter? _concurrencyLimiter;
+    // #330: limiters swapped out by ApplyConfig, disposed in StopAsync/Dispose after in-flight
+    // requests have drained — a retired TokenBucketRateLimiter with AutoReplenishment roots a
+    // replenish Timer that GC never collects, so "let GC handle it" leaked one timer per reload.
+    private readonly List<IDisposable> _retiredLimiters = [];
     private IReadOnlyList<string>? _corsAllowedOrigins;
     private readonly BgpMetrics _metrics;
     // #263: required, not optional. Each of these was a silent feature switch: without
@@ -114,13 +118,18 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // Swap every reloadable field atomically. A request that has already captured the old
         // references into locals finishes against them; the next request reads the new ones.
         // _config is swapped last so CORS / client-IP and the limiters always move together.
-        Interlocked.Exchange(ref _rateLimiter, rateLimiter);
-        Interlocked.Exchange(ref _concurrencyLimiter, concurrencyLimiter);
+        var oldRateLimiter = Interlocked.Exchange(ref _rateLimiter, rateLimiter);
+        var oldConcurrencyLimiter = Interlocked.Exchange(ref _concurrencyLimiter, concurrencyLimiter);
         Interlocked.Exchange(ref _trustedProxyNetworks, trusted);
         Interlocked.Exchange(ref _corsAllowedOrigins, newConfig.CorsAllowedOrigins);
 
-        // Old limiters are NOT disposed: a concurrent HandleAsync may have captured the old reference
-        // and be mid-acquire. Let GC collect them (reload is rare, one retired object per reload).
+        // Old limiters cannot be disposed here — a concurrent HandleAsync may still be mid-acquire
+        // on them (#137). Park them for StopAsync/Dispose, which run after the in-flight drain.
+        lock (_retiredLimiters)
+        {
+            if (oldRateLimiter is not null) _retiredLimiters.Add(oldRateLimiter);
+            if (oldConcurrencyLimiter is not null) _retiredLimiters.Add(oldConcurrencyLimiter);
+        }
 
         _logger.LogInformation(
             "Soft config reloaded: trustedProxies={TrustedProxyCount}, corsOrigins={CorsOriginCount}, rateLimit={RateLimitEnabled}, concurrencyLimit={ConcurrencyEnabled}",
@@ -209,6 +218,25 @@ public sealed class ManagementApi : IHostedService, IDisposable
             try { await Task.WhenAny(Task.WhenAll(pending), Task.Delay(TimeSpan.FromSeconds(10), cancellationToken)); }
             catch { /* host grace elapsed — proceed */ }
         }
+
+        // In-flight requests have drained (boundedly) — limiters retired by ApplyConfig can go.
+        DisposeRetiredLimiters();
+    }
+
+    /// <summary>
+    /// #330: dispose limiters retired by <see cref="ApplyConfig"/>. Safe after the in-flight drain
+    /// in StopAsync; Dispose calls it as best-effort teardown — a request still mid-acquire on a
+    /// retired limiter there (direct Dispose without StopAsync, embedded use) surfaces as an
+    /// ObjectDisposedException in its fault log. Idempotent.
+    /// </summary>
+    private void DisposeRetiredLimiters()
+    {
+        lock (_retiredLimiters)
+        {
+            foreach (var limiter in _retiredLimiters)
+                try { limiter.Dispose(); } catch { /* best-effort teardown */ }
+            _retiredLimiters.Clear();
+        }
     }
 
     private async Task ListenAsync(CancellationToken ct)
@@ -266,6 +294,10 @@ public sealed class ManagementApi : IHostedService, IDisposable
         }
         finally
         {
+            // #330: fault paths that never reach WriteResponse (429/503 early returns, a throwing
+            // WriteResponse, the shutdown unwind above) must not leave the response to the
+            // finalizer — Close is idempotent after a successful write.
+            try { ctx.Response.Close(); } catch { /* best-effort teardown */ }
             // Tolerate teardown racing the StopAsync drain (e.g. direct Dispose without StopAsync).
             try { _inflightCap.Release(); }
             catch (ObjectDisposedException) { /* cap already disposed */ }
@@ -1091,6 +1123,10 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
     #region GET /api/routes
 
+    // #330: the peer-owned rows are live, but the unowned seed rows are a STARTUP snapshot —
+    // auto-refresh pushes updated source content to peers per-session; the seed rows themselves
+    // are only rebuilt on restart. Operators reading this endpoint should treat seed counts
+    // accordingly.
     private ApiResponse HandleGetRoutes()
     {
         var routes = _routeTable.GetAll();
@@ -1429,8 +1465,9 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         _cts.Cancel();
         _cts.Dispose();
+        DisposeRetiredLimiters();
         // At shutdown no requests are in-flight, so disposing the current limiters is safe
-        // (unlike ApplyConfig mid-flight where we leave old ones for GC per #137's CodeRabbit fix).
+        // (unlike ApplyConfig mid-flight, where old ones are parked for later disposal — #137/#330).
         Volatile.Read(ref _rateLimiter)?.Dispose();
         Volatile.Read(ref _concurrencyLimiter)?.Dispose();
         _inflightCap.Dispose();

--- a/BGPLite.Protocol/AttributeHelper.cs
+++ b/BGPLite.Protocol/AttributeHelper.cs
@@ -162,8 +162,8 @@ public static class AttributeHelper
     /// <summary>
     /// Decodes a BGP Large Communities attribute (RFC 8092 §2). Each Large Community is three
     /// 4-octet fields — Global Administrator : Local Data 1 : Local Data 2 — in network byte
-    /// order, so the attribute payload MUST be a multiple of 12 bytes. A zero-length payload is
-    /// a valid (empty) set; any other non-multiple-of-12 length is malformed.
+    /// order, so the attribute payload MUST be a non-zero multiple of 12 bytes — a zero-length
+    /// payload is malformed, not an empty set (see Read_ZeroLength_Throws).
     /// </summary>
     public static (uint Global, uint Local1, uint Local2)[] ReadLargeCommunities(PathAttribute attr)
     {

--- a/BGPLite.Protocol/BgpMessageWriter.cs
+++ b/BGPLite.Protocol/BgpMessageWriter.cs
@@ -146,9 +146,9 @@ public static class BgpMessageWriter
         foreach (var w in msg.WithdrawnRoutes)
             p += PrefixCodec.Encode(w, buffer[p..]);
 
-        // Path attributes. RFC 4271 §5: well-known attributes MUST be sent ordered by type code
-        // (ORIGIN → AS_PATH → NEXT_HOP → MED → LOCAL_PREF — ascending). Producers already emit
-        // ordered (UpdateCodec.BuildUpdateAttributes); an OrderBy here makes the writer guarantee
+        // Path attributes. Ascending type-code order is an implementation invariant (D15) —
+        // RFC 4271 does NOT require attributes to be ordered. Producers already emit ordered
+        // (UpdateCodec.BuildUpdateAttributes); an OrderBy here makes the writer guarantee
         // it for any future producer — LINQ OrderBy is stable, so equal type codes keep their
         // caller-supplied relative order (#272, epic #6).
         var attrs = msg.PathAttributes.Count > 1

--- a/BGPLite.Providers/PrefixService.cs
+++ b/BGPLite.Providers/PrefixService.cs
@@ -248,9 +248,12 @@ public sealed class PrefixService : IPrefixService
             // caller-initiated cancellation propagates.
             throw;
         }
-        catch
+        catch (Exception ex)
         {
-            // skip failed ASN (a transient RIPEstat error), continue with the others
+            // Skip the failed ASN (a transient RIPEstat error) and continue with the others — but
+            // not silently: its prefixes vanish from this cycle's advertisement, and the operator
+            // must be able to tell "ASN no longer has prefixes" from "fetch failed" (#330).
+            _logger?.LogWarning(ex, "AS{Asn}: RIPEstat resolve failed — advertising no prefixes for this ASN this cycle", asn);
             return [];
         }
     }

--- a/BGPLite.Server/RouteAssembler.cs
+++ b/BGPLite.Server/RouteAssembler.cs
@@ -84,6 +84,7 @@ public sealed class RouteAssembler : IRouteAssembler
                     _logger.LogInformation("Sent {Count} RU prefixes to unconfigured peer {Peer}",
                         ruPrefixes.Count, peerLabel);
                 }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#330: only CALLER cancellation — a per-source timeout OCE (HttpPrefixProvider's linked CTS, live ct) must stay a fetch failure below
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Failed to fetch RU prefixes for {Peer}", peerLabel);
@@ -120,6 +121,7 @@ public sealed class RouteAssembler : IRouteAssembler
                             // on the wire — pass null instead of allocating [asn] per prefix.
                             routes.Add(MakeRoute(prefix, length, nextHop, null, comms));
                     }
+                    catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#330
                     catch (Exception ex)
                     {
                         _logger.LogError(ex, "Failed to fetch prefixes for {Peer} (list '{List}')", peerLabel, list.Name);
@@ -142,6 +144,7 @@ public sealed class RouteAssembler : IRouteAssembler
                         routes.Add(MakeRoute(prefix, length, nextHop, null, comms));
                     _logger.LogInformation("Fetched {Count} RU prefixes for {Peer}", ruPrefixes.Count, peerLabel);
                 }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#330
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Failed to fetch RU prefixes for {Peer}", peerLabel);
@@ -165,6 +168,7 @@ public sealed class RouteAssembler : IRouteAssembler
                     _logger.LogInformation("Fetched {Count} prefixes from source '{Source}' for {Peer}",
                         srcPrefixes.Count, name, peerLabel);
                 }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#330
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Failed to fetch source '{Source}' for {Peer}", name, peerLabel);
@@ -202,6 +206,7 @@ public sealed class RouteAssembler : IRouteAssembler
                     _logger.LogInformation("Peer {Peer} custom AS: {Asns} -> {Count} prefixes",
                         peerLabel, string.Join(",", customAsns), asnPrefixes.Count);
                 }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#330
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Failed to fetch custom AS prefixes for {Peer}", peerLabel);
@@ -227,6 +232,7 @@ public sealed class RouteAssembler : IRouteAssembler
                     foreach (var (prefix, length, _) in ruPrefixes)
                         routes.Add(MakeRoute(prefix, length, nextHop, null, defaultComms));
                 }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#330
                 catch (Exception ex)
                 {
                     _logger.LogError(ex, "Failed to fetch RU fallback for {Peer}", peerLabel);
@@ -259,6 +265,7 @@ public sealed class RouteAssembler : IRouteAssembler
                 _logger.LogInformation("Fetched {Count} RU prefixes for unknown peer {Peer}",
                     ruPrefixes.Count, peerLabel);
             }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#330
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to fetch RU prefixes for {Peer}", peerLabel);

--- a/BGPLite.Tests/PrefixServiceTests.cs
+++ b/BGPLite.Tests/PrefixServiceTests.cs
@@ -3,6 +3,7 @@ using BGPLite.Configuration;
 using BGPLite.Providers;
 using BGPLite.Protocol;
 using Microsoft.Extensions.Http;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -70,7 +71,7 @@ public class PrefixServiceTests
         public HttpClient CreateClient(string name) => new(_handler, disposeHandler: false);
     }
 
-    private static PrefixService Service(PerAsnHandler handler, TimeSpan? cacheTtl = null, TimeSpan? negativeTtl = null, int? maxCacheEntries = null, int retryAttempts = 2) =>
+    private static PrefixService Service(PerAsnHandler handler, TimeSpan? cacheTtl = null, TimeSpan? negativeTtl = null, int? maxCacheEntries = null, int retryAttempts = 2, ILogger<PrefixService>? logger = null) =>
         new(new AppConfig(),
             new RipeStatProvider(new StubFactory(handler),
                 NullLogger<RipeStatProvider>.Instance,
@@ -78,6 +79,7 @@ public class PrefixServiceTests
             null!, // IPrefixSourceService is not on the GetPrefixesForAsns path
             null!, // HttpPrefixProvider is only on the per-peer user-source path (#263)
             cacheTtl: cacheTtl ?? TimeSpan.FromHours(1),
+            logger: logger,
             negativeTtl: negativeTtl,
             maxCacheEntries: maxCacheEntries);
 
@@ -120,6 +122,31 @@ public class PrefixServiceTests
         Assert.Equal([100u, 300u], result.Select(r => r.Asn).ToArray());
         Assert.Equal(PrefixFor(100), result[0].Prefix);
         Assert.Equal(PrefixFor(300), result[1].Prefix);
+    }
+
+    [Fact]
+    public async Task GetPrefixesForAsns_FailedAsn_LogsWarning()
+    {
+        // #330: a transient RIPEstat failure for one ASN must not be silent — its prefixes vanish
+        // from this cycle's advertisement and the operator has to tell "no prefixes" from
+        // "fetch failed". Previously the bare catch returned [] without any log line.
+        var handler = new PerAsnHandler(200);
+        var logger = new CapturingLogger();
+        var service = Service(handler, logger: logger);
+
+        await service.GetPrefixesForAsns([100, 200, 300]);
+
+        Assert.Contains(logger.Entries, e => e.Contains("AS200") && e.Contains("RIPEstat resolve failed"));
+    }
+
+    private sealed class CapturingLogger : ILogger<PrefixService>
+    {
+        public List<string> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) =>
+            Entries.Add(formatter(state, exception));
     }
 
     [Fact]

--- a/BGPLite.Tests/RouteAssemblerCancellationTests.cs
+++ b/BGPLite.Tests/RouteAssemblerCancellationTests.cs
@@ -1,0 +1,107 @@
+using BGPLite.Configuration;
+using BGPLite.Contracts;
+using BGPLite.Routing;
+using BGPLite.Server;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #330 item 1: RouteAssembler's per-fetch catch-alls used to swallow OperationCanceledException,
+/// so a session teardown mid-build logged a burst of ERROR "Failed to fetch ..." lines for what is
+/// a normal shutdown. OCE must propagate — but ONLY caller-initiated cancellation: a per-source
+/// timeout surfaces as OCE too (HttpPrefixProvider's linked CTS with a LIVE caller token) and must
+/// stay a logged fetch failure, or one slow source tears down the whole session (#330 review).
+/// </summary>
+public sealed class RouteAssemblerCancellationTests
+{
+    [Fact]
+    public async Task BuildOutboundRoutes_CallerCancelled_PropagatesOCE()
+    {
+        var assembler = NewAssembler(new CancelledRuFetchPrefixService());
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            assembler.BuildOutboundRoutesAsync(
+                "203.0.113.7", 65002, new PeerConfig { Address = "203.0.113.7" }, "203.0.113.7",
+                new CancellationToken(canceled: true)));
+    }
+
+    [Fact]
+    public async Task BuildOutboundRoutes_PerSourceTimeoutOCE_LoggedNotPropagated()
+    {
+        // Same OCE from the provider, but the caller token is LIVE — this is a per-source
+        // timeout, not teardown: the build must continue (return an empty set here) and log a
+        // fetch failure instead of unwinding into a session reset / withdraw-all.
+        var logger = new CapturingLogger();
+        var assembler = NewAssembler(new CancelledRuFetchPrefixService(), logger);
+
+        var routes = await assembler.BuildOutboundRoutesAsync(
+            "203.0.113.7", 65002, new PeerConfig { Address = "203.0.113.7" }, "203.0.113.7",
+            CancellationToken.None);
+
+        Assert.Empty(routes);
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Error);   // a fetch failure, logged — not a silent swallow
+    }
+
+    private static RouteAssembler NewAssembler(IPrefixService prefixService, ILogger<RouteAssembler>? logger = null)
+    {
+        var config = new AppConfig { Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" } };
+        return new RouteAssembler(
+            prefixService,
+            new UnconfiguredPeerStore(),
+            new ConfigCommunityResolver(config, config.Bgp),
+            AllowAllFilter.Instance,
+            config,
+            config.Bgp,
+            logger ?? NullLogger<RouteAssembler>.Instance);
+    }
+
+    /// <summary>Every fetch succeeds except the RU list, which reports a cancelled task.</summary>
+    private sealed class CancelledRuFetchPrefixService : IPrefixService
+    {
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
+            => Task.FromResult(new List<(uint Prefix, byte Length, uint Asn)>());
+        public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
+        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
+            => Task.FromCanceled<List<(uint Prefix, byte Length, uint Asn)>>(new CancellationToken(canceled: true));
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    /// <summary>Resolves to an existing peer with no subscriptions — the unconfigured-peer branch.</summary>
+    private sealed class UnconfiguredPeerStore : IPeerStore
+    {
+        public string CreatePeer(string ip, uint asn, string? description) => "id";
+        public void UpsertPeer(string ip, uint asn) { }
+        public void UpdateSessionStatus(string ip, uint asn, bool active) { }
+        public void DeletePeer(string id) { }
+        public PeerInfo? GetPeerByIp(string ip) => null;
+        public PeerInfo? GetPeer(string ip, uint asn) => null;
+        public PeerInfo? GetPeerById(string id) => null;
+        public List<string> GetSubscriptions(string peerId) => [];
+        public List<string> GetCustomPrefixes(string peerId) => [];
+        public List<uint> GetCustomAsns(string peerId) => [];
+        public HashSet<uint> GetCommunities(string peerId) => [];
+        public HashSet<uint> GetCommunities(string ip, uint asn) => [];
+        public void SetCommunities(string peerId, HashSet<uint> communities) { }
+        public void ClearCommunities(string peerId) { }
+        public void SetDescription(string id, string description) { }
+        public PeerRoutingView? LoadPeerRoutingView(string ip, uint asn) => new("id", [], [], [], []);
+    }
+
+    private sealed class CapturingLogger : ILogger<RouteAssembler>
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) =>
+            Entries.Add((logLevel, formatter(state, exception)));
+    }
+}


### PR DESCRIPTION
Closes #330 (items 1, 2, 4, 5, 6, 7 — item 3 deferred, see below)

**Stacked on #337 (fix #326)** — base is that branch; retarget to main after it merges. Review the delta against `fix/326-stopasync-cancellation`.

## Items

1. **RouteAssembler OCE swallowing** — all 7 per-fetch catch-alls rethrow OCE gated on `ct.IsCancellationRequested`: teardown cancellation propagates (#114) with no ERROR burst; a per-source **timeout** OCE (HttpPrefixProvider's linked CTS, live caller token) stays a logged fetch failure. The review pass caught that an *unguarded* rethrow would tear the session down / withdraw-all on one slow source. The pre-existing unguarded clause in `AddUserSourceRoutesAsync` is deliberately untouched — guarding it breaks the recorded #114 contract (`OperationCanceled_Propagates`); resolving that tension (e.g. an `oce.CancellationToken`-aware discriminator) belongs with #320, noted on the issue.
2. **Seed-table staleness** — documented at `GET /api/routes`: peer rows are live, unowned seed rows are a startup snapshot (the issue allowed fix-or-document; re-seeding on change is a feature).
4. **Retired limiter disposal** — swapped-out limiters are parked and disposed in StopAsync (after the bounded drain) and Dispose; the old "let GC collect them" comment was wrong (AutoReplenishment roots a Timer). No dedicated test: the limiters have no injectable creation seam and a reflection test would be brittle — the parking logic is 10 structural lines covered by build + existing hot-reload tests.
5. **Response close on fault paths** — the handler wrapper's finally closes the response (idempotent after a successful write), so 429/503/throwing-WriteResponse paths no longer wait for the finalizer.
6. **Silent ASN failure** — `ResolveAsnAsync` logs a Warning when an ASN's RIPEstat fetch fails; previously its prefixes vanished from the cycle with no trace. Tested via the existing PerAsnHandler harness.
7. **Doc drift** — ReadLargeCommunities docstring now matches code+test (zero-length is malformed); the writer's ordering comment states the D15 invariant instead of a nonexistent RFC 4271 MUST.

## Verification

- `dotnet test` — **773/773** on the stack (3 new tests: caller-cancelled propagation, timeout-OCE swallowed-and-logged, ASN-failure Warning).
- Internal reviewer: three passes — the first found the per-source-timeout BLOCKER (fixed by the guard + two-sided tests), the second confirmed everything except nits; third pass **PRISTINE**.

## Deferred

Item 3 (dispose-time send-lock waiter) — concurrency-sensitive (#285/#302 territory), deferred with a note on the issue rather than landed at the tail of an overnight batch.