### PR TITLE
fix(providers): parse RIPEstat prefixes through the canonical PrefixCidr parser

### DIFF
--- a/BGPLite.Providers/RipeStatProvider.cs
+++ b/BGPLite.Providers/RipeStatProvider.cs
@@ -50,11 +50,20 @@ public sealed class RipeStatProvider
 
         foreach (var element in prefixes.EnumerateArray())
         {
-            var cidr = element.GetString()!;
-            var slash = cidr.IndexOf('/');
-            var ip = IPAddress.Parse(cidr[..slash]);
-            var length = byte.Parse(cidr[(slash + 1)..]);
-            var prefix = BgpConstants.IPAddressToUint(ip);
+            var cidr = element.GetString();
+            // #319: the canonical parser every other prefix input path uses (#236): host-bit
+            // masking, /0 rejection, length 1..32, IPv4-only. RIS collectors return what third
+            // parties ANNOUNCED — non-canonical NLRI ("10.0.0.1/8") must not reach the route
+            // table under a corrupt key, and "0.0.0.0/0" must not become a default-route leak
+            // (#162 closed the same hole for URL sources). Skip + warn, like stored custom
+            // prefixes; also covers a null/garbage element without throwing (previously NRE/
+            // FormatException took the whole ASN fetch down).
+            if (!PrefixCidr.TryParse(cidr, out var prefix, out var length))
+            {
+                _logger.LogWarning("AS{Asn}: RIPEstat returned a non-canonical prefix '{Cidr}'; skipped", asn, cidr);
+                continue;
+            }
+
             result.Add((prefix, length));
         }
 

--- a/BGPLite.Tests/RipeStatProviderTests.cs
+++ b/BGPLite.Tests/RipeStatProviderTests.cs
@@ -120,6 +120,28 @@ public class RipeStatProviderTests
         }
     }
 
+
+    /// <summary>
+    /// #319: RIPEstat returns what third parties ANNOUNCED — non-canonical NLRI must go through
+    /// the canonical parser (#236): host bits masked, /0 rejected, length range enforced, garbage
+    /// skipped instead of throwing the whole fetch. Pre-fix, "10.0.0.1/8" landed unmasked under a
+    /// corrupt route-table key and "0.0.0.0/0" was a default-route leak.
+    /// </summary>
+    [Fact]
+    public async Task NonCanonicalPrefixes_MaskedOrSkipped()
+    {
+        const string body =
+            """{"status":"ok","data":{"resource":"65001","prefixes":{"v4":{"originating":["10.0.0.1/8","0.0.0.0/0","1.2.3.4/33","not-a-cidr","192.168.0.0/16"]},"v6":{"originating":[]}}}}""";
+        var handler = new StubHandler(HttpStatusCode.OK, body);
+        var result = await Provider(handler).GetPrefixesAsync(65001);
+
+        Assert.Contains((0x0A000000u, (byte)8), result);      // 10.0.0.1/8 masked to the network
+        Assert.DoesNotContain((0x0A000001u, (byte)8), result); // unmasked key never stored
+        Assert.Contains((0xC0A80000u, (byte)16), result);      // canonical row unaffected
+        Assert.DoesNotContain(result, p => p.PrefixLength is 0 or > 32); // /0 and /33 rejected
+        Assert.Equal(2, result.Count);                          // garbage skipped, not thrown
+    }
+
     /// <summary>A handler that honors the CancellationToken like HttpClient's real handler does.</summary>
     private sealed class CancelAwareHandler : HttpMessageHandler
     {


### PR DESCRIPTION
Closes #319   # linkage; closure lands with the integration PR

## Problem
`GetPrefixesAsync` hand-parsed CIDR strings — the one prefix input path bypassing `PrefixCidr` (#236): host bits stored unmasked (`10.0.0.1/8` → `(0x0A000001, 8)`, a corrupt `RouteTable` key breaking dedup and double-announcing under two keys), `0.0.0.0/0` admitted (default-route leak to every subscriber of that AS — the hole #162 closed for URL sources), `/33+` surviving into `Route.PrefixLength` until `PrefixCodec.Encode` kills the session, and a null/garbage element throwing and failing the whole ASN fetch.

## Root Cause
The last un-migrated parser after the #236 unification.

## Fix
Route every element through `PrefixCidr.TryParse` and skip + warn on failure (the stored-custom-prefix precedent): host-bit masking, /0 rejection, length 1..32, IPv4-only. Non-canonical NLRI is realistic here — RIS collectors return what third parties ANNOUNCED, and inbound BGP NLRI is already masked by `PrefixCodec.Decode`; this was the one unmasked path.

## Regression Test
`NonCanonicalPrefixes_MaskedOrSkipped` — `10.0.0.1/8` masked to the network, unmasked key absent, `/0` and `/33` rejected, `not-a-cidr` skipped without throwing, canonical row unaffected. Behavioral test, naturally red on the hand parser (verified) and green after.

## Verification
`dotnet format` / `dotnet build` (0 errors) / `RipeStatProviderTests` 6/6 / full suite **808/808**.

## RFC
None — management/provisioning plane (the BGP wire side already masks NLRI per RFC 4271 encoding).

## Behavior Change
Deliberate: non-canonical RIPEstat rows are now canonicalized (host bits masked) or skipped with a warning, instead of stored corrupt or leaking a default route.

## Deviation from Issue Proposal
None — implemented as proposed (the issue's exact fix direction).