### PR TITLE
fix(providers): cap UserSourceCache entries — port the #165 eviction sweep

### DIFF
--- a/BGPLite.Providers/UserSourceCache.cs
+++ b/BGPLite.Providers/UserSourceCache.cs
@@ -27,19 +27,30 @@ internal sealed class UserSourceCache
     private readonly TimeSpan _negativeTtl;
     private readonly ILogger? _logger;
     private readonly TimeProvider _timeProvider;
+    // Upper bound on _cache/_locks entries (#261, port of PrefixService's #165 pattern). Without a
+    // cap, every unique peer-supplied URL leaves a permanent entry — up to ~10 MB of parsed prefixes
+    // each (the HTTP body cap) plus a SemaphoreSlim — so operator churn or an API client loop grows
+    // the cache without limit. Exceeded → sweep expired entries first, then the oldest by CachedAt.
+    private readonly int _maxEntries;
 
     // url → (list, cached at, is negative). Negative entries (failed loads) use _negativeTtl.
     private readonly ConcurrentDictionary<string, (IReadOnlyList<(uint Prefix, byte Length)> List, DateTime CachedAt, bool Negative)> _cache = new();
     // url → gate serializing the cache-miss fetch path (prevents thundering herd on cold/expired keys).
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new();
 
-    public UserSourceCache(TimeSpan? positiveTtl = null, TimeSpan? negativeTtl = null, ILogger? logger = null, TimeProvider? timeProvider = null)
+    public UserSourceCache(TimeSpan? positiveTtl = null, TimeSpan? negativeTtl = null, ILogger? logger = null, TimeProvider? timeProvider = null, int? maxCacheEntries = null)
     {
         _positiveTtl = positiveTtl ?? TimeSpan.FromHours(1);
         _negativeTtl = negativeTtl ?? TimeSpan.FromSeconds(30);
         _logger = logger;
         _timeProvider = timeProvider ?? TimeProvider.System;
+        // Generous vs. real deployments (peers × a few active sources each); the cap defends
+        // against unbounded growth from churn/adversarial URL variety, not normal operation.
+        _maxEntries = maxCacheEntries ?? 1024;
     }
+
+    /// <summary>Entries currently tracked (test/observability).</summary>
+    internal int TrackedCount => _cache.Count;
 
     /// <param name="url">Cache key (the source URL — dedupes across peers).</param>
     /// <param name="logLabel">Safe identifier (the source <c>Name</c>) for log lines — the URL itself is
@@ -80,18 +91,62 @@ internal sealed class UserSourceCache
                 }
 
                 // Otherwise remember the failure briefly so repeated calls don't hammer the fetcher.
+                EvictIfAtCapacity(url);
                 _cache[url] = ([], _timeProvider.GetUtcNow().UtcDateTime, Negative: true);
                 _logger?.LogWarning(ex, "User-source '{Name}' load failed (no cached copy); negative-cached for {Seconds}s.",
                     logLabel, (int)_negativeTtl.TotalSeconds);
                 throw;
             }
 
