### PR TITLE
fix(server): unwind sends parked on _sendLock at Dispose instead of hanging RunAsync

### DIFF
--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -547,6 +547,10 @@ public sealed class BgpSession : IDisposable
     }
 
     private readonly SemaphoreSlim _sendLock = new(1, 1);
+    // #341: set in Dispose() BEFORE _sendLock.Dispose() — SemaphoreSlim.Dispose never wakes
+    // queued waiters, so sends parked on _sendLock race their wait against this signal
+    // (SendMessageAsync) and unwind as "not sent" instead of hanging RunAsync forever.
+    private readonly TaskCompletionSource _sendLockDisposed = new(TaskCreationOptions.RunContinuationsAsynchronously);
     // Guards mutations of _advertisedPrefixes so initial-send and RefreshRoutesAsync can't interleave.
     // SemaphoreSlim instead of lock{} so it composes correctly with await.
     private readonly SemaphoreSlim _advertisedPrefixesLock = new(1, 1);
@@ -1158,14 +1162,31 @@ public sealed class BgpSession : IDisposable
     // failure to reach RefreshCycleAsync.
     private async Task<bool> SendMessageAsync(BgpMessage message, CancellationToken ct = default)
     {
+        // #341: SemaphoreSlim.Dispose never wakes queued waiters (verified: a waiter parked with
+        // CancellationToken.None stays WaitingForActivation forever), so a send queued on
+        // _sendLock while Dispose runs would hang RunAsync. The wait is therefore raced against
+        // a dispose signal (set in Dispose BEFORE the semaphore goes away) — the loser unwinds as
+        // "not sent". The wait itself keeps the CALLER's token (None for keepalive/route sends):
+        // RunEstablishedAsync cancels _cts BEFORE RunAsync's catch blocks send their
+        // best-effort NOTIFICATION, so binding the wait to _cts would suppress those sends
+        // (regression caught by InvalidHeaderLength_OnWire…). Fast path: an uncontended
+        // WaitAsync completes synchronously and skips the WhenAny entirely.
+        Task waitTask;
         try
         {
-            await _sendLock.WaitAsync(ct);
+            waitTask = _sendLock.WaitAsync(ct);
         }
-        catch (OperationCanceledException) { return false; }
         catch (ObjectDisposedException)
         {
-            return false;
+            return false; // semaphore already disposed — nothing to send
+        }
+
+        if (!waitTask.IsCompletedSuccessfully)
+        {
+            var winner = await Task.WhenAny(waitTask, _sendLockDisposed.Task);
+            if (winner != waitTask)
+                return false; // _sendLock disposed while queued (#341) — abandon the wait
+            await waitTask; // propagate OCE (caller token) / complete the acquisition
         }
 
         try
@@ -1393,6 +1414,9 @@ public sealed class BgpSession : IDisposable
         if (Interlocked.Exchange(ref _disposed, 1) == 1)
             return;
 
+        // #341: wake any send parked on _sendLock BEFORE the semaphore (and its waiter queue)
+        // goes away — SendMessageAsync abandons such waits and reports "not sent".
+        _sendLockDisposed.TrySetResult();
         _cts.Cancel();
         _connection.Dispose();   // owns the socket (SocketBgpConnection wraps NetworkStream ownsSocket:true)
         _cts.Dispose();

--- a/BGPLite.Tests/BgpSessionHoldTimerTests.cs
+++ b/BGPLite.Tests/BgpSessionHoldTimerTests.cs
@@ -89,16 +89,38 @@ public class BgpSessionHoldTimerTests
 
         public ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
         {
+            // #341 test seam: an optional write gate. When set, every WriteAsync signals entry and
+            // parks on the gate — a slow peer (TCP zero window) that accepts nothing, holding the
+            // session's _sendLock from inside the blocked write.
+            if (_writeGate is { } gate)
+            {
+                _writeEntered.TrySetResult();
+                return new ValueTask(gate.Task);
+            }
             // Capture the outbound bytes for assertions. A copy is needed because the caller
             // (SendMessageAsync) returns the ArrayPool buffer to the pool after this returns.
             _sent.Add(buffer.ToArray());
             return default;
         }
 
+        private TaskCompletionSource? _writeGate;
+        private TaskCompletionSource? _writeEntered;
+        public void BlockWrites()
+        {
+            _writeGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            _writeEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+        public void UnblockWrites() => _writeGate?.TrySetResult();
+        public Task WriteEntered => _writeEntered?.Task ?? Task.CompletedTask;
+
         public void Dispose()
         {
             Disposed = true;
             _inbound.Writer.TryComplete();
+            // Mirror the real transport: disposing a SocketBgpConnection aborts a pending
+            // WriteAsync (the stream is disposed under it). A gated fake write parked forever
+            // would otherwise pin the sending loop past Dispose — behavior production never has.
+            _writeGate?.TrySetCanceled();
         }
     }
 
@@ -619,5 +641,71 @@ public class BgpSessionHoldTimerTests
         Assert.DoesNotContain(messages, m => m.Contains("Session error"));
 
         conn.Dispose();
+    }
+
+    /// <summary>
+    /// #341: a blocked writer (a refresh send parked inside WriteAsync — the slow-peer holder of
+    /// the issue) holds <c>_sendLock</c>; the next keepalive tick queues on the semaphore with NO
+    /// token of its own; <c>Dispose</c> cancels <c>_cts</c> and then disposes the semaphore.
+    /// <c>SemaphoreSlim.Dispose</c> never wakes queued waiters, so pre-fix the keepalive waiter —
+    /// and with it <c>RunAsync</c> — hung forever. The lock WAIT must be bounded by the session's
+    /// own lifetime token so teardown unwinds it.
+    /// </summary>
+    [Fact]
+    public async Task Dispose_WhileSenderHoldsSendLock_RunAsyncCompletes()
+    {
+        var time = new FakeTimeProvider();
+        var conn = new FakeBgpConnection();
+        var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 9, KeepAlive = 3 };
+        var table = new RouteTable();
+        table.AddOrUpdate(new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 0x01020304 });
+        using var session = new BgpSession(
+            conn,
+            new PeerConfig { Address = "127.0.0.1" },
+            bgpConfig,
+            table,
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            new NopLogger<BgpSession>(),
+            timeProvider: time);
+
+        var runTask = await EstablishAsync(session, conn, bgpConfig, time);
+        Assert.True(session.IsEstablished, "session must reach Established");
+
+        // Wait for the initial route dump to finish (OPEN, KEEPALIVE, UPDATE) so the refresh below
+        // is what grabs the lock, not the dump.
+        for (var i = 0; i < 200 && conn.Sent.Count < 3; i++)
+        {
+            time.Advance(TimeSpan.FromMilliseconds(50));
+            await Task.Delay(2);
+        }
+        Assert.True(conn.Sent.Count >= 3, "initial route dump must have been sent");
+
+        // Freeze writes, then start a refresh — its withdraw UPDATE acquires _sendLock and parks
+        // inside WriteAsync: the slow-peer holder.
+        conn.BlockWrites();
+        var refreshTask = Task.Run(() => session.RefreshRoutesAsync());
+        await conn.WriteEntered.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Keepalive ticks queue on _sendLock — the #341 waiter (no token of its own). Two
+        // interval-steps with real-time pauses between them guarantee the tick fires (a single
+        // Advance can land exactly on the timer's due instant) and the send attempt parks.
+        for (var i = 0; i < 2; i++)
+        {
+            time.Advance(TimeSpan.FromSeconds(3));
+            await Task.Delay(50);
+        }
+
+        // Dispose mid-wait: cancels _cts, then disposes the semaphore. Pre-fix the waiter is
+        // never woken and runTask never completes; post-fix the wait unwinds on the session token.
+        session.Dispose();
+
+        var completed = await Task.WhenAny(runTask, Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.Same(runTask, completed); // RED pre-fix: the 5s timeout elapses instead
+
+        // Cleanup: release the holder — its Release() on the disposed semaphore is swallowed by
+        // SendMessageAsync's finally, and the refresh unwinds as a best-effort failure.
+        conn.UnblockWrites();
+        try { await refreshTask.WaitAsync(TimeSpan.FromSeconds(5)); } catch { /* best effort */ }
     }
 }


