### PR TITLE
fix(config): reject Bgp.HoldTime above the 2-octet OPEN field range

### DIFF
--- a/BGPLite.Configuration/BgpConfig.cs
+++ b/BGPLite.Configuration/BgpConfig.cs
@@ -88,6 +88,12 @@ public sealed class BgpConfig
             throw new InvalidOperationException(
                 $"Invalid configuration: Bgp.HoldTime must be 0 (disabled) or at least 3 seconds (got {HoldTime}).");
 
+        // RFC 4271 §4.2: Hold Time is a 2-octet field — a value above 65535 cannot be carried in
+        // an OPEN; the wire write silently truncated it before ((ushort)70000 -> 4464) (#265 item 2).
+        if (HoldTime > ushort.MaxValue)
+            throw new InvalidOperationException(
+                $"Invalid configuration: Bgp.HoldTime must fit the 2-octet OPEN field (0..65535, got {HoldTime}).");
+
         // KeepAlive is only meaningful when a Hold Time is negotiated. The session computes its
         // keepalive interval as max(HoldTime/3, 1) (BgpSession OPEN negotiation), so the configured
         // value must fit within the same window: 1..max(HoldTime/3, 1).

--- a/BGPLite.Tests/ConfigValidationTests.cs
+++ b/BGPLite.Tests/ConfigValidationTests.cs
@@ -295,6 +295,29 @@ public class ConfigValidationTests
         Assert.Contains("Bgp.HoldTime", ex.Message);
     }
 
+    /// <summary>
+    /// #265 item 2: Hold Time is a 2-octet OPEN field — a value above 65535 cannot be carried on
+    /// the wire, and the write path used to truncate it silently ((ushort)70000 -> 4464).
+    /// </summary>
+    [Theory]
+    [InlineData(65536)]
+    [InlineData(70000)]
+    public void Validate_RejectsHoldTimeAboveUshortRange(int holdTime)
+    {
+        var config = Config(Bgp(holdTime: holdTime, keepAlive: 60));
+
+        var ex = Assert.Throws<InvalidOperationException>(() => config.Validate());
+        Assert.Contains("Bgp.HoldTime", ex.Message);
+        Assert.Contains("65535", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_AcceptsHoldTimeAtUshortMax()
+    {
+        // The boundary itself is representable and must pass (KeepAlive within max(65535/3,1)).
+        Config(Bgp(holdTime: 65535, keepAlive: 60)).Validate();
+    }
+
     [Fact]
     public void Validate_RejectsKeepAliveAboveHoldTimeThird()
     {


### PR DESCRIPTION
Split from #265 (item 2).

## Problem
Hold Time is a 2-octet field (RFC 4271 §4.2); Validate() only checked the lower bound, so HoldTime=70000 passed and the wire write silently truncated it ((ushort)70000 → 4464) — the session negotiated a timer the operator never configured.

## Fix
Upper-bound validation at startup (fail loud, #89 posture): values > 65535 rejected with the field range in the message.

## Regression Test
65536/70000 rejected (red 2/2 pre-fix), boundary 65535 accepted.

## Verification
`dotnet format` / `dotnet build` (0 errors) / full suite 822/822.

## RFC
RFC 4271 §4.2 — Hold Time is a 2-octet unsigned integer.

## Behavior Change
Configs with HoldTime > 65535 now fail at startup instead of truncating on the wire.

Note: NOT merging until #358 lands — the integration head stays stable during its review window.