### PR TITLE
chore: integrate dev — 6 fixes (protocol/session/config/api hardening)

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -953,6 +953,14 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (data is null || string.IsNullOrWhiteSpace(data.Name) || string.IsNullOrWhiteSpace(data.Url))
             return ApiResponse.Error("Name and Url are required", 400);
 
+        // #266 item 3: the community is peer-supplied and reaches the wire through
+        // CommunityCodec at send time — validate the SAME contract at the API boundary (#255
+        // posture). #328 made the codec reject out-of-range halves instead of masking them, so
+        // this check now catches what previously became a silently-wrong tag.
+        if (!IsValidCommunity(data.Community))
+            return ApiResponse.Error(
+                $"Invalid community '{SanitizeForLog(data.Community)}': expected 'ASN:VALUE' with each part 0-65535.", 400);
+
         // #232: full SSRF validation at save time (defence-in-depth on top of the fetch-time
         // ConnectCallback). Reject a URL that is malformed, uses a non-http(s) scheme, resolves to
         // a private/loopback/link-local address, or uses a non-80/443 port — before persisting it,
@@ -1359,6 +1367,19 @@ public sealed class ManagementApi : IHostedService, IDisposable
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Whether a peer-supplied community string satisfies the wire contract (#266 item 3): a
+    /// well-formed <c>ASN:VALUE</c> with both halves 0-65535 (RFC 1997 encoding; the same rule
+    /// <see cref="CommunityCodec.Parse"/> enforces — #328). Null/whitespace means "no community"
+    /// and is valid.
+    /// </summary>
+    internal static bool IsValidCommunity(string? community)
+    {
+        if (string.IsNullOrWhiteSpace(community)) return true;
+        try { CommunityCodec.Parse(community); return true; }
+        catch (FormatException) { return false; }
     }
 
     private string GetClientIp(HttpListenerContext ctx) =>

--- a/BGPLite.Configuration/BgpConfig.cs
+++ b/BGPLite.Configuration/BgpConfig.cs
@@ -88,6 +88,12 @@ public sealed class BgpConfig
             throw new InvalidOperationException(
                 $"Invalid configuration: Bgp.HoldTime must be 0 (disabled) or at least 3 seconds (got {HoldTime}).");
 
+        // RFC 4271 §4.2: Hold Time is a 2-octet field — a value above 65535 cannot be carried in
+        // an OPEN; the wire write silently truncated it before ((ushort)70000 -> 4464) (#265 item 2).
+        if (HoldTime > ushort.MaxValue)
+            throw new InvalidOperationException(
+                $"Invalid configuration: Bgp.HoldTime must fit the 2-octet OPEN field (0..65535, got {HoldTime}).");
+
         // KeepAlive is only meaningful when a Hold Time is negotiated. The session computes its
         // keepalive interval as max(HoldTime/3, 1) (BgpSession OPEN negotiation), so the configured
         // value must fit within the same window: 1..max(HoldTime/3, 1).

--- a/BGPLite.Protocol/UpdateCodec.cs
+++ b/BGPLite.Protocol/UpdateCodec.cs
@@ -204,7 +204,7 @@ public static class UpdateCodec
     /// caller can apply treat-as-withdraw (RFC 7606) — the exact pipeline previously inlined in
     /// BgpSession.HandleUpdateAsync, moved verbatim (#270).
     /// </summary>
-    public static RouteAttributes ParseRouteAttributes(BgpUpdateMessage update, bool fourByteAsnSession)
+    public static RouteAttributes ParseRouteAttributes(BgpUpdateMessage update, bool fourByteAsnSession, uint? localRouterId = null)
     {
         try
         {
@@ -303,6 +303,12 @@ public static class UpdateCodec
             }
 
             ValidateMandatoryAttributes(originSeen, asPathSeen, nextHopSeen);
+            // RFC 4271 §6.3/§6.8: a semantically incorrect NEXT_HOP MUST be rejected with subcode 8
+            // (Invalid NEXT_HOP Attribute) — "a valid unicast host address", never multicast, never
+            // the receiving speaker's own address. Routed through the caller's treat-as-withdraw
+            // path per RFC 7606 §7.3 (#292 item 1).
+            if (nextHopSeen)
+                ValidateNextHopSemantics(nextHop, localRouterId);
             asPath = MergeAsPathWithAs4Path(asPath, as4Path);
             ValidateAggregatorReconstruction(aggregatorAsn, as4AggregatorAsn);
 
@@ -316,6 +322,34 @@ public static class UpdateCodec
             throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, ex.SubErrorCode ?? BgpConstants.SubError.Unspecific, ex.Message);
         }
     }
