### PR TITLE
fix(providers,server): arm a fetch budget for user URL sources; treat its OCE as a load failure

### DIFF
--- a/BGPLite.Providers/PrefixService.cs
+++ b/BGPLite.Providers/PrefixService.cs
@@ -34,7 +34,7 @@ public sealed class PrefixService : IPrefixService
     // when the TTL elapses. Mirrors the per-ASN gate pattern in GetPrefixesAsync.
     private readonly SemaphoreSlim _ruGate = new(1, 1);
 
-    public PrefixService(AppConfig config, RipeStatProvider ripeStat, IPrefixSourceService prefixSources, HttpPrefixProvider httpProvider, TimeSpan? cacheTtl = null, ILogger<PrefixService>? logger = null, TimeSpan? negativeTtl = null, int? maxCacheEntries = null, TimeProvider? timeProvider = null)
+    public PrefixService(AppConfig config, RipeStatProvider ripeStat, IPrefixSourceService prefixSources, HttpPrefixProvider httpProvider, TimeSpan? cacheTtl = null, ILogger<PrefixService>? logger = null, TimeSpan? negativeTtl = null, int? maxCacheEntries = null, TimeProvider? timeProvider = null, int? userSourceTimeoutSeconds = null)
     {
         _config = config;
         _ripeStat = ripeStat;
@@ -48,8 +48,16 @@ public sealed class PrefixService : IPrefixService
         _maxCacheEntries = maxCacheEntries ?? 4096;
         _logger = logger;
         _timeProvider = timeProvider ?? TimeProvider.System;
+        // #320: fetch budget for peer-supplied URL sources — generous for a real prefix list
+        // (10 MB cap streams in well under it), bounded enough that a dripping/hung body cannot
+        // stall the route dump behind the per-URL gate.
+        _userSourceTimeoutSeconds = userSourceTimeoutSeconds ?? DefaultUserSourceTimeoutSeconds;
         _userSourceCache = new UserSourceCache(logger: logger, timeProvider: _timeProvider);
     }
+
+    /// <summary>Default per-fetch budget for peer-supplied URL sources (#320).</summary>
+    public const int DefaultUserSourceTimeoutSeconds = 30;
+    private readonly int _userSourceTimeoutSeconds;
 
     /// <summary>
     /// Fetches a per-peer user-supplied URL prefix-list source (issues #147 / #150). The URL is
@@ -59,6 +67,15 @@ public sealed class PrefixService : IPrefixService
     /// the http provider's named client. The <c>Active</c>
     /// lifecycle is handled by the caller (LoadPeerRoutingView filters Active before this is reached),
     /// so paused sources are never advertised regardless of cache state.
