### PR TITLE
fix(providers): arm the fetch budget for config sources; stop the pipeline from clipping configured timeouts

### DIFF
--- a/BGPLite.Providers/HttpPrefixProvider.cs
+++ b/BGPLite.Providers/HttpPrefixProvider.cs
@@ -21,13 +21,23 @@ namespace BGPLite.Providers;
 /// </summary>
 public sealed class HttpPrefixProvider(
     IHttpClientFactory httpFactory,
-    ILogger<HttpPrefixProvider> logger)
+    ILogger<HttpPrefixProvider> logger,
+    int defaultFetchTimeoutSeconds = 30) // mirrors DefaultFetchTimeoutSeconds (a ctor default cannot reference the member const)
     : IPrefixSourceProvider
 {
     public const string ClientName = "http";
 
     /// <summary>Maximum response body size (10 MB) — defends against OOM from huge/malicious files (#144).</summary>
     internal const int MaxResponseBytes = 10 * 1024 * 1024;
+
+    /// <summary>
+    /// #324: budget applied when the source does not configure one. Without it, a YAML-configured
+    /// PrefixSource omitting <c>Timeout</c> armed no deadline at all — the named client is
+    /// InfiniteTimeSpan (Polly) and the pipeline's timeout only wrapped SendAsync up to the
+    /// headers, so a headers-then-drip body hung seeding and auto-refresh indefinitely (size is
+    /// bounded by <see cref="MaxResponseBytes"/>, time was not). Injectable for tests via the ctor.
+    /// </summary>
+    public const int DefaultFetchTimeoutSeconds = 30;
 
     public string Kind => "http";
 
@@ -45,13 +55,16 @@ public sealed class HttpPrefixProvider(
 
         var http = httpFactory.CreateClient(ClientName);
 
-        // Per-source timeout: link the caller's token with a CancelAfter so a slow peer URL can't pin
-        // the fetch past its configured budget. We do NOT mutate http.Timeout (#155 regression): the
-        // named client is pooled by IHttpClientFactory, and mutating it leaks the per-source timeout
-        // onto the next caller that reuses the same client within the handler-lifetime window.
+        // Per-source timeout: link the caller's token with a CancelAfter so a slow source can't pin
+        // the fetch past its budget — now ALWAYS armed (#324): a configured Timeout wins, otherwise
+        // the default budget covers config sources that omit it (and #320's user sources pass it
+        // explicitly). The linked token covers headers AND the body loop below.
+        // We do NOT mutate http.Timeout (#155 regression): the named client is pooled by
+        // IHttpClientFactory, and mutating it leaks the per-source timeout onto the next caller.
+        var seconds = source.Timeout is int configured && configured > 0 ? configured : defaultFetchTimeoutSeconds;
         CancellationTokenSource? timeoutCts = null;
         CancellationToken linkedToken;
-        if (source.Timeout is int seconds && seconds > 0)
+        if (seconds > 0)
         {
             timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             timeoutCts.CancelAfter(TimeSpan.FromSeconds(seconds));

--- a/BGPLite.Providers/PrefixSourceService.cs
+++ b/BGPLite.Providers/PrefixSourceService.cs
@@ -69,7 +69,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
         }
 
         try { return (await LoadCachedAsync(source, ct)).Prefixes; }
-        catch (OperationCanceledException) { throw; }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #324: only CALLER cancellation — the #324 default fetch budget fires as a foreign-token OCE (live ct) and must stay a per-source failure below
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to load prefix source '{Name}'.", name);
@@ -90,7 +90,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
         }
 
         try { return (await LoadCachedAsync(source, ct)).Prefixes; }
-        catch (OperationCanceledException) { throw; }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #324: only CALLER cancellation — the #324 default fetch budget fires as a foreign-token OCE (live ct) and must stay a per-source failure below
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to load default prefix source '{Name}'.", defaultName);
@@ -105,7 +105,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
         {
             IReadOnlyList<(uint Prefix, byte Length)> prefixes;
             try { prefixes = (await LoadCachedAsync(source, ct)).Prefixes; }
-            catch (OperationCanceledException) { throw; }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #324: only CALLER cancellation — the #324 default fetch budget fires as a foreign-token OCE (live ct) and must stay a per-source failure below
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Failed to load prefix source '{Name}' ({Kind}).", source.Name, source.Kind);
@@ -143,7 +143,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
             var (_, changed) = await LoadCachedAsync(source, ct, forceRefresh: true, triggerCallback: false);
             return changed;
         }
-        catch (OperationCanceledException) { throw; }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #324: only CALLER cancellation — the #324 default fetch budget fires as a foreign-token OCE (live ct) and must stay a per-source failure below
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Auto-refresh: failed to reload source '{Name}'.", source.Name);
@@ -203,7 +203,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
                 var provider = _factory.Get(source.Kind);
                 result = await provider.LoadAsync(source, etag, lastModified, ct);
             }