+
+    /// <summary>
+    /// Validates that a received NEXT_HOP is a semantically valid unicast host address
+    /// (RFC 4271 §6.3, subcode 8 "Invalid NEXT_HOP Attribute"; §6.8: "the IP address ... defined
+    /// as a valid unicast host address ... MUST NOT be ... the IP address of the receiving
+    /// speaker ... multicast ... addresses are never advertised"). Rejects: unspecified (0.0.0.0),
+    /// loopback (127/8), multicast (224/4), reserved (240/4 — includes the broadcast address),
+    /// and the local router-id when known. Throws <see cref="BgpNotificationException"/> so the
+    /// caller applies treat-as-withdraw (RFC 7606 §7.3) — the route never reaches the table with
+    /// a next hop that could blackhole or loop traffic (#292 item 1).
+    /// </summary>
+    public static void ValidateNextHopSemantics(uint nextHop, uint? localRouterId)
+    {
+        if (nextHop == 0)
+            throw InvalidNextHop(nextHop, "the unspecified address 0.0.0.0");
+        if ((nextHop >> 24) == 127)
+            throw InvalidNextHop(nextHop, "a loopback address (127/8)");
+        // 224/4 (multicast) and 240/4 (reserved, incl. 255.255.255.255) both live in the top
+        // eighth of the address space: first nibble >= 0xE.
+        if ((nextHop >> 28) >= 0xE)
+            throw InvalidNextHop(nextHop, "a multicast or reserved address (224/4, 240/4)");
+        if (localRouterId.HasValue && nextHop == localRouterId.Value)
+            throw InvalidNextHop(nextHop, "the local speaker's own address (RFC 4271 §6.8)");
+    }
+
+    private static BgpNotificationException InvalidNextHop(uint nextHop, string why) => new(
+        BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNextHopAttribute,
+        $"Invalid NEXT_HOP attribute: {BgpConstants.UintToIPAddress(nextHop)} is {why}");
 
     /// <summary>
     /// The RFC-mandated shape of a recognized path attribute: the required Optional/Transitive flag

--- a/BGPLite.Server/BgpServer.cs
+++ b/BGPLite.Server/BgpServer.cs
@@ -183,6 +183,11 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
                 var peerConfig = new PeerConfig { Address = peerAddress, Port = remoteEndpoint.Port };
 
                 var session = _sessionFactory.Create(new SocketBgpConnection(socket), peerConfig);
+                // #265 item 1: the session's finally-block consults this before flipping the
+                // peer row to inactive — "still the registered session for your slot?" A
+                // replacement (TryUpdate below) removes this session from the registry, so its
+                // slow unwind cannot clobber the replacement's Status=active.
+                session.StillRegisteredProbe = s => _sessions.Values.Any(v => ReferenceEquals(v, s));
 
                 if (Volatile.Read(ref _acceptingConnections) == 0)
                 {

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -556,6 +556,20 @@ public sealed class BgpSession : IDisposable
                 {
                     try { _peerStore?.UpdateSessionStatus(_peerConfig.Address, _remoteAsn, false); }
                     catch (Exception ex) { _logger.LogWarning(ex, "Failed to persist session status for {Peer}", _peer); }
+
+                    // #366 review: a replacement can land between the probe and the write —
+                    // re-probe and REPAIR. A false second probe means the registry swapped us out
+                    // mid-write and the replacement owns the (Ip, Asn): restore the row to active.
+                    // Idempotent with the replacement's own LoadPeerRoutingView write, and
+                    // race-free in the other direction — the own-runner's registry removal happens
+                    // only AFTER RunAsync returns, so during this finally a false probe can only
+                    // mean replacement. Genuine teardowns (still registered) never repair.
+                    if (_stillRegisteredProbe?.Invoke(this) == false)
+                    {
+                        _logger.LogInformation("Replacement detected after status write for {Peer} — restoring active", _peer);
+                        try { _peerStore?.UpdateSessionStatus(_peerConfig.Address, _remoteAsn, true); }
+                        catch (Exception ex) { _logger.LogWarning(ex, "Failed to restore session status for {Peer}", _peer); }
+                    }
                 }
             }
             _metrics.PeerDisconnected();

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -915,6 +915,21 @@ public sealed class BgpSession : IDisposable
                     LargeCommunities = attrs.LargeCommunities
                 };
 
