### PR TITLE
fix(server): treat a live-token user-source OCE as a fetch failure

### DIFF
--- a/BGPLite.Server/RouteAssembler.cs
+++ b/BGPLite.Server/RouteAssembler.cs
@@ -302,8 +302,10 @@ public sealed class RouteAssembler : IRouteAssembler
     /// <summary>
     /// Fetches one per-peer user URL source and appends its routes (stamped with the UserSource
     /// community) to <paramref name="routes"/>. Static so all dependencies are parameters —
-    /// unit-testable without a RouteAssembler instance. Catches all exceptions except
-    /// <see cref="OperationCanceledException"/> (#114 propagation).
+    /// unit-testable without a RouteAssembler instance. Catches all exceptions except an OCE
+    /// raised by the CALLER's cancellation (#114/#342): a per-source timeout OCE (a live token,
+    /// e.g. #320's linked CTS in HttpPrefixProvider) is a fetch failure like any other, so one
+    /// slow URL skips its source instead of aborting the whole dump.
     /// </summary>
     internal static async Task AddUserSourceRoutesAsync(
         List<Route> routes, CustomSourceView source, uint nextHop,
@@ -319,7 +321,7 @@ public sealed class RouteAssembler : IRouteAssembler
                 routes.Add(MakeRoute(prefix, length, nextHop, null, comms));
             logger.LogInformation("User-source '{Name}': {Count} prefixes for {Peer}", source.Name, prefixes.Count, peerLabel);
         }
-        catch (OperationCanceledException) { throw; }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#342: only CALLER cancellation — a per-source timeout OCE (#320's linked CTS, live ct) must stay a fetch failure below
         catch (Exception ex)
         {
             logger.LogWarning(ex, "User-source '{Name}' failed for {Peer}; skipped", source.Name, peerLabel);

--- a/BGPLite.Tests/BgpSessionUserSourceTests.cs
+++ b/BGPLite.Tests/BgpSessionUserSourceTests.cs
@@ -96,13 +96,39 @@ public class BgpSessionUserSourceTests
     [Fact]
     public async Task OperationCanceled_Propagates()
     {
-        // Regression for #114: cancellation must NOT be swallowed by the per-source catch.
+        // Regression for #114/#342: cancellation must NOT be swallowed by the per-source catch.
+        // Propagation is keyed on the CALLER's token: an OCE arriving while the caller's token is
+        // cancelled is teardown and must unwind. An OCE with a live token is a per-source timeout
+        // (#320's linked CTS) and stays a fetch failure — see TimeoutOCE_LiveToken_SkipsSource.
         var svc = new StubPrefixService { Throw = new OperationCanceledException() };
         var routes = new List<Route>();
 
         await Assert.ThrowsAsync<OperationCanceledException>(() => RouteAssembler.AddUserSourceRoutesAsync(
             routes, new CustomSourceView("c", "https://x/c", null), 1, svc, new StubResolver(),
-            NullLogger.Instance, "peer", CancellationToken.None));
+            NullLogger.Instance, "peer", new CancellationToken(canceled: true)));
+    }
+
+    [Fact]
+    public async Task TimeoutOCE_LiveToken_SkipsSource()
+    {
+        // Regression for #342: a per-source timeout surfaces as OCE with a LIVE caller token
+        // (#320 arms it via HttpPrefixProvider's linked CTS). It must be a fetch failure like
+        // any other — the source is skipped and the dump continues — not rethrown, or one slow
+        // URL would abort the whole dump and tear down a freshly established session through
+        // RunAsync's OCE handler.
+        var routes = new List<Route>();
+        var slowSvc = new StubPrefixService { Throw = new OperationCanceledException() };
+        var okSvc = new StubPrefixService { Result = [(0x0A000000u, (byte)8)] };
+
+        await RouteAssembler.AddUserSourceRoutesAsync(
+            routes, new CustomSourceView("slow", "https://x/s", null), 1, slowSvc, new StubResolver(),
+            NullLogger.Instance, "peer", CancellationToken.None);
+        await RouteAssembler.AddUserSourceRoutesAsync(
+            routes, new CustomSourceView("good", "https://x/g", null), 1, okSvc, new StubResolver(),
+            NullLogger.Instance, "peer", CancellationToken.None);
+
+        var route = Assert.Single(routes);           // slow source skipped, good source landed
+        Assert.Equal(0x0A000000u, route.Prefix);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #342

## Problem

`RouteAssembler.AddUserSourceRoutesAsync` was the only catch in the file with a bare `catch (OperationCanceledException) { throw; }` — the other seven catch-alls discriminate on the caller's token (`when (ct.IsCancellationRequested)`, landed in #330). Today every OCE on this path is genuine cancellation (no live-token OCE source exists), so the defect is latent. The trigger is already scheduled: #320/#324 arm per-source timeouts for user sources via `HttpPrefixProvider`'s linked CTS, which surfaces a timeout as OCE **with a live caller token**. Through the bare rethrow, one slow peer URL would then abort the whole route dump — and on the initial send, `RunAsync`'s OCE handler would log "SessionClosed (cancelled)" and tear down a freshly established session.

## Fix

Align the catch with the rest of the file:

```csharp
catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
```

Only caller cancellation (session/host teardown, which always flows through `ct`) propagates; a live-token OCE becomes an ordinary fetch failure — its source is skipped, the dump continues.

**Deviation from the issue discussion:** #330's follow-up suggested propagating on `ct.IsCancellationRequested || oce.CancellationToken.IsCancellationRequested`. The second half is not adopted: for a linked-CTS timeout the OCE's own token IS cancelled, so that variant would still propagate timeouts and reintroduce the bug. The single `ct.IsCancellationRequested` condition matches the seven sibling catch-alls and is the correct root-cause discriminator.

Today's runtime behavior is bit-identical (no live-token OCE source exists on this path yet); the change locks the contract in ahead of the #320 timeout arming.

## Verification

- New regression test `TimeoutOCE_LiveToken_SkipsSource` — **red before the fix** (OCE escaped `RouteAssembler.cs`), green after; asserts the slow source is skipped and the next source still loads.
- `OperationCanceled_Propagates` updated to encode the preserved #114 contract: an OCE while the **caller's** token is cancelled still propagates (now asserted with a cancelled token).
- `dotnet build BGPLite.sln` — 0 errors; `dotnet test BGPLite.sln` — 797/797 passed; `dotnet format --severity warn` — clean.

## Risk

Low: no wire/protocol surface; the only behavior change is for a scenario that cannot occur until #320 lands. Reviewer note recorded for #320: a timeout-OCE currently bypasses `UserSourceCache`'s negative cache/stale-on-failure (the rethrow precedes the generic catch), so #320 should add throttling for timeout failures when it arms them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling during source processing.
  * Caller-requested cancellations now stop the operation as expected.
  * Per-source timeouts no longer abort the entire dump; affected sources are skipped and a warning is logged.

* **Tests**
  * Added coverage for caller cancellation and source timeout scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->