### PR TITLE
chore: integrate dev — 11 fixes (perf/security/robustness) + CI dev-flow bootstrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   schedule:
     - cron: '37 5 * * 2'
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -2,7 +2,7 @@ name: format
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 permissions:
   contents: read

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -50,7 +50,17 @@ public sealed class ManagementApi : IHostedService, IDisposable
     /// </summary>
     private const int DefaultInflightCap = 64;
     private readonly SemaphoreSlim _inflightCap = new(DefaultInflightCap);
-    private readonly List<Task> _inflightHandlers = new();
+    // #258: in-flight tracking is a COUNT plus an idle Task (completed whenever the count is 0),
+    // not a List<Task> — the #248 design appended every handler and never removed it, so each
+    // completed request leaked its Task (and its exception, if faulted) for the process lifetime
+    // and the drain snapshot grew without bound. StopAsync drains by awaiting the idle task.
+    private readonly object _inflightSync = new();
+    private int _inflightCount;
+    private TaskCompletionSource? _inflightActive;
+    private Task _inflightIdle = Task.CompletedTask;
+
+    /// <summary>Currently in-flight request handlers (#258) — bounded by the cap, zero when idle.</summary>
+    internal int InflightRequestCount { get { lock (_inflightSync) return _inflightCount; } }
     private HttpListener? _listener;
     private Task? _listenTask;
     private readonly CancellationTokenSource _cts = new();
@@ -210,12 +220,14 @@ public sealed class ManagementApi : IHostedService, IDisposable
         }
 
         // Drain in-flight handlers, but bounded: 10 s after cancellation is enough for a response
-        // write or an orderly OCE unwind, and short of the host's 30 s shutdown grace.
-        Task[] pending;
-        lock (_inflightHandlers) pending = _inflightHandlers.ToArray();
-        if (pending.Length > 0)
+        // write or an orderly OCE unwind, and short of the host's 30 s shutdown grace. The drain
+        // awaits the in-flight idle task (#258) — it completes when the last handler's finally
+        // runs, so no per-request bookkeeping outlives the request.
+        Task idle;
+        lock (_inflightSync) idle = _inflightIdle;
+        if (!idle.IsCompleted)
         {
-            try { await Task.WhenAny(Task.WhenAll(pending), Task.Delay(TimeSpan.FromSeconds(10), cancellationToken)); }
+            try { await Task.WhenAny(idle, Task.Delay(TimeSpan.FromSeconds(10), cancellationToken)); }
             catch { /* host grace elapsed — proceed */ }
         }
 
@@ -251,10 +263,20 @@ public sealed class ManagementApi : IHostedService, IDisposable
                 // #238: acquire an in-flight slot before spawning so the default posture is
                 // bounded even when the operator has not enabled the #119 concurrency limiter.
                 await _inflightCap.WaitAsync(ct);
+                // Register BEFORE spawning: the handler's finally decrements, and a handler that
+                // completes before this thread runs would otherwise drive the count negative.
+                lock (_inflightSync)
+                {
+                    _inflightCount++;
+                    if (_inflightCount == 1)
+                    {
+                        _inflightActive = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                        _inflightIdle = _inflightActive.Task;
+                    }
+                }
                 var accepted = ctx;
                 ctx = null; // ownership transferred to the handler task
-                var handler = HandleWithInflightReleaseAsync(accepted);
-                lock (_inflightHandlers) _inflightHandlers.Add(handler);
+                _ = HandleWithInflightReleaseAsync(accepted);
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested) { break; }
             catch (HttpListenerException) when (ct.IsCancellationRequested) { break; }
@@ -301,6 +323,18 @@ public sealed class ManagementApi : IHostedService, IDisposable
             // Tolerate teardown racing the StopAsync drain (e.g. direct Dispose without StopAsync).
             try { _inflightCap.Release(); }
             catch (ObjectDisposedException) { /* cap already disposed */ }
+            // #258: a handler leaving the in-flight set completes the idle task when it was the
+            // last one — that is what StopAsync's bounded drain awaits.
+            lock (_inflightSync)
+            {
+                _inflightCount--;
+                if (_inflightCount == 0)
+                {
+                    _inflightActive?.TrySetResult();
+                    _inflightActive = null;
+                    _inflightIdle = Task.CompletedTask;
+                }
+            }
         }
     }
 

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -525,6 +525,14 @@ public sealed class ManagementApi : IHostedService, IDisposable
     /// deserialization. <c>HttpListener</c> has no default body limit, so without this a single
     /// client could stream gigabytes into the process. The cap also covers chunked-transfer bodies
     /// (no Content-Length) via the read-loop's running byte count.
+    /// <para>
+    /// #257: HttpListener also exposes no client-disconnect token, so a slow-drip body (a byte
+    /// every few seconds) otherwise parks the handler — and its in-flight slot — forever; 64 such
+    /// connections starve the whole API. Each read is therefore bounded by
+    /// <paramref name="readTimeout"/>; a breach surfaces as <c>408 Request Timeout</c>. The
+    /// abandoned read parks on the (dead) socket holding this call's buffer — bounded by the
+    /// in-flight cap (64 × 8 KB), never reused, collected with the socket.
+    /// </para>
     /// </summary>
     private async Task<(string? Body, ApiResponse? Error)> ReadBodyAsync(HttpListenerContext ctx)
     {
@@ -535,21 +543,42 @@ public sealed class ManagementApi : IHostedService, IDisposable
             return (null, ApiResponse.Error(
                 $"Request body too large ({ctx.Request.ContentLength64} bytes, max {maxBytes}).", 413));
 
-        return await ReadBoundedBodyAsync(ctx.Request.InputStream, maxBytes);
+        return await ReadBoundedBodyAsync(ctx.Request.InputStream, maxBytes, BodyReadTimeout);
     }
+
+    /// <summary>#257: per-read deadline for request bodies — the time dimension of the #156 size cap.</summary>
+    private static readonly TimeSpan BodyReadTimeout = TimeSpan.FromSeconds(30);
 
     /// <summary>
     /// Pure body reader with a hard byte cap — extracted for unit testing (#156). Returns
     /// <c>(null, 413-error)</c> when the stream yields more than <paramref name="maxBytes"/> bytes,
+    /// <c>(null, 408-error)</c> when a single read breaches <paramref name="readTimeout"/> (#257),
     /// otherwise the full body decoded as UTF-8. Covers both sized and chunked/streaming bodies.
     /// </summary>