+                // RFC 4271 §9.1.2 (#292 item 6): "AS loop detection is done by scanning the full
+                // AS path ... and checking that the autonomous system number of the local system
+                // does not appear in the AS path" — such routes "should be excluded from the
+                // Phase 2 decision function". A route carrying our own ASN would loop straight
+                // back to us if re-advertised (with our ASN prepended yet again). Route-level
+                // exclusion, not a session error (the old subcode 7 is deprecated); excluded
+                // routes are never installed, so a later withdrawal for them removes nothing.
+                if (attrs.AsPath.AsSpan().Contains(_bgpConfig.Asn))
+                {
+                    if (_logger.IsEnabled(LogLevel.Debug))
+                        _logger.LogDebug("Excluded looping route {Prefix} from {Peer}: local AS {Asn} in AS_PATH",
+                            nlri, _peer, _bgpConfig.Asn);
+                    continue;
+                }
+
                 if (_routeFilter.AcceptIncoming(route, filterPeerConfig))
                 {
                     // Tagged with this session as the owner, so only this peer's own withdrawal can

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -859,7 +859,9 @@ public sealed class BgpSession : IDisposable
             UpdateCodec.RouteAttributes attrs;
             try
             {
-                attrs = UpdateCodec.ParseRouteAttributes(update, _remoteFourByteAsn);
+                // #292 item 1: local router-id for the §6.8 self-address check on NEXT_HOP.
+                attrs = UpdateCodec.ParseRouteAttributes(update, _remoteFourByteAsn,
+                    BgpConstants.IPAddressToUint(_bgpConfig.GetRouterIdAddress()));
             }
             catch (BgpNotificationException ex) when (ex.ErrorCode == BgpConstants.Error.UpdateMessageError)
             {

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -768,6 +768,21 @@ public sealed class BgpSession : IDisposable
                     // further full dumps); faults log instead of tearing down the read loop.
                     _ = Task.Run(() => RefreshInBackgroundAsync(cancellationToken), CancellationToken.None);
                     break;
+
+                default:
+                    // RFC 4271 FSM: in Established only UPDATE, KEEPALIVE, NOTIFICATION and
+                    // ROUTE_REFRESH are legal inputs; anything else (e.g. an OPEN) is an FSM
+                    // error — NOTIFICATION 5/0, release resources, Idle. Previously such messages
+                    // were silently swallowed (#265 item 3). The CAS claims the teardown BEFORE
+                    // sending so the finally-block cannot double-emit a Cease (§8.1).
+                    _logger.LogWarning("Unexpected message {Type} from {Peer} in Established — FSM error",
+                        message.Type, _peer);
+                    if (Interlocked.CompareExchange(ref _teardownReason, (int)TeardownReason.LocalCease, (int)TeardownReason.None) == (int)TeardownReason.None)
+                    {
+                        try { await SendNotificationAsync(BgpConstants.Error.FiniteStateMachineError, BgpConstants.SubError.Unspecific); }
+                        catch { /* best-effort — partial write counts, see RFC 4271 §8.1 */ }
+                    }
+                    return;
             }
         }
     }

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -32,6 +32,11 @@ public sealed class BgpSession : IDisposable
     private readonly CancellationTokenSource _cts = new();
     private readonly Action<string, uint>? _onPeerIdentified;
     private readonly IPeerStore? _peerStore;
+    // #265 item 1: set by BgpServer right after creation — "is this session still the registered
+    // one?" A false answer at teardown-time means a replacement took the slot and owns the
+    // (Ip, Asn) status now; this session must not overwrite it back to inactive.
+    private Func<BgpSession, bool>? _stillRegisteredProbe;
+    internal Func<BgpSession, bool>? StillRegisteredProbe { set => _stillRegisteredProbe = value; }
     private readonly IPrefixAggregator _prefixAggregator;
     // #93 Phase 2: the outbound route-assembly policy lives here, not in the session. The session
     // delegates to BuildOutboundRoutesAsync and keeps the send/withdraw mirror (_advertisedPrefixes)
