### PR TITLE
fix(api): validate the AddSource community at the boundary

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -953,6 +953,14 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (data is null || string.IsNullOrWhiteSpace(data.Name) || string.IsNullOrWhiteSpace(data.Url))
             return ApiResponse.Error("Name and Url are required", 400);
 
+        // #266 item 3: the community is peer-supplied and reaches the wire through
+        // CommunityCodec at send time — validate the SAME contract at the API boundary (#255
+        // posture). #328 made the codec reject out-of-range halves instead of masking them, so
+        // this check now catches what previously became a silently-wrong tag.
+        if (!IsValidCommunity(data.Community))
+            return ApiResponse.Error(
+                $"Invalid community '{SanitizeForLog(data.Community)}': expected 'ASN:VALUE' with each part 0-65535.", 400);
+
         // #232: full SSRF validation at save time (defence-in-depth on top of the fetch-time
         // ConnectCallback). Reject a URL that is malformed, uses a non-http(s) scheme, resolves to
         // a private/loopback/link-local address, or uses a non-80/443 port — before persisting it,
@@ -1359,6 +1367,19 @@ public sealed class ManagementApi : IHostedService, IDisposable
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Whether a peer-supplied community string satisfies the wire contract (#266 item 3): a
+    /// well-formed <c>ASN:VALUE</c> with both halves 0-65535 (RFC 1997 encoding; the same rule
+    /// <see cref="CommunityCodec.Parse"/> enforces — #328). Null/whitespace means "no community"
+    /// and is valid.
+    /// </summary>
+    internal static bool IsValidCommunity(string? community)
+    {
+        if (string.IsNullOrWhiteSpace(community)) return true;
+        try { CommunityCodec.Parse(community); return true; }
+        catch (FormatException) { return false; }
     }
 
     private string GetClientIp(HttpListenerContext ctx) =>

--- a/BGPLite.Tests/CommunityCodecTests.cs
+++ b/BGPLite.Tests/CommunityCodecTests.cs
@@ -1,3 +1,4 @@
+using BGPLite.Api;
 using BGPLite.Protocol;
 
 namespace BGPLite.Tests;
@@ -54,4 +55,32 @@ public class CommunityCodecTests
         // A 4-byte ASN would silently wrap to 0 if not validated (131072 << 16 == 0 in uint).
         Assert.Throws<FormatException>(() => CommunityCodec.Parse("131072:100"));
     }
+}
+
+/// <summary>
+/// #266 item 3: the API-boundary contract for peer-supplied source communities — the exact rule
+/// CommunityCodec enforces (#328), so an out-of-range half or garbage is a 400 at save time
+/// instead of a silently-masked or auto-substituted tag at send time.
+/// </summary>
+public class AddSourceCommunityValidationTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("65000:100")]
+    [InlineData("0:0")]
+    [InlineData("65535:65535")]
+    public void IsValidCommunity_Accepts(string? community)
+        => Assert.True(ManagementApi.IsValidCommunity(community));
+
+    [Theory]
+    [InlineData("65000:70000")]   // VALUE above 65535 — the #328 case the old codec masked to 4464
+    [InlineData("70000:100")]     // ASN half
+    [InlineData("65000")]         // no colon
+    [InlineData("a:b")]
+    [InlineData("65000:100:1")]   // large-community shape is NOT a valid small community
+    [InlineData("-1:5")]
+    public void IsValidCommunity_Rejects(string community)
+        => Assert.False(ManagementApi.IsValidCommunity(community));
 }


### PR DESCRIPTION
Split from #266 (item 3).

## Problem
`POST /api/peers/{id}/sources` accepted any community string. At send time #328's strict codec rejects out-of-range halves and `ConfigCommunityResolver` silently substitutes an auto-generated hash tag — the peer's filters match nothing the operator configured, one Warning the only trace.

## Fix
`IsValidCommunity` (the exact `CommunityCodec.Parse` contract: ASN:VALUE, halves 0-65535, null = no community) checked before the URL SSRF validation — a malformed community never pays the DNS probe.

## Regression Tests
Accept matrix (0:0, 65535:65535, null/empty/whitespace) + reject matrix (70000 halves, missing colon, garbage, large-community shape, negative) — reject matrix red 6/6 on an always-true shim, green after.

## Verification
`dotnet format` / `dotnet build` (0 errors) / full suite **845/845**.

## RFC
RFC 1997 encoding constraints (each half 16-bit) — enforced at the boundary per the project's API-validation rule.

## Behavior Change
Deliberate: malformed communities now get a stable 400 at save time instead of a silent send-time substitution.

## Deviation from Issue Proposal
None — item 3's direction; wired ahead of URL validation so the cheap check runs first.