-    internal static async Task<(string? Body, ApiResponse? Error)> ReadBoundedBodyAsync(Stream input, long maxBytes)
+    internal static async Task<(string? Body, ApiResponse? Error)> ReadBoundedBodyAsync(
+        Stream input, long maxBytes, TimeSpan? readTimeout = null)
     {
         using var ms = new MemoryStream();
         var buffer = new byte[8192];
-        int read;
-        while ((read = await input.ReadAsync(buffer, 0, buffer.Length)) > 0)
+        while (true)
         {
+            int read;
+            var readTask = input.ReadAsync(buffer, 0, buffer.Length);
+            try
+            {
+                // #257: no client-disconnect token exists on HttpListener streams — the deadline
+                // is the only bound on a slow-drip body. WaitAsync leaves the abandoned read
+                // parked on the socket with this call's buffer (bounded by the in-flight cap,
+                // never reused); the caller unwinds, answers 408, and frees its slot.
+                read = readTimeout is { } timeout ? await readTask.WaitAsync(timeout) : await readTask;
+            }
+            catch (TimeoutException)
+            {
+                return (null, ApiResponse.Error("Request body read timed out.", 408));
+            }
+            if (read <= 0)
+                break;
+
             ms.Write(buffer, 0, read);
             if (ms.Length > maxBytes)
                 return (null, ApiResponse.Error(

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -552,25 +552,39 @@ public sealed class ManagementApi : IHostedService, IDisposable
     /// <summary>
     /// Pure body reader with a hard byte cap — extracted for unit testing (#156). Returns
     /// <c>(null, 413-error)</c> when the stream yields more than <paramref name="maxBytes"/> bytes,
-    /// <c>(null, 408-error)</c> when a single read breaches <paramref name="readTimeout"/> (#257),
-    /// otherwise the full body decoded as UTF-8. Covers both sized and chunked/streaming bodies.
+    /// <c>(null, 408-error)</c> when the body misses <paramref name="readTimeout"/> (#257) — an
+    /// ABSOLUTE deadline for the whole body, not a per-read window: a per-read WaitAsync restarts
+    /// on every byte, and a client trickling one byte per window held its slot indefinitely
+    /// (#358 review). Otherwise the full body decoded as UTF-8. Covers sized and chunked bodies.
     /// </summary>
     internal static async Task<(string? Body, ApiResponse? Error)> ReadBoundedBodyAsync(
         Stream input, long maxBytes, TimeSpan? readTimeout = null)
     {
         using var ms = new MemoryStream();
         var buffer = new byte[8192];
+        var deadline = readTimeout is { } timeout ? DateTime.UtcNow + timeout : (DateTime?)null;
         while (true)
         {
             int read;
             var readTask = input.ReadAsync(buffer, 0, buffer.Length);
             try
             {
-                // #257: no client-disconnect token exists on HttpListener streams — the deadline
-                // is the only bound on a slow-drip body. WaitAsync leaves the abandoned read
-                // parked on the socket with this call's buffer (bounded by the in-flight cap,
-                // never reused); the caller unwinds, answers 408, and frees its slot.
-                read = readTimeout is { } timeout ? await readTask.WaitAsync(timeout) : await readTask;
+                if (deadline is { } byThen)
+                {
+                    // #257/#358: no client-disconnect token exists on HttpListener streams — the
+                    // deadline is the only bound on a slow-drip body, and it is TOTAL: each read
+                    // gets only the remaining budget, so trickling cannot reset the clock. The
+                    // abandoned read parks on the socket with this call's buffer (bounded by the
+                    // in-flight cap, never reused); the caller unwinds, answers 408, frees its slot.
+                    var remaining = byThen - DateTime.UtcNow;
+                    if (remaining <= TimeSpan.Zero)
+                        throw new TimeoutException();
+                    read = await readTask.WaitAsync(remaining);
+                }
+                else
+                {
+                    read = await readTask;
+                }
             }
             catch (TimeoutException)
             {

--- a/BGPLite.Protocol/BgpMessageReader.cs
+++ b/BGPLite.Protocol/BgpMessageReader.cs
@@ -103,8 +103,16 @@ public static class BgpMessageReader
 
         var version = payload[0];
         if (version != BgpConstants.BgpVersion)
+            // RFC 4271 §6.2 Unsupported Version Number: the Data field "indicates the largest,
+            // locally-supported version number less than the version the remote BGP peer bid …
+            // or if the smallest locally-supported version number is larger than the peer's bid,
+            // the smallest locally-supported version number". BGPLite supports only version 4, so
+            // both branches resolve to 4: bid>4 → largest-below-bid is 4; bid<4 → smallest is 4.
+            // Without the field a BGPv3 speaker gets no downgrade hint (#317). Byte-identical
+            // with OpenNegotiator.Validate, the other reject site for the same condition.
             throw new BgpParseException($"Unsupported BGP version: {version}",
-                BgpConstants.Error.OpenMessageError, BgpConstants.SubError.UnsupportedVersion);
+                BgpConstants.Error.OpenMessageError, BgpConstants.SubError.UnsupportedVersion,
+                notificationData: [(byte)(BgpConstants.BgpVersion >> 8), (byte)BgpConstants.BgpVersion]);
 
         var asn = BinaryPrimitives.ReadUInt16BigEndian(payload[1..]);
         var holdTime = BinaryPrimitives.ReadUInt16BigEndian(payload[3..]);

--- a/BGPLite.Protocol/OpenNegotiator.cs
+++ b/BGPLite.Protocol/OpenNegotiator.cs
@@ -45,7 +45,15 @@ public static class OpenNegotiator
                 $"Local hold time must be 0 (disabled) or at least 3 seconds (RFC 4271 §4.2).");
 
         if (open.Version != BgpConstants.BgpVersion)
-            throw new BgpNotificationException(BgpConstants.Error.OpenMessageError, BgpConstants.SubError.UnsupportedVersion, $"Unsupported BGP version: {open.Version}");
+            // RFC 4271 §6.2: the Data field indicates the largest locally-supported version less
+            // than the peer's bid, or the smallest locally-supported version when even that is
+            // larger. BGPLite supports only version 4, so both branches resolve to 4 (#317).
+            // Mirrors BgpMessageReader.ParseOpen byte-for-byte — one wire behavior for one
+            // condition regardless of which reject site fires.
+            throw new BgpNotificationException(
+                BgpConstants.Error.OpenMessageError, BgpConstants.SubError.UnsupportedVersion,
+                $"Unsupported BGP version: {open.Version}",
+                [(byte)(BgpConstants.BgpVersion >> 8), (byte)BgpConstants.BgpVersion]);
 
         var malformedFourOctetAsnCapability = UpdateCodec.GetMalformedFourOctetAsnCapabilityData(open);
         if (malformedFourOctetAsnCapability.Length > 0)

--- a/BGPLite.Providers/HttpPrefixProvider.cs
+++ b/BGPLite.Providers/HttpPrefixProvider.cs
@@ -21,13 +21,23 @@ namespace BGPLite.Providers;
 /// </summary>
 public sealed class HttpPrefixProvider(
     IHttpClientFactory httpFactory,
-    ILogger<HttpPrefixProvider> logger)
+    ILogger<HttpPrefixProvider> logger,
+    int defaultFetchTimeoutSeconds = 30) // mirrors DefaultFetchTimeoutSeconds (a ctor default cannot reference the member const)
     : IPrefixSourceProvider
 {
     public const string ClientName = "http";
 
     /// <summary>Maximum response body size (10 MB) — defends against OOM from huge/malicious files (#144).</summary>
     internal const int MaxResponseBytes = 10 * 1024 * 1024;
+
+    /// <summary>
+    /// #324: budget applied when the source does not configure one. Without it, a YAML-configured
+    /// PrefixSource omitting <c>Timeout</c> armed no deadline at all — the named client is
+    /// InfiniteTimeSpan (Polly) and the pipeline's timeout only wrapped SendAsync up to the
+    /// headers, so a headers-then-drip body hung seeding and auto-refresh indefinitely (size is
+    /// bounded by <see cref="MaxResponseBytes"/>, time was not). Injectable for tests via the ctor.
+    /// </summary>
+    public const int DefaultFetchTimeoutSeconds = 30;
 
     public string Kind => "http";
 
@@ -45,13 +55,16 @@ public sealed class HttpPrefixProvider(
 
         var http = httpFactory.CreateClient(ClientName);
 
-        // Per-source timeout: link the caller's token with a CancelAfter so a slow peer URL can't pin
-        // the fetch past its configured budget. We do NOT mutate http.Timeout (#155 regression): the
-        // named client is pooled by IHttpClientFactory, and mutating it leaks the per-source timeout
-        // onto the next caller that reuses the same client within the handler-lifetime window.
+        // Per-source timeout: link the caller's token with a CancelAfter so a slow source can't pin
+        // the fetch past its budget — now ALWAYS armed (#324): a configured Timeout wins, otherwise
+        // the default budget covers config sources that omit it (and #320's user sources pass it
+        // explicitly). The linked token covers headers AND the body loop below.
+        // We do NOT mutate http.Timeout (#155 regression): the named client is pooled by
+        // IHttpClientFactory, and mutating it leaks the per-source timeout onto the next caller.
+        var seconds = source.Timeout is int configured && configured > 0 ? configured : defaultFetchTimeoutSeconds;
         CancellationTokenSource? timeoutCts = null;
         CancellationToken linkedToken;
-        if (source.Timeout is int seconds && seconds > 0)
+        if (seconds > 0)
         {
             timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             timeoutCts.CancelAfter(TimeSpan.FromSeconds(seconds));

--- a/BGPLite.Providers/PrefixService.cs
+++ b/BGPLite.Providers/PrefixService.cs
@@ -34,7 +34,7 @@ public sealed class PrefixService : IPrefixService
     // when the TTL elapses. Mirrors the per-ASN gate pattern in GetPrefixesAsync.
     private readonly SemaphoreSlim _ruGate = new(1, 1);
 
-    public PrefixService(AppConfig config, RipeStatProvider ripeStat, IPrefixSourceService prefixSources, HttpPrefixProvider httpProvider, TimeSpan? cacheTtl = null, ILogger<PrefixService>? logger = null, TimeSpan? negativeTtl = null, int? maxCacheEntries = null, TimeProvider? timeProvider = null)
+    public PrefixService(AppConfig config, RipeStatProvider ripeStat, IPrefixSourceService prefixSources, HttpPrefixProvider httpProvider, TimeSpan? cacheTtl = null, ILogger<PrefixService>? logger = null, TimeSpan? negativeTtl = null, int? maxCacheEntries = null, TimeProvider? timeProvider = null, int? userSourceTimeoutSeconds = null)
     {
         _config = config;
         _ripeStat = ripeStat;
@@ -48,8 +48,16 @@ public sealed class PrefixService : IPrefixService
         _maxCacheEntries = maxCacheEntries ?? 4096;
         _logger = logger;
         _timeProvider = timeProvider ?? TimeProvider.System;
+        // #320: fetch budget for peer-supplied URL sources — generous for a real prefix list
+        // (10 MB cap streams in well under it), bounded enough that a dripping/hung body cannot
+        // stall the route dump behind the per-URL gate.
+        _userSourceTimeoutSeconds = userSourceTimeoutSeconds ?? DefaultUserSourceTimeoutSeconds;
         _userSourceCache = new UserSourceCache(logger: logger, timeProvider: _timeProvider);
     }
+
+    /// <summary>Default per-fetch budget for peer-supplied URL sources (#320).</summary>
+    public const int DefaultUserSourceTimeoutSeconds = 30;
+    private readonly int _userSourceTimeoutSeconds;
 
     /// <summary>
     /// Fetches a per-peer user-supplied URL prefix-list source (issues #147 / #150). The URL is
@@ -59,6 +67,15 @@ public sealed class PrefixService : IPrefixService
     /// the http provider's named client. The <c>Active</c>
     /// lifecycle is handled by the caller (LoadPeerRoutingView filters Active before this is reached),
     /// so paused sources are never advertised regardless of cache state.
+    /// <para>
+    /// #320: the config is built WITH a fetch budget. Without one, HttpPrefixProvider's linked-CTS
+    /// timeout is never armed and the body-read loop is guarded only by the session token — a
+    /// server that answers headers then drips (or never sends) the body hangs the whole route dump
+    /// behind the per-URL gate while the session stays Established (KEEPALIVEs keep the hold timer
+    /// fed). A timed-out fetch throws OCE with a live caller token — a per-source fetch failure per
+    /// the #342 boundary — and is negative-cached by <see cref="UserSourceCache"/>, so repeated
+    /// refreshes do not re-pay the budget.
+    /// </para>
     /// </summary>
     public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
     {
@@ -67,7 +84,8 @@ public sealed class PrefixService : IPrefixService
             Kind = "http",
             Name = name,
             Url = url,
-            Community = community
+            Community = community,
+            Timeout = _userSourceTimeoutSeconds
         };
         return await _userSourceCache.GetOrLoadAsync(url, name, async ct =>
         {

--- a/BGPLite.Providers/PrefixSourceService.cs
+++ b/BGPLite.Providers/PrefixSourceService.cs
@@ -69,7 +69,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
         }
 
         try { return (await LoadCachedAsync(source, ct)).Prefixes; }
-        catch (OperationCanceledException) { throw; }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #324: only CALLER cancellation — the #324 default fetch budget fires as a foreign-token OCE (live ct) and must stay a per-source failure below
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to load prefix source '{Name}'.", name);
@@ -90,7 +90,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
         }
 
         try { return (await LoadCachedAsync(source, ct)).Prefixes; }
-        catch (OperationCanceledException) { throw; }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #324: only CALLER cancellation — the #324 default fetch budget fires as a foreign-token OCE (live ct) and must stay a per-source failure below
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to load default prefix source '{Name}'.", defaultName);
@@ -105,7 +105,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
         {
             IReadOnlyList<(uint Prefix, byte Length)> prefixes;
             try { prefixes = (await LoadCachedAsync(source, ct)).Prefixes; }
-            catch (OperationCanceledException) { throw; }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #324: only CALLER cancellation — the #324 default fetch budget fires as a foreign-token OCE (live ct) and must stay a per-source failure below
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Failed to load prefix source '{Name}' ({Kind}).", source.Name, source.Kind);
@@ -143,7 +143,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
             var (_, changed) = await LoadCachedAsync(source, ct, forceRefresh: true, triggerCallback: false);
             return changed;
         }
-        catch (OperationCanceledException) { throw; }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #324: only CALLER cancellation — the #324 default fetch budget fires as a foreign-token OCE (live ct) and must stay a per-source failure below
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Auto-refresh: failed to reload source '{Name}'.", source.Name);
@@ -203,7 +203,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
                 var provider = _factory.Get(source.Kind);
                 result = await provider.LoadAsync(source, etag, lastModified, ct);
             }
-            catch (OperationCanceledException) { throw; }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #324: only CALLER cancellation — the #324 default fetch budget fires as a foreign-token OCE (live ct) and must stay a per-source failure below
             catch
             {
                 if (_cache.TryGetValue(source.Name, out var staleCopy) && !staleCopy.Negative)

--- a/BGPLite.Providers/RipeStatProvider.cs
+++ b/BGPLite.Providers/RipeStatProvider.cs
@@ -50,14 +50,15 @@ public sealed class RipeStatProvider
 
         foreach (var element in prefixes.EnumerateArray())
         {
-            var cidr = element.GetString();
-            // #319: the canonical parser every other prefix input path uses (#236): host-bit
-            // masking, /0 rejection, length 1..32, IPv4-only. RIS collectors return what third
-            // parties ANNOUNCED — non-canonical NLRI ("10.0.0.1/8") must not reach the route
+            // #319/#358-review: the canonical parser every other prefix input path uses (#236):
+            // host-bit masking, /0 rejection, length 1..32, IPv4-only. RIS collectors return what
+            // third parties ANNOUNCED — non-canonical NLRI ("10.0.0.1/8") must not reach the route
             // table under a corrupt key, and "0.0.0.0/0" must not become a default-route leak
             // (#162 closed the same hole for URL sources). Skip + warn, like stored custom
-            // prefixes; also covers a null/garbage element without throwing (previously NRE/
-            // FormatException took the whole ASN fetch down).
+            // prefixes; a null element, garbage string, or NON-STRING JSON element (GetString
+            // throws InvalidOperationException on numbers/objects) is skipped without taking the
+            // whole ASN fetch down with it.
+            var cidr = element.ValueKind == JsonValueKind.String ? element.GetString() : null;
             if (!PrefixCidr.TryParse(cidr, out var prefix, out var length))
             {
                 _logger.LogWarning("AS{Asn}: RIPEstat returned a non-canonical prefix '{Cidr}'; skipped", asn, cidr);

--- a/BGPLite.Providers/RipeStatProvider.cs
+++ b/BGPLite.Providers/RipeStatProvider.cs
@@ -50,11 +50,20 @@ public sealed class RipeStatProvider
 
         foreach (var element in prefixes.EnumerateArray())
         {
-            var cidr = element.GetString()!;
-            var slash = cidr.IndexOf('/');
-            var ip = IPAddress.Parse(cidr[..slash]);
-            var length = byte.Parse(cidr[(slash + 1)..]);
-            var prefix = BgpConstants.IPAddressToUint(ip);
+            var cidr = element.GetString();
+            // #319: the canonical parser every other prefix input path uses (#236): host-bit
+            // masking, /0 rejection, length 1..32, IPv4-only. RIS collectors return what third
+            // parties ANNOUNCED — non-canonical NLRI ("10.0.0.1/8") must not reach the route
+            // table under a corrupt key, and "0.0.0.0/0" must not become a default-route leak
+            // (#162 closed the same hole for URL sources). Skip + warn, like stored custom
+            // prefixes; also covers a null/garbage element without throwing (previously NRE/
+            // FormatException took the whole ASN fetch down).
+            if (!PrefixCidr.TryParse(cidr, out var prefix, out var length))
+            {
+                _logger.LogWarning("AS{Asn}: RIPEstat returned a non-canonical prefix '{Cidr}'; skipped", asn, cidr);
+                continue;
+            }
+
             result.Add((prefix, length));
         }
 

--- a/BGPLite.Providers/UserSourceCache.cs
+++ b/BGPLite.Providers/UserSourceCache.cs
@@ -27,19 +27,30 @@ internal sealed class UserSourceCache
     private readonly TimeSpan _negativeTtl;
     private readonly ILogger? _logger;
     private readonly TimeProvider _timeProvider;
+    // Upper bound on _cache/_locks entries (#261, port of PrefixService's #165 pattern). Without a
+    // cap, every unique peer-supplied URL leaves a permanent entry — up to ~10 MB of parsed prefixes
+    // each (the HTTP body cap) plus a SemaphoreSlim — so operator churn or an API client loop grows
+    // the cache without limit. Exceeded → sweep expired entries first, then the oldest by CachedAt.
+    private readonly int _maxEntries;
 
     // url → (list, cached at, is negative). Negative entries (failed loads) use _negativeTtl.
     private readonly ConcurrentDictionary<string, (IReadOnlyList<(uint Prefix, byte Length)> List, DateTime CachedAt, bool Negative)> _cache = new();
     // url → gate serializing the cache-miss fetch path (prevents thundering herd on cold/expired keys).
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new();
 
-    public UserSourceCache(TimeSpan? positiveTtl = null, TimeSpan? negativeTtl = null, ILogger? logger = null, TimeProvider? timeProvider = null)
+    public UserSourceCache(TimeSpan? positiveTtl = null, TimeSpan? negativeTtl = null, ILogger? logger = null, TimeProvider? timeProvider = null, int? maxCacheEntries = null)
     {
         _positiveTtl = positiveTtl ?? TimeSpan.FromHours(1);
         _negativeTtl = negativeTtl ?? TimeSpan.FromSeconds(30);
         _logger = logger;
         _timeProvider = timeProvider ?? TimeProvider.System;
+        // Generous vs. real deployments (peers × a few active sources each); the cap defends
+        // against unbounded growth from churn/adversarial URL variety, not normal operation.
+        _maxEntries = maxCacheEntries ?? 1024;
     }
+
+    /// <summary>Entries currently tracked (test/observability).</summary>
+    internal int TrackedCount => _cache.Count;
 
     /// <param name="url">Cache key (the source URL — dedupes across peers).</param>
     /// <param name="logLabel">Safe identifier (the source <c>Name</c>) for log lines — the URL itself is
@@ -80,18 +91,62 @@ internal sealed class UserSourceCache
                 }
 
                 // Otherwise remember the failure briefly so repeated calls don't hammer the fetcher.
+                EvictIfAtCapacity(url);
                 _cache[url] = ([], _timeProvider.GetUtcNow().UtcDateTime, Negative: true);
                 _logger?.LogWarning(ex, "User-source '{Name}' load failed (no cached copy); negative-cached for {Seconds}s.",
                     logLabel, (int)_negativeTtl.TotalSeconds);
                 throw;
             }
 
+            EvictIfAtCapacity(url);
             _cache[url] = (prefixes, _timeProvider.GetUtcNow().UtcDateTime, Negative: false);
             return prefixes;
         }
         finally
         {
             gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Enforces the _maxEntries bound (#261). Called before inserting a NEW key, under the caller's
+    /// per-URL gate. Drops expired entries first (cheapest eviction), then the oldest by CachedAt
+    /// until below the cap, removing the matching _locks entries with them. Same tradeoff as
+    /// PrefixService's #165 sweep: a concurrent loader may still hold an evicted URL's semaphore — it
+    /// finishes on its own reference and a fresh caller GetOrAdd's a new gate, so the worst case is
+    /// one duplicate idempotent GET, never a correctness loss.
+    /// </summary>
+    private void EvictIfAtCapacity(string insertingUrl)
+    {
+        if (_cache.Count < _maxEntries) return;
+        if (_cache.ContainsKey(insertingUrl)) return; // already present, no insert coming
+
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        var toEvict = new List<string>();
+        foreach (var (key, entry) in _cache)
+        {
+            var ttl = entry.Negative ? _negativeTtl : _positiveTtl;
+            if (now - entry.CachedAt >= ttl)
+                toEvict.Add(key);
+        }
+        // If still at/over capacity after dropping expired, evict the oldest until below the cap.
+        if (_cache.Count - toEvict.Count >= _maxEntries)
+        {
+            var oldest = _cache
+                .Where(kvp => !toEvict.Contains(kvp.Key))
+                .OrderBy(kvp => kvp.Value.CachedAt)
+                .Select(kvp => kvp.Key);
+            foreach (var key in oldest)
+            {
+                toEvict.Add(key);
+                if (_cache.Count - toEvict.Count < _maxEntries) break;
+            }
+        }
+
+        foreach (var key in toEvict)
+        {
+            if (_cache.TryRemove(key, out _))
+                _locks.TryRemove(key, out _);
         }
     }
 

--- a/BGPLite.Providers/UserSourceCache.cs
+++ b/BGPLite.Providers/UserSourceCache.cs
@@ -52,6 +52,9 @@ internal sealed class UserSourceCache
     /// <summary>Entries currently tracked (test/observability).</summary>
     internal int TrackedCount => _cache.Count;
 
+    /// <summary>Gates currently tracked (test/observability — orphan-lock hygiene, #358 review).</summary>
+    internal int TrackedGateCount => _locks.Count;
+
     /// <param name="url">Cache key (the source URL — dedupes across peers).</param>
     /// <param name="logLabel">Safe identifier (the source <c>Name</c>) for log lines — the URL itself is
     /// never logged, since peer URLs may carry query-string tokens (#149).</param>
@@ -68,7 +71,21 @@ internal sealed class UserSourceCache
         // Serialize per-key so concurrent callers (e.g. several peers refreshing the same URL) share
         // a single fetch — no thundering herd.
         var gate = _locks.GetOrAdd(url, _ => new SemaphoreSlim(1, 1));
-        await gate.WaitAsync(ct);
+        try
+        {
+            await gate.WaitAsync(ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // #358 review (orphan-lock hygiene for #261): a caller cancelled while queued never
+            // writes a cache entry, so its freshly-created gate would never be evicted (the sweep
+            // removes locks only for removed cache keys) — cancelled URLs accumulated semaphores.
+            // Pair-remove OUR gate instance: a concurrent waiter keeps running on its own
+            // reference, and a fresh caller GetOrAdd's a new gate — the same duplicate-fetch
+            // tradeoff the eviction sweep already accepts.
+            ((ICollection<KeyValuePair<string, SemaphoreSlim>>)_locks).Remove(new KeyValuePair<string, SemaphoreSlim>(url, gate));
+            throw;
+        }
         try
         {
             if (TryGetFresh(url, out var rechecked))

--- a/BGPLite.Providers/UserSourceCache.cs
+++ b/BGPLite.Providers/UserSourceCache.cs
@@ -79,7 +79,15 @@ internal sealed class UserSourceCache
             {
                 prefixes = await loadAsync(ct);
             }
-            catch (OperationCanceledException) { throw; }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                // #114: CALLER-initiated cancellation always propagates and is never cached — it
+                // is teardown, not a property of the source. A foreign-token OCE (e.g. the #320
+                // per-fetch budget's linked CTS firing on a live caller token) falls through to
+                // the failure handling below instead: stale-on-failure serve if possible, else a
+                // brief negative-cache so repeated refreshes do not re-pay the full budget.
+                throw;
+            }
             catch (Exception ex)
             {
                 // Serve the last good copy if we have one (regardless of its age).

--- a/BGPLite.Routing/RouteTable.cs
+++ b/BGPLite.Routing/RouteTable.cs
@@ -17,6 +17,13 @@ public sealed class RouteTable
 {
     private readonly ConcurrentDictionary<(uint Prefix, byte Length), Entry> _routes = new();
 
+    // #343: maintained count — every successful mutation adjusts it exactly once (1:1 with the
+    // dictionary transition), so Count is an O(1) Volatile.Read instead of ConcurrentDictionary.Count,
+    // which acquires ALL lock strips. That read ran twice per inbound UPDATE on the session read
+    // loops, racing every writer. Transiently approximate only within a concurrent-mutation window
+    // (adjust happens after the dictionary op); exact whenever no mutation is in flight.
+    private int _count;
+
     /// <summary>
     /// A stored route plus the object that installed it. A <c>record struct</c> so the generated
     /// structural equality gives <see cref="RemoveOwnedBy"/> its compare-and-remove: both the
@@ -24,7 +31,9 @@ public sealed class RouteTable
     /// </summary>
     private readonly record struct Entry(Route Route, object? Owner);
 
-    public int Count => _routes.Count;
+    /// <summary>Current number of routes — O(1) via the maintained counter (#343). Transiently
+    /// approximate under concurrent mutation; exact when quiescent.</summary>
+    public int Count => Volatile.Read(ref _count);
 
     /// <summary>Installs a route with no owner — startup seeding and tests. Nobody can remove it via <see cref="RemoveOwnedBy"/>.</summary>
     public bool AddOrUpdate(Route route) => AddOrUpdate(route, owner: null);
@@ -38,19 +47,38 @@ public sealed class RouteTable
     {
         // #85: avoid ConcurrentDictionary.AddOrUpdate's closure allocations (two delegate lambdas
         // per call). The try-pattern is allocation-free and equivalent: TryAdd for the new-key
-        // case, indexer for the update case.
+        // case, TryUpdate for the replace case.
+        // #346 (CodeRabbit review): a plain indexer for the replace case is NOT count-safe —
+        // TryAdd returning false does not guarantee the key still exists by the write; a
+        // concurrent remove in that window let the indexer re-insert the entry without
+        // incrementing _count, drifting it permanently (negative after enough removals). The CAS
+        // pair keeps the 1:1 transition invariant: TryAdd wins the new-key transition (+1);
+        // TryGetValue+TryUpdate wins a true replace (±0) — TryUpdate succeeds only against the
+        // value just read, so a key that vanished (or was replaced) in between loops back to
+        // TryAdd, which then increments. Entry's record-struct value equality is fine here:
+        // TryUpdate success merely proves the key was present, which is all ±0 needs.
         var entry = new Entry(route, owner);
-        if (!_routes.TryAdd(route.Key, entry))
+        while (true)
         {
-            _routes[route.Key] = entry;
-            return false;
+            if (_routes.TryAdd(route.Key, entry))
+            {
+                Interlocked.Increment(ref _count);
+                return true;
+            }
+            if (_routes.TryGetValue(route.Key, out var existing) &&
+                _routes.TryUpdate(route.Key, entry, existing))
+                return false; // replaced an entry that was still present — no count transition
         }
-        return true;
     }
 
     /// <summary>Unconditional removal, regardless of owner — administrative paths only.</summary>
-    public bool Remove(uint prefix, byte length) =>
-        _routes.TryRemove((prefix, length), out _);
+    public bool Remove(uint prefix, byte length)
+    {
+        var removed = _routes.TryRemove((prefix, length), out _);
+        if (removed)
+            Interlocked.Decrement(ref _count);
+        return removed;
+    }
 
     /// <summary>
     /// Removes the route at <paramref name="prefix"/>/<paramref name="length"/> only if
@@ -73,8 +101,11 @@ public sealed class RouteTable
         if (!_routes.TryGetValue(key, out var entry) || !ReferenceEquals(entry.Owner, owner))
             return false;
 
-        return ((ICollection<KeyValuePair<(uint Prefix, byte Length), Entry>>)_routes)
+        var removed = ((ICollection<KeyValuePair<(uint Prefix, byte Length), Entry>>)_routes)
             .Remove(new KeyValuePair<(uint Prefix, byte Length), Entry>(key, entry));
+        if (removed)
+            Interlocked.Decrement(ref _count);
+        return removed;
     }
 
     /// <summary>
@@ -104,6 +135,8 @@ public sealed class RouteTable
             if (((ICollection<KeyValuePair<(uint Prefix, byte Length), Entry>>)_routes).Remove(pair))
                 removed++;
         }
+        if (removed > 0)
+            Interlocked.Add(ref _count, -removed);
         return removed;
     }
 
@@ -112,7 +145,9 @@ public sealed class RouteTable
 
     public IReadOnlyList<Route> GetAll()
     {
-        var routes = new List<Route>(_routes.Count);
+        // #346: clamp the capacity hint — a hint must never turn a hypothetical negative count
+        // into List<Route>(negative) throwing ArgumentOutOfRangeException on the API read path.
+        var routes = new List<Route>(Math.Max(0, Count));
         foreach (var entry in _routes.Values)
             routes.Add(entry.Route);
         return routes;
@@ -145,6 +180,13 @@ public sealed class RouteTable
         }
     }
 
-    public void Clear() =>
-        _routes.Clear();
+    public void Clear()
+    {
+        // TryRemove loop rather than _routes.Clear(): each successful removal decrements the
+        // maintained counter, keeping the 1:1 mutation↔transition invariant even when a writer
+        // adds concurrently with the clear (#343).
+        foreach (var key in _routes.Keys)
+            if (_routes.TryRemove(key, out _))
+                Interlocked.Decrement(ref _count);
+    }
 }

--- a/BGPLite.Server/BgpServer.cs
+++ b/BGPLite.Server/BgpServer.cs
@@ -60,7 +60,10 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
         _listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
         _listener.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
         _listener.Bind(new IPEndPoint(IPAddress.Any, BgpConstants.BgpPort));
-        _listener.Listen(16);
+        // #344: after a restart every peer reconnects at once; backlog 16 dropped SYNs and pushed
+        // peers into their own retry backoff, stretching reconvergence for no benefit. A few
+        // hundred pending accepts costs nothing on a route-server host.
+        _listener.Listen(512);
 
         _logger.LogInformation("BGP server listening on port {Port}", BgpConstants.BgpPort);
         _logger.LogInformation("Local ASN={Asn}, RouterId={RouterId}", _config.Bgp.Asn, _config.Bgp.RouterId);

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -834,8 +834,12 @@ public sealed class BgpSession : IDisposable
 
     private async Task HandleUpdateAsync(BgpUpdateMessage update)
     {
-        _logger.LogInformation("UpdateReceived from {Peer}: {Withdrawn} withdrawn, {Nlri} announced",
-            _peer, update.WithdrawnRoutes.Count, update.Nlri.Count);
+        // #344: per-UPDATE at Debug — a full-table dump sends hundreds-to-thousands of UPDATEs and
+        // a flap storm floods the log pipeline on the read loop, drowning the Warning-level
+        // signals; the per-dump aggregation summaries one level up stay at Information.
+        if (_logger.IsEnabled(LogLevel.Debug))
+            _logger.LogDebug("UpdateReceived from {Peer}: {Withdrawn} withdrawn, {Nlri} announced",
+                _peer, update.WithdrawnRoutes.Count, update.Nlri.Count);
 
         // Process withdrawals. RFC 4271 §3.2/§9: a withdrawal removes the route received FROM THIS
         // PEER, not whatever happens to sit at that prefix. BGPLite has one shared RouteTable rather

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -547,6 +547,10 @@ public sealed class BgpSession : IDisposable
     }
 
     private readonly SemaphoreSlim _sendLock = new(1, 1);
+    // #341: set in Dispose() BEFORE _sendLock.Dispose() — SemaphoreSlim.Dispose never wakes
+    // queued waiters, so sends parked on _sendLock race their wait against this signal
+    // (SendMessageAsync) and unwind as "not sent" instead of hanging RunAsync forever.
+    private readonly TaskCompletionSource _sendLockDisposed = new(TaskCreationOptions.RunContinuationsAsynchronously);
     // Guards mutations of _advertisedPrefixes so initial-send and RefreshRoutesAsync can't interleave.
     // SemaphoreSlim instead of lock{} so it composes correctly with await.
     private readonly SemaphoreSlim _advertisedPrefixesLock = new(1, 1);
@@ -1158,14 +1162,31 @@ public sealed class BgpSession : IDisposable
     // failure to reach RefreshCycleAsync.
     private async Task<bool> SendMessageAsync(BgpMessage message, CancellationToken ct = default)
     {
+        // #341: SemaphoreSlim.Dispose never wakes queued waiters (verified: a waiter parked with
+        // CancellationToken.None stays WaitingForActivation forever), so a send queued on
+        // _sendLock while Dispose runs would hang RunAsync. The wait is therefore raced against
+        // a dispose signal (set in Dispose BEFORE the semaphore goes away) — the loser unwinds as
+        // "not sent". The wait itself keeps the CALLER's token (None for keepalive/route sends):
+        // RunEstablishedAsync cancels _cts BEFORE RunAsync's catch blocks send their
+        // best-effort NOTIFICATION, so binding the wait to _cts would suppress those sends
+        // (regression caught by InvalidHeaderLength_OnWire…). Fast path: an uncontended
+        // WaitAsync completes synchronously and skips the WhenAny entirely.
+        Task waitTask;
         try
         {
-            await _sendLock.WaitAsync(ct);
+            waitTask = _sendLock.WaitAsync(ct);
         }
-        catch (OperationCanceledException) { return false; }
         catch (ObjectDisposedException)
         {
-            return false;
+            return false; // semaphore already disposed — nothing to send
+        }
+
+        if (!waitTask.IsCompletedSuccessfully)
+        {
+            var winner = await Task.WhenAny(waitTask, _sendLockDisposed.Task);
+            if (winner != waitTask)
+                return false; // _sendLock disposed while queued (#341) — abandon the wait
+            await waitTask; // propagate OCE (caller token) / complete the acquisition
         }
 
         try
@@ -1393,6 +1414,9 @@ public sealed class BgpSession : IDisposable
         if (Interlocked.Exchange(ref _disposed, 1) == 1)
             return;
 
+        // #341: wake any send parked on _sendLock BEFORE the semaphore (and its waiter queue)
+        // goes away — SendMessageAsync abandons such waits and reports "not sent".
+        _sendLockDisposed.TrySetResult();
         _cts.Cancel();
         _connection.Dispose();   // owns the socket (SocketBgpConnection wraps NetworkStream ownsSocket:true)
         _cts.Dispose();

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -89,6 +89,21 @@ public class BgpMessageTests
     }
 
     [Fact]
+    public void Open_UnsupportedVersion_CarriesMaxSupportedVersionData()
+    {
+        // RFC 4271 §6.2 (#317): the Unsupported Version NOTIFICATION's Data field must carry the
+        // 2-octet version hint. BGPLite supports only v4 — both §6.2 branches resolve to 4.
+        var message = BuildRawOpen(0, []);
+        message[19] = 3; // BGPv3
+
+        var ex = Assert.Throws<BgpParseException>(() => BgpMessageReader.ReadMessage(message));
+
+        Assert.Equal(BgpConstants.Error.OpenMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.UnsupportedVersion, ex.SubErrorCode);
+        Assert.Equal([(byte)0, (byte)4], ex.NotificationData);
+    }
+
+    [Fact]
     public void Open_WellFormedRawOptParams_Parses()
     {
         // Capability parameter (type 2) carrying a Four-Octet-ASN TLV (code 65, len 4, ASN 200000).

--- a/BGPLite.Tests/BgpSessionHoldTimerTests.cs
+++ b/BGPLite.Tests/BgpSessionHoldTimerTests.cs
@@ -89,16 +89,38 @@ public class BgpSessionHoldTimerTests
 
         public ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
         {
+            // #341 test seam: an optional write gate. When set, every WriteAsync signals entry and
+            // parks on the gate — a slow peer (TCP zero window) that accepts nothing, holding the
+            // session's _sendLock from inside the blocked write.
+            if (_writeGate is { } gate)
+            {
+                _writeEntered.TrySetResult();
+                return new ValueTask(gate.Task);
+            }
             // Capture the outbound bytes for assertions. A copy is needed because the caller
             // (SendMessageAsync) returns the ArrayPool buffer to the pool after this returns.
             _sent.Add(buffer.ToArray());
             return default;
         }
 
+        private TaskCompletionSource? _writeGate;
+        private TaskCompletionSource? _writeEntered;
+        public void BlockWrites()
+        {
+            _writeGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            _writeEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+        public void UnblockWrites() => _writeGate?.TrySetResult();
+        public Task WriteEntered => _writeEntered?.Task ?? Task.CompletedTask;
+
         public void Dispose()
         {
             Disposed = true;
             _inbound.Writer.TryComplete();
+            // Mirror the real transport: disposing a SocketBgpConnection aborts a pending
+            // WriteAsync (the stream is disposed under it). A gated fake write parked forever
+            // would otherwise pin the sending loop past Dispose — behavior production never has.
+            _writeGate?.TrySetCanceled();
         }
     }
 
@@ -619,5 +641,71 @@ public class BgpSessionHoldTimerTests
         Assert.DoesNotContain(messages, m => m.Contains("Session error"));
 
         conn.Dispose();
+    }
+
+    /// <summary>
+    /// #341: a blocked writer (a refresh send parked inside WriteAsync — the slow-peer holder of
+    /// the issue) holds <c>_sendLock</c>; the next keepalive tick queues on the semaphore with NO
+    /// token of its own; <c>Dispose</c> cancels <c>_cts</c> and then disposes the semaphore.
+    /// <c>SemaphoreSlim.Dispose</c> never wakes queued waiters, so pre-fix the keepalive waiter —
+    /// and with it <c>RunAsync</c> — hung forever. The lock WAIT must be bounded by the session's
+    /// own lifetime token so teardown unwinds it.
+    /// </summary>
+    [Fact]
+    public async Task Dispose_WhileSenderHoldsSendLock_RunAsyncCompletes()
+    {
+        var time = new FakeTimeProvider();
+        var conn = new FakeBgpConnection();
+        var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 9, KeepAlive = 3 };
+        var table = new RouteTable();
+        table.AddOrUpdate(new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 0x01020304 });
+        using var session = new BgpSession(
+            conn,
+            new PeerConfig { Address = "127.0.0.1" },
+            bgpConfig,
+            table,
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            new NopLogger<BgpSession>(),
+            timeProvider: time);
+
+        var runTask = await EstablishAsync(session, conn, bgpConfig, time);
+        Assert.True(session.IsEstablished, "session must reach Established");
+
+        // Wait for the initial route dump to finish (OPEN, KEEPALIVE, UPDATE) so the refresh below
+        // is what grabs the lock, not the dump.
+        for (var i = 0; i < 200 && conn.Sent.Count < 3; i++)
+        {
+            time.Advance(TimeSpan.FromMilliseconds(50));
+            await Task.Delay(2);
+        }
+        Assert.True(conn.Sent.Count >= 3, "initial route dump must have been sent");
+
+        // Freeze writes, then start a refresh — its withdraw UPDATE acquires _sendLock and parks
+        // inside WriteAsync: the slow-peer holder.
+        conn.BlockWrites();
+        var refreshTask = Task.Run(() => session.RefreshRoutesAsync());
+        await conn.WriteEntered.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Keepalive ticks queue on _sendLock — the #341 waiter (no token of its own). Two
+        // interval-steps with real-time pauses between them guarantee the tick fires (a single
+        // Advance can land exactly on the timer's due instant) and the send attempt parks.
+        for (var i = 0; i < 2; i++)
+        {
+            time.Advance(TimeSpan.FromSeconds(3));
+            await Task.Delay(50);
+        }
+
+        // Dispose mid-wait: cancels _cts, then disposes the semaphore. Pre-fix the waiter is
+        // never woken and runTask never completes; post-fix the wait unwinds on the session token.
+        session.Dispose();
+
+        var completed = await Task.WhenAny(runTask, Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.Same(runTask, completed); // RED pre-fix: the 5s timeout elapses instead
+
+        // Cleanup: release the holder — its Release() on the disposed semaphore is swallowed by
+        // SendMessageAsync's finally, and the refresh unwinds as a best-effort failure.
+        conn.UnblockWrites();
+        try { await refreshTask.WaitAsync(TimeSpan.FromSeconds(5)); } catch { /* best effort */ }
     }
 }

--- a/BGPLite.Tests/HttpPrefixProviderTests.cs
+++ b/BGPLite.Tests/HttpPrefixProviderTests.cs
@@ -200,6 +200,81 @@ public class HttpPrefixProviderTests
         Assert.Equal("curl/8.0", handler.LastUserAgent);
     }
 
+    /// <summary>
+    /// #324: a source with NO configured Timeout still gets a budget — the default is armed, so a
+    /// server that answers headers and then never sends the body fails by T+default instead of
+    /// hanging the fetch (and seeding/auto-refresh behind it). The outer WaitAsync guard doubles
+    /// as the red guard: on default-less code the load never completes.
+    /// </summary>
+    private sealed class HeadersThenHangHandler : HttpMessageHandler
+    {
+        public int Calls { get; private set; }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Calls++;
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StreamContent(new HangingBodyStream())
+            };
+            response.Content.Headers.ContentLength = 1024;
+            return Task.FromResult(response);
+        }
+    }
+
+    private sealed class HangingBodyStream : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => 1024;
+        public override long Position { get => 0; set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return 0;
+        }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    [Fact]
+    public async Task NoTimeoutConfigured_DefaultBudgetBoundsTheFetch()
+    {
+        var handler = new HeadersThenHangHandler();
+        var provider = new HttpPrefixProvider(
+            new StubFactory(handler), NullLogger<HttpPrefixProvider>.Instance,
+            defaultFetchTimeoutSeconds: 1);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            provider.LoadAsync(HttpSource("https://example.com/slow.txt"))
+                .WaitAsync(TimeSpan.FromSeconds(8)));
+
+        Assert.Equal(1, handler.Calls);
+    }
+
+    [Fact]
+    public async Task ConfiguredTimeout_WinsOverDefault()
+    {
+        // The configured value overrides the default (both arm the same mechanism); a small
+        // configured budget on the same hanging server fails FAST — proving the configured path
+        // still arms and is not clipped by anything.
+        var handler = new HeadersThenHangHandler();
+        var provider = new HttpPrefixProvider(
+            new StubFactory(handler), NullLogger<HttpPrefixProvider>.Instance,
+            defaultFetchTimeoutSeconds: 30);
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            provider.LoadAsync(new PrefixSourceConfig { Name = "t", Kind = "http", Url = "https://example.com/slow.txt", Timeout = 1 })
+                .WaitAsync(TimeSpan.FromSeconds(8)));
+        sw.Stop();
+
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(6), $"configured 1s budget fired in {sw.Elapsed}");
+    }
+
     [Fact]
     public async Task HttpErrorThrows()
     {

--- a/BGPLite.Tests/ManagementApiShutdownTests.cs
+++ b/BGPLite.Tests/ManagementApiShutdownTests.cs
@@ -131,6 +131,62 @@ public sealed class ManagementApiShutdownTests : IDisposable
         blocker.Stop();
     }
 
