### PR TITLE
chore: record D17, demote the per-UPDATE log, raise the BGP listen backlog

### DIFF
--- a/BGPLite.Server/BgpServer.cs
+++ b/BGPLite.Server/BgpServer.cs
@@ -60,7 +60,10 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
         _listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
         _listener.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
         _listener.Bind(new IPEndPoint(IPAddress.Any, BgpConstants.BgpPort));
-        _listener.Listen(16);
+        // #344: after a restart every peer reconnects at once; backlog 16 dropped SYNs and pushed
+        // peers into their own retry backoff, stretching reconvergence for no benefit. A few
+        // hundred pending accepts costs nothing on a route-server host.
+        _listener.Listen(512);
 
         _logger.LogInformation("BGP server listening on port {Port}", BgpConstants.BgpPort);
         _logger.LogInformation("Local ASN={Asn}, RouterId={RouterId}", _config.Bgp.Asn, _config.Bgp.RouterId);

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -834,8 +834,12 @@ public sealed class BgpSession : IDisposable
 
     private async Task HandleUpdateAsync(BgpUpdateMessage update)
     {
-        _logger.LogInformation("UpdateReceived from {Peer}: {Withdrawn} withdrawn, {Nlri} announced",
-            _peer, update.WithdrawnRoutes.Count, update.Nlri.Count);
+        // #344: per-UPDATE at Debug — a full-table dump sends hundreds-to-thousands of UPDATEs and
+        // a flap storm floods the log pipeline on the read loop, drowning the Warning-level
+        // signals; the per-dump aggregation summaries one level up stay at Information.
+        if (_logger.IsEnabled(LogLevel.Debug))
+            _logger.LogDebug("UpdateReceived from {Peer}: {Withdrawn} withdrawn, {Nlri} announced",
+                _peer, update.WithdrawnRoutes.Count, update.Nlri.Count);
 
         // Process withdrawals. RFC 4271 §3.2/§9: a withdrawal removes the route received FROM THIS
         // PEER, not whatever happens to sit at that prefix. BGPLite has one shared RouteTable rather

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -160,3 +160,25 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
   Pre-OPEN connections (remote ASN not yet known) are not matched by the (ip, asn) termination and
   may re-register the row once their OPEN arrives.
 - **Tracker:** #323.
+
+### D17. UPDATE body errors keep the session alive across BOTH reject classes
+- **Decision:** a malformed inbound UPDATE never tears down the session, in both reject classes:
+  (a) a frame-level `BgpParseException` with an Update Message Error code (body unparseable, e.g.
+  truncated NLRI — the D2 case), and (b) a `BgpNotificationException(3, …)` from the attribute
+  pipeline (malformed/missing mandatory attributes, duplicate-first-wins, AS4 reconstruction — and
+  unrecognized **well-known** attributes). The message is rejected (`UpdateRejected`), the session
+  stays Established, and no NOTIFICATION is sent.
+- **Context:** RFC baseline — RFC 4271 §6.3 prescribes NOTIFICATION + session reset for these
+  errors, and RFC 7606 revises only part of the space toward treat-as-withdraw: malformed/missing
+  attributes become treat-as-withdraw, but **unrecognized well-known stays session-reset** (7606
+  does not revise it; verified against the RFC text 2026-08-30) and §3(j) mandates session reset
+  when the NLRI itself cannot be parsed. BGPLite deviates deliberately in both places: a route
+  server must not lose a long-lived session — and every other peer's view of it — over one bad or
+  adversarial UPDATE (#94, #222, #284 lineage). No NOTIFICATION is sent because RFC 4271 §6.3
+  requires its receiver to tear down, defeating the purpose. Withdrawal semantics: class (b)
+  withdraws the peer's own NLRI (RFC 7606's "treat" half, #288); class (a) cannot — the NLRI is
+  unrecoverable — and discards only (D2).
+- **Consequence:** a peer sending structurally valid but semantically rejected UPDATEs gets them
+  silently dropped (log Warning + `UpdatesRejected` metric) instead of a session reset; operators
+  comparing against RFC-strict speakers will see BGPLite retain sessions others would close.
+- **Tracker:** #94, #222, #284, #288, #322 (closed); recorded via #344.


### PR DESCRIPTION
Closes #344   # linkage; closure lands with the integration PR

## Problem (three grouped audit follow-ups)
1. The session-survives-rejected-UPDATE policy was only half-recorded (D2 covers unparseable NLRI); the attribute-pipeline reject class — including unrecognized well-known attributes, where the RFC baseline is session reset — lived in code comments.
2. Every inbound UPDATE logged at Information — log flooding under full-table dumps/flap storms on the hottest read path.
3. BGP listen backlog 16 dropped SYNs during post-restart reconnect storms.

## Fix
1. **D17** added to `docs/DESIGN_DECISIONS.md`: both reject classes, the precise RFC baseline (RFC 4271 §6.3 reset; RFC 7606 revises malformed/missing attributes to treat-as-withdraw but NOT unrecognized well-known — verified against the RFC text — and §3(j) mandates reset for unparseable NLRI), the deliberate deviation and its rationale, and the asymmetric withdrawal semantics (#288 vs D2).
2. `UpdateReceived` → Debug (`IsEnabled`-guarded); aggregation summaries stay Information.
3. Backlog 16 → 512 with rationale comment.

## Verification
`dotnet format` / `dotnet build` (0 errors) / full suite **815/815** (docs + log-level + constant; no new behavioral surface — acceptance for items 2/3 is the code change itself, per the issue's own acceptance text).

## RFC
D17 cites RFC 4271 §6.3 and RFC 7606 §3 precisely (incl. the verified fact that 7606 does not revise unrecognized-well-known).

## Behavior Change
Log volume (per-UPDATE lines now Debug) and SYN handling under reconnect storms; no protocol change.

## Deviation from Issue Proposal
None — the three items as filed.