### PR TITLE
fix(api): bound each request-body read with a deadline — slow-drip bodies can no longer starve the API

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -525,6 +525,14 @@ public sealed class ManagementApi : IHostedService, IDisposable
     /// deserialization. <c>HttpListener</c> has no default body limit, so without this a single
     /// client could stream gigabytes into the process. The cap also covers chunked-transfer bodies
     /// (no Content-Length) via the read-loop's running byte count.
+    /// <para>
+    /// #257: HttpListener also exposes no client-disconnect token, so a slow-drip body (a byte
+    /// every few seconds) otherwise parks the handler — and its in-flight slot — forever; 64 such
+    /// connections starve the whole API. Each read is therefore bounded by
+    /// <paramref name="readTimeout"/>; a breach surfaces as <c>408 Request Timeout</c>. The
+    /// abandoned read parks on the (dead) socket holding this call's buffer — bounded by the
+    /// in-flight cap (64 × 8 KB), never reused, collected with the socket.
+    /// </para>
     /// </summary>
     private async Task<(string? Body, ApiResponse? Error)> ReadBodyAsync(HttpListenerContext ctx)
     {
@@ -535,21 +543,42 @@ public sealed class ManagementApi : IHostedService, IDisposable
             return (null, ApiResponse.Error(
                 $"Request body too large ({ctx.Request.ContentLength64} bytes, max {maxBytes}).", 413));
 
-        return await ReadBoundedBodyAsync(ctx.Request.InputStream, maxBytes);
+        return await ReadBoundedBodyAsync(ctx.Request.InputStream, maxBytes, BodyReadTimeout);
     }
+
+    /// <summary>#257: per-read deadline for request bodies — the time dimension of the #156 size cap.</summary>
+    private static readonly TimeSpan BodyReadTimeout = TimeSpan.FromSeconds(30);
 
     /// <summary>
     /// Pure body reader with a hard byte cap — extracted for unit testing (#156). Returns
     /// <c>(null, 413-error)</c> when the stream yields more than <paramref name="maxBytes"/> bytes,
+    /// <c>(null, 408-error)</c> when a single read breaches <paramref name="readTimeout"/> (#257),
     /// otherwise the full body decoded as UTF-8. Covers both sized and chunked/streaming bodies.
     /// </summary>