+    /// <summary>
+    /// #258: completed handlers must leave the in-flight set — the #248 bookkeeping appended
+    /// every request's Task and never removed it, so the tracking grew monotonically with request
+    /// count (a slow memory leak plus an ever-growing drain snapshot). After a burst of requests
+    /// the in-flight count must return to exactly zero.
+    /// </summary>
+    [Fact]
+    public async Task CompletedRequests_LeaveTheInFlightSet()
+    {
+        for (var attempt = 0; ; attempt++)
+        {
+            var port = FreeTcpPort();
+            var config = new AppConfig
+            {
+                ApiListen = "127.0.0.1",
+                ApiPort = port,
+                Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" }
+            };
+            _api = new ManagementApi(
+                new PeerStore(new StaticOptionsFactory(new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(_connection).Options)),
+                new RouteTable(),
+                config,
+                new BgpMetrics(),
+                NullLogger<ManagementApi>.Instance,
+                new BlockingRuPrefixService(),
+                new InertPrefixSourceService(),
+                new InertSessionManager());
+            try
+            {
+                await _api.StartAsync(CancellationToken.None);
+                _port = port;
+                break;
+            }
+            catch (HttpListenerException) when (attempt < 2)
+            {
+                _api.Dispose();
+                _api = null;
+            }
+        }
+        _client = new HttpClient();
+
+        for (var i = 0; i < 25; i++)
+        {
+            using var response = await _client.GetAsync($"http://127.0.0.1:{_port}/api/sessions");
+            Assert.True(response.IsSuccessStatusCode);
+        }
+
+        // The handler's finally (response close + slot release) runs just after the response is
+        // observed — settle within a bounded window, then demand exactly zero.
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(3);
+        while (_api.InflightRequestCount > 0 && DateTime.UtcNow < deadline)
+            await Task.Delay(20);
+
+        Assert.Equal(0, _api.InflightRequestCount);
+    }
+
     private static int FreeTcpPort()
     {
         var listener = new TcpListener(IPAddress.Loopback, 0);

--- a/BGPLite.Tests/OpenNegotiatorTests.cs
+++ b/BGPLite.Tests/OpenNegotiatorTests.cs
@@ -98,6 +98,21 @@ public class OpenNegotiatorTests
 
         Assert.Equal(BgpConstants.Error.OpenMessageError, ex.ErrorCode);
         Assert.Equal(BgpConstants.SubError.UnsupportedVersion, ex.SubErrorCode);
+        // RFC 4271 §6.2 (#317): the Data field carries a 2-octet version hint. BGPLite supports
+        // only v4, so a bid of 3 hits the "smallest locally-supported" branch → 4.
+        Assert.Equal([(byte)0, (byte)4], ex.NotificationData);
+    }
+
+    [Fact]
+    public void UnsupportedVersion_BidAboveSupported_DataFieldStillFour()
+    {
+        // A bid ABOVE 4 hits the "largest locally-supported less than the bid" branch, which
+        // also resolves to 4 — one constant is correct for both §6.2 branches.
+        var ex = Assert.Throws<BgpNotificationException>(
+            () => Negotiate(Open(version: 5)));
+
+        Assert.Equal(BgpConstants.SubError.UnsupportedVersion, ex.SubErrorCode);
+        Assert.Equal([(byte)0, (byte)4], ex.NotificationData);
     }
 
     [Fact]

