### PR TITLE
fix: address CodeRabbit findings on the integration batch

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -552,25 +552,39 @@ public sealed class ManagementApi : IHostedService, IDisposable
     /// <summary>
     /// Pure body reader with a hard byte cap — extracted for unit testing (#156). Returns
     /// <c>(null, 413-error)</c> when the stream yields more than <paramref name="maxBytes"/> bytes,
-    /// <c>(null, 408-error)</c> when a single read breaches <paramref name="readTimeout"/> (#257),
-    /// otherwise the full body decoded as UTF-8. Covers both sized and chunked/streaming bodies.
+    /// <c>(null, 408-error)</c> when the body misses <paramref name="readTimeout"/> (#257) — an
+    /// ABSOLUTE deadline for the whole body, not a per-read window: a per-read WaitAsync restarts
+    /// on every byte, and a client trickling one byte per window held its slot indefinitely
+    /// (#358 review). Otherwise the full body decoded as UTF-8. Covers sized and chunked bodies.
     /// </summary>
     internal static async Task<(string? Body, ApiResponse? Error)> ReadBoundedBodyAsync(
         Stream input, long maxBytes, TimeSpan? readTimeout = null)
     {
         using var ms = new MemoryStream();
         var buffer = new byte[8192];
+        var deadline = readTimeout is { } timeout ? DateTime.UtcNow + timeout : (DateTime?)null;
         while (true)
         {
             int read;
             var readTask = input.ReadAsync(buffer, 0, buffer.Length);
             try
             {
-                // #257: no client-disconnect token exists on HttpListener streams — the deadline
-                // is the only bound on a slow-drip body. WaitAsync leaves the abandoned read
-                // parked on the socket with this call's buffer (bounded by the in-flight cap,
-                // never reused); the caller unwinds, answers 408, and frees its slot.
-                read = readTimeout is { } timeout ? await readTask.WaitAsync(timeout) : await readTask;
+                if (deadline is { } byThen)
+                {
+                    // #257/#358: no client-disconnect token exists on HttpListener streams — the
+                    // deadline is the only bound on a slow-drip body, and it is TOTAL: each read
+                    // gets only the remaining budget, so trickling cannot reset the clock. The
+                    // abandoned read parks on the socket with this call's buffer (bounded by the
+                    // in-flight cap, never reused); the caller unwinds, answers 408, frees its slot.
+                    var remaining = byThen - DateTime.UtcNow;
+                    if (remaining <= TimeSpan.Zero)
+                        throw new TimeoutException();
+                    read = await readTask.WaitAsync(remaining);
+                }
+                else
+                {
+                    read = await readTask;
+                }
             }
             catch (TimeoutException)
             {

--- a/BGPLite.Providers/RipeStatProvider.cs
+++ b/BGPLite.Providers/RipeStatProvider.cs
@@ -50,14 +50,15 @@ public sealed class RipeStatProvider
 
         foreach (var element in prefixes.EnumerateArray())
         {
-            var cidr = element.GetString();
-            // #319: the canonical parser every other prefix input path uses (#236): host-bit
-            // masking, /0 rejection, length 1..32, IPv4-only. RIS collectors return what third
-            // parties ANNOUNCED — non-canonical NLRI ("10.0.0.1/8") must not reach the route
+            // #319/#358-review: the canonical parser every other prefix input path uses (#236):
+            // host-bit masking, /0 rejection, length 1..32, IPv4-only. RIS collectors return what
+            // third parties ANNOUNCED — non-canonical NLRI ("10.0.0.1/8") must not reach the route
             // table under a corrupt key, and "0.0.0.0/0" must not become a default-route leak
             // (#162 closed the same hole for URL sources). Skip + warn, like stored custom
-            // prefixes; also covers a null/garbage element without throwing (previously NRE/
-            // FormatException took the whole ASN fetch down).
+            // prefixes; a null element, garbage string, or NON-STRING JSON element (GetString
+            // throws InvalidOperationException on numbers/objects) is skipped without taking the
+            // whole ASN fetch down with it.
+            var cidr = element.ValueKind == JsonValueKind.String ? element.GetString() : null;
             if (!PrefixCidr.TryParse(cidr, out var prefix, out var length))
             {
                 _logger.LogWarning("AS{Asn}: RIPEstat returned a non-canonical prefix '{Cidr}'; skipped", asn, cidr);

--- a/BGPLite.Providers/UserSourceCache.cs
+++ b/BGPLite.Providers/UserSourceCache.cs
@@ -52,6 +52,9 @@ internal sealed class UserSourceCache
     /// <summary>Entries currently tracked (test/observability).</summary>
     internal int TrackedCount => _cache.Count;
 
+    /// <summary>Gates currently tracked (test/observability — orphan-lock hygiene, #358 review).</summary>
+    internal int TrackedGateCount => _locks.Count;
+
     /// <param name="url">Cache key (the source URL — dedupes across peers).</param>
     /// <param name="logLabel">Safe identifier (the source <c>Name</c>) for log lines — the URL itself is
     /// never logged, since peer URLs may carry query-string tokens (#149).</param>
@@ -68,7 +71,21 @@ internal sealed class UserSourceCache
         // Serialize per-key so concurrent callers (e.g. several peers refreshing the same URL) share
         // a single fetch — no thundering herd.
         var gate = _locks.GetOrAdd(url, _ => new SemaphoreSlim(1, 1));
-        await gate.WaitAsync(ct);
+        try
+        {
+            await gate.WaitAsync(ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // #358 review (orphan-lock hygiene for #261): a caller cancelled while queued never
+            // writes a cache entry, so its freshly-created gate would never be evicted (the sweep
+            // removes locks only for removed cache keys) — cancelled URLs accumulated semaphores.
+            // Pair-remove OUR gate instance: a concurrent waiter keeps running on its own
+            // reference, and a fresh caller GetOrAdd's a new gate — the same duplicate-fetch
+            // tradeoff the eviction sweep already accepts.
+            ((ICollection<KeyValuePair<string, SemaphoreSlim>>)_locks).Remove(new KeyValuePair<string, SemaphoreSlim>(url, gate));
+            throw;
+        }
         try
         {
             if (TryGetFresh(url, out var rechecked))

--- a/BGPLite.Tests/RequestBodyLimitsTests.cs
+++ b/BGPLite.Tests/RequestBodyLimitsTests.cs
@@ -137,6 +137,48 @@ public class RequestBodyLimitsTests
         Assert.Equal("{\"ip\":\"1.2.3.4\"}", body);
     }
 
+    /// <summary>
+    /// #358 review (hardens #257): a per-read deadline restarts on every byte — a client trickling
+    /// one byte per window retained its slot indefinitely. The deadline must be TOTAL for the
+    /// body. This stream yields one byte every 100 ms forever; with a 500 ms total budget the read
+    /// must 408 by ~T+0.5s, not keep pace forever. The outer 5s guard doubles as the red guard
+    /// against the per-read implementation.
+    /// </summary>
+    [Fact]
+    public async Task TrickleBody_OneBytePerWindow_KilledByTotalDeadline()
+    {
+        using var input = new TrickleStream(byteInterval: TimeSpan.FromMilliseconds(100));
+
+        var (body, error) = await ManagementApi
+            .ReadBoundedBodyAsync(input, maxBytes: 1024, readTimeout: TimeSpan.FromMilliseconds(500))
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Null(body);
+        Assert.NotNull(error);
+        Assert.Equal(408, error!.StatusCode);
+    }
+
+    /// <summary>Endless one-byte trickle — each individual read is well inside any per-read window.</summary>
+    private sealed class TrickleStream(TimeSpan byteInterval) : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => long.MaxValue;
+        public override long Position { get => 0; set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            await Task.Delay(byteInterval, cancellationToken);
+            buffer[offset] = (byte)'x';
+            return 1;
+        }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
     /// <summary>A stream whose ReadAsync never completes — the slow-drip attacker's socket.</summary>
     private sealed class NeverCompletingStream : Stream
     {

--- a/BGPLite.Tests/RipeStatProviderTests.cs
+++ b/BGPLite.Tests/RipeStatProviderTests.cs
@@ -49,6 +49,25 @@ public class RipeStatProviderTests
     private static RipeStatProvider Provider(HttpMessageHandler handler) =>
         new(new StubFactory(handler), NullLogger<RipeStatProvider>.Instance, new RipeStatConfig());
 
+    /// <summary>
+    /// #358 review (hardens #319): a non-string element in the originating array (number/object)
+    /// used to throw InvalidOperationException out of GetString() and discard the whole ASN's
+    /// valid prefixes; it must be skipped like any other non-canonical row.
+    /// </summary>
+    [Fact]
+    public async Task NonStringJsonElement_SkippedWithoutAborting()
+    {
+        const string body =
+            """{"status":"ok","data":{"resource":"65001","prefixes":{"v4":{"originating":[42,{"bad":1},"10.0.0.0/24"]},"v6":{"originating":[]}}}}""";
+        var handler = new StubHandler(HttpStatusCode.OK, body);
+
+        var result = await Provider(handler).GetPrefixesAsync(65001);
+
+        var row = Assert.Single(result);
+        Assert.Equal(0x0A000000u, row.Prefix);
+        Assert.Equal(24, row.PrefixLength);
+    }
+
     [Fact]
     public async Task ParsesPrefixes()
     {

--- a/BGPLite.Tests/UserSourceCacheTests.cs
+++ b/BGPLite.Tests/UserSourceCacheTests.cs
@@ -132,9 +132,13 @@ public class UserSourceCacheTests
         var cache = new UserSourceCache();
         var cts = new CancellationTokenSource();
         var calls = 0;
+        // #358 review: a fixed delay does not prove the caller entered the loader — synchronize
+        // on entry explicitly instead of racing Task.Run's start.
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        static async Task<IReadOnlyList<(uint Prefix, byte Length)>> Parked(CancellationToken ct)
+        static async Task<IReadOnlyList<(uint Prefix, byte Length)>> Parked(CancellationToken ct, TaskCompletionSource entered)
         {
+            entered.TrySetResult();
             await Task.Delay(Timeout.InfiniteTimeSpan, ct);
             return [];
         }
@@ -142,11 +146,11 @@ public class UserSourceCacheTests
         Task<IReadOnlyList<(uint Prefix, byte Length)>> Invoke(CancellationToken ct)
         {
             calls++;
-            return Parked(ct);
+            return Parked(ct, entered);
         }
 
         var fetch = Task.Run(() => cache.GetOrLoadAsync("https://example.com/l", "src", Invoke, cts.Token));
-        await Task.Delay(50);   // let the caller enter the parked loader
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
         cts.Cancel();
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => fetch);
@@ -260,5 +264,69 @@ public class UserSourceCacheTests
 
         Assert.Empty(second);
         Assert.Equal(1, f.Calls);
+    }
+
+    /// <summary>
+    /// #358 review (orphan-lock hygiene for #261): a caller cancelled while queued on the gate
+    /// never writes a cache entry, so its freshly-created gate had nothing to evict — cancelled
+    /// URLs accumulated SemaphoreSlims forever. The cancellation path must pair-remove its gate.
+    /// </summary>
+    [Fact]
+    public async Task CancelledWhileQueued_DoesNotLeaveAnOrphanGate()
+    {
+        var cache = new UserSourceCache();
+        Assert.Equal(0, cache.TrackedGateCount);
+
+        var holder = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var holdCts = new CancellationTokenSource();
+
+        Task<IReadOnlyList<(uint Prefix, byte Length)>> Hold(CancellationToken ct)
+        {
+            entered.TrySetResult();
+            return holder.Task.ContinueWith<IReadOnlyList<(uint Prefix, byte Length)>>(_ => [], CancellationToken.None);
+        }
+
+        // First caller holds the gate without completing.
+        var holding = cache.GetOrLoadAsync("https://example.com/l", "src", Hold, CancellationToken.None);
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Second caller queues on the same gate, then is cancelled while queued.
+        var queuedCts = new CancellationTokenSource();
+        var queued = Task.Run(() => cache.GetOrLoadAsync("https://example.com/l", "src", Hold, queuedCts.Token));
+        await Task.Delay(50);            // let it queue behind the holder
+        queuedCts.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => queued);
+
+        // Release the holder; its load completes and caches the entry. The cancelled caller must
+        // not have left a gate dictionary that grows: still exactly one gate for one url.
+        holder.TrySetResult();
+        await holding.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // The cancelled caller's pair-remove took the SHARED gate instance (the holder kept
+        // running on its own reference — the accepted duplicate-fetch tradeoff), and nothing
+        // re-adds a gate until the next call: zero gates, one cached entry, no orphan.
+        Assert.Equal(0, cache.TrackedGateCount);
+        Assert.Equal(1, cache.TrackedCount);
+    }
+
+    /// <summary>
+    /// #358 review: repeated cancelled-then-never-loaded URLs must not accumulate gates — the
+    /// observable orphan-growth case (fresh url per cancelled call, no cache entry ever written).
+    /// </summary>
+    [Fact]
+    public async Task CancelledFreshUrls_DoNotAccumulateGates()
+    {
+        var cache = new UserSourceCache();
+
+        for (var i = 0; i < 5; i++)
+        {
+            var cts = new CancellationTokenSource();
+            cts.Cancel();   // cancelled before the gate is even acquired
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                cache.GetOrLoadAsync($"https://example.com/never-{i}", "src", ct => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]), cts.Token));
+        }
+
+        Assert.Equal(0, cache.TrackedGateCount);   // pre-fix: 5 orphan gates
     }
 }

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -165,8 +165,9 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
 - **Decision:** a malformed inbound UPDATE never tears down the session, in both reject classes:
   (a) a frame-level `BgpParseException` with an Update Message Error code (body unparseable, e.g.
   truncated NLRI — the D2 case), and (b) a `BgpNotificationException(3, …)` from the attribute
-  pipeline (malformed/missing mandatory attributes, duplicate-first-wins, AS4 reconstruction — and
-  unrecognized **well-known** attributes). The message is rejected (`UpdateRejected`), the session
+  pipeline (malformed/missing mandatory attributes, AS4 reconstruction — and unrecognized
+  **well-known** attributes; duplicate attributes are NOT a rejection: per RFC 7606 §3(g) later
+  occurrences are discarded, the first one keeps processing). The message is rejected (`UpdateRejected`), the session
   stays Established, and no NOTIFICATION is sent.
 - **Context:** RFC baseline — RFC 4271 §6.3 prescribes NOTIFICATION + session reset for these
   errors, and RFC 7606 revises only part of the space toward treat-as-withdraw: malformed/missing


### PR DESCRIPTION
Review response to the batched review on #358. Five verified findings fixed (absolute body deadline / RIPEstat ValueKind guard / UserSourceCache orphan gates / test-race sync / D17 wording), two answered with rationale (Entry equality divergence unreachable for current owner types; cross-URL admission overshoot bounded and #165-consistent). Each fix red/green-proven where deterministically possible — details in the commit body. Suite 819/819. This lands on dev and re-triggers the #358 review on the new head.