-            catch (OperationCanceledException) { throw; }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #324: only CALLER cancellation — the #324 default fetch budget fires as a foreign-token OCE (live ct) and must stay a per-source failure below
             catch
             {
                 if (_cache.TryGetValue(source.Name, out var staleCopy) && !staleCopy.Negative)

--- a/BGPLite.Tests/HttpPrefixProviderTests.cs
+++ b/BGPLite.Tests/HttpPrefixProviderTests.cs
@@ -200,6 +200,81 @@ public class HttpPrefixProviderTests
         Assert.Equal("curl/8.0", handler.LastUserAgent);
     }
 
+    /// <summary>
+    /// #324: a source with NO configured Timeout still gets a budget — the default is armed, so a
+    /// server that answers headers and then never sends the body fails by T+default instead of
+    /// hanging the fetch (and seeding/auto-refresh behind it). The outer WaitAsync guard doubles
+    /// as the red guard: on default-less code the load never completes.
+    /// </summary>
+    private sealed class HeadersThenHangHandler : HttpMessageHandler
+    {
+        public int Calls { get; private set; }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Calls++;
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StreamContent(new HangingBodyStream())
+            };
+            response.Content.Headers.ContentLength = 1024;
+            return Task.FromResult(response);
+        }
+    }
+
+    private sealed class HangingBodyStream : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => 1024;
+        public override long Position { get => 0; set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return 0;
+        }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    [Fact]
+    public async Task NoTimeoutConfigured_DefaultBudgetBoundsTheFetch()
+    {
+        var handler = new HeadersThenHangHandler();
+        var provider = new HttpPrefixProvider(
+            new StubFactory(handler), NullLogger<HttpPrefixProvider>.Instance,
+            defaultFetchTimeoutSeconds: 1);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            provider.LoadAsync(HttpSource("https://example.com/slow.txt"))
+                .WaitAsync(TimeSpan.FromSeconds(8)));
+
+        Assert.Equal(1, handler.Calls);
+    }
+
+    [Fact]
+    public async Task ConfiguredTimeout_WinsOverDefault()
+    {
+        // The configured value overrides the default (both arm the same mechanism); a small
+        // configured budget on the same hanging server fails FAST — proving the configured path
+        // still arms and is not clipped by anything.
+        var handler = new HeadersThenHangHandler();
+        var provider = new HttpPrefixProvider(
+            new StubFactory(handler), NullLogger<HttpPrefixProvider>.Instance,
+            defaultFetchTimeoutSeconds: 30);
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            provider.LoadAsync(new PrefixSourceConfig { Name = "t", Kind = "http", Url = "https://example.com/slow.txt", Timeout = 1 })
+                .WaitAsync(TimeSpan.FromSeconds(8)));
+        sw.Stop();
+
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(6), $"configured 1s budget fired in {sw.Elapsed}");
+    }
+
     [Fact]
     public async Task HttpErrorThrows()
     {

--- a/BGPLite.Tests/PrefixServiceTests.cs
+++ b/BGPLite.Tests/PrefixServiceTests.cs
@@ -395,4 +395,71 @@ public class PrefixServiceTests
         Assert.Empty(second);
         Assert.Equal(1, handler.Calls);
     }
+
+    /// <summary>
+    /// #324: a config source that hangs must not wedge sequential seeding — LoadAllAsync awaits
+    /// sources one by one, so before the default budget one dripping source stalled every later
+    /// source, WarmUp, and the final peer push until restart. With the provider-level budget the
+    /// hung source fails on its own deadline and the GOOD source still loads. The outer WaitAsync
+    /// guard doubles as the red guard on budget-less code.
+    /// </summary>
+    private sealed class PerUrlHandler : HttpMessageHandler
+    {
+        private readonly string _hangUrl;
+        public PerUrlHandler(string hangUrl) => _hangUrl = hangUrl;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            if (request.RequestUri?.ToString() == _hangUrl)
+            {
+                var hang = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(new HangingStream()) };
+                hang.Content.Headers.ContentLength = 1024;
+                return Task.FromResult(hang);
+            }
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("10.2.0.0/24\n")
+            });
+        }
+    }
+
+    private sealed class HangingStream : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => 1024;
+        public override long Position { get => 0; set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return 0;
+        }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    [Fact]
+    public async Task LoadAllAsync_HangingFirstSource_DoesNotWedgeTheRest()
+    {
+        var handler = new PerUrlHandler("https://example.com/hang.txt");
+        var httpProvider = new HttpPrefixProvider(
+            new StubFactory(handler), NullLogger<HttpPrefixProvider>.Instance, defaultFetchTimeoutSeconds: 1);
+        var yaml = "Bgp:\n  Asn: 65444\n  RouterId: 10.0.0.1\nPrefixSources:\n" +
+                   "  - Name: hang\n    Kind: http\n    Url: https://example.com/hang.txt\n" +
+                   "  - Name: good\n    Kind: http\n    Url: https://example.com/good.txt\n";
+        var svc = new PrefixSourceService(
+            ConfigLoader.LoadFromText(yaml),
+            new PrefixSourceProviderFactory([httpProvider]),
+            NullLogger<PrefixSourceService>.Instance);
+
+        var all = await svc.LoadAllAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Equal(2, all.Count);
+        Assert.Empty(all[0].Prefixes);       // hung source: budget fired → failure → empty set
+        Assert.Single(all[1].Prefixes);      // good source still loaded — seeding not wedged
+    }
 }