--- a/BGPLite.Tests/PrefixServiceTests.cs
+++ b/BGPLite.Tests/PrefixServiceTests.cs
@@ -329,4 +329,70 @@ public class PrefixServiceTests
         var result = await service.GetPrefixesAsync(100);
         Assert.Single(result);
     }
+
+    /// <summary>
+    /// #320: user sources get a fetch budget end-to-end. A server that answers headers instantly
+    /// and then never sends the body used to hang the fetch (and the per-URL gate, and the whole
+    /// route dump) forever. With the budget armed, the fetch fails within it and the negative
+    /// cache throttles the retry — one HTTP attempt total.
+    /// </summary>
+    private sealed class HeadersThenHangHandler : HttpMessageHandler
+    {
+        public int Calls { get; private set; }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Calls++;
+            var body = new HangingBodyStream();
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StreamContent(body)
+            };
+            response.Content.Headers.ContentLength = 1024; // plausible, under the size cap
+            return Task.FromResult(response);
+        }
+    }
+
+    /// <summary>Delivers nothing; honors the read token like a real socket stream would.</summary>
+    private sealed class HangingBodyStream : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => 1024;
+        public override long Position { get => 0; set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return 0;
+        }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    [Fact]
+    public async Task UserSource_SlowBody_BoundedByBudget_NegativeCached()
+    {
+        var handler = new HeadersThenHangHandler();
+        var httpProvider = new HttpPrefixProvider(new StubFactory(handler), NullLogger<HttpPrefixProvider>.Instance);
+        var service = new PrefixService(
+            new AppConfig(),
+            null!, // RipeStatProvider is not on the user-source path
+            null!, // IPrefixSourceService is not on the user-source path
+            httpProvider,
+            userSourceTimeoutSeconds: 1);
+
+        // The fetch must fail within the budget (not hang) — the 8 s guard doubles as the red
+        // guard: on budget-less code the call never completes.
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => service.GetUserSourcePrefixesAsync("slow", "https://example.com/slow.txt", null)
+                .WaitAsync(TimeSpan.FromSeconds(8)));
+
+        // The negative cache throttles the retry: no second HTTP attempt.
+        var second = await service.GetUserSourcePrefixesAsync("slow", "https://example.com/slow.txt", null);
+        Assert.Empty(second);
+        Assert.Equal(1, handler.Calls);
+    }
 }