@@ -538,8 +543,20 @@ public sealed class BgpSession : IDisposable
                 // store failure (SQLite "database is locked" past busy_timeout) must not escape —
                 // it would fault RunAsync unobserved, skip PeerDisconnected() below, and leak
                 // PeerCount plus the row's Status=active forever (#325).
-                try { _peerStore?.UpdateSessionStatus(_peerConfig.Address, _remoteAsn, false); }
-                catch (Exception ex) { _logger.LogWarning(ex, "Failed to persist session status for {Peer}", _peer); }
+                // #265 item 1: the write must not clobber a REPLACEMENT session's Status=active.
+                // Two guards: (a) SilentClose teardowns (session replacement, GR-aware shutdown —
+                // RFC 4724 §4) skip the write outright; (b) when a registration probe is wired
+                // (BgpServer), a session no longer present in the registry was replaced mid-unwind
+                // and also skips. Covers the slow-unwind race (e.g. a sender parked on _sendLock
+                // inside the #285 budget) whose finally runs after the new session's first
+                // LoadPeerRoutingView already wrote active.
+                var silent = (TeardownReason)Interlocked.CompareExchange(ref _teardownReason, 0, 0) == TeardownReason.SilentClose;
+                var stillRegistered = _stillRegisteredProbe?.Invoke(this) ?? true;
+                if (!silent && stillRegistered)
+                {
+                    try { _peerStore?.UpdateSessionStatus(_peerConfig.Address, _remoteAsn, false); }
+                    catch (Exception ex) { _logger.LogWarning(ex, "Failed to persist session status for {Peer}", _peer); }
+                }
             }
             _metrics.PeerDisconnected();
             _logger.LogInformation("SessionClosed with {Peer}", _peer);

--- a/BGPLite.Tests/BgpSessionHoldTimerTests.cs
+++ b/BGPLite.Tests/BgpSessionHoldTimerTests.cs
@@ -644,6 +644,54 @@ public class BgpSessionHoldTimerTests
     }
 
     /// <summary>
+    /// #265 item 3: in Established only UPDATE/KEEPALIVE/NOTIFICATION/ROUTE_REFRESH are legal
+    /// inputs (RFC 4271 FSM) — an unexpected message type (e.g. a second OPEN) is an FSM error:
+    /// NOTIFICATION 5/0, teardown, Idle. Previously the message was silently swallowed and the
+    /// session limped on in an undefined state.
+    /// </summary>
+    [Fact]
+    public async Task UnexpectedMessageInEstablished_FsmErrorNotification_AndTeardown()
+    {
+        var time = new FakeTimeProvider();
+        var conn = new FakeBgpConnection();
+        var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 9, KeepAlive = 3 };
+        using var session = new BgpSession(
+            conn,
+            new PeerConfig { Address = "127.0.0.1" },
+            bgpConfig,
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            new NopLogger<BgpSession>(),
+            timeProvider: time);
+
+        var runTask = await EstablishAsync(session, conn, bgpConfig, time);
+        Assert.True(session.IsEstablished, "session must reach Established");
+        var sentBefore = conn.Sent.Count;
+
+        // A second OPEN is not a legal Established input.
+        conn.Enqueue(Serialize(new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = (ushort)bgpConfig.HoldTime,
+            RouterId = 0x7F000002
+        }));
+
+        var completed = await Task.WhenAny(runTask, Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.Same(runTask, completed);   // RED pre-fix: the OPEN is swallowed, the session keeps running
+
+        var notifs = conn.Sent.Skip(sentBefore)
+            .Select(b => BgpMessageReader.ReadMessage(b.AsSpan()))
+            .OfType<BgpNotificationMessage>()
+            .ToList();
+        var fsm = Assert.Single(notifs);
+        Assert.Equal(BgpConstants.Error.FiniteStateMachineError, fsm.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.Unspecific, fsm.SubErrorCode);
+        Assert.Equal(BgpFsmState.Idle, session.State);
+    }
+
+    /// <summary>
     /// #341: a blocked writer (a refresh send parked inside WriteAsync — the slow-peer holder of
     /// the issue) holds <c>_sendLock</c>; the next keepalive tick queues on the semaphore with NO
     /// token of its own; <c>Dispose</c> cancels <c>_cts</c> and then disposes the semaphore.

--- a/BGPLite.Tests/BgpSessionRfc6793Tests.cs
+++ b/BGPLite.Tests/BgpSessionRfc6793Tests.cs
@@ -87,6 +87,60 @@ public class BgpSessionRfc6793Tests
         Assert.Equal([(64512u, 1u, 2u)], attrs.LargeCommunities);
     }
 
