### PR TITLE
fix(api): replace the append-only in-flight handler list with a count + idle task

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -50,7 +50,17 @@ public sealed class ManagementApi : IHostedService, IDisposable
     /// </summary>
     private const int DefaultInflightCap = 64;
     private readonly SemaphoreSlim _inflightCap = new(DefaultInflightCap);
-    private readonly List<Task> _inflightHandlers = new();
+    // #258: in-flight tracking is a COUNT plus an idle Task (completed whenever the count is 0),
+    // not a List<Task> — the #248 design appended every handler and never removed it, so each
+    // completed request leaked its Task (and its exception, if faulted) for the process lifetime
+    // and the drain snapshot grew without bound. StopAsync drains by awaiting the idle task.
+    private readonly object _inflightSync = new();
+    private int _inflightCount;
+    private TaskCompletionSource? _inflightActive;
+    private Task _inflightIdle = Task.CompletedTask;
+
+    /// <summary>Currently in-flight request handlers (#258) — bounded by the cap, zero when idle.</summary>
+    internal int InflightRequestCount { get { lock (_inflightSync) return _inflightCount; } }
     private HttpListener? _listener;
     private Task? _listenTask;
     private readonly CancellationTokenSource _cts = new();
@@ -210,12 +220,14 @@ public sealed class ManagementApi : IHostedService, IDisposable
         }
 
         // Drain in-flight handlers, but bounded: 10 s after cancellation is enough for a response
-        // write or an orderly OCE unwind, and short of the host's 30 s shutdown grace.
-        Task[] pending;
-        lock (_inflightHandlers) pending = _inflightHandlers.ToArray();
-        if (pending.Length > 0)
+        // write or an orderly OCE unwind, and short of the host's 30 s shutdown grace. The drain
+        // awaits the in-flight idle task (#258) — it completes when the last handler's finally
+        // runs, so no per-request bookkeeping outlives the request.
+        Task idle;
+        lock (_inflightSync) idle = _inflightIdle;
+        if (!idle.IsCompleted)
         {
-            try { await Task.WhenAny(Task.WhenAll(pending), Task.Delay(TimeSpan.FromSeconds(10), cancellationToken)); }
+            try { await Task.WhenAny(idle, Task.Delay(TimeSpan.FromSeconds(10), cancellationToken)); }
             catch { /* host grace elapsed — proceed */ }
         }
 
@@ -251,10 +263,20 @@ public sealed class ManagementApi : IHostedService, IDisposable
                 // #238: acquire an in-flight slot before spawning so the default posture is
                 // bounded even when the operator has not enabled the #119 concurrency limiter.
                 await _inflightCap.WaitAsync(ct);
+                // Register BEFORE spawning: the handler's finally decrements, and a handler that
+                // completes before this thread runs would otherwise drive the count negative.
+                lock (_inflightSync)
+                {
+                    _inflightCount++;
+                    if (_inflightCount == 1)
+                    {
+                        _inflightActive = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                        _inflightIdle = _inflightActive.Task;
+                    }
+                }
                 var accepted = ctx;
                 ctx = null; // ownership transferred to the handler task
-                var handler = HandleWithInflightReleaseAsync(accepted);
-                lock (_inflightHandlers) _inflightHandlers.Add(handler);
+                _ = HandleWithInflightReleaseAsync(accepted);
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested) { break; }
             catch (HttpListenerException) when (ct.IsCancellationRequested) { break; }
@@ -301,6 +323,18 @@ public sealed class ManagementApi : IHostedService, IDisposable
             // Tolerate teardown racing the StopAsync drain (e.g. direct Dispose without StopAsync).
             try { _inflightCap.Release(); }
             catch (ObjectDisposedException) { /* cap already disposed */ }
+            // #258: a handler leaving the in-flight set completes the idle task when it was the
+            // last one — that is what StopAsync's bounded drain awaits.
+            lock (_inflightSync)
+            {
+                _inflightCount--;
+                if (_inflightCount == 0)
+                {
+                    _inflightActive?.TrySetResult();
+                    _inflightActive = null;
+                    _inflightIdle = Task.CompletedTask;
+                }
+            }
         }
     }
 

