### PR TITLE
ci: run CI/format/CodeQL on dev PRs and pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   schedule:
     - cron: '37 5 * * 2'
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -2,7 +2,7 @@ name: format
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 permissions:
   contents: read


### PR DESCRIPTION
Dev-flow prerequisite: ci/format/CodeQL triggered only on main, so dev-based PRs (the fix-integration branch) got no check runs and the required contexts on dev could never be satisfied. Adds dev to the push/pull_request branch filters. release.yml stays main-only. This PR itself cannot pass the required checks (the triggers it adds are not active until it merges) — merged with --admin as the bootstrap.