+    /// <summary>
+    /// #292 item 1: RFC 4271 §6.3/§6.8 — a semantically invalid NEXT_HOP MUST be rejected with
+    /// subcode 8 (Invalid NEXT_HOP Attribute) and routed through treat-as-withdraw (RFC 7606
+    /// §7.3). Previously every one of these was accepted into the route table.
+    /// </summary>
+    [Theory]
+    [InlineData(0x00000000u, "unspecified")]        // 0.0.0.0
+    [InlineData(0x7F000001u, "loopback")]           // 127.0.0.1
+    [InlineData(0xE0000001u, "multicast")]          // 224.0.0.1
+    [InlineData(0xF0FF00FFu, "reserved")]           // 240.255.0.255
+    [InlineData(0xFFFFFFFFu, "broadcast")]          // 255.255.255.255
+    [InlineData(0x0A000001u, "self")]               // == localRouterId
+    public void ParseRouteAttributes_InvalidNextHop_ThrowsSubcode8(uint nextHop, string why)
+    {
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+                AttributeHelper.WriteAsPath([65001u], fourByteAsn: true),
+                AttributeHelper.WriteNextHop(nextHop),
+            ],
+            Nlri = []
+        };
+
+        var ex = Assert.Throws<BgpNotificationException>(
+            () => UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: true, localRouterId: 0x0A000001u));
+
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.InvalidNextHopAttribute, ex.SubErrorCode);
+        // 255.255.255.255 lands in the 240/4 bucket of the validator's message.
+        var expected = why switch { "self" => "own address", "broadcast" => "reserved", _ => why };
+        Assert.Contains(expected, ex.Message);
+    }
+
+    [Fact]
+    public void ParseRouteAttributes_ValidNextHop_Accepted()
+    {
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+                AttributeHelper.WriteAsPath([65001u], fourByteAsn: true),
+                AttributeHelper.WriteNextHop(0x0A000001u),
+            ],
+            Nlri = []
+        };
+
+        // 10.0.0.1 with no localRouterId known (optional parameter): a legitimate peer address.
+        var attrs = UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: true);
+        Assert.Equal(0x0A000001u, attrs.NextHop);
+    }
+
     [Fact]
     public void ParseRouteAttributes_MissingMandatoryAttribute_ThrowsSubcode3()
     {

--- a/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
+++ b/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
@@ -567,6 +567,46 @@ public class BgpSessionRouteOwnershipTests
         Assert.DoesNotContain(store.StatusWrites, w => !w.Active);
     }
 
+    /// <summary>
+    /// #366 review (TOCTOU in the #265 item 1 guard): a replacement can land in the registry in
+    /// the window between the probe and the inactive write. A probe that flips true→false across
+    /// those two calls models exactly that; the finally must REPAIR the row back to active — the
+    /// final write must be active, not the stale inactive.
+    /// </summary>
+    [Fact]
+    public async Task ReplacementLandingDuringStatusWrite_IsRepairedToActive()
+    {
+        // Non-silent teardown so the write path runs: peer NOTIFICATION.
+        var conn = new ScriptedConnection();
+        var store = new RecordingPeerStore();
+        var config = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
+        var session = new BgpSession(
+            conn, new PeerConfig { Address = "127.0.0.1" }, config, new RouteTable(),
+            AllowAllFilter.Instance, new BgpMetrics(), NullLogger<BgpSession>.Instance, peerStore: store);
+        var calls = 0;
+        session.StillRegisteredProbe = _ => Interlocked.Increment(ref calls) switch { 1 => true, _ => false };
+        var run = session.RunAsync();
+        conn.EnqueueMessage(new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = 0,
+            RouterId = 0x0A000002,
+            Capabilities = [BgpCapabilityInfo.FourOctetAsn(65002)],
+        });
+        conn.EnqueueMessage(BgpKeepaliveMessage.Instance);
+        for (var i = 0; i < 200 && !session.IsEstablished; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        Assert.True(session.IsEstablished, "session must reach Established");
+
+        conn.EnqueueMessage(new BgpNotificationMessage { ErrorCode = BgpConstants.Error.Cease, SubErrorCode = 0 });
+        try { await run.WaitAsync(TimeSpan.FromSeconds(5)); } catch { /* teardown unwinds */ }
+
+        Assert.NotEmpty(store.StatusWrites);
+        Assert.True(store.StatusWrites[^1].Active, "the replacement-during-write race must end with the row ACTIVE");
+        Assert.Contains(store.StatusWrites, w => !w.Active);   // the stale inactive write happened, then the repair
+    }
+
     [Fact]
     public async Task GenuineTeardown_StillWritesInactive()
     {

--- a/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
+++ b/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
@@ -496,6 +496,92 @@ public class BgpSessionRouteOwnershipTests
         await TeardownAsync(session, run);
     }
 
+    /// <summary>
+    /// #265 item 1: a REPLACED session's slow finally must not flip the peer row back to
+    /// inactive after the replacement wrote active. Two guards: the SilentClose teardown reason
+    /// (replacement / GR-aware shutdown) skips the write, and the registration probe answers
+    /// false once the session is no longer the registered one. A genuine teardown still writes.
+    /// </summary>
+    private sealed class RecordingPeerStore : IPeerStore
+    {
+        public List<(string Ip, uint Asn, bool Active)> StatusWrites = [];
+        public string CreatePeer(string ip, uint asn, string? description) => "id";
+        public void UpsertPeer(string ip, uint asn) { }
+        public void UpdateSessionStatus(string ip, uint asn, bool active) => StatusWrites.Add((ip, asn, active));
+        public void DeletePeer(string id) { }
+        public PeerInfo? GetPeerByIp(string ip) => null;
+        public PeerInfo? GetPeer(string ip, uint asn) => null;
+        public PeerInfo? GetPeerById(string id) => null;
+        public List<string> GetSubscriptions(string peerId) => [];
+        public List<string> GetCustomPrefixes(string peerId) => [];
+        public List<uint> GetCustomAsns(string peerId) => [];
+        public HashSet<uint> GetCommunities(string peerId) => [];
+        public HashSet<uint> GetCommunities(string ip, uint asn) => [];
+        public void SetCommunities(string peerId, HashSet<uint> communities) { }
+        public void ClearCommunities(string peerId) { }
+        public void SetDescription(string id, string description) { }
+        public PeerRoutingView? LoadPeerRoutingView(string ip, uint asn) => new("id", [], [], [], []);
+    }
+
+    private static async Task<(BgpSession Session, Task Run, RecordingPeerStore Store)> EstablishWithStoreAsync(
+        RouteTable routeTable, Func<BgpSession, bool>? probe = null)
+    {
+        var conn = new ScriptedConnection();
+        var store = new RecordingPeerStore();
+        var config = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
+        var session = new BgpSession(
+            conn,
+            new PeerConfig { Address = "127.0.0.1" },
+            config,
+            routeTable,
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            NullLogger<BgpSession>.Instance,
+            peerStore: store);
+        session.StillRegisteredProbe = probe ?? (_ => true);
+        var run = session.RunAsync();
+        conn.EnqueueMessage(new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = 0,
+            RouterId = 0x0A000002,
+            Capabilities = [BgpCapabilityInfo.FourOctetAsn(65002)],
+        });
+        conn.EnqueueMessage(BgpKeepaliveMessage.Instance);
+        for (var i = 0; i < 200 && !session.IsEstablished; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        Assert.True(session.IsEstablished, "session must reach Established");
+        return (session, run, store);
+    }
+
+    [Fact]
+    public async Task ReplacedSession_Teardown_DoesNotOverwriteStatusInactive()
+    {
+        // The probe answers false — the registry no longer holds this session (TryUpdate
+        // swapped a replacement in). Its finally must not write inactive.
+        var (session, run, store) = await EstablishWithStoreAsync(new RouteTable(), probe: _ => false);
+
+        await TeardownAsync(session, run);   // SilentClose + probe-false — both guards skip
+
+        Assert.DoesNotContain(store.StatusWrites, w => !w.Active);
+    }
+
+    [Fact]
+    public async Task GenuineTeardown_StillWritesInactive()
+    {
+        // Registered + non-silent teardown: the write must still happen (no regression of #325).
+        var (session, run, store) = await EstablishWithStoreAsync(new RouteTable());
+
+        // A peer NOTIFICATION tears down with RemoteNotification — not SilentClose, probe true.
+        var connField = typeof(BgpSession).GetField("_connection", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var conn = (ScriptedConnection)connField.GetValue(session)!;
+        conn.EnqueueMessage(new BgpNotificationMessage { ErrorCode = BgpConstants.Error.Cease, SubErrorCode = 0 });
+        try { await run.WaitAsync(TimeSpan.FromSeconds(5)); } catch { /* teardown unwinds */ }
+
+        Assert.Contains(store.StatusWrites, w => !w.Active);
+    }
+
     private sealed class RejectAllIncomingFilter : IRouteFilter
     {
         private static readonly IReadOnlySet<uint> Empty = new HashSet<uint>();

--- a/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
+++ b/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
@@ -463,6 +463,39 @@ public class BgpSessionRouteOwnershipTests
     }
 
     /// <summary>Rejects every inbound route, so nothing this peer announces reaches the table.</summary>
+    /// <summary>
+    /// #292 item 6: RFC 4271 §9.1.2 — a route whose AS_PATH contains the local system's ASN is
+    /// excluded from selection (loop detection). It must not be installed (and the session must
+    /// survive — route-level exclusion, not a protocol error), while an otherwise identical route
+    /// without the local ASN installs normally.
+    /// </summary>
+    [Fact]
+    public async Task Announce_WithLocalAsnInAsPath_IsExcludedNotInstalled()
+    {
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        // AS_PATH seq [100, 65001] — 65001 is the session's own ASN (4-octet session).
+        var loopingAttributes = new byte[]
+        {
+            0x40, 0x01, 0x01, 0x00,                                                     // ORIGIN igp
+            0x40, 0x02, 0x0A, 0x02, 0x02, 0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0xFD, 0xE9, // AS_PATH [100, 65001]
+            0x40, 0x03, 0x04, 0xC0, 0x00, 0x02, 0x01,                                   // NEXT_HOP 192.0.2.1
+        };
+        conn.EnqueueFrame(BuildAnnounce(loopingAttributes, 8, [0x0A]));
+        await SettleAsync(conn); // frameless settle: the assertion is that NOTHING happened
+
+        Assert.Equal(0, routeTable.Count);                      // RED pre-fix: the looping route installed
+        Assert.True(session.IsEstablished, "a looping route is excluded, not a session error");
+
+        // The same NLRI without the local ASN installs normally — proves exclusion, not rejection.
+        conn.EnqueueFrame(AnnounceFrame(8, 0x0A));
+        await SettleAsync(conn, () => routeTable.Count == 1);
+        Assert.NotNull(routeTable.Get(TenSlashEight, 8));
+
+        await TeardownAsync(session, run);
+    }
+
     private sealed class RejectAllIncomingFilter : IRouteFilter
     {
         private static readonly IReadOnlySet<uint> Empty = new HashSet<uint>();

--- a/BGPLite.Tests/CommunityCodecTests.cs
+++ b/BGPLite.Tests/CommunityCodecTests.cs
@@ -1,3 +1,4 @@
+using BGPLite.Api;
 using BGPLite.Protocol;
 
 namespace BGPLite.Tests;
@@ -54,4 +55,32 @@ public class CommunityCodecTests
         // A 4-byte ASN would silently wrap to 0 if not validated (131072 << 16 == 0 in uint).
         Assert.Throws<FormatException>(() => CommunityCodec.Parse("131072:100"));
     }
+}
+
+/// <summary>
+/// #266 item 3: the API-boundary contract for peer-supplied source communities — the exact rule
+/// CommunityCodec enforces (#328), so an out-of-range half or garbage is a 400 at save time
+/// instead of a silently-masked or auto-substituted tag at send time.
+/// </summary>
+public class AddSourceCommunityValidationTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("65000:100")]
+    [InlineData("0:0")]
+    [InlineData("65535:65535")]
+    public void IsValidCommunity_Accepts(string? community)
+        => Assert.True(ManagementApi.IsValidCommunity(community));
+
+    [Theory]
+    [InlineData("65000:70000")]   // VALUE above 65535 — the #328 case the old codec masked to 4464
+    [InlineData("70000:100")]     // ASN half
+    [InlineData("65000")]         // no colon
+    [InlineData("a:b")]
+    [InlineData("65000:100:1")]   // large-community shape is NOT a valid small community
+    [InlineData("-1:5")]
+    public void IsValidCommunity_Rejects(string community)
+        => Assert.False(ManagementApi.IsValidCommunity(community));
 }

--- a/BGPLite.Tests/ConfigValidationTests.cs
+++ b/BGPLite.Tests/ConfigValidationTests.cs
@@ -295,6 +295,29 @@ public class ConfigValidationTests
         Assert.Contains("Bgp.HoldTime", ex.Message);
     }
 
+    /// <summary>
+    /// #265 item 2: Hold Time is a 2-octet OPEN field — a value above 65535 cannot be carried on
+    /// the wire, and the write path used to truncate it silently ((ushort)70000 -> 4464).
+    /// </summary>
+    [Theory]
+    [InlineData(65536)]
+    [InlineData(70000)]
+    public void Validate_RejectsHoldTimeAboveUshortRange(int holdTime)
+    {
+        var config = Config(Bgp(holdTime: holdTime, keepAlive: 60));
+
+        var ex = Assert.Throws<InvalidOperationException>(() => config.Validate());
+        Assert.Contains("Bgp.HoldTime", ex.Message);
+        Assert.Contains("65535", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_AcceptsHoldTimeAtUshortMax()
+    {
+        // The boundary itself is representable and must pass (KeepAlive within max(65535/3,1)).
+        Config(Bgp(holdTime: 65535, keepAlive: 60)).Validate();
+    }
+
     [Fact]
     public void Validate_RejectsKeepAliveAboveHoldTimeThird()
     {


### PR DESCRIPTION
Second integration of `dev` into `main`: six issue fixes from the follow-up batch, each landed on `dev` as its own CI-green squash commit with red/green regression coverage (details in the linked PRs).

Closes #292

`#265` and `#266` stay open — these are umbrella issues with remaining items (#265 item 4 is the recorded D9 decision; #266 has several unstarted minors); this PR closes their items 1–3 / item 3 respectively, tracked in the status comments on both.

## What ships

| Split | Area | Summary | PR |
|---|---|---|---|
| #292 item 1 | protocol | semantically invalid NEXT_HOP rejected with subcode 8 (0.0.0.0, 127/8, 224/4, 240/4, self) via treat-as-withdraw — RFC 4271 §6.3/§6.8 | #360 |
| #292 item 6 | server | AS_PATH loop exclusion per RFC 4271 §9.1.2 — routes carrying the local ASN are never installed (session survives) | #363 |
| #265 item 3 | server | unexpected message type in Established → NOTIFICATION 5/0 + Idle (was silently swallowed) — RFC 4271 FSM | #361 |
| #265 item 2 | config | HoldTime > 65535 rejected at startup (was silently truncated to a wrong wire value) — RFC 4271 §4.2 2-octet field | #362 |
| #265 item 1 | server | a replaced session's slow teardown no longer overwrites the live peer's Status=active (SilentClose gate + registration probe) | #364 |
| #266 item 3 | api | AddSource community validated at the boundary (exact CommunityCodec contract) → 400 instead of a silent send-time substitution | #365 |

Also included: #292 item 3 was verified as **not-a-defect** (RFC 6793 §4.1 — the receiver MUST prefer the capability value, which the code already does) and documented on the issue; no code change.

## Verification
- Every fix red/green-proven (reject matrices, natural behavioral reds, or shim-based reds where the seam required it) — per-PR details.
- Full suite on `dev` head: **845/845**.
- This PR runs the full main-gate: CI + CodeQL + CodeRabbit (batched review for the six commits).

## Behavior changes (deliberate, documented per PR)
- Martian/self next hops and looping AS_PATHs no longer install; garbage message types tear the session down with 5/0; HoldTime > 65535 fails startup; malformed AddSource communities get 400; replaced sessions keep the DB status truthful.

## RFCs touched
RFC 4271 §6.3/§6.8 (NEXT_HOP subcode 8), §9.1.2 (loop exclusion), FSM (Established error event), §4.2 (2-octet HoldTime); RFC 7606 §7.3 (treat-as-withdraw routing); RFC 1997 (community halves); RFC 6793 §4.1 (item 3 verification, no change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid community values are now rejected when adding a source.
  * Configuration rejects unsupported hold times above 65,535 seconds.
  * Invalid BGP next-hop addresses are rejected.
  * Routes containing the local ASN are excluded to prevent routing loops.
  * Unexpected messages now correctly terminate sessions with an FSM error.
  * Replaced sessions no longer overwrite the active status of newer sessions.
* **Validation**
  * Improved handling of route attributes, peer status updates, and session teardown scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->