+    /// <para>
+    /// #320: the config is built WITH a fetch budget. Without one, HttpPrefixProvider's linked-CTS
+    /// timeout is never armed and the body-read loop is guarded only by the session token — a
+    /// server that answers headers then drips (or never sends) the body hangs the whole route dump
+    /// behind the per-URL gate while the session stays Established (KEEPALIVEs keep the hold timer
+    /// fed). A timed-out fetch throws OCE with a live caller token — a per-source fetch failure per
+    /// the #342 boundary — and is negative-cached by <see cref="UserSourceCache"/>, so repeated
+    /// refreshes do not re-pay the budget.
+    /// </para>
     /// </summary>
     public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
     {
@@ -67,7 +84,8 @@ public sealed class PrefixService : IPrefixService
             Kind = "http",
             Name = name,
             Url = url,
-            Community = community
+            Community = community,
+            Timeout = _userSourceTimeoutSeconds
         };
         return await _userSourceCache.GetOrLoadAsync(url, name, async ct =>
         {

--- a/BGPLite.Providers/UserSourceCache.cs
+++ b/BGPLite.Providers/UserSourceCache.cs
@@ -79,7 +79,15 @@ internal sealed class UserSourceCache
             {
                 prefixes = await loadAsync(ct);
             }
-            catch (OperationCanceledException) { throw; }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                // #114: CALLER-initiated cancellation always propagates and is never cached — it
+                // is teardown, not a property of the source. A foreign-token OCE (e.g. the #320
+                // per-fetch budget's linked CTS firing on a live caller token) falls through to
+                // the failure handling below instead: stale-on-failure serve if possible, else a
+                // brief negative-cache so repeated refreshes do not re-pay the full budget.
+                throw;
+            }
             catch (Exception ex)
             {
                 // Serve the last good copy if we have one (regardless of its age).

--- a/BGPLite.Tests/PrefixServiceTests.cs
+++ b/BGPLite.Tests/PrefixServiceTests.cs
@@ -329,4 +329,70 @@ public class PrefixServiceTests
         var result = await service.GetPrefixesAsync(100);
         Assert.Single(result);
     }
+
+    /// <summary>
+    /// #320: user sources get a fetch budget end-to-end. A server that answers headers instantly
+    /// and then never sends the body used to hang the fetch (and the per-URL gate, and the whole
+    /// route dump) forever. With the budget armed, the fetch fails within it and the negative
+    /// cache throttles the retry — one HTTP attempt total.
+    /// </summary>
+    private sealed class HeadersThenHangHandler : HttpMessageHandler
+    {
+        public int Calls { get; private set; }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Calls++;
+            var body = new HangingBodyStream();
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StreamContent(body)
+            };
+            response.Content.Headers.ContentLength = 1024; // plausible, under the size cap
+            return Task.FromResult(response);
+        }
+    }
+
+    /// <summary>Delivers nothing; honors the read token like a real socket stream would.</summary>
+    private sealed class HangingBodyStream : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => 1024;
+        public override long Position { get => 0; set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return 0;
+        }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    [Fact]
+    public async Task UserSource_SlowBody_BoundedByBudget_NegativeCached()
+    {
+        var handler = new HeadersThenHangHandler();
+        var httpProvider = new HttpPrefixProvider(new StubFactory(handler), NullLogger<HttpPrefixProvider>.Instance);
+        var service = new PrefixService(
+            new AppConfig(),
+            null!, // RipeStatProvider is not on the user-source path
+            null!, // IPrefixSourceService is not on the user-source path
+            httpProvider,
+            userSourceTimeoutSeconds: 1);
+
+        // The fetch must fail within the budget (not hang) — the 8 s guard doubles as the red
+        // guard: on budget-less code the call never completes.
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => service.GetUserSourcePrefixesAsync("slow", "https://example.com/slow.txt", null)
+                .WaitAsync(TimeSpan.FromSeconds(8)));
+
+        // The negative cache throttles the retry: no second HTTP attempt.
+        var second = await service.GetUserSourcePrefixesAsync("slow", "https://example.com/slow.txt", null);
+        Assert.Empty(second);
+        Assert.Equal(1, handler.Calls);
+    }
 }

--- a/BGPLite.Tests/UserSourceCacheTests.cs
+++ b/BGPLite.Tests/UserSourceCacheTests.cs
@@ -123,19 +123,39 @@ public class UserSourceCacheTests
     [Fact]
     public async Task OperationCanceled_Propagates_And_Is_Not_Negative_Cached()
     {
-        // #114: cancellation must propagate and must not be recorded as a negative entry.
+        // #114: CALLER cancellation must propagate and must not be recorded as a negative entry.
+        // #320 refined the discriminator: the cache rethrows only OCEs whose CALLER token is
+        // cancelled — a foreign-token OCE (the per-fetch budget) is a load failure and IS
+        // negative-cached (see ForeignTokenOCE_IsAFailure_NegativeCachedAndThrottled). The
+        // faithful simulation is cancellation arriving WHILE the fetch is in flight (a
+        // pre-cancelled token never even passes the gate).
         var cache = new UserSourceCache();
-        var f = new Fetcher { Throw = new OperationCanceledException() };
+        var cts = new CancellationTokenSource();
+        var calls = 0;
 
-        await Assert.ThrowsAsync<OperationCanceledException>(
-            () => cache.GetOrLoadAsync("https://example.com/l", "src", f.Invoke, default));
-        Assert.Equal(1, f.Calls);
+        static async Task<IReadOnlyList<(uint Prefix, byte Length)>> Parked(CancellationToken ct)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+            return [];
+        }
+
+        Task<IReadOnlyList<(uint Prefix, byte Length)>> Invoke(CancellationToken ct)
+        {
+            calls++;
+            return Parked(ct);
+        }
+
+        var fetch = Task.Run(() => cache.GetOrLoadAsync("https://example.com/l", "src", Invoke, cts.Token));
+        await Task.Delay(50);   // let the caller enter the parked loader
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => fetch);
+        Assert.Equal(1, calls);
 
         // No negative cache → the next call reaches the fetcher again.
-        f.Throw = null;
-        f.OnSuccess = () => P((1u, 1));
+        var f = new Fetcher { OnSuccess = () => P((1u, 1)) };
         var served = await cache.GetOrLoadAsync("https://example.com/l", "src", f.Invoke, default);