--- a/BGPLite.Tests/PrefixServiceTests.cs
+++ b/BGPLite.Tests/PrefixServiceTests.cs
@@ -395,4 +395,71 @@ public class PrefixServiceTests
         Assert.Empty(second);
         Assert.Equal(1, handler.Calls);
     }
+
+    /// <summary>
+    /// #324: a config source that hangs must not wedge sequential seeding — LoadAllAsync awaits
+    /// sources one by one, so before the default budget one dripping source stalled every later
+    /// source, WarmUp, and the final peer push until restart. With the provider-level budget the
+    /// hung source fails on its own deadline and the GOOD source still loads. The outer WaitAsync
+    /// guard doubles as the red guard on budget-less code.
+    /// </summary>
+    private sealed class PerUrlHandler : HttpMessageHandler
+    {
+        private readonly string _hangUrl;
+        public PerUrlHandler(string hangUrl) => _hangUrl = hangUrl;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            if (request.RequestUri?.ToString() == _hangUrl)
+            {
+                var hang = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StreamContent(new HangingStream()) };
+                hang.Content.Headers.ContentLength = 1024;
+                return Task.FromResult(hang);
+            }
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("10.2.0.0/24\n")
+            });
+        }
+    }
+
+    private sealed class HangingStream : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => 1024;
+        public override long Position { get => 0; set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return 0;
+        }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    [Fact]
+    public async Task LoadAllAsync_HangingFirstSource_DoesNotWedgeTheRest()
+    {
+        var handler = new PerUrlHandler("https://example.com/hang.txt");
+        var httpProvider = new HttpPrefixProvider(
+            new StubFactory(handler), NullLogger<HttpPrefixProvider>.Instance, defaultFetchTimeoutSeconds: 1);
+        var yaml = "Bgp:\n  Asn: 65444\n  RouterId: 10.0.0.1\nPrefixSources:\n" +
+                   "  - Name: hang\n    Kind: http\n    Url: https://example.com/hang.txt\n" +
+                   "  - Name: good\n    Kind: http\n    Url: https://example.com/good.txt\n";
+        var svc = new PrefixSourceService(
+            ConfigLoader.LoadFromText(yaml),
+            new PrefixSourceProviderFactory([httpProvider]),
+            NullLogger<PrefixSourceService>.Instance);
+
+        var all = await svc.LoadAllAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Equal(2, all.Count);
+        Assert.Empty(all[0].Prefixes);       // hung source: budget fired → failure → empty set
+        Assert.Single(all[1].Prefixes);      // good source still loaded — seeding not wedged
+    }
 }

--- a/BGPLite.Tests/PrefixSourceServiceTests.cs
+++ b/BGPLite.Tests/PrefixSourceServiceTests.cs
@@ -291,30 +291,44 @@ public class PrefixSourceServiceTests
     }
 
     /// <summary>
-    /// #214 TOCTOU regression: the changed-detection must be computed inside the per-source gate, so a
-    /// concurrent GetAsync (TTL-expired connect path) that itself loads the new list cannot mask the
-    /// change by making before==after. SequenceProvider returns the new list on the 2nd call regardless
-    /// of which caller wins the gate — and RefreshAsync must still report changed=true.
+    /// #332 (replaces the scheduling-dependent RefreshAsync_DetectsChange_DespiteConcurrentGetAsync):
+    /// the GetAsync-wins interleaving of the #214 TOCTOU scenario, forced deterministically instead
+    /// of racing a cold thread pool. The correct outcome for THIS ordering is <c>changed=false</c>:
+    /// GetAsync's load already detected the change INSIDE the per-source gate, updated the cache,
+    /// and fired <c>onSourceChanged</c> — the change is consumed, and RefreshAsync's own in-gate
+    /// compare then legitimately sees identical lists. What must NOT happen is the change being
+    /// silently lost: exactly one push for it (via GetAsync) is the observable contract.
     /// </summary>
     [Fact]
