### PR TITLE
fix(server): a replaced session's teardown no longer overwrites the live peer status

### DIFF
--- a/BGPLite.Server/BgpServer.cs
+++ b/BGPLite.Server/BgpServer.cs
@@ -183,6 +183,11 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
                 var peerConfig = new PeerConfig { Address = peerAddress, Port = remoteEndpoint.Port };
 
                 var session = _sessionFactory.Create(new SocketBgpConnection(socket), peerConfig);
+                // #265 item 1: the session's finally-block consults this before flipping the
+                // peer row to inactive — "still the registered session for your slot?" A
+                // replacement (TryUpdate below) removes this session from the registry, so its
+                // slow unwind cannot clobber the replacement's Status=active.
+                session.StillRegisteredProbe = s => _sessions.Values.Any(v => ReferenceEquals(v, s));
 
                 if (Volatile.Read(ref _acceptingConnections) == 0)
                 {

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -32,6 +32,11 @@ public sealed class BgpSession : IDisposable
     private readonly CancellationTokenSource _cts = new();
     private readonly Action<string, uint>? _onPeerIdentified;
     private readonly IPeerStore? _peerStore;
+    // #265 item 1: set by BgpServer right after creation — "is this session still the registered
+    // one?" A false answer at teardown-time means a replacement took the slot and owns the
+    // (Ip, Asn) status now; this session must not overwrite it back to inactive.
+    private Func<BgpSession, bool>? _stillRegisteredProbe;
+    internal Func<BgpSession, bool>? StillRegisteredProbe { set => _stillRegisteredProbe = value; }
     private readonly IPrefixAggregator _prefixAggregator;
     // #93 Phase 2: the outbound route-assembly policy lives here, not in the session. The session
     // delegates to BuildOutboundRoutesAsync and keeps the send/withdraw mirror (_advertisedPrefixes)
@@ -538,8 +543,20 @@ public sealed class BgpSession : IDisposable
                 // store failure (SQLite "database is locked" past busy_timeout) must not escape —
                 // it would fault RunAsync unobserved, skip PeerDisconnected() below, and leak
                 // PeerCount plus the row's Status=active forever (#325).
-                try { _peerStore?.UpdateSessionStatus(_peerConfig.Address, _remoteAsn, false); }
-                catch (Exception ex) { _logger.LogWarning(ex, "Failed to persist session status for {Peer}", _peer); }
+                // #265 item 1: the write must not clobber a REPLACEMENT session's Status=active.
+                // Two guards: (a) SilentClose teardowns (session replacement, GR-aware shutdown —
+                // RFC 4724 §4) skip the write outright; (b) when a registration probe is wired
+                // (BgpServer), a session no longer present in the registry was replaced mid-unwind
+                // and also skips. Covers the slow-unwind race (e.g. a sender parked on _sendLock
+                // inside the #285 budget) whose finally runs after the new session's first
+                // LoadPeerRoutingView already wrote active.
+                var silent = (TeardownReason)Interlocked.CompareExchange(ref _teardownReason, 0, 0) == TeardownReason.SilentClose;
+                var stillRegistered = _stillRegisteredProbe?.Invoke(this) ?? true;
+                if (!silent && stillRegistered)
+                {
+                    try { _peerStore?.UpdateSessionStatus(_peerConfig.Address, _remoteAsn, false); }
+                    catch (Exception ex) { _logger.LogWarning(ex, "Failed to persist session status for {Peer}", _peer); }
+                }
             }
             _metrics.PeerDisconnected();
             _logger.LogInformation("SessionClosed with {Peer}", _peer);

--- a/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
+++ b/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
@@ -496,6 +496,92 @@ public class BgpSessionRouteOwnershipTests
         await TeardownAsync(session, run);
     }
 