### PR DESCRIPTION
Closes #341   # linkage only — the integration PR aggregates the keywords that actually close issues

## Problem
`SendKeepaliveAsync` was the one send path entering `_sendLock.WaitAsync(CancellationToken.None)`. If `Dispose` ran while another sender held the lock (a slow-peer send inside the #285 budget), the queued keepalive waiter was never released: `SemaphoreSlim.Dispose` does not wake waiters (verified directly with a standalone probe — a parked waiter stays `WaitingForActivation` forever), and the holder's `Release` in its finally is swallowed by `ObjectDisposedException`. `HoldTimerLoopAsync` never completed → `RunAsync` never returned → the session graph stayed rooted by the semaphore's waiter queue. Reachable via `BgpServer.StopAsync`'s dispose loop and session replacement.

## Root Cause
The lock wait had no teardown observation channel: the only wake sources were the holder's `Release` (swallowed post-Dispose) and the caller token (`None`).

## Fix
Race the wait against a dispose signal: a `TaskCompletionSource` (`RunContinuationsAsynchronously`) set at the top of `Dispose()` BEFORE `_sendLock.Dispose()`; a parked wait loses the `Task.WhenAny` and unwinds as "not sent" (the existing best-effort contract). The wait keeps the CALLER's token. Fast path: an uncontended `WaitAsync` completes synchronously (`IsCompletedSuccessfully`) and skips the `WhenAny` — keepalives on a healthy session allocate nothing extra.

**Design deviation from the issue's proposal (wait on `_cts.Token`):** that variant was implemented first and caught by the full suite going red — `RunEstablishedAsync` cancels `_cts` BEFORE `RunAsync`'s catch blocks send their best-effort NOTIFICATION, so binding the wait to `_cts.Token` silently suppressed every post-teardown NOTIFICATION (e.g. Bad Message Length on a malformed header — `InvalidHeaderLength_OnWire_TearsDownSession_With_MessageHeaderError` failed). The WhenAny+signal design fixes the hang without touching the post-cancel send semantics.

## Correctness
- The abandoned (losing) wait task stays parked in the disposed semaphore's queue, but `RunAsync` now completes and the whole session graph (semaphore included) becomes GC-collectable — the actual harm in #341 was the never-completing task, not the parked node.
- The signal fires only inside final `Dispose` (idempotent CAS), so there is no live-operation window where a queued wait could be abandoned while the semaphore still serves sends.
- Grace-token callers (`NotifyCeaseAsync`) get the same dispose protection via the signal.

## Regression Test
`Dispose_WhileSenderHoldsSendLock_RunAsyncCompletes` — gated `WriteAsync` parks a refresh as the lock holder, a keepalive tick queues behind it, `Dispose` fires mid-wait; asserts `RunAsync` completes within 5s. Pre-fix: 3/3 red (the 5s timeout elapses — the exact hang). Post-fix: 8/8 green + full suite 802/802. The fake connection's gated write now cancels on `Dispose`, mirroring the real transport aborting a pending write (without it the fake could pin the sending loop past Dispose — behavior production never has).

## Verification
- `dotnet format` / `dotnet build` (0 errors) / `dotnet test` **802/802**
- Regression class + `MalformedUpdateResilienceTests` (the regression detector) — 5/5 consecutive green runs

## RFC
None directly (lifecycle fix); preserves RFC 4271 §6.1/§6.3 NOTIFICATION delivery on teardown — the rejected first draft would have broken it.

## Behavior Change
None observable on a healthy session. A send queued behind the lock at Dispose now reports "not sent" instead of hanging the session task forever.

## Deviation from Issue Proposal
Yes — see Fix: `_cts.Token` wait replaced by WhenAny dispose-signal (the issue's suggestion suppressed post-cancel NOTIFICATIONs; verified by a red full-suite run).