+            EvictIfAtCapacity(url);
             _cache[url] = (prefixes, _timeProvider.GetUtcNow().UtcDateTime, Negative: false);
             return prefixes;
         }
         finally
         {
             gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Enforces the _maxEntries bound (#261). Called before inserting a NEW key, under the caller's
+    /// per-URL gate. Drops expired entries first (cheapest eviction), then the oldest by CachedAt
+    /// until below the cap, removing the matching _locks entries with them. Same tradeoff as
+    /// PrefixService's #165 sweep: a concurrent loader may still hold an evicted URL's semaphore — it
+    /// finishes on its own reference and a fresh caller GetOrAdd's a new gate, so the worst case is
+    /// one duplicate idempotent GET, never a correctness loss.
+    /// </summary>
+    private void EvictIfAtCapacity(string insertingUrl)
+    {
+        if (_cache.Count < _maxEntries) return;
+        if (_cache.ContainsKey(insertingUrl)) return; // already present, no insert coming
+
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        var toEvict = new List<string>();
+        foreach (var (key, entry) in _cache)
+        {
+            var ttl = entry.Negative ? _negativeTtl : _positiveTtl;
+            if (now - entry.CachedAt >= ttl)
+                toEvict.Add(key);
+        }
+        // If still at/over capacity after dropping expired, evict the oldest until below the cap.
+        if (_cache.Count - toEvict.Count >= _maxEntries)
+        {
+            var oldest = _cache
+                .Where(kvp => !toEvict.Contains(kvp.Key))
+                .OrderBy(kvp => kvp.Value.CachedAt)
+                .Select(kvp => kvp.Key);
+            foreach (var key in oldest)
+            {
+                toEvict.Add(key);
+                if (_cache.Count - toEvict.Count < _maxEntries) break;
+            }
+        }
+
+        foreach (var key in toEvict)
+        {
+            if (_cache.TryRemove(key, out _))
+                _locks.TryRemove(key, out _);
         }
     }
 

--- a/BGPLite.Tests/UserSourceCacheTests.cs
+++ b/BGPLite.Tests/UserSourceCacheTests.cs
@@ -166,4 +166,55 @@ public class UserSourceCacheTests
 
         Assert.Equal(2, f.Calls); // negative entry expired → refetched
     }
+
+    /// <summary>
+    /// #261: unique peer-supplied URLs must not grow the cache without bound — port of the #165
+    /// cap. Inserting more distinct URLs than maxCacheEntries keeps the tracked count at the cap.
+    /// </summary>
+    [Fact]
+    public async Task UniqueUrls_BeyondCap_KeepCacheBounded()
+    {
+        var cache = new UserSourceCache(maxCacheEntries: 5);
+        var f = new Fetcher { OnSuccess = () => P((0x0A000000u, (byte)8)) };
+
+        for (var i = 0; i < 12; i++)
+            await cache.GetOrLoadAsync($"https://example.com/list-{i}", "src", f.Invoke, CancellationToken.None);
+
+        Assert.Equal(5, cache.TrackedCount);
+    }
+
+    /// <summary>
+    /// #261: the sweep drops the OLDEST entries (expired-first, then by CachedAt), so a fresh
+    /// entry survives and an evicted one refetches on next use.
+    /// </summary>
+    [Fact]
+    public async Task Eviction_DropsOldest_First_FreshEntriesSurvive()
+    {
+        var cache = new UserSourceCache(maxCacheEntries: 3);
+        var calls = new Dictionary<string, int>();
+        Task<IReadOnlyList<(uint Prefix, byte Length)>> Load(string url) => Task.Run(async () =>
+        {
+            lock (calls) calls[url] = calls.TryGetValue(url, out var c) ? c + 1 : 1;
+            await Task.Yield();
+            return P((0x0A000000u, (byte)8));
+        });
+
+        await cache.GetOrLoadAsync("https://example.com/a", "a", ct => Load("a"), CancellationToken.None);
+        await cache.GetOrLoadAsync("https://example.com/b", "b", ct => Load("b"), CancellationToken.None);
+        await cache.GetOrLoadAsync("https://example.com/c", "c", ct => Load("c"), CancellationToken.None);
+        await cache.GetOrLoadAsync("https://example.com/d", "d", ct => Load("d"), CancellationToken.None); // evicts "a"
+
+        Assert.Equal(3, cache.TrackedCount);
+        lock (calls) Assert.Equal(1, calls["d"]); // fresh entry is cached
+        lock (calls) Assert.Equal(1, calls["b"]); // survivor served from cache below
+        lock (calls) Assert.Equal(1, calls["c"]);
+
+        var b = await cache.GetOrLoadAsync("https://example.com/b", "b", ct => Load("b"), CancellationToken.None);
+        Assert.NotNull(b);
+        lock (calls) Assert.Equal(1, calls["b"]); // still cached — no refetch
+
+        var a = await cache.GetOrLoadAsync("https://example.com/a", "a", ct => Load("a"), CancellationToken.None);
+        Assert.NotNull(a);
+        lock (calls) Assert.Equal(2, calls["a"]); // evicted earlier → refetched
+    }
 }


### PR DESCRIPTION
Closes #261   # linkage; closure lands with the integration PR

## Problem
`UserSourceCache` had logical TTLs but no removal: every unique peer-supplied URL left a permanent entry — up to ~10 MB of parsed prefixes (the HTTP body cap) plus a `SemaphoreSlim` — so operator churn or an API-client loop over `POST /api/peers/{id}/sources` grew the cache and lock dictionary without bound.

## Root Cause
The cache mirrored `PrefixSourceService`'s shape but not its #165 capacity bound.

## Fix
Port the #165 sweep: before each insert of a NEW key — drop expired entries first (per-kind TTL), then the oldest by `CachedAt` until below the cap, removing matching `_locks` entries together. Same semaphore tradeoff #165 already accepts and documents: an in-flight loader for an evicted URL keeps running on its own gate reference; a fresh caller GetOrAdd's a new gate — worst case one duplicate idempotent GET, never a correctness loss. Default cap 1024; `internal TrackedCount` for tests.

## Correctness
- Inserts of already-present keys never trigger a sweep (guard mirrors PrefixService).
- Both insert paths covered: positive and negative-cache writes.
- Fresh in-flight URLs are not evicted by their own insert (the sweep runs BEFORE the insert, and skips when the key exists).

## Regression Tests
`UniqueUrls_BeyondCap_KeepCacheBounded` (12 unique URLs, cap 5 → tracked == 5; verified RED on cap-less code: 12 != 5) and `Eviction_DropsOldest_First_FreshEntriesSurvive` (oldest evicted + refetched on next use; fresh entry and survivors served from cache). Suite **807/807**.

## Verification
`dotnet format` / `dotnet build` (0 errors) / `UserSourceCacheTests` 10/10 / full suite 807/807.

## RFC / Behavior Change
None — internal cache bound; externally, a URL unused for a long time under churn may refetch once.

## Deviation from Issue Proposal
None — the suggested #165 port implemented as proposed.