-    public async Task RefreshAsync_DetectsChange_DespiteConcurrentGetAsync()
+    public async Task RefreshAsync_AfterConcurrentGetAsyncConsumedChange_ReportsFalse_PushFiresOnce()
     {
         var provider = new SequenceProvider([(1u, (byte)24)], [(1u, (byte)24), (2u, (byte)16)]);
+        var pushed = new List<string>();
+        var gate = new object();
         var svc = new PrefixSourceService(
             ConfigWith("ru"),
             new PrefixSourceProviderFactory([provider]),
             NullLogger<PrefixSourceService>.Instance,
-            cacheTtl: TimeSpan.Zero); // TTL=0 forces GetAsync to always refetch (races RefreshAsync)
+            cacheTtl: TimeSpan.Zero, // TTL=0: GetAsync always refetches (the connect-path racer)
+            onSourceChanged: name => { lock (gate) pushed.Add(name); return Task.CompletedTask; });
 
-        await svc.GetAsync("ru"); // prime with first list
+        await svc.GetAsync("ru"); // prime: call 1 loads list1; first-ever load counts as changed (#251 push)
 
-        // Concurrent: GetAsync (TTL=0 → refetches, may grab the gate first) and RefreshAsync.
-        var getTask = Task.Run(() => svc.GetAsync("ru"));
-        var refreshTask = svc.RefreshAsync("ru");
-        await Task.WhenAll(getTask, refreshTask);
+        // The "GetAsync wins the gate" leg, sequential and deterministic: call 2 loads list2,
+        // detects the change inside the gate, updates the cache, and pushes.
+        await svc.GetAsync("ru");
 
-        // Regardless of which task loaded the new list first, RefreshAsync must report the change.
-        Assert.True(await refreshTask, "RefreshAsync must detect the change even if GetAsync raced ahead");
+        // RefreshAsync now runs third: call 3 returns list2 again (SequenceProvider clamps to the
+        // last list), the in-gate compare sees cache==fresh, and the already-consumed change is
+        // correctly reported as unchanged.
+        var changed = await svc.RefreshAsync("ru");
+
+        Assert.False(changed, "the change was consumed by the winning GetAsync; nothing new for RefreshAsync");
+        Assert.Equal(3, provider.Calls);
+        lock (gate)
+        {
+            Assert.Equal(["ru", "ru"], pushed); // prime push + exactly ONE push for the real change
+        }
     }
 
     /// <summary>#214: SourceSupportsConditional reflects the provider's SupportsConditionalRequests.</summary>

--- a/BGPLite.Tests/RequestBodyLimitsTests.cs
+++ b/BGPLite.Tests/RequestBodyLimitsTests.cs
@@ -137,6 +137,48 @@ public class RequestBodyLimitsTests
         Assert.Equal("{\"ip\":\"1.2.3.4\"}", body);
     }
 
+    /// <summary>
+    /// #358 review (hardens #257): a per-read deadline restarts on every byte — a client trickling
+    /// one byte per window retained its slot indefinitely. The deadline must be TOTAL for the
+    /// body. This stream yields one byte every 100 ms forever; with a 500 ms total budget the read
+    /// must 408 by ~T+0.5s, not keep pace forever. The outer 5s guard doubles as the red guard
+    /// against the per-read implementation.
+    /// </summary>
+    [Fact]
+    public async Task TrickleBody_OneBytePerWindow_KilledByTotalDeadline()
+    {
+        using var input = new TrickleStream(byteInterval: TimeSpan.FromMilliseconds(100));
+
+        var (body, error) = await ManagementApi
+            .ReadBoundedBodyAsync(input, maxBytes: 1024, readTimeout: TimeSpan.FromMilliseconds(500))
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Null(body);
+        Assert.NotNull(error);
+        Assert.Equal(408, error!.StatusCode);
+    }
+
+    /// <summary>Endless one-byte trickle — each individual read is well inside any per-read window.</summary>
+    private sealed class TrickleStream(TimeSpan byteInterval) : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => long.MaxValue;
+        public override long Position { get => 0; set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            await Task.Delay(byteInterval, cancellationToken);
+            buffer[offset] = (byte)'x';
+            return 1;
+        }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
     /// <summary>A stream whose ReadAsync never completes — the slow-drip attacker's socket.</summary>
     private sealed class NeverCompletingStream : Stream
     {

--- a/BGPLite.Tests/RequestBodyLimitsTests.cs
+++ b/BGPLite.Tests/RequestBodyLimitsTests.cs
@@ -104,4 +104,54 @@ public class RequestBodyLimitsTests
         public override void SetLength(long value) => throw new NotSupportedException();
         public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
     }
+
+    /// <summary>
+    /// #257: a body that never arrives parks <c>ReadBoundedBodyAsync</c> forever — with the
+    /// 64-slot in-flight cap, 64 such connections starve the whole API. Each read must be bounded
+    /// by the deadline and surface as 408. The outer WaitAsync(3s) doubles as the red guard: on
+    /// pre-fix code the call never completes and the test fails on the guard timeout.
+    /// </summary>
+    [Fact]
+    public async Task SlowDripBody_NeverCompletingRead_Returns408()
+    {
+        using var input = new NeverCompletingStream();
+
+        var (body, error) = await ManagementApi
+            .ReadBoundedBodyAsync(input, maxBytes: 1024, readTimeout: TimeSpan.FromMilliseconds(100))
+            .WaitAsync(TimeSpan.FromSeconds(3));
+
+        Assert.Null(body);
+        Assert.NotNull(error);
+        Assert.Equal(408, error!.StatusCode);
+    }
+
+    /// <summary>#257: the deadline must not affect a body that arrives within it.</summary>
+    [Fact]
+    public async Task BodyWithinDeadline_StillRead()
+    {
+        using var input = new MemoryStream(Encoding.UTF8.GetBytes("{\"ip\":\"1.2.3.4\"}"));
+        var (body, error) = await ManagementApi.ReadBoundedBodyAsync(
+            input, maxBytes: 1024, readTimeout: TimeSpan.FromSeconds(30));
+
+        Assert.Null(error);
+        Assert.Equal("{\"ip\":\"1.2.3.4\"}", body);
+    }
+
+    /// <summary>A stream whose ReadAsync never completes — the slow-drip attacker's socket.</summary>
+    private sealed class NeverCompletingStream : Stream
+    {
+        private readonly TaskCompletionSource<int> _never = new();
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => _never.Task.Result;
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => _never.Task;
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
 }

--- a/BGPLite.Tests/RipeStatProviderTests.cs
+++ b/BGPLite.Tests/RipeStatProviderTests.cs
@@ -49,6 +49,25 @@ public class RipeStatProviderTests
     private static RipeStatProvider Provider(HttpMessageHandler handler) =>
         new(new StubFactory(handler), NullLogger<RipeStatProvider>.Instance, new RipeStatConfig());
 
+    /// <summary>
+    /// #358 review (hardens #319): a non-string element in the originating array (number/object)
+    /// used to throw InvalidOperationException out of GetString() and discard the whole ASN's
+    /// valid prefixes; it must be skipped like any other non-canonical row.
+    /// </summary>
+    [Fact]
+    public async Task NonStringJsonElement_SkippedWithoutAborting()
+    {
+        const string body =
+            """{"status":"ok","data":{"resource":"65001","prefixes":{"v4":{"originating":[42,{"bad":1},"10.0.0.0/24"]},"v6":{"originating":[]}}}}""";
+        var handler = new StubHandler(HttpStatusCode.OK, body);
+
+        var result = await Provider(handler).GetPrefixesAsync(65001);
+
+        var row = Assert.Single(result);
+        Assert.Equal(0x0A000000u, row.Prefix);
+        Assert.Equal(24, row.PrefixLength);
+    }
+
     [Fact]
     public async Task ParsesPrefixes()
     {

--- a/BGPLite.Tests/RipeStatProviderTests.cs
+++ b/BGPLite.Tests/RipeStatProviderTests.cs
@@ -120,6 +120,28 @@ public class RipeStatProviderTests
         }
     }
 