+    /// <summary>
+    /// #265 item 1: a REPLACED session's slow finally must not flip the peer row back to
+    /// inactive after the replacement wrote active. Two guards: the SilentClose teardown reason
+    /// (replacement / GR-aware shutdown) skips the write, and the registration probe answers
+    /// false once the session is no longer the registered one. A genuine teardown still writes.
+    /// </summary>
+    private sealed class RecordingPeerStore : IPeerStore
+    {
+        public List<(string Ip, uint Asn, bool Active)> StatusWrites = [];
+        public string CreatePeer(string ip, uint asn, string? description) => "id";
+        public void UpsertPeer(string ip, uint asn) { }
+        public void UpdateSessionStatus(string ip, uint asn, bool active) => StatusWrites.Add((ip, asn, active));
+        public void DeletePeer(string id) { }
+        public PeerInfo? GetPeerByIp(string ip) => null;
+        public PeerInfo? GetPeer(string ip, uint asn) => null;
+        public PeerInfo? GetPeerById(string id) => null;
+        public List<string> GetSubscriptions(string peerId) => [];
+        public List<string> GetCustomPrefixes(string peerId) => [];
+        public List<uint> GetCustomAsns(string peerId) => [];
+        public HashSet<uint> GetCommunities(string peerId) => [];
+        public HashSet<uint> GetCommunities(string ip, uint asn) => [];
+        public void SetCommunities(string peerId, HashSet<uint> communities) { }
+        public void ClearCommunities(string peerId) { }
+        public void SetDescription(string id, string description) { }
+        public PeerRoutingView? LoadPeerRoutingView(string ip, uint asn) => new("id", [], [], [], []);
+    }
+
+    private static async Task<(BgpSession Session, Task Run, RecordingPeerStore Store)> EstablishWithStoreAsync(
+        RouteTable routeTable, Func<BgpSession, bool>? probe = null)
+    {
+        var conn = new ScriptedConnection();
+        var store = new RecordingPeerStore();
+        var config = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
+        var session = new BgpSession(
+            conn,
+            new PeerConfig { Address = "127.0.0.1" },
+            config,
+            routeTable,
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            NullLogger<BgpSession>.Instance,
+            peerStore: store);
+        session.StillRegisteredProbe = probe ?? (_ => true);
+        var run = session.RunAsync();
+        conn.EnqueueMessage(new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = 0,
+            RouterId = 0x0A000002,
+            Capabilities = [BgpCapabilityInfo.FourOctetAsn(65002)],
+        });
+        conn.EnqueueMessage(BgpKeepaliveMessage.Instance);
+        for (var i = 0; i < 200 && !session.IsEstablished; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        Assert.True(session.IsEstablished, "session must reach Established");
+        return (session, run, store);
+    }
+
+    [Fact]
+    public async Task ReplacedSession_Teardown_DoesNotOverwriteStatusInactive()
+    {
+        // The probe answers false — the registry no longer holds this session (TryUpdate
+        // swapped a replacement in). Its finally must not write inactive.
+        var (session, run, store) = await EstablishWithStoreAsync(new RouteTable(), probe: _ => false);
+
+        await TeardownAsync(session, run);   // SilentClose + probe-false — both guards skip
+
+        Assert.DoesNotContain(store.StatusWrites, w => !w.Active);
+    }
+
+    [Fact]
+    public async Task GenuineTeardown_StillWritesInactive()
+    {
+        // Registered + non-silent teardown: the write must still happen (no regression of #325).
+        var (session, run, store) = await EstablishWithStoreAsync(new RouteTable());
+
+        // A peer NOTIFICATION tears down with RemoteNotification — not SilentClose, probe true.
+        var connField = typeof(BgpSession).GetField("_connection", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var conn = (ScriptedConnection)connField.GetValue(session)!;
+        conn.EnqueueMessage(new BgpNotificationMessage { ErrorCode = BgpConstants.Error.Cease, SubErrorCode = 0 });
+        try { await run.WaitAsync(TimeSpan.FromSeconds(5)); } catch { /* teardown unwinds */ }
+
+        Assert.Contains(store.StatusWrites, w => !w.Active);
+    }
+
     private sealed class RejectAllIncomingFilter : IRouteFilter
     {
         private static readonly IReadOnlySet<uint> Empty = new HashSet<uint>();


### PR DESCRIPTION
Split from #265 (item 1 — with this, items 1–3 of the umbrella are done; item 4 is a decision, see below).

## Problem
The RunAsync finally wrote Status=inactive unconditionally. On session replacement the new session's first LoadPeerRoutingView writes active; the old session's delayed finally (e.g. a sender parked on _sendLock inside the #285 budget) flipped it back — API/UI showed a live peer as inactive.

## Fix
Two guards in the finally: (a) SilentClose teardowns (replacement / GR-aware shutdown, RFC 4724 §4) skip the write; (b) BgpServer wires a registration probe (StillRegisteredProbe) right after Create — the finally consults it, and a session no longer present in the registry was replaced mid-unwind. Guard (b) covers the narrow window where the old session latched another reason before the replacement's MarkSilentClose CAS. Genuine teardowns keep writing inactive (#325 unchanged).

## Regression Tests
`ReplacedSession_Teardown_DoesNotOverwriteStatusInactive` (red on the unconditional write via a no-op-probe shim) and `GenuineTeardown_StillWritesInactive` (no #325 regression).

## Verification
`dotnet format` / `dotnet build` (0 errors) / full suite **833/833**.

## RFC / Behavior Change
None on the wire; DB status now reflects reality across replacements.

## Deviation from Issue Proposal
The issue suggested 'write inactive only if this session still owns the manager slot' — implemented via the probe (guard b); the SilentClose gate (guard a) is an additional cheap guard covering the standard replacement path without the probe. Item 4 of the umbrella (max-active) is a recorded-decision matter (D9) — AGENTS.md already documents the deliberate omission; propose resolving it there, not in code.