### PR TITLE
fix(protocol): reject semantically invalid NEXT_HOP with subcode 8

### DIFF
--- a/BGPLite.Protocol/UpdateCodec.cs
+++ b/BGPLite.Protocol/UpdateCodec.cs
@@ -204,7 +204,7 @@ public static class UpdateCodec
     /// caller can apply treat-as-withdraw (RFC 7606) — the exact pipeline previously inlined in
     /// BgpSession.HandleUpdateAsync, moved verbatim (#270).
     /// </summary>
-    public static RouteAttributes ParseRouteAttributes(BgpUpdateMessage update, bool fourByteAsnSession)
+    public static RouteAttributes ParseRouteAttributes(BgpUpdateMessage update, bool fourByteAsnSession, uint? localRouterId = null)
     {
         try
         {
@@ -303,6 +303,12 @@ public static class UpdateCodec
             }
 
             ValidateMandatoryAttributes(originSeen, asPathSeen, nextHopSeen);
+            // RFC 4271 §6.3/§6.8: a semantically incorrect NEXT_HOP MUST be rejected with subcode 8
+            // (Invalid NEXT_HOP Attribute) — "a valid unicast host address", never multicast, never
+            // the receiving speaker's own address. Routed through the caller's treat-as-withdraw
+            // path per RFC 7606 §7.3 (#292 item 1).
+            if (nextHopSeen)
+                ValidateNextHopSemantics(nextHop, localRouterId);
             asPath = MergeAsPathWithAs4Path(asPath, as4Path);
             ValidateAggregatorReconstruction(aggregatorAsn, as4AggregatorAsn);
 
@@ -316,6 +322,34 @@ public static class UpdateCodec
             throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, ex.SubErrorCode ?? BgpConstants.SubError.Unspecific, ex.Message);
         }
     }
+
+    /// <summary>
+    /// Validates that a received NEXT_HOP is a semantically valid unicast host address
+    /// (RFC 4271 §6.3, subcode 8 "Invalid NEXT_HOP Attribute"; §6.8: "the IP address ... defined
+    /// as a valid unicast host address ... MUST NOT be ... the IP address of the receiving
+    /// speaker ... multicast ... addresses are never advertised"). Rejects: unspecified (0.0.0.0),
+    /// loopback (127/8), multicast (224/4), reserved (240/4 — includes the broadcast address),
+    /// and the local router-id when known. Throws <see cref="BgpNotificationException"/> so the
+    /// caller applies treat-as-withdraw (RFC 7606 §7.3) — the route never reaches the table with
+    /// a next hop that could blackhole or loop traffic (#292 item 1).
+    /// </summary>
+    public static void ValidateNextHopSemantics(uint nextHop, uint? localRouterId)
+    {
+        if (nextHop == 0)
+            throw InvalidNextHop(nextHop, "the unspecified address 0.0.0.0");
+        if ((nextHop >> 24) == 127)
+            throw InvalidNextHop(nextHop, "a loopback address (127/8)");
+        // 224/4 (multicast) and 240/4 (reserved, incl. 255.255.255.255) both live in the top
+        // eighth of the address space: first nibble >= 0xE.
+        if ((nextHop >> 28) >= 0xE)
+            throw InvalidNextHop(nextHop, "a multicast or reserved address (224/4, 240/4)");
+        if (localRouterId.HasValue && nextHop == localRouterId.Value)
+            throw InvalidNextHop(nextHop, "the local speaker's own address (RFC 4271 §6.8)");
+    }
+
+    private static BgpNotificationException InvalidNextHop(uint nextHop, string why) => new(
+        BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNextHopAttribute,
+        $"Invalid NEXT_HOP attribute: {BgpConstants.UintToIPAddress(nextHop)} is {why}");
 
     /// <summary>
     /// The RFC-mandated shape of a recognized path attribute: the required Optional/Transitive flag

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -859,7 +859,9 @@ public sealed class BgpSession : IDisposable
             UpdateCodec.RouteAttributes attrs;
             try
             {
-                attrs = UpdateCodec.ParseRouteAttributes(update, _remoteFourByteAsn);
+                // #292 item 1: local router-id for the §6.8 self-address check on NEXT_HOP.
+                attrs = UpdateCodec.ParseRouteAttributes(update, _remoteFourByteAsn,
+                    BgpConstants.IPAddressToUint(_bgpConfig.GetRouterIdAddress()));
             }
             catch (BgpNotificationException ex) when (ex.ErrorCode == BgpConstants.Error.UpdateMessageError)
             {

--- a/BGPLite.Tests/BgpSessionRfc6793Tests.cs
+++ b/BGPLite.Tests/BgpSessionRfc6793Tests.cs
@@ -117,7 +117,9 @@ public class BgpSessionRfc6793Tests
 
         Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
         Assert.Equal(BgpConstants.SubError.InvalidNextHopAttribute, ex.SubErrorCode);
-        Assert.Contains(why is "self" ? "own address" : why, ex.Message);
+        // 255.255.255.255 lands in the 240/4 bucket of the validator's message.
+        var expected = why switch { "self" => "own address", "broadcast" => "reserved", _ => why };
+        Assert.Contains(expected, ex.Message);
     }
 
     [Fact]