+
+    /// <summary>
+    /// #319: RIPEstat returns what third parties ANNOUNCED — non-canonical NLRI must go through
+    /// the canonical parser (#236): host bits masked, /0 rejected, length range enforced, garbage
+    /// skipped instead of throwing the whole fetch. Pre-fix, "10.0.0.1/8" landed unmasked under a
+    /// corrupt route-table key and "0.0.0.0/0" was a default-route leak.
+    /// </summary>
+    [Fact]
+    public async Task NonCanonicalPrefixes_MaskedOrSkipped()
+    {
+        const string body =
+            """{"status":"ok","data":{"resource":"65001","prefixes":{"v4":{"originating":["10.0.0.1/8","0.0.0.0/0","1.2.3.4/33","not-a-cidr","192.168.0.0/16"]},"v6":{"originating":[]}}}}""";
+        var handler = new StubHandler(HttpStatusCode.OK, body);
+        var result = await Provider(handler).GetPrefixesAsync(65001);
+
+        Assert.Contains((0x0A000000u, (byte)8), result);      // 10.0.0.1/8 masked to the network
+        Assert.DoesNotContain((0x0A000001u, (byte)8), result); // unmasked key never stored
+        Assert.Contains((0xC0A80000u, (byte)16), result);      // canonical row unaffected
+        Assert.DoesNotContain(result, p => p.PrefixLength is 0 or > 32); // /0 and /33 rejected
+        Assert.Equal(2, result.Count);                          // garbage skipped, not thrown
+    }
+
     /// <summary>A handler that honors the CancellationToken like HttpClient's real handler does.</summary>
     private sealed class CancelAwareHandler : HttpMessageHandler
     {

--- a/BGPLite.Tests/RouteTableTests.cs
+++ b/BGPLite.Tests/RouteTableTests.cs
@@ -119,4 +119,120 @@ public class RouteTableTests
     [Fact]
     public void RemoveAllOwnedBy_NullOwner_Throws() =>
         Assert.Throws<ArgumentNullException>(() => new RouteTable().RemoveAllOwnedBy(null!));
+
+    /// <summary>
+    /// #343: Count is a maintained counter, not ConcurrentDictionary.Count. Every mutation path
+    /// must adjust it exactly once — a drift on ANY path desynchronizes the metric and /api/routes
+    /// totals forever (there is no re-sync once quiescent).
+    /// </summary>
+    [Fact]
+    public void Count_TracksEveryMutationPath()
+    {
+        var table = new RouteTable();
+        var owner = new object();
+        Assert.Equal(0, table.Count);
+
+        table.AddOrUpdate(new Route { Prefix = 0xC0A80000, PrefixLength = 24, NextHop = 1 });        // new +1
+        Assert.Equal(1, table.Count);
+        table.AddOrUpdate(new Route { Prefix = 0xC0A80000, PrefixLength = 24, NextHop = 2 });        // replace ±0
+        Assert.Equal(1, table.Count);
+        table.AddOrUpdate(new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 1 }, owner);  // new +1
+        table.AddOrUpdate(new Route { Prefix = 0x0B000000, PrefixLength = 8, NextHop = 1 }, owner);  // new +1
+        Assert.Equal(3, table.Count);
+
+        Assert.False(table.Remove(0x7F000000, 8));                                                  // miss ±0
+        Assert.False(table.RemoveOwnedBy(0x0A000000, 8, new object()));                              // wrong owner ±0
+        Assert.Equal(3, table.Count);
+
+        Assert.True(table.RemoveOwnedBy(0x0A000000, 8, owner));                                     // owned −1
+        Assert.Equal(2, table.Count);
+        Assert.True(table.Remove(0xC0A80000, 24));                                                  // unconditional −1
+        Assert.Equal(1, table.Count);
+        Assert.Equal(1, table.RemoveAllOwnedBy(owner));                                             // flush −1
+        Assert.Equal(0, table.Count);
+    }
+
+    /// <summary>#343: Clear must reset the maintained count (and keep accepting traffic after).</summary>
+    [Fact]
+    public void Clear_ResetsMaintainedCount()
+    {
+        var table = new RouteTable();
+        table.AddOrUpdate(new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 1 });
+        table.AddOrUpdate(new Route { Prefix = 0x0B000000, PrefixLength = 8, NextHop = 1 });
+        table.AddOrUpdate(new Route { Prefix = 0x0C000000, PrefixLength = 8, NextHop = 1 });
+
+        table.Clear();
+
+        Assert.Equal(0, table.Count);
+        table.AddOrUpdate(new Route { Prefix = 0x0D000000, PrefixLength = 8, NextHop = 1 });
+        Assert.Equal(1, table.Count);
+    }
+
+    /// <summary>
+    /// #343: under concurrent mixed mutations the counter must converge to the dictionary's actual
+    /// contents once drained — the 1:1 mutation↔transition invariant. Keys are worker-private, so
+    /// the expected survivors are deterministic: each worker keeps its odd-index keys (added, then
+    /// replaced ±0) and loses its even-index ones (added, then removed).
+    /// </summary>
+    [Fact]
+    public async Task Count_MixedConcurrentMutations_ExactAfterDrain()
+    {
+        var table = new RouteTable();
+        const int workers = 8, keys = 500;
+
+        var tasks = Enumerable.Range(0, workers).Select(w => Task.Run(() =>
+        {
+            for (var i = 0; i < keys; i++)
+            {
+                var prefix = (uint)(0x0A000000 + w * keys + i);
+                table.AddOrUpdate(new Route { Prefix = prefix, PrefixLength = 24, NextHop = 1 });
+                if ((i & 1) == 0)
+                    table.Remove(prefix, 24);
+                else
+                    table.AddOrUpdate(new Route { Prefix = prefix, PrefixLength = 24, NextHop = 2 });
+            }
+        })).ToArray();
+        await Task.WhenAll(tasks);
+
+        const int expected = workers * keys / 2;        // odd-index keys survive per worker
+        Assert.Equal(expected, table.GetAll().Count);   // dictionary truth
+        Assert.Equal(expected, table.Count);            // maintained counter converged to it
+    }
+
+    /// <summary>
+    /// #346 (CodeRabbit): TryAdd returning false does NOT guarantee the key still exists at the
+    /// replacement write — a concurrent remove in that window used to re-insert the entry via the
+    /// plain indexer without incrementing the maintained count, drifting it permanently (negative
+    /// after enough removals). Writers and removers hammering the SAME small key set hit that
+    /// window constantly. Interleaving-dependent, so a deterministic red is impossible — this is
+    /// the statistical catcher: after drain the counter must equal the dictionary's contents.
+    /// </summary>
+    [Fact]
+    public async Task Count_SameKeyConcurrentAddReplaceRemove_ExactAfterDrain()
+    {
+        var table = new RouteTable();
+        const int keys = 16, iterations = 3000, writers = 4, removers = 4;
+
+        var workers = new List<Task>();
+        for (var w = 0; w < writers; w++)
+            workers.Add(Task.Run(() =>
+            {
+                for (var i = 0; i < iterations; i++)
+                {
+                    var prefix = (uint)(0x0A000000 + i % keys);
+                    table.AddOrUpdate(new Route { Prefix = prefix, PrefixLength = 24, NextHop = (uint)i });
+                }
+            }));
+        for (var r = 0; r < removers; r++)
+            workers.Add(Task.Run(() =>
+            {
+                for (var i = 0; i < iterations; i++)
+                    table.Remove((uint)(0x0A000000 + i % keys), 24);
+            }));
+        await Task.WhenAll(workers);
+
+        var actual = table.GetAll().Count;
+        Assert.InRange(actual, 0, keys);   // sanity: some subset of the key set survived
+        Assert.Equal(actual, table.Count); // counter == dictionary truth (no drift, never negative)
+    }
 }

--- a/BGPLite.Tests/UserSourceCacheTests.cs
+++ b/BGPLite.Tests/UserSourceCacheTests.cs
@@ -123,19 +123,39 @@ public class UserSourceCacheTests
     [Fact]
     public async Task OperationCanceled_Propagates_And_Is_Not_Negative_Cached()
     {
-        // #114: cancellation must propagate and must not be recorded as a negative entry.
+        // #114: CALLER cancellation must propagate and must not be recorded as a negative entry.
+        // #320 refined the discriminator: the cache rethrows only OCEs whose CALLER token is
+        // cancelled — a foreign-token OCE (the per-fetch budget) is a load failure and IS
+        // negative-cached (see ForeignTokenOCE_IsAFailure_NegativeCachedAndThrottled). The
+        // faithful simulation is cancellation arriving WHILE the fetch is in flight (a
+        // pre-cancelled token never even passes the gate).
         var cache = new UserSourceCache();
-        var f = new Fetcher { Throw = new OperationCanceledException() };
+        var cts = new CancellationTokenSource();
+        var calls = 0;
 
-        await Assert.ThrowsAsync<OperationCanceledException>(
-            () => cache.GetOrLoadAsync("https://example.com/l", "src", f.Invoke, default));
-        Assert.Equal(1, f.Calls);
+        static async Task<IReadOnlyList<(uint Prefix, byte Length)>> Parked(CancellationToken ct)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+            return [];
+        }
+
+        Task<IReadOnlyList<(uint Prefix, byte Length)>> Invoke(CancellationToken ct)
+        {
+            calls++;
+            return Parked(ct);
+        }
+
+        var fetch = Task.Run(() => cache.GetOrLoadAsync("https://example.com/l", "src", Invoke, cts.Token));
+        await Task.Delay(50);   // let the caller enter the parked loader
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => fetch);
+        Assert.Equal(1, calls);
 
         // No negative cache → the next call reaches the fetcher again.
-        f.Throw = null;
-        f.OnSuccess = () => P((1u, 1));
+        var f = new Fetcher { OnSuccess = () => P((1u, 1)) };
         var served = await cache.GetOrLoadAsync("https://example.com/l", "src", f.Invoke, default);
-        Assert.Equal(2, f.Calls);
+        Assert.Equal(1, f.Calls); // a fresh fetcher ran once more
         Assert.Single(served);
     }
 
@@ -216,5 +236,29 @@ public class UserSourceCacheTests
         var a = await cache.GetOrLoadAsync("https://example.com/a", "a", ct => Load("a"), CancellationToken.None);
         Assert.NotNull(a);
         lock (calls) Assert.Equal(2, calls["a"]); // evicted earlier → refetched
+    }
+
+    /// <summary>
+    /// #320: a fetch budget fires as a foreign-token OCE (live caller token). It is a load
+    /// FAILURE, not teardown: it still throws (the caller's #342 boundary treats it as a
+    /// per-source failure), it is negative-cached, and the negative entry throttles the next
+    /// call — no loader invocation, no re-paying the budget.
+    /// </summary>
+    [Fact]
+    public async Task ForeignTokenOCE_IsAFailure_NegativeCachedAndThrottled()
+    {
+        var cache = new UserSourceCache(negativeTtl: TimeSpan.FromSeconds(5));
+        var f = new Fetcher { Throw = new OperationCanceledException() }; // no live caller token attached
+
+        // First call: the budget fired → OCE propagates (failure semantics), entry negative-cached.
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => cache.GetOrLoadAsync("https://example.com/l", "src", f.Invoke, CancellationToken.None));
+
+        // Second call within the negative TTL: throttled — the loader is NOT invoked again and
+        // the negative entry reports "no prefixes" instead of re-paying the budget.
+        var second = await cache.GetOrLoadAsync("https://example.com/l", "src", f.Invoke, CancellationToken.None);
+
+        Assert.Empty(second);
+        Assert.Equal(1, f.Calls);
     }
 }

--- a/BGPLite.Tests/UserSourceCacheTests.cs
+++ b/BGPLite.Tests/UserSourceCacheTests.cs
@@ -166,4 +166,55 @@ public class UserSourceCacheTests
 
         Assert.Equal(2, f.Calls); // negative entry expired → refetched
     }
+
+    /// <summary>
+    /// #261: unique peer-supplied URLs must not grow the cache without bound — port of the #165
+    /// cap. Inserting more distinct URLs than maxCacheEntries keeps the tracked count at the cap.
+    /// </summary>
+    [Fact]
+    public async Task UniqueUrls_BeyondCap_KeepCacheBounded()
+    {
+        var cache = new UserSourceCache(maxCacheEntries: 5);
+        var f = new Fetcher { OnSuccess = () => P((0x0A000000u, (byte)8)) };
+
+        for (var i = 0; i < 12; i++)
+            await cache.GetOrLoadAsync($"https://example.com/list-{i}", "src", f.Invoke, CancellationToken.None);
+
+        Assert.Equal(5, cache.TrackedCount);
+    }
+
+    /// <summary>
+    /// #261: the sweep drops the OLDEST entries (expired-first, then by CachedAt), so a fresh
+    /// entry survives and an evicted one refetches on next use.
+    /// </summary>
+    [Fact]
+    public async Task Eviction_DropsOldest_First_FreshEntriesSurvive()
+    {
+        var cache = new UserSourceCache(maxCacheEntries: 3);
+        var calls = new Dictionary<string, int>();
+        Task<IReadOnlyList<(uint Prefix, byte Length)>> Load(string url) => Task.Run(async () =>
+        {
+            lock (calls) calls[url] = calls.TryGetValue(url, out var c) ? c + 1 : 1;
+            await Task.Yield();
+            return P((0x0A000000u, (byte)8));
+        });
+
+        await cache.GetOrLoadAsync("https://example.com/a", "a", ct => Load("a"), CancellationToken.None);
+        await cache.GetOrLoadAsync("https://example.com/b", "b", ct => Load("b"), CancellationToken.None);
+        await cache.GetOrLoadAsync("https://example.com/c", "c", ct => Load("c"), CancellationToken.None);
+        await cache.GetOrLoadAsync("https://example.com/d", "d", ct => Load("d"), CancellationToken.None); // evicts "a"
+
+        Assert.Equal(3, cache.TrackedCount);
+        lock (calls) Assert.Equal(1, calls["d"]); // fresh entry is cached
+        lock (calls) Assert.Equal(1, calls["b"]); // survivor served from cache below
+        lock (calls) Assert.Equal(1, calls["c"]);
+
+        var b = await cache.GetOrLoadAsync("https://example.com/b", "b", ct => Load("b"), CancellationToken.None);
+        Assert.NotNull(b);
+        lock (calls) Assert.Equal(1, calls["b"]); // still cached — no refetch
+
+        var a = await cache.GetOrLoadAsync("https://example.com/a", "a", ct => Load("a"), CancellationToken.None);
+        Assert.NotNull(a);
+        lock (calls) Assert.Equal(2, calls["a"]); // evicted earlier → refetched
+    }
 }

--- a/BGPLite.Tests/UserSourceCacheTests.cs
+++ b/BGPLite.Tests/UserSourceCacheTests.cs
@@ -132,9 +132,13 @@ public class UserSourceCacheTests
         var cache = new UserSourceCache();
         var cts = new CancellationTokenSource();
         var calls = 0;
+        // #358 review: a fixed delay does not prove the caller entered the loader — synchronize
+        // on entry explicitly instead of racing Task.Run's start.
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        static async Task<IReadOnlyList<(uint Prefix, byte Length)>> Parked(CancellationToken ct)
+        static async Task<IReadOnlyList<(uint Prefix, byte Length)>> Parked(CancellationToken ct, TaskCompletionSource entered)
         {
+            entered.TrySetResult();
             await Task.Delay(Timeout.InfiniteTimeSpan, ct);
             return [];
         }
