### PR TITLE
fix(server): an unexpected message in Established is an FSM error, not silence

### DIFF
--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -768,6 +768,21 @@ public sealed class BgpSession : IDisposable
                     // further full dumps); faults log instead of tearing down the read loop.
                     _ = Task.Run(() => RefreshInBackgroundAsync(cancellationToken), CancellationToken.None);
                     break;
+
+                default:
+                    // RFC 4271 FSM: in Established only UPDATE, KEEPALIVE, NOTIFICATION and
+                    // ROUTE_REFRESH are legal inputs; anything else (e.g. an OPEN) is an FSM
+                    // error — NOTIFICATION 5/0, release resources, Idle. Previously such messages
+                    // were silently swallowed (#265 item 3). The CAS claims the teardown BEFORE
+                    // sending so the finally-block cannot double-emit a Cease (§8.1).
+                    _logger.LogWarning("Unexpected message {Type} from {Peer} in Established — FSM error",
+                        message.Type, _peer);
+                    if (Interlocked.CompareExchange(ref _teardownReason, (int)TeardownReason.LocalCease, (int)TeardownReason.None) == (int)TeardownReason.None)
+                    {
+                        try { await SendNotificationAsync(BgpConstants.Error.FiniteStateMachineError, BgpConstants.SubError.Unspecific); }
+                        catch { /* best-effort — partial write counts, see RFC 4271 §8.1 */ }
+                    }
+                    return;
             }
         }
     }

--- a/BGPLite.Tests/BgpSessionHoldTimerTests.cs
+++ b/BGPLite.Tests/BgpSessionHoldTimerTests.cs
@@ -644,6 +644,54 @@ public class BgpSessionHoldTimerTests
     }
 
     /// <summary>
+    /// #265 item 3: in Established only UPDATE/KEEPALIVE/NOTIFICATION/ROUTE_REFRESH are legal
+    /// inputs (RFC 4271 FSM) — an unexpected message type (e.g. a second OPEN) is an FSM error:
+    /// NOTIFICATION 5/0, teardown, Idle. Previously the message was silently swallowed and the
+    /// session limped on in an undefined state.
+    /// </summary>
+    [Fact]
+    public async Task UnexpectedMessageInEstablished_FsmErrorNotification_AndTeardown()
+    {
+        var time = new FakeTimeProvider();
+        var conn = new FakeBgpConnection();
+        var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 9, KeepAlive = 3 };
+        using var session = new BgpSession(
+            conn,
+            new PeerConfig { Address = "127.0.0.1" },
+            bgpConfig,
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            new NopLogger<BgpSession>(),
+            timeProvider: time);
+
+        var runTask = await EstablishAsync(session, conn, bgpConfig, time);
+        Assert.True(session.IsEstablished, "session must reach Established");
+        var sentBefore = conn.Sent.Count;
+
+        // A second OPEN is not a legal Established input.
+        conn.Enqueue(Serialize(new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = (ushort)bgpConfig.HoldTime,
+            RouterId = 0x7F000002
+        }));
+
+        var completed = await Task.WhenAny(runTask, Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.Same(runTask, completed);   // RED pre-fix: the OPEN is swallowed, the session keeps running
+
+        var notifs = conn.Sent.Skip(sentBefore)
+            .Select(b => BgpMessageReader.ReadMessage(b.AsSpan()))
+            .OfType<BgpNotificationMessage>()
+            .ToList();
+        var fsm = Assert.Single(notifs);
+        Assert.Equal(BgpConstants.Error.FiniteStateMachineError, fsm.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.Unspecific, fsm.SubErrorCode);
+        Assert.Equal(BgpFsmState.Idle, session.State);
+    }
+
+    /// <summary>
     /// #341: a blocked writer (a refresh send parked inside WriteAsync — the slow-peer holder of
     /// the issue) holds <c>_sendLock</c>; the next keepalive tick queues on the semaphore with NO
     /// token of its own; <c>Dispose</c> cancels <c>_cts</c> and then disposes the semaphore.


### PR DESCRIPTION
Split from #265 (item 3). The umbrella tracks the item list; this closes item 3 of it.

## Problem
The Established read loop had no default branch: an unexpected message type (e.g. a second OPEN) was silently swallowed and the session continued in an undefined state — RFC 4271's FSM defines this as an error (NOTIFICATION 5/0 → Idle), exactly what the OpenConfirm default already does.

## Fix
Default branch: Warning log, CAS-claim teardown as LocalCease BEFORE sending (no double Cease from the finally, §8.1), best-effort NOTIFICATION FiniteStateMachineError/0, return → Idle.

## Regression Test
`UnexpectedMessageInEstablished_FsmErrorNotification_AndTeardown` — second OPEN post-establishment → exactly one NOTIFICATION 5/0, `RunAsync` completes, state Idle. Naturally red on the swallowing code (5s guard), green after.

## Verification
`dotnet format` / `dotnet build` (0 errors) / full suite green.

## RFC
RFC 4271 FSM (§8.2.3 Established event handling): unexpected message types are error events → NOTIFICATION 5/0 + Idle.

## Behavior Change
Deliberate: a peer sending garbage types mid-session now gets torn down with 5/0 instead of being ignored.

Note: NOT merging until #358 lands — the integration head stays stable during its review window.