--- a/BGPLite.Tests/BgpSessionRfc6793Tests.cs
+++ b/BGPLite.Tests/BgpSessionRfc6793Tests.cs
@@ -87,6 +87,58 @@ public class BgpSessionRfc6793Tests
         Assert.Equal([(64512u, 1u, 2u)], attrs.LargeCommunities);
     }
 
+    /// <summary>
+    /// #292 item 1: RFC 4271 §6.3/§6.8 — a semantically invalid NEXT_HOP MUST be rejected with
+    /// subcode 8 (Invalid NEXT_HOP Attribute) and routed through treat-as-withdraw (RFC 7606
+    /// §7.3). Previously every one of these was accepted into the route table.
+    /// </summary>
+    [Theory]
+    [InlineData(0x00000000u, "unspecified")]        // 0.0.0.0
+    [InlineData(0x7F000001u, "loopback")]           // 127.0.0.1
+    [InlineData(0xE0000001u, "multicast")]          // 224.0.0.1
+    [InlineData(0xF0FF00FFu, "reserved")]           // 240.255.0.255
+    [InlineData(0xFFFFFFFFu, "broadcast")]          // 255.255.255.255
+    [InlineData(0x0A000001u, "self")]               // == localRouterId
+    public void ParseRouteAttributes_InvalidNextHop_ThrowsSubcode8(uint nextHop, string why)
+    {
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+                AttributeHelper.WriteAsPath([65001u], fourByteAsn: true),
+                AttributeHelper.WriteNextHop(nextHop),
+            ],
+            Nlri = []
+        };
+
+        var ex = Assert.Throws<BgpNotificationException>(
+            () => UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: true, localRouterId: 0x0A000001u));
+
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.InvalidNextHopAttribute, ex.SubErrorCode);
+        Assert.Contains(why is "self" ? "own address" : why, ex.Message);
+    }
+
+    [Fact]
+    public void ParseRouteAttributes_ValidNextHop_Accepted()
+    {
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+                AttributeHelper.WriteAsPath([65001u], fourByteAsn: true),
+                AttributeHelper.WriteNextHop(0x0A000001u),
+            ],
+            Nlri = []
+        };
+
+        // 10.0.0.1 with no localRouterId known (optional parameter): a legitimate peer address.
+        var attrs = UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: true);
+        Assert.Equal(0x0A000001u, attrs.NextHop);
+    }
+
     [Fact]
     public void ParseRouteAttributes_MissingMandatoryAttribute_ThrowsSubcode3()
     {


### PR DESCRIPTION
Split from #292 (item 1). Closes nothing standalone — the umbrella tracks the item list; this closes item 1 of it.

## Problem
NEXT_HOP was only shape-checked (length 4, RFC 7606 §7.3); its VALUE was taken unconditionally — routes with next hop 0.0.0.0, 127/8, 224/4, 240/4 (incl. broadcast), or the local speaker's own address landed in the table and were re-advertised.

## Root Cause
The inbound pipeline validated every other consumed attribute's semantics (ORIGIN values, COMMUNITY %4, AS_PATH segments) but never NEXT_HOP's.

## RFC
RFC 4271 §6.3 — subcode 8 (Invalid NEXT_HOP Attribute) for a semantically incorrect field; §6.8 — "a valid unicast host address" which "MUST NOT be the IP address of the receiving speaker"; multicast never advertised. RFC 7606 §7.3 routes attribute-level errors to treat-as-withdraw — session survives, UPDATE discarded.

## Fix
`ValidateNextHopSemantics(nextHop, localRouterId?)` after the mandatory-attribute check: rejects unspecified, 127/8, 224/4, 240/4, and the router-id when known. `localRouterId` is an optional parameter — the standalone Protocol package API stays usable without session context; `BgpSession` passes the configured router-id.

## Regression Test
6-case theory asserting 3/8 for each invalid class (red 6/6 on validation-less code via a signature shim, green after) + valid-next-hop acceptance with and without a known router-id.

## Verification
`dotnet format` / `dotnet build` (0 errors) / full suite green (see checks).

## Behavior Change
Deliberate: UPDATEs with martian/self next hops are now discarded (treat-as-withdraw, Warning + UpdatesRejected) instead of installed.

## Deviation from Issue Proposal
None — the umbrella's item-1 fix set implemented as specified.

Note: NOT merging until #358 lands — the integration PR head must stay stable during its review window.