-    internal static async Task<(string? Body, ApiResponse? Error)> ReadBoundedBodyAsync(Stream input, long maxBytes)
+    internal static async Task<(string? Body, ApiResponse? Error)> ReadBoundedBodyAsync(
+        Stream input, long maxBytes, TimeSpan? readTimeout = null)
     {
         using var ms = new MemoryStream();
         var buffer = new byte[8192];
-        int read;
-        while ((read = await input.ReadAsync(buffer, 0, buffer.Length)) > 0)
+        while (true)
         {
+            int read;
+            var readTask = input.ReadAsync(buffer, 0, buffer.Length);
+            try
+            {
+                // #257: no client-disconnect token exists on HttpListener streams — the deadline
+                // is the only bound on a slow-drip body. WaitAsync leaves the abandoned read
+                // parked on the socket with this call's buffer (bounded by the in-flight cap,
+                // never reused); the caller unwinds, answers 408, and frees its slot.
+                read = readTimeout is { } timeout ? await readTask.WaitAsync(timeout) : await readTask;
+            }
+            catch (TimeoutException)
+            {
+                return (null, ApiResponse.Error("Request body read timed out.", 408));
+            }
+            if (read <= 0)
+                break;
+
             ms.Write(buffer, 0, read);
             if (ms.Length > maxBytes)
                 return (null, ApiResponse.Error(

--- a/BGPLite.Tests/RequestBodyLimitsTests.cs
+++ b/BGPLite.Tests/RequestBodyLimitsTests.cs
@@ -104,4 +104,54 @@ public class RequestBodyLimitsTests
         public override void SetLength(long value) => throw new NotSupportedException();
         public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
     }
+
+    /// <summary>
+    /// #257: a body that never arrives parks <c>ReadBoundedBodyAsync</c> forever — with the
+    /// 64-slot in-flight cap, 64 such connections starve the whole API. Each read must be bounded
+    /// by the deadline and surface as 408. The outer WaitAsync(3s) doubles as the red guard: on
+    /// pre-fix code the call never completes and the test fails on the guard timeout.
+    /// </summary>
+    [Fact]
+    public async Task SlowDripBody_NeverCompletingRead_Returns408()
+    {
+        using var input = new NeverCompletingStream();
+
+        var (body, error) = await ManagementApi
+            .ReadBoundedBodyAsync(input, maxBytes: 1024, readTimeout: TimeSpan.FromMilliseconds(100))
+            .WaitAsync(TimeSpan.FromSeconds(3));
+
+        Assert.Null(body);
+        Assert.NotNull(error);
+        Assert.Equal(408, error!.StatusCode);
+    }
+
+    /// <summary>#257: the deadline must not affect a body that arrives within it.</summary>
+    [Fact]
+    public async Task BodyWithinDeadline_StillRead()
+    {
+        using var input = new MemoryStream(Encoding.UTF8.GetBytes("{\"ip\":\"1.2.3.4\"}"));
+        var (body, error) = await ManagementApi.ReadBoundedBodyAsync(
+            input, maxBytes: 1024, readTimeout: TimeSpan.FromSeconds(30));
+
+        Assert.Null(error);
+        Assert.Equal("{\"ip\":\"1.2.3.4\"}", body);
+    }
+
+    /// <summary>A stream whose ReadAsync never completes — the slow-drip attacker's socket.</summary>
+    private sealed class NeverCompletingStream : Stream
+    {
+        private readonly TaskCompletionSource<int> _never = new();
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => _never.Task.Result;
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => _never.Task;
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
 }


### PR DESCRIPTION
Closes #257   # linkage; closure lands with the integration PR

## Problem
`ReadBoundedBodyAsync` awaited `input.ReadAsync` with no timeout or cancellation, and the in-flight slot (acquired in the accept loop BEFORE rate limiting) is held for the whole body read. HttpListener exposes no client-disconnect token, so a client sending POST headers and then a byte every few seconds parked its handler forever: 64 such connections (`DefaultInflightCap`) held every slot, the accept loop blocked on the cap, and rate limiting (#116) never fired. Total API DoS with 64 cheap connections.

## Root Cause
The #156 size cap covered the SPACE dimension; the TIME dimension was unbounded, and no signal exists to detect a gone-silent client except a deadline.

## Fix
Bound each read with `Task.WaitAsync(timeout)`: a breach surfaces as `408 Request Timeout` and the handler unwinds, freeing its in-flight slot. Production callers pass a 30 s deadline (`BodyReadTimeout` const); the pure helper's parameter stays optional so the existing size-cap unit tests run unbounded. The abandoned read parks on the (dead) socket holding that call's 8 KB buffer — bounded by the in-flight cap (64 × 8 KB), never reused, collected with the socket.

## Correctness
- Normal bodies arriving within the deadline are unaffected (`BodyWithinDeadline_StillRead`).
- 413 size-cap behavior byte-identical (existing tests untouched, still green).
- The issue's secondary suggestion (acquire the slot after a rate-limit precheck) is deliberately NOT taken here: reordering the accept pipeline is a behavioral change with its own tradeoffs and independent of the deadline fix — noted as a follow-up option, not smuggled in.

## Regression Test
`SlowDripBody_NeverCompletingRead_Returns408` — a `NeverCompletingStream` (the slow-drip attacker's socket) with a 100 ms deadline; the outer 3 s guard doubles as the red guard. Verified red on deadline-less code (guard TimeoutException) and green after (408). Suite 805/805.

## Verification
`dotnet format` / `dotnet build` (0 errors) / `RequestBodyLimitsTests` 7/7 / full suite **805/805**.

## RFC
None — management plane.

## Behavior Change
Bodies slower than 30 s per read now get 408 instead of holding a slot indefinitely.

## Deviation from Issue Proposal
The CancelAfter-over-whole-handler variant was narrowed to a per-read WaitAsync (same deadline semantics, no extra CTS per request); the slot/rate-limit reordering suggestion deferred (see Correctness).