### PR TITLE
fix(server): exclude looping routes — local ASN in AS_PATH is never installed

### DIFF
--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -915,6 +915,21 @@ public sealed class BgpSession : IDisposable
                     LargeCommunities = attrs.LargeCommunities
                 };
 
+                // RFC 4271 §9.1.2 (#292 item 6): "AS loop detection is done by scanning the full
+                // AS path ... and checking that the autonomous system number of the local system
+                // does not appear in the AS path" — such routes "should be excluded from the
+                // Phase 2 decision function". A route carrying our own ASN would loop straight
+                // back to us if re-advertised (with our ASN prepended yet again). Route-level
+                // exclusion, not a session error (the old subcode 7 is deprecated); excluded
+                // routes are never installed, so a later withdrawal for them removes nothing.
+                if (attrs.AsPath.AsSpan().Contains(_bgpConfig.Asn))
+                {
+                    if (_logger.IsEnabled(LogLevel.Debug))
+                        _logger.LogDebug("Excluded looping route {Prefix} from {Peer}: local AS {Asn} in AS_PATH",
+                            nlri, _peer, _bgpConfig.Asn);
+                    continue;
+                }
+
                 if (_routeFilter.AcceptIncoming(route, filterPeerConfig))
                 {
                     // Tagged with this session as the owner, so only this peer's own withdrawal can

--- a/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
+++ b/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
@@ -463,6 +463,39 @@ public class BgpSessionRouteOwnershipTests
     }
 
     /// <summary>Rejects every inbound route, so nothing this peer announces reaches the table.</summary>
+    /// <summary>
+    /// #292 item 6: RFC 4271 §9.1.2 — a route whose AS_PATH contains the local system's ASN is
+    /// excluded from selection (loop detection). It must not be installed (and the session must
+    /// survive — route-level exclusion, not a protocol error), while an otherwise identical route
+    /// without the local ASN installs normally.
+    /// </summary>
+    [Fact]
+    public async Task Announce_WithLocalAsnInAsPath_IsExcludedNotInstalled()
+    {
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        // AS_PATH seq [100, 65001] — 65001 is the session's own ASN (4-octet session).
+        var loopingAttributes = new byte[]
+        {
+            0x40, 0x01, 0x01, 0x00,                                                     // ORIGIN igp
+            0x40, 0x02, 0x0A, 0x02, 0x02, 0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0xFD, 0xE9, // AS_PATH [100, 65001]
+            0x40, 0x03, 0x04, 0xC0, 0x00, 0x02, 0x01,                                   // NEXT_HOP 192.0.2.1
+        };
+        conn.EnqueueFrame(BuildAnnounce(loopingAttributes, 8, [0x0A]));
+        await SettleAsync(conn); // frameless settle: the assertion is that NOTHING happened
+
+        Assert.Equal(0, routeTable.Count);                      // RED pre-fix: the looping route installed
+        Assert.True(session.IsEstablished, "a looping route is excluded, not a session error");
+
+        // The same NLRI without the local ASN installs normally — proves exclusion, not rejection.
+        conn.EnqueueFrame(AnnounceFrame(8, 0x0A));
+        await SettleAsync(conn, () => routeTable.Count == 1);
+        Assert.NotNull(routeTable.Get(TenSlashEight, 8));
+
+        await TeardownAsync(session, run);
+    }
+
     private sealed class RejectAllIncomingFilter : IRouteFilter
     {
         private static readonly IReadOnlySet<uint> Empty = new HashSet<uint>();


### PR DESCRIPTION
Split from #292 (item 6, the umbrella's last code item — items 1 and 3 handled in #360 / closed as not-a-defect).

## Problem
RFC 4271 §9.1.2 loop detection was absent: a route whose AS_PATH contains the local ASN was installed and re-advertised with our ASN prepended again — a churn/echo loop waiting to happen.

## RFC
RFC 4271 §9.1.2 — lowercase-should exclusion from the decision function (route-level, NOT a session error; subcode 7 deprecated). Exclusion before installation also means a later withdrawal for the excluded NLRI removes nothing — consistent with #289 ownership.

## Fix
Per-NLRI check after `ParseRouteAttributes` (post AS4_PATH merge, so 2-byte sessions see the reconstructed real ASNs): `attrs.AsPath.AsSpan().Contains(localAsn)` → skip + Debug log. Never matches AS_TRANS — the merged path carries the real ASN where relevant (23456 is a placeholder for ANY 4-byte speaker on OLD sessions; matching it would over-exclude).

## Regression Test
`Announce_WithLocalAsnInAsPath_IsExcludedNotInstalled` — AS_PATH [100, 65001] → table empty, session Established; same NLRI with [100] installs right after. Red on the installing code, green after.

## Verification
`dotnet format` / `dotnet build` (0 errors) / full suite green (checks).

## Behavior Change
Deliberate: looping routes are now silently excluded (Debug log) instead of installed and re-advertised.

## Deviation from Issue Proposal
None — the umbrella's item-6 direction implemented; severity was LOW partly because the production assembler never re-advertises peer-injected routes, but /api/routes and the shared-table fallback path made the exclusion worth having regardless.