-        Assert.Equal(2, f.Calls);
+        Assert.Equal(1, f.Calls); // a fresh fetcher ran once more
         Assert.Single(served);
     }
 
@@ -216,5 +236,29 @@ public class UserSourceCacheTests
         var a = await cache.GetOrLoadAsync("https://example.com/a", "a", ct => Load("a"), CancellationToken.None);
         Assert.NotNull(a);
         lock (calls) Assert.Equal(2, calls["a"]); // evicted earlier → refetched
+    }
+
+    /// <summary>
+    /// #320: a fetch budget fires as a foreign-token OCE (live caller token). It is a load
+    /// FAILURE, not teardown: it still throws (the caller's #342 boundary treats it as a
+    /// per-source failure), it is negative-cached, and the negative entry throttles the next
+    /// call — no loader invocation, no re-paying the budget.
+    /// </summary>
+    [Fact]
+    public async Task ForeignTokenOCE_IsAFailure_NegativeCachedAndThrottled()
+    {
+        var cache = new UserSourceCache(negativeTtl: TimeSpan.FromSeconds(5));
+        var f = new Fetcher { Throw = new OperationCanceledException() }; // no live caller token attached
+
+        // First call: the budget fired → OCE propagates (failure semantics), entry negative-cached.
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => cache.GetOrLoadAsync("https://example.com/l", "src", f.Invoke, CancellationToken.None));
+
+        // Second call within the negative TTL: throttled — the loader is NOT invoked again and
+        // the negative entry reports "no prefixes" instead of re-paying the budget.
+        var second = await cache.GetOrLoadAsync("https://example.com/l", "src", f.Invoke, CancellationToken.None);
+
+        Assert.Empty(second);
+        Assert.Equal(1, f.Calls);
     }
 }


### PR DESCRIPTION
Closes #320   # linkage; closure lands with the integration PR

## Problem
Per-peer user sources built their `PrefixSourceConfig` without a `Timeout`, so `HttpPrefixProvider`'s linked-CTS deadline was never armed and the body-read loop ran under the session token only. A server answering headers then dripping/never sending the body hung the fetch indefinitely while the session stayed Established: the whole outbound dump stalled behind the per-URL gate, `_refreshRunning` stayed latched (every later refresh only set `_refreshPending`), and other peers on the same URL queued. A slow big list triggers it without malice.

## Root Cause
The timeout mechanism existed and was config-driven; this caller never armed it. Secondarily, arming it safely required the #330-follow-up discriminator in `UserSourceCache` (predicted in the #345 PR body): a foreign-token budget OCE must be a load failure, else every refresh re-pays the full budget per source.

## Fix
1. `PrefixService` builds the user-source config with `Timeout = 30 s` (`DefaultUserSourceTimeoutSeconds`, ctor-injectable). The existing linked-CTS path covers headers AND body.
2. `UserSourceCache`: `catch (OCE) when (ct.IsCancellationRequested) { throw; }` — caller-token OCE propagates uncached (#114); a foreign-token OCE falls to failure handling: stale-on-failure serve, else negative-cache, then throw — throttling retries on the 30 s negative TTL. The #342 boundary in `RouteAssembler` turns it into skip-this-source, session and dump survive.

## Regression Tests
- `UserSource_SlowBody_BoundedByBudget_NegativeCached` — headers-then-hang handler; red on budget-less code (8 s guard); asserts the budget bounds the fetch AND exactly one HTTP attempt total.
- `ForeignTokenOCE_IsAFailure_NegativeCachedAndThrottled` — cache-level contract.
- `OperationCanceled_Propagates_And_Is_Not_Negative_Cached` (#114) re-simulated faithfully (cancellation arriving while the fetch is in flight; a pre-cancelled token never passes the gate) — intent unchanged, simulation updated for the refined discriminator, explained above.

## Verification
`dotnet format` / `dotnet build` (0 errors) / focused 3/3 green / full suite **812/812**.

## RFC
None — provisioning plane.

## Behavior Change
Deliberate: user-source fetches now fail after 30 s (skipping that source for the cycle) instead of hanging the dump; foreign-token OCEs are negative-cached. Caller-cancellation semantics unchanged.

## Deviation from Issue Proposal
Substance as proposed (construction-site arming with a constant default); additionally landed the discriminator the issue's own follow-up context (#330 comment / #345 review note) called out as required for this to be safe and non-hammering.