### PR TITLE
fix(protocol): carry the max-supported-version Data field in Unsupported Version NOTIFICATIONs

### DIFF
--- a/BGPLite.Protocol/BgpMessageReader.cs
+++ b/BGPLite.Protocol/BgpMessageReader.cs
@@ -103,8 +103,16 @@ public static class BgpMessageReader
 
         var version = payload[0];
         if (version != BgpConstants.BgpVersion)
+            // RFC 4271 §6.2 Unsupported Version Number: the Data field "indicates the largest,
+            // locally-supported version number less than the version the remote BGP peer bid …
+            // or if the smallest locally-supported version number is larger than the peer's bid,
+            // the smallest locally-supported version number". BGPLite supports only version 4, so
+            // both branches resolve to 4: bid>4 → largest-below-bid is 4; bid<4 → smallest is 4.
+            // Without the field a BGPv3 speaker gets no downgrade hint (#317). Byte-identical
+            // with OpenNegotiator.Validate, the other reject site for the same condition.
             throw new BgpParseException($"Unsupported BGP version: {version}",
-                BgpConstants.Error.OpenMessageError, BgpConstants.SubError.UnsupportedVersion);
+                BgpConstants.Error.OpenMessageError, BgpConstants.SubError.UnsupportedVersion,
+                notificationData: [(byte)(BgpConstants.BgpVersion >> 8), (byte)BgpConstants.BgpVersion]);
 
         var asn = BinaryPrimitives.ReadUInt16BigEndian(payload[1..]);
         var holdTime = BinaryPrimitives.ReadUInt16BigEndian(payload[3..]);

--- a/BGPLite.Protocol/OpenNegotiator.cs
+++ b/BGPLite.Protocol/OpenNegotiator.cs
@@ -45,7 +45,15 @@ public static class OpenNegotiator
                 $"Local hold time must be 0 (disabled) or at least 3 seconds (RFC 4271 §4.2).");
 
         if (open.Version != BgpConstants.BgpVersion)
-            throw new BgpNotificationException(BgpConstants.Error.OpenMessageError, BgpConstants.SubError.UnsupportedVersion, $"Unsupported BGP version: {open.Version}");
+            // RFC 4271 §6.2: the Data field indicates the largest locally-supported version less
+            // than the peer's bid, or the smallest locally-supported version when even that is
+            // larger. BGPLite supports only version 4, so both branches resolve to 4 (#317).
+            // Mirrors BgpMessageReader.ParseOpen byte-for-byte — one wire behavior for one
+            // condition regardless of which reject site fires.
+            throw new BgpNotificationException(
+                BgpConstants.Error.OpenMessageError, BgpConstants.SubError.UnsupportedVersion,
+                $"Unsupported BGP version: {open.Version}",
+                [(byte)(BgpConstants.BgpVersion >> 8), (byte)BgpConstants.BgpVersion]);
 
         var malformedFourOctetAsnCapability = UpdateCodec.GetMalformedFourOctetAsnCapabilityData(open);
         if (malformedFourOctetAsnCapability.Length > 0)

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -89,6 +89,21 @@ public class BgpMessageTests
     }
 
     [Fact]
+    public void Open_UnsupportedVersion_CarriesMaxSupportedVersionData()
+    {
+        // RFC 4271 §6.2 (#317): the Unsupported Version NOTIFICATION's Data field must carry the
+        // 2-octet version hint. BGPLite supports only v4 — both §6.2 branches resolve to 4.
+        var message = BuildRawOpen(0, []);
+        message[19] = 3; // BGPv3
+
+        var ex = Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(message));
+
+        Assert.Equal(BgpConstants.Error.OpenMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.UnsupportedVersion, ex.SubErrorCode);
+        Assert.Equal([(byte)0, (byte)4], ex.NotificationData);
+    }
+
+    [Fact]
     public void Open_WellFormedRawOptParams_Parses()
     {
         // Capability parameter (type 2) carrying a Four-Octet-ASN TLV (code 65, len 4, ASN 200000).

--- a/BGPLite.Tests/OpenNegotiatorTests.cs
+++ b/BGPLite.Tests/OpenNegotiatorTests.cs
@@ -98,6 +98,21 @@ public class OpenNegotiatorTests
 
         Assert.Equal(BgpConstants.Error.OpenMessageError, ex.ErrorCode);
         Assert.Equal(BgpConstants.SubError.UnsupportedVersion, ex.SubErrorCode);
+        // RFC 4271 §6.2 (#317): the Data field carries a 2-octet version hint. BGPLite supports
+        // only v4, so a bid of 3 hits the "smallest locally-supported" branch → 4.
+        Assert.Equal([(byte)0, (byte)4], ex.NotificationData);
+    }
+
+    [Fact]
+    public void UnsupportedVersion_BidAboveSupported_DataFieldStillFour()
+    {
+        // A bid ABOVE 4 hits the "largest locally-supported less than the bid" branch, which
+        // also resolves to 4 — one constant is correct for both §6.2 branches.
+        var ex = Assert.Throws<BgpNotificationException>(
+            () => Negotiate(Open(version: 5)));
+
+        Assert.Equal(BgpConstants.SubError.UnsupportedVersion, ex.SubErrorCode);
+        Assert.Equal([(byte)0, (byte)4], ex.NotificationData);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #317   # linkage; closure lands with the integration PR

## Problem
Both reject sites (`BgpMessageReader.ParseOpen`, `OpenNegotiator.Validate`) sent OPEN Message Error / Unsupported Version (2/1) with no Data field — a BGPv3 speaker gets no downgrade hint.

## Root Cause
The `notificationData` plumbing (through to `SendNotificationAsync`) landed with #300; this path never used it.

## RFC
RFC 4271 §6.2 (verified against the RFC text during implementation): the Data field "indicates the largest, locally-supported version number less than the version the remote BGP peer bid … or if the smallest locally-supported version number is larger than the peer's bid, the smallest locally-supported version number".

## Fix
BGPLite supports only version 4, so BOTH §6.2 branches resolve to the same 2-octet value: bid>4 → largest-below-bid is 4; bid<4 → smallest is 4. Both sites emit the constant `[0x00, 0x04]`, byte-identical.

## Regression Tests
`NotificationData` asserted on three paths: `Validate` with bid 3 and bid 5 (both §6.2 branches), and the `ParseOpen` wire path (raw BGPv3 OPEN). Red on the data-less throws (3 failed assertions pre-fix), green after.

## Verification
`dotnet format` / `dotnet build` (0 errors) / focused 109/109 / full suite **810/810**.

## Behavior Change
The 2/1 NOTIFICATION now carries 2 data bytes — strictly more RFC-conformant; no state-machine change.

## Deviation from Issue Proposal
The issue's RFC quote ("MUST be set to … highest, locally supported version") is a paraphrase; the verified §6.2 text is two-branch (largest-below-bid / smallest). The emitted bytes are identical under BGPLite's single-version reality; the code comments cite the precise rule.