--- a/BGPLite/Program.cs
+++ b/BGPLite/Program.cs
@@ -299,8 +299,13 @@ void ConfigureDefaultHttpResilience(ResiliencePipelineBuilder<HttpResponseMessag
             FailureRatio = 0.5,
             MinimumThroughput = 10,
             BreakDuration = TimeSpan.FromSeconds(30),
-        })
-        .AddTimeout(TimeSpan.FromSeconds(5));
+        });
+// #324/#267-item-2: no pipeline-level AddTimeout. It wrapped SendAsync only up to the
+// response headers (ResponseHeadersRead) and silently CLIPPED any configured source
+// Timeout above it, while the body loop ran outside the pipeline unbounded. The per-source
+// budget in HttpPrefixProvider.LoadAsync is now always armed (configured Timeout or the
+// 30s default) on a linked token that flows through the pipeline and covers headers AND
+// body — one deadline, never clipped, still bounding every attempt and retry.
 
 void ConfigureRipeStatResilience(ResiliencePipelineBuilder<HttpResponseMessage> pipelineBuilder, RipeStatConfig cfg) =>
     pipelineBuilder


### PR DESCRIPTION
Closes #324   # linkage; closure lands with the integration PR

## Problem
YAML `PrefixSources` omitting `Timeout` armed no deadline: the named client is `InfiniteTimeSpan` (Polly) and the pipeline's `AddTimeout(5s)` wrapped `SendAsync` only to the headers — the body loop ran unbounded. A headers-then-drip source hung sequential seeding (every later source, WarmUp, and the final peer push stalled until restart) and the auto-refresh loop's per-source gates forever. Complementarily (#267 item 2), a configured `Timeout` > 5s was silently clipped by the pipeline.

## Root Cause
Two layered gaps: no default budget when the config omits one, and a pipeline timeout that (a) covered only headers and (b) capped configured values.

## Fix
1. `HttpPrefixProvider.LoadAsync` arms the deadline UNCONDITIONALLY: configured `Timeout` wins, else the new default (`DefaultFetchTimeoutSeconds = 30`, ctor-injectable) — one mechanism covering headers AND body; #320's user sources flow through the same default.
2. The pipeline `AddTimeout(5s)` is removed from Program.cs: the per-source linked token flows through the pipeline and bounds every attempt, retry, and body read — one deadline, never clipped.
3. The five bare OCE rethrows in `PrefixSourceService` gain the #342 discriminator (`when (ct.IsCancellationRequested)`): without it, the budget's foreign-token OCE would fail the WHOLE `LoadAllAsync`/`GetAsync` on one slow source — the exact wedge #324 exists to remove. Caller cancellation still propagates (#114).

## Regression Tests
- `NoTimeoutConfigured_DefaultBudgetBoundsTheFetch` — headers-then-hang, default armed (red on budget-less code via the 8 s guard).
- `ConfiguredTimeout_WinsOverDefault` — configured value fires fast, unclipped.
- `LoadAllAsync_HangingFirstSource_DoesNotWedgeTheRest` — hung first source fails on its own deadline; the good source still loads (red via the 10 s guard).

## Verification
`dotnet format` / `dotnet build` (0 errors) / full suite **815/815**.

## RFC
None — provisioning plane.

## Behavior Change
Deliberate: config sources without Timeout now fail (skip, in seeding) after 30 s instead of hanging forever; configured timeouts above 5 s now take effect instead of being clipped.

## Deviation from Issue Proposal
Substance as proposed (unconditional arming with a 30 s default); the pipeline timeout is REMOVED rather than raised/parameterized — with the per-source budget always armed it is strictly redundant and was the clipping culprit; the PrefixSourceService discriminator addition is the issue's own acceptance criterion ("the second is still loaded") made to actually hold.