--- a/BGPLite.Tests/ManagementApiShutdownTests.cs
+++ b/BGPLite.Tests/ManagementApiShutdownTests.cs
@@ -131,6 +131,62 @@ public sealed class ManagementApiShutdownTests : IDisposable
         blocker.Stop();
     }
 
+    /// <summary>
+    /// #258: completed handlers must leave the in-flight set — the #248 bookkeeping appended
+    /// every request's Task and never removed it, so the tracking grew monotonically with request
+    /// count (a slow memory leak plus an ever-growing drain snapshot). After a burst of requests
+    /// the in-flight count must return to exactly zero.
+    /// </summary>
+    [Fact]
+    public async Task CompletedRequests_LeaveTheInFlightSet()
+    {
+        for (var attempt = 0; ; attempt++)
+        {
+            var port = FreeTcpPort();
+            var config = new AppConfig
+            {
+                ApiListen = "127.0.0.1",
+                ApiPort = port,
+                Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" }
+            };
+            _api = new ManagementApi(
+                new PeerStore(new StaticOptionsFactory(new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(_connection).Options)),
+                new RouteTable(),
+                config,
+                new BgpMetrics(),
+                NullLogger<ManagementApi>.Instance,
+                new BlockingRuPrefixService(),
+                new InertPrefixSourceService(),
+                new InertSessionManager());
+            try
+            {
+                await _api.StartAsync(CancellationToken.None);
+                _port = port;
+                break;
+            }
+            catch (HttpListenerException) when (attempt < 2)
+            {
+                _api.Dispose();
+                _api = null;
+            }
+        }
+        _client = new HttpClient();
+
+        for (var i = 0; i < 25; i++)
+        {
+            using var response = await _client.GetAsync($"http://127.0.0.1:{_port}/api/sessions");
+            Assert.True(response.IsSuccessStatusCode);
+        }
+
+        // The handler's finally (response close + slot release) runs just after the response is
+        // observed — settle within a bounded window, then demand exactly zero.
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(3);
+        while (_api.InflightRequestCount > 0 && DateTime.UtcNow < deadline)
+            await Task.Delay(20);
+
+        Assert.Equal(0, _api.InflightRequestCount);
+    }
+
     private static int FreeTcpPort()
     {
         var listener = new TcpListener(IPAddress.Loopback, 0);


### PR DESCRIPTION
Closes #258   # linkage; closure lands with the integration PR

## Problem
The #248 bookkeeping appended every request's handler `Task` to `_inflightHandlers` and never removed it: each completed request leaked its Task (and its retained Exception, when faulted) for the process lifetime, memory grew monotonically with request count, and every `StopAsync` drain snapshotted an ever-growing list under the same lock.

## Root Cause
Bookkeeping designed for the drain kept strong references with no completion path.

## Fix (issue's option 2)
Track a count: incremented under a small lock BEFORE the handler is spawned (after the cap slot is acquired — so a handler that completes early cannot drive the count negative), decremented in the handler's finally, with a `TaskCompletionSource` completed when the count returns to zero. `StopAsync`'s bounded drain (10s, host token) now awaits that idle task — the same #248/#326 drain semantics without per-request retention. `internal int InflightRequestCount` exposes the live count.

## Correctness
- Increments happen only in the accept loop; `StopAsync` stops the listener and awaits the loop first, so no handler can register after the drain's idle-task snapshot.
- The idle task starts completed (count 0), so an idle API drains instantly.
- Cap release stays in the handler finally; the count decrement sits after it, both idempotent-safe under races with direct Dispose.

## Regression Test
`CompletedRequests_LeaveTheInFlightSet` — 25 sequential requests, then the in-flight count must settle to exactly zero within 3s. Red/green proven by temporarily reverting the fix and exposing the same accessor over the old list: RED (25 != 0), then green after the fix (3/3 focused runs, full suite 803/803).

## Verification
`dotnet format` / `dotnet build` (0 errors) / focused 3/3 / full suite **803/803**.

## RFC / Behavior Change
None — internal bookkeeping; externally observable behavior unchanged (drain bounds identical).

## Deviation from Issue Proposal
None in substance — implemented the issue's option 2 (count + completion) over option 1 (per-task removal continuation): fewer moving parts, no per-request allocation.