@@ -142,11 +146,11 @@ public class UserSourceCacheTests
         Task<IReadOnlyList<(uint Prefix, byte Length)>> Invoke(CancellationToken ct)
         {
             calls++;
-            return Parked(ct);
+            return Parked(ct, entered);
         }
 
         var fetch = Task.Run(() => cache.GetOrLoadAsync("https://example.com/l", "src", Invoke, cts.Token));
-        await Task.Delay(50);   // let the caller enter the parked loader
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
         cts.Cancel();
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => fetch);
@@ -260,5 +264,69 @@ public class UserSourceCacheTests
 
         Assert.Empty(second);
         Assert.Equal(1, f.Calls);
+    }
+
+    /// <summary>
+    /// #358 review (orphan-lock hygiene for #261): a caller cancelled while queued on the gate
+    /// never writes a cache entry, so its freshly-created gate had nothing to evict — cancelled
+    /// URLs accumulated SemaphoreSlims forever. The cancellation path must pair-remove its gate.
+    /// </summary>
+    [Fact]
+    public async Task CancelledWhileQueued_DoesNotLeaveAnOrphanGate()
+    {
+        var cache = new UserSourceCache();
+        Assert.Equal(0, cache.TrackedGateCount);
+
+        var holder = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var holdCts = new CancellationTokenSource();
+
+        Task<IReadOnlyList<(uint Prefix, byte Length)>> Hold(CancellationToken ct)
+        {
+            entered.TrySetResult();
+            return holder.Task.ContinueWith<IReadOnlyList<(uint Prefix, byte Length)>>(_ => [], CancellationToken.None);
+        }
+
+        // First caller holds the gate without completing.
+        var holding = cache.GetOrLoadAsync("https://example.com/l", "src", Hold, CancellationToken.None);
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Second caller queues on the same gate, then is cancelled while queued.
+        var queuedCts = new CancellationTokenSource();
+        var queued = Task.Run(() => cache.GetOrLoadAsync("https://example.com/l", "src", Hold, queuedCts.Token));
+        await Task.Delay(50);            // let it queue behind the holder
+        queuedCts.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => queued);
+
+        // Release the holder; its load completes and caches the entry. The cancelled caller must
+        // not have left a gate dictionary that grows: still exactly one gate for one url.
+        holder.TrySetResult();
+        await holding.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // The cancelled caller's pair-remove took the SHARED gate instance (the holder kept
+        // running on its own reference — the accepted duplicate-fetch tradeoff), and nothing
+        // re-adds a gate until the next call: zero gates, one cached entry, no orphan.
+        Assert.Equal(0, cache.TrackedGateCount);
+        Assert.Equal(1, cache.TrackedCount);
+    }
+
+    /// <summary>
+    /// #358 review: repeated cancelled-then-never-loaded URLs must not accumulate gates — the
+    /// observable orphan-growth case (fresh url per cancelled call, no cache entry ever written).
+    /// </summary>
+    [Fact]
+    public async Task CancelledFreshUrls_DoNotAccumulateGates()
+    {
+        var cache = new UserSourceCache();
+
+        for (var i = 0; i < 5; i++)
+        {
+            var cts = new CancellationTokenSource();
+            cts.Cancel();   // cancelled before the gate is even acquired
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                cache.GetOrLoadAsync($"https://example.com/never-{i}", "src", ct => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]), cts.Token));
+        }
+
+        Assert.Equal(0, cache.TrackedGateCount);   // pre-fix: 5 orphan gates
     }
 }

--- a/BGPLite/Program.cs
+++ b/BGPLite/Program.cs
@@ -299,8 +299,13 @@ void ConfigureDefaultHttpResilience(ResiliencePipelineBuilder<HttpResponseMessag
             FailureRatio = 0.5,
             MinimumThroughput = 10,
             BreakDuration = TimeSpan.FromSeconds(30),
-        })
-        .AddTimeout(TimeSpan.FromSeconds(5));
+        });
+// #324/#267-item-2: no pipeline-level AddTimeout. It wrapped SendAsync only up to the
+// response headers (ResponseHeadersRead) and silently CLIPPED any configured source
+// Timeout above it, while the body loop ran outside the pipeline unbounded. The per-source
+// budget in HttpPrefixProvider.LoadAsync is now always armed (configured Timeout or the
+// 30s default) on a linked token that flows through the pipeline and covers headers AND
+// body — one deadline, never clipped, still bounding every attempt and retry.
 
 void ConfigureRipeStatResilience(ResiliencePipelineBuilder<HttpResponseMessage> pipelineBuilder, RipeStatConfig cfg) =>
     pipelineBuilder

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -160,3 +160,25 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
   Pre-OPEN connections (remote ASN not yet known) are not matched by the (ip, asn) termination and
   may re-register the row once their OPEN arrives.
 - **Tracker:** #323.
+
+### D17. UPDATE body errors keep the session alive across BOTH reject classes
+- **Decision:** a malformed inbound UPDATE never tears down the session, in both reject classes:
+  (a) a frame-level `BgpParseException` with an Update Message Error code (body unparseable, e.g.
+  truncated NLRI — the D2 case), and (b) a `BgpNotificationException(3, …)` from the attribute
+  pipeline (malformed/missing mandatory attributes, duplicate-first-wins, AS4 reconstruction — and
+  unrecognized **well-known** attributes). The message is rejected (`UpdateRejected`), the session
+  stays Established, and no NOTIFICATION is sent.
+- **Context:** RFC baseline — RFC 4271 §6.3 prescribes NOTIFICATION + session reset for these
+  errors, and RFC 7606 revises only part of the space toward treat-as-withdraw: malformed/missing
+  attributes become treat-as-withdraw, but **unrecognized well-known stays session-reset** (7606
+  does not revise it; verified against the RFC text 2026-08-30) and §3(j) mandates session reset
+  when the NLRI itself cannot be parsed. BGPLite deviates deliberately in both places: a route
+  server must not lose a long-lived session — and every other peer's view of it — over one bad or
+  adversarial UPDATE (#94, #222, #284 lineage). No NOTIFICATION is sent because RFC 4271 §6.3
+  requires its receiver to tear down, defeating the purpose. Withdrawal semantics: class (b)
+  withdraws the peer's own NLRI (RFC 7606's "treat" half, #288); class (a) cannot — the NLRI is
+  unrecoverable — and discards only (D2).
+- **Consequence:** a peer sending structurally valid but semantically rejected UPDATEs gets them
+  silently dropped (log Warning + `UpdatesRejected` metric) instead of a session reset; operators
+  comparing against RFC-strict speakers will see BGPLite retain sessions others would close.
+- **Tracker:** #94, #222, #284, #288, #322 (closed); recorded via #344.

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -165,8 +165,9 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
 - **Decision:** a malformed inbound UPDATE never tears down the session, in both reject classes:
   (a) a frame-level `BgpParseException` with an Update Message Error code (body unparseable, e.g.
   truncated NLRI — the D2 case), and (b) a `BgpNotificationException(3, …)` from the attribute
-  pipeline (malformed/missing mandatory attributes, duplicate-first-wins, AS4 reconstruction — and
-  unrecognized **well-known** attributes). The message is rejected (`UpdateRejected`), the session
+  pipeline (malformed/missing mandatory attributes, AS4 reconstruction — and unrecognized
+  **well-known** attributes; duplicate attributes are NOT a rejection: per RFC 7606 §3(g) later
+  occurrences are discarded, the first one keeps processing). The message is rejected (`UpdateRejected`), the session
   stays Established, and no NOTIFICATION is sent.
 - **Context:** RFC baseline — RFC 4271 §6.3 prescribes NOTIFICATION + session reset for these
   errors, and RFC 7606 revises only part of the space toward treat-as-withdraw: malformed/missing


### PR DESCRIPTION
Integration of `dev` into `main`: 12 commits — one perf fix, one CI bootstrap, ten issue fixes from the 2026-08-30/31 batch. Each landed on `dev` as its own reviewed, CI-green squash commit (full per-issue verification in the linked PRs).

Closes #343
Closes #341
Closes #332
Closes #258
Closes #257
Closes #261
Closes #319
Closes #317
Closes #320
Closes #324
Closes #344

## What ships

| Issue | Area | Summary | PR |
|---|---|---|---|
| #343 | routing perf | `RouteTable.Count` O(1) via maintained counter (was: all-lock-strips read twice per inbound UPDATE); review-found replace-race closed with CAS retry | #346 |
| #341 | server | sends parked on `_sendLock` at Dispose unwind via a dispose signal — `RunAsync` no longer hangs forever; NOTIFICATION delivery on teardown preserved | #347 |
| #332 | tests | flaky `RefreshAsync_DetectsChange` replaced with the deterministic GetAsync-wins ordering assertion (service behavior was correct) | #349 |
| #258 | api | in-flight handler leak: append-only list → count + idle task; StopAsync drains on the idle task | #350 |
| #257 | api,security | per-read deadline on request bodies (30 s → 408) — 64 slow-drip connections can no longer starve the API | #351 |
| #261 | providers | `UserSourceCache` capacity cap (1024) with the #165 eviction sweep; locks evicted with entries | #352 |
| #319 | providers | RIPEstat prefixes through the canonical `PrefixCidr` parser: host-bit masking, /0 and /33+ rejection, skip+warn instead of throw | #353 |
| #317 | protocol | Unsupported Version NOTIFICATION (2/1) now carries the 2-octet version Data field per RFC 4271 §6.2 | #354 |
| #320 | providers,server | fetch budget (30 s) for user URL sources; foreign-token OCE = load failure, negative-cached (throttled) — no more indefinite dump/refresh wedge behind the per-URL gate | #355 |
| #324 | providers | fetch budget armed unconditionally for config sources; pipeline `AddTimeout(5s)` removed (clipped configured timeouts, ignored the body); PrefixSourceService OCE catches discriminated | #356 |
| #344 | docs/chore | D17 recorded (session-survives-rejected-UPDATE across both reject classes, precise RFC 4271 §6.3 / RFC 7606 baseline); per-UPDATE log → Debug; listen backlog 16→512 | #357 |
| — | ci | CI/format/CodeQL also run on dev PRs (dev-flow bootstrap, admin-merged chicken-and-egg) | #348 |

## Verification
- Every fix has a red/green regression test (red proven against pre-fix code; where the seam required it, via a temporary reverted-code run) — details in each PR.
- Full suite on `dev` head: **815/815** (797 baseline + 18 new tests).
- This PR runs the full main-gate: CI + CodeQL + CodeRabbit (the batched review — CodeRabbit is intentionally disabled on dev PRs to respect the plan's rate limit).

## Behavior changes (all deliberate, documented in the PRs)
- Slow request bodies (>30 s/read) get 408 instead of holding a slot forever.
- User/config prefix sources that exceed their fetch budget are skipped for the cycle (session survives) instead of wedging the dump/refresh.
- RIPEstat non-canonical rows are masked or skipped+warned instead of corrupting route-table keys or leaking a default route.
- 2/1 NOTIFICATION carries 2 data bytes (RFC-conformant).
- Log volume: per-UPDATE lines demoted to Debug; BGP listen backlog 512.

## RFCs touched
RFC 4271 §6.2 (#317 — verified two-branch Data-field rule), §6.3 + RFC 7606 §3 (D17 records the deliberate treat-as-withdraw deviation precisely), §8.1/§4724 §4 semantics untouched (#341 preserves them).

## Risks
Recorded in the batch report: the #341 abandoned-wait node (GC-collectable, harmless), the OCE-discriminator pattern now living in three places (any future per-source timeout must use a linked CTS over the caller token), the removed pipeline timeout leaving per-source budgets as the only attempt bound (by design, with circuit breaker + negative cache).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added default and configurable timeouts for HTTP prefix sources, including slow response bodies.
  - Improved handling of malformed or non-canonical prefixes without interrupting imports.
  - Prevented shutdown hangs and ensured completed management requests are released correctly.
  - BGP unsupported-version notifications now include the supported version details.
  - Improved route tracking accuracy and bounded prefix-source cache growth.
  - Increased the BGP listener backlog to better handle connection bursts.

- **Documentation**
  - Documented behavior for malformed inbound UPDATE messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->