### PR TITLE
feat(server): per-peer prefix limit — Cease/MaxPrefixesExceeded on breach

### DIFF
--- a/BGPLite.Configuration/BgpConfig.cs
+++ b/BGPLite.Configuration/BgpConfig.cs
@@ -60,6 +60,13 @@ public sealed class BgpConfig
     [YamlMember(Alias = "MaxAcceptsPerIpPerMinute")]
     public int MaxAcceptsPerIpPerMinute { get; init; } = 60;
 
+    /// <summary>#304: per-peer ceiling on prefixes installed from one session (distinct
+    /// NLRI this session currently owns); exceeding it tears the session down with
+    /// NOTIFICATION(Cease, MaxPrefixesExceeded) per RFC 4271 §6.7 / RFC 4486 §2.
+    /// 0 = unlimited (the convention of OpenTimeoutSeconds / MaxAcceptsPerIpPerMinute).</summary>
+    [YamlMember(Alias = "MaxPrefixesPerPeer")]
+    public int MaxPrefixesPerPeer { get; init; } = 0;
+
     public IPAddress GetRouterIdAddress() => IPAddress.Parse(RouterId);
 
     /// <summary>
@@ -116,5 +123,9 @@ public sealed class BgpConfig
         if (MaxAcceptsPerIpPerMinute < 0)
             throw new InvalidOperationException(
                 $"Invalid configuration: Bgp.MaxAcceptsPerIpPerMinute must be >= 0 (got {MaxAcceptsPerIpPerMinute}).");
+
+        if (MaxPrefixesPerPeer < 0)
+            throw new InvalidOperationException(
+                $"Invalid configuration: Bgp.MaxPrefixesPerPeer must be >= 0, 0 = unlimited (got {MaxPrefixesPerPeer}).");
     }
 }

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -67,6 +67,10 @@ public sealed class BgpSession : IDisposable
     private bool _localFourByteAsn; // derived from negotiated OPEN capability (RFC 6793)
     private ushort _negotiatedHoldTime;
     private List<IpPrefix> _advertisedPrefixes = [];
+    // #304: distinct NLRI this session currently owns in the shared table — drives the per-peer
+    // prefix cap (Bgp.MaxPrefixesPerPeer) and its 75% warning.
+    private readonly HashSet<IpPrefix> _installedPrefixes = [];
+    private bool _maxPrefixesWarned;
     // #212: actual count sent on the wire (after aggregation + dedup). Updated at the end of
     // SendRoutesAsync. Read via AdvertisedPrefixCount for the management API/UI so operators see
     // the real number their peer's router receives, not the raw pre-aggregation count.
@@ -963,10 +967,29 @@ public sealed class BgpSession : IDisposable
 
                 if (_routeFilter.AcceptIncoming(route, filterPeerConfig))
                 {
+                    // #304: per-peer prefix ceiling (RFC 4271 §6.7 / RFC 4486 §2) — counted on the
+                    // distinct NLRI this session currently owns; replacements of an owned prefix
+                    // do not grow the count, withdrawals shrink it. Exceeding the cap throws
+                    // Cease/MaxPrefixesExceeded: deliberately NOT UpdateMessageError, so the read
+                    // loop's treat-as-withdraw filter does not swallow it — it unwinds to RunAsync's
+                    // BgpNotificationException handler, which sends the NOTIFICATION and tears the
+                    // session down (owned routes are flushed by the finally, RFC 4271 §8.2.2).
+                    var cap = _bgpConfig.MaxPrefixesPerPeer;
+                    if (cap > 0 && !_installedPrefixes.Contains(nlri) && _installedPrefixes.Count >= cap)
+                        throw new BgpNotificationException(
+                            BgpConstants.Error.Cease, BgpConstants.SubError.CeaseMaxPrefixes,
+                            $"Peer {_peer} exceeded the per-peer prefix limit ({cap}); session reset per RFC 4486");
+                    if (cap > 0 && !_maxPrefixesWarned && _installedPrefixes.Count >= cap * 3 / 4)
+                    {
+                        _maxPrefixesWarned = true;
+                        _logger.LogWarning("Peer {Peer} at {Count}/{Cap} of the per-peer prefix limit", _peer, _installedPrefixes.Count, cap);
+                    }
+
                     // Tagged with this session as the owner, so only this peer's own withdrawal can
                     // remove it (#289). A route the filter dropped is never installed and therefore
                     // never owned, so a later withdrawal for it removes nothing.
                     _routeTable.AddOrUpdate(route, owner: this);
+                    _installedPrefixes.Add(nlri);
                     // #85: guard the UintToIPAddress allocation behind IsEnabled — LogDebug
                     // evaluates the arg eagerly even when Debug is filtered out.
                     if (_logger.IsEnabled(LogLevel.Debug))
@@ -993,6 +1016,9 @@ public sealed class BgpSession : IDisposable
                 _logger.LogDebug("Ignoring withdrawal of {Prefix} from {Peer}: not owned by this session", prefix, _peer);
             return;
         }
+
+        // #304: the cap counts what this session currently owns — a withdrawal frees budget.
+        _installedPrefixes.Remove(prefix);
 
         if (_logger.IsEnabled(LogLevel.Debug))
             _logger.LogDebug("{Reason}: {Prefix}", reason, prefix);

--- a/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
+++ b/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
@@ -622,6 +622,88 @@ public class BgpSessionRouteOwnershipTests
         Assert.Contains(store.StatusWrites, w => !w.Active);
     }
 
+    /// <summary>
+    /// #304: exceeding Bgp.MaxPrefixesPerPeer tears the session down with NOTIFICATION
+    /// (Cease, MaxPrefixesExceeded) per RFC 4271 §6.7 / RFC 4486 §2, and the finally flushes
+    /// the peer's owned routes (RFC 4271 §8.2.2) — the table does not keep the attacker's rows.
+    /// </summary>
+    private static async Task<(BgpSession Session, Task Run, ScriptedConnection Conn, RouteTable Table)> EstablishCappedAsync(int cap)
+    {
+        var routeTable = new RouteTable();
+        var conn = new ScriptedConnection();
+        var config = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0, MaxPrefixesPerPeer = cap };
+        var session = new BgpSession(
+            conn, new PeerConfig { Address = "127.0.0.1" }, config, routeTable,
+            AllowAllFilter.Instance, new BgpMetrics(), NullLogger<BgpSession>.Instance);
+        var run = session.RunAsync();
+        conn.EnqueueMessage(new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = 0,
+            RouterId = 0x0A000002,
+            Capabilities = [BgpCapabilityInfo.FourOctetAsn(65002)],
+        });
+        conn.EnqueueMessage(BgpKeepaliveMessage.Instance);
+        for (var i = 0; i < 200 && !session.IsEstablished; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        Assert.True(session.IsEstablished, "session must reach Established");
+        return (session, run, conn, routeTable);
+    }
+
+    [Fact]
+    public async Task ExceedingMaxPrefixes_SendsCeaseMaxPrefixes_AndFlushesOwned()
+    {
+        var (session, run, conn, routeTable) = await EstablishCappedAsync(cap: 2);
+
+        conn.EnqueueFrame(AnnounceFrame(8, 0x0A));          // 1/2
+        conn.EnqueueFrame(AnnounceFrame(24, 0xC0, 0x00, 0x02)); // 2/2 — at the limit, still up
+        await SettleAsync(conn, () => routeTable.Count == 2);
+        Assert.True(session.IsEstablished, "at exactly the limit the session stays up");
+
+        conn.EnqueueFrame(AnnounceFrame(16, 0xC0, 0x01));   // 3rd distinct prefix — over
+        var completed = await Task.WhenAny(run, Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.Same(run, completed);                        // RED pre-fix: session keeps running
+        Assert.False(session.IsEstablished);
+
+        var notif = conn.Sent
+            .Select(b => BgpMessageReader.ReadMessage(b.AsSpan()))
+            .OfType<BgpNotificationMessage>()
+            .SingleOrDefault(n => n.ErrorCode == BgpConstants.Error.Cease);
+        Assert.NotNull(notif);
+        Assert.Equal(BgpConstants.SubError.CeaseMaxPrefixes, notif.SubErrorCode);
+        Assert.Equal(0, routeTable.Count);                  // owned routes flushed by the finally
+    }
+
+    [Fact]
+    public async Task AtLimitWithdrawal_FreesBudget()
+    {
+        var (session, run, conn, routeTable) = await EstablishCappedAsync(cap: 1);
+        conn.EnqueueFrame(AnnounceFrame(8, 0x0A));
+        await SettleAsync(conn, () => routeTable.Count == 1);
+
+        // Withdraw it — the budget frees — then a DIFFERENT prefix installs without a reset.
+        conn.EnqueueFrame(WithdrawFrame([8, 0x0A]));
+        await SettleAsync(conn, () => routeTable.Count == 0);
+        conn.EnqueueFrame(AnnounceFrame(24, 0xC0, 0x00, 0x02));
+        await SettleAsync(conn, () => routeTable.Count == 1);
+        Assert.True(session.IsEstablished, "withdrawals free prefix budget");
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task ZeroCap_IsUnlimited()
+    {
+        var (session, run, conn, routeTable) = await EstablishCappedAsync(cap: 0);
+        for (var i = 0; i < 5; i++)
+            conn.EnqueueFrame(AnnounceFrame(24, 0xC0, 0x00, (byte)(10 + i)));
+        await SettleAsync(conn, () => routeTable.Count == 5);
+        Assert.True(session.IsEstablished, "cap 0 = unlimited");
+
+        await TeardownAsync(session, run);
+    }
+
     private sealed class RejectAllIncomingFilter : IRouteFilter
     {
         private static readonly IReadOnlySet<uint> Empty = new HashSet<uint>();

--- a/BGPLite.Tests/ConfigValidationTests.cs
+++ b/BGPLite.Tests/ConfigValidationTests.cs
@@ -8,7 +8,7 @@ public class ConfigValidationTests
     // under test. Defaults match appsettings.Example.yml: a known-good baseline.
     private static BgpConfig Bgp(
         uint asn = 65001, string routerId = "10.0.0.1", int keepAlive = 60, int holdTime = 180,
-        int openTimeoutSeconds = 30, int maxAcceptsPerIpPerMinute = 60)
+        int openTimeoutSeconds = 30, int maxAcceptsPerIpPerMinute = 60, int maxPrefixesPerPeer = 0)
         => new()
         {
             Asn = asn,
@@ -16,7 +16,8 @@ public class ConfigValidationTests
             KeepAlive = keepAlive,
             HoldTime = holdTime,
             OpenTimeoutSeconds = openTimeoutSeconds,
-            MaxAcceptsPerIpPerMinute = maxAcceptsPerIpPerMinute
+            MaxAcceptsPerIpPerMinute = maxAcceptsPerIpPerMinute,
+            MaxPrefixesPerPeer = maxPrefixesPerPeer
         };
 
     private static AppConfig Config(BgpConfig? bgp = null, int apiPort = 5001, List<PeerConfig>? peers = null,
@@ -309,6 +310,16 @@ public class ConfigValidationTests
         var ex = Assert.Throws<InvalidOperationException>(() => config.Validate());
         Assert.Contains("Bgp.HoldTime", ex.Message);
         Assert.Contains("65535", ex.Message);
+    }
+
+    /// <summary>#304: the per-peer prefix cap validates like the other 0=unlimited knobs.</summary>
+    [Fact]
+    public void Validate_RejectsNegativeMaxPrefixesPerPeer()
+    {
+        var config = Config(Bgp(maxPrefixesPerPeer: -1));
+
+        var ex = Assert.Throws<InvalidOperationException>(() => config.Validate());
+        Assert.Contains("MaxPrefixesPerPeer", ex.Message);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #304   # linkage; closure lands with the integration PR

## Problem
Nothing bounded prefixes-per-peer: a handshake-completing peer could grow the shared RouteTable until OOM (auto-registration makes the surface one connect + OPEN). `CeaseMaxPrefixes` existed since #235, unused.

## RFC
RFC 4271 §6.7 (max-prefix check → NOTIFICATION), RFC 4486 §2 (Cease subcode 1); teardown flushes owned routes per RFC 4271 §8.2.2.

## Fix
`Bgp.MaxPrefixesPerPeer` (0 = unlimited per the existing knob convention, validated ≥ 0) over a per-session set of distinct owned NLRI — replacements don't grow, withdrawals free budget. Breach throws `BgpNotificationException(Cease, CeaseMaxPrefixes)`, deliberately outside the treat-as-withdraw filter, so RunAsync's handler sends the NOTIFICATION and tears down; the finally flushes the peer's rows. One-shot 75% warning.

## Regression Tests
- `ExceedingMaxPrefixes_SendsCeaseMaxPrefixes_AndFlushesOwned` — cap 2: at-limit stays Established, 3rd distinct prefix → exactly Cease/1 + empty table. Red on cap-less code (5s guard).
- `AtLimitWithdrawal_FreesBudget`, `ZeroCap_IsUnlimited`, config negative.

## Verification
`dotnet format` / `dotnet build` (0 errors) / focused 3/3 green / full suite **850/850**.

## Behavior Change
Default 0 keeps today's behavior; operators opting into the cap get RFC-conformant resets instead of unbounded growth.

## Deviation from Issue Proposal
None — the recommended design implemented (knob name, 0=unlimited, counting structure — generalized from the referenced \`_installedByPeer\` shape to the current ownership model, 75% warning included).