### PR TITLE
refactor(providers): one shared per-ASN RIPEstat cache for both mechanisms

### DIFF
--- a/BGPLite.Providers/AsnPrefixProvider.cs
+++ b/BGPLite.Providers/AsnPrefixProvider.cs
@@ -5,21 +5,24 @@ namespace BGPLite.Providers;
 
 /// <summary>
 /// Loads the prefixes originated by a single AS via RIPEstat (Kind = <c>"asn"</c>).
-/// Requires <see cref="PrefixSourceConfig.Asn"/>. Shares the RIPEstat client, retry, and per-ASN
-/// caching of <see cref="RipeStatProvider"/>/PrefixService, so adding it as a <c>Kind: asn</c>
-/// source under <c>PrefixSources</c> does not multiply RIPEstat traffic.
+/// Requires <see cref="PrefixSourceConfig.Asn"/>. Goes through the SHARED per-ASN cache
+/// (<see cref="RipeStatPrefixCache"/>, #267 item 5) — the same instance PrefixService uses for
+/// <c>RipeStat.AsnLists</c> and custom ASNs — so an ASN configured in both mechanisms is fetched
+/// and cached once (the previous direct-to-wire path doubled RIPEstat traffic and served
+/// disagreeing snapshots with independent TTLs).
 /// <para>RIPEstat does not support ETag / Last-Modified — the <paramref name="etag"/> and
 /// <paramref name="lastModified"/> parameters are ignored. Content-change detection for auto-refresh
-/// (#214) is handled by hash comparison in <see cref="PrefixSourceService"/> (the cache layer).</para>
+/// (#214) stays at the source-NAME level: hash comparison in <see cref="PrefixSourceService"/> over
+/// this provider's (cache-served) result.</para>
 /// </summary>
 public sealed class AsnPrefixProvider : IPrefixSourceProvider
 {
-    private readonly RipeStatProvider _ripe;
+    private readonly RipeStatPrefixCache _cache;
     private readonly ILogger<AsnPrefixProvider> _logger;
 
-    public AsnPrefixProvider(RipeStatProvider ripe, ILogger<AsnPrefixProvider> logger)
+    public AsnPrefixProvider(RipeStatPrefixCache cache, ILogger<AsnPrefixProvider> logger)
     {
-        _ripe = ripe;
+        _cache = cache;
         _logger = logger;
     }
 
@@ -41,10 +44,10 @@ public sealed class AsnPrefixProvider : IPrefixSourceProvider
         if (!source.Asn.HasValue)
             throw new InvalidOperationException($"Prefix source '{source.Name}': Kind=asn requires an Asn.");
 
-        var prefixes = await _ripe.GetPrefixesAsync(source.Asn.Value, ct);
+        var prefixes = await _cache.GetPrefixesAsync(source.Asn.Value, ct);
         _logger.LogInformation(
             "Source '{Name}' (asn AS{Asn}): loaded {Count} prefixes via RIPEstat",
             source.Name, source.Asn.Value, prefixes.Count);
-        return SourceLoadResult.Ok(prefixes.Select(p => (Prefix: p.Prefix, Length: p.PrefixLength)).ToList());
+        return SourceLoadResult.Ok(prefixes.Select(p => (Prefix: p.Prefix, Length: p.Length)).ToList());
     }
 }

--- a/BGPLite.Providers/PrefixService.cs
+++ b/BGPLite.Providers/PrefixService.cs
@@ -7,24 +7,16 @@ namespace BGPLite.Providers;
 
 public sealed class PrefixService : IPrefixService
 {
-    private readonly RipeStatProvider _ripeStat;
+    // #267 item 5: the per-ASN RIPEstat cache is a shared component — PrefixService (RipeStat
+    // AsnLists + custom ASNs) and AsnPrefixProvider (Kind: asn sources) consume ONE instance, so
+    // an ASN configured in both mechanisms is fetched and cached once. TTL/stale-on-failure/
+    // negative-cache/eviction (#163/#164/#165) live there now.
+    private readonly RipeStatPrefixCache _ripeStatCache;
     private readonly IPrefixSourceService _prefixSources;
     private readonly AppConfig _config;
     private readonly HttpPrefixProvider _httpProvider;
-    // asn → (prefix list, cached at, is negative). Negative entries (failed RIPEstat fetches) use
-    // _negativeTtl. The tuple is shaped to mirror PrefixSourceService so the resilience semantics
-    // (stale-on-failure, negative cache, bounded sweep) are identical across both caches.
-    private readonly ConcurrentDictionary<uint, (IReadOnlyList<(uint Prefix, byte Length)> Data, DateTime CachedAt, bool Negative)> _cache = new();
-    // asn → gate serializing the cache-miss fetch path (prevents thundering herd on cold/expired
-    // ASNs — #164). Mirrors PrefixSourceService._locks.
-    private readonly ConcurrentDictionary<uint, SemaphoreSlim> _locks = new();
-    private readonly TimeSpan _cacheTtl;
-    private readonly TimeSpan _negativeTtl;
-    // Upper bound on _cache/_locks entries (#165). Without a cap, a malicious or churning peer
-    // querying distinct ASNs grows the dictionaries without limit. Exceeded → least-recently-used
-    // sweep before insert. The configured ASN universe is small (operator AsnLists), so a generous
-    // default does not constrain real deployments.
-    private readonly int _maxCacheEntries;
+    // Freshness of the RU/default projection cache below (the per-ASN TTL moved to the shared cache).
+    private readonly TimeSpan _ruCacheTtl;
     private readonly ILogger<PrefixService>? _logger;
     private readonly TimeProvider _timeProvider;
     private readonly UserSourceCache _userSourceCache;
@@ -34,18 +26,13 @@ public sealed class PrefixService : IPrefixService
     // when the TTL elapses. Mirrors the per-ASN gate pattern in GetPrefixesAsync.
     private readonly SemaphoreSlim _ruGate = new(1, 1);
 
-    public PrefixService(AppConfig config, RipeStatProvider ripeStat, IPrefixSourceService prefixSources, HttpPrefixProvider httpProvider, TimeSpan? cacheTtl = null, ILogger<PrefixService>? logger = null, TimeSpan? negativeTtl = null, int? maxCacheEntries = null, TimeProvider? timeProvider = null, int? userSourceTimeoutSeconds = null)
+    public PrefixService(AppConfig config, RipeStatPrefixCache ripeStatCache, IPrefixSourceService prefixSources, HttpPrefixProvider httpProvider, TimeSpan? ruCacheTtl = null, ILogger<PrefixService>? logger = null, TimeProvider? timeProvider = null, int? userSourceTimeoutSeconds = null)
     {
         _config = config;
-        _ripeStat = ripeStat;
+        _ripeStatCache = ripeStatCache;
         _prefixSources = prefixSources;
         _httpProvider = httpProvider;
-        _cacheTtl = cacheTtl ?? TimeSpan.FromHours(1);
-        _negativeTtl = negativeTtl ?? TimeSpan.FromSeconds(30);
-        // 2× a generous operator-configured ASN universe (a route server typically tracks tens to
-        // low-hundreds of origin ASNs). The cap defends against unbounded growth from adversarial /
-        // churn traffic, not normal operation.
-        _maxCacheEntries = maxCacheEntries ?? 4096;
+        _ruCacheTtl = ruCacheTtl ?? TimeSpan.FromHours(1);
         _logger = logger;
         _timeProvider = timeProvider ?? TimeProvider.System;
         // #320: fetch budget for peer-supplied URL sources — generous for a real prefix list
@@ -94,115 +81,11 @@ public sealed class PrefixService : IPrefixService
         }, ct);
     }
 
-    public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
-    {
-        // Fast path: fresh entry (positive or negative within its TTL).
-        if (TryGetFresh(asn, out var fresh))
-            return fresh;
-
-        // Serialize per-ASN so concurrent callers share a single RIPEstat fetch — no thundering herd
-        // on a cold or just-expired ASN (#164). Mirrors PrefixSourceService.LoadCachedAsync.
-        var gate = _locks.GetOrAdd(asn, _ => new SemaphoreSlim(1, 1));
-        await gate.WaitAsync(ct);
-        try
-        {
-            // Re-check after acquiring the lock: another caller may have just populated the entry.
-            if (TryGetFresh(asn, out var rechecked))
-                return rechecked;
-
-            IReadOnlyList<(uint Prefix, byte Length)> prefixes;
-            try
-            {
-                prefixes = await _ripeStat.GetPrefixesAsync(asn, ct);
-            }
-            catch (OperationCanceledException) { throw; }
-            catch (Exception ex)
-            {
-                // Stale-on-failure (#163): serve the last good copy regardless of its age so a
-                // transient RIPEstat outage (429/5xx/network) does not drop the ASN's routes the
-                // instant its TTL elapses. Asymmetric with the old behavior — previously the throw
-                // propagated and (via GetPrefixesForAsns) the ASN's prefixes vanished from peers.
-                if (_cache.TryGetValue(asn, out var stale) && !stale.Negative)
-                {
-                    _logger?.LogWarning(ex,
-                        "AS{Asn}: RIPEstat fetch failed; serving cached copy ({Count} prefixes).", asn, stale.Data.Count);
-                    return stale.Data;
-                }
-
-                // No cached copy: remember the failure briefly so repeated calls don't hammer RIPEstat.
-                EvictIfAtCapacity(asn);
-                _cache[asn] = ([], _timeProvider.GetUtcNow().UtcDateTime, Negative: true);
-                throw;
-            }
-
-            EvictIfAtCapacity(asn);
-            _cache[asn] = (prefixes, _timeProvider.GetUtcNow().UtcDateTime, Negative: false);
-            return prefixes;
-        }
-        finally
-        {
-            gate.Release();
-        }
-    }
-
-    /// <summary>True if <paramref name="asn"/> has a non-expired entry (positive within _cacheTtl,
-    /// negative within _negativeTtl).</summary>
-    private bool TryGetFresh(uint asn, out IReadOnlyList<(uint Prefix, byte Length)> data)
-    {
-        data = null!;
-        if (!_cache.TryGetValue(asn, out var entry)) return false;
-
-        var ttl = entry.Negative ? _negativeTtl : _cacheTtl;
-        if (_timeProvider.GetUtcNow().UtcDateTime - entry.CachedAt < ttl)
-        {
-            data = entry.Data;
-            return true;
-        }
-        return false;
-    }
-
-    /// <summary>Enforces the _maxCacheEntries bound (#165). Called before inserting a NEW key.
-    /// Removes a few least-recently-cached entries (by CachedAt) plus any expired entries it
-    /// encounters, and drops the corresponding _locks entries. Under the lock of the caller's
-    /// per-ASN gate, so the sweep is serialized against itself; ConcurrentDictionary enumeration
-    /// is a snapshot and safe against concurrent writers.</summary>
-    private void EvictIfAtCapacity(uint insertingKey)
-    {
-        if (_cache.Count < _maxCacheEntries) return;
-        if (_cache.ContainsKey(insertingKey)) return; // already present, no insert coming
-
-        // Snapshot, drop expired entries first (cheapest eviction), then by oldest CachedAt.
-        var now = _timeProvider.GetUtcNow().UtcDateTime;
-        var toEvict = new List<uint>();
-        foreach (var (key, entry) in _cache)
-        {
-            var ttl = entry.Negative ? _negativeTtl : _cacheTtl;
-            if (now - entry.CachedAt >= ttl)
-                toEvict.Add(key);
-        }
-        // If still at/over capacity after dropping expired, evict the oldest until below the cap.
-        if (_cache.Count - toEvict.Count >= _maxCacheEntries)
-        {
-            var oldest = _cache
-                .Where(kvp => !toEvict.Contains(kvp.Key))
-                .OrderBy(kvp => kvp.Value.CachedAt)
-                .Select(kvp => kvp.Key);
-            foreach (var key in oldest)
-            {
-                toEvict.Add(key);
-                if (_cache.Count - toEvict.Count < _maxCacheEntries) break;
-            }
-        }
-
-        foreach (var key in toEvict)
-        {
-            // TryUpdate/TryRemove under no per-key lock: a concurrent fetch for this key may be
-            // racing, but that's fine — it will re-populate the entry; losing a transient cache hit
-            // is acceptable, and never losing correctness.
-            if (_cache.TryRemove(key, out _))
-                _locks.TryRemove(key, out _);
-        }
-    }
+    public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
+        // Per-ASN caching, stale-on-failure, negative TTL, fetch gates, and the #165 eviction
+        // sweep all live in the shared cache (#267 item 5) — one wire fetch per ASN regardless
+        // of which mechanism asked.
+        => _ripeStatCache.GetPrefixesAsync(asn, ct);
 
     /// <summary>Bounds how many ASNs are resolved against RIPEstat concurrently on a cold cache
     /// (warm traffic is cache-flat). Keeps cold-start fan-out from tripping RIPEstat rate limits.</summary>
@@ -302,7 +185,7 @@ public sealed class PrefixService : IPrefixService
         // Fast path: fresh entry. A single Volatile.Read of the immutable entry reference gives a
         // consistent (projection, ticks) snapshot — no two-field torn read.
         var cached = Volatile.Read(ref _ruCache);
-        if (cached is not null && _timeProvider.GetUtcNow().UtcDateTime.Ticks - cached.CachedAtTicks < _cacheTtl.Ticks)
+        if (cached is not null && _timeProvider.GetUtcNow().UtcDateTime.Ticks - cached.CachedAtTicks < _ruCacheTtl.Ticks)
             return cached.Projected;
 
         // Serialize the cache-miss fetch so concurrent callers share one default-source fetch
@@ -312,7 +195,7 @@ public sealed class PrefixService : IPrefixService
         {
             // Re-check under the lock: another caller may have just populated the entry.
             cached = Volatile.Read(ref _ruCache);
-            if (cached is not null && _timeProvider.GetUtcNow().UtcDateTime.Ticks - cached.CachedAtTicks < _cacheTtl.Ticks)
+            if (cached is not null && _timeProvider.GetUtcNow().UtcDateTime.Ticks - cached.CachedAtTicks < _ruCacheTtl.Ticks)
                 return cached.Projected;
 
             List<(uint Prefix, byte Length, uint Asn)> projected;

--- a/BGPLite.Providers/RipeStatPrefixCache.cs
+++ b/BGPLite.Providers/RipeStatPrefixCache.cs
@@ -1,0 +1,168 @@
+using System.Collections.Concurrent;
+using BGPLite.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace BGPLite.Providers;
+
+/// <summary>
+/// The single per-ASN RIPEstat prefix cache (#267 item 5). Every consumer of RIPEstat
+/// per-ASN data goes through one instance of this class — the legacy
+/// <c>RipeStat.AsnLists</c>/custom-ASN path (<see cref="PrefixService"/>) and
+/// <c>PrefixSources</c> entries of <c>Kind: asn</c> (<see cref="AsnPrefixProvider"/>).
+/// Before it existed the two mechanisms fetched and cached the same ASN independently with
+/// separate TTLs — an ASN configured in both doubled RIPEstat traffic and could serve
+/// disagreeing snapshots.
+/// <para>
+/// Shape (moved verbatim from <see cref="PrefixService"/>): per-ASN TTL cache with
+/// stale-on-failure (#163), short negative TTL for failed fetches, per-ASN fetch gates against
+/// thundering herds (#164), and a capacity cap with the #165 eviction sweep.
+/// </para>
+/// </summary>
+public sealed class RipeStatPrefixCache
+{
+    private readonly RipeStatProvider _ripe;
+    private readonly ILogger<RipeStatPrefixCache>? _logger;
+    private readonly TimeSpan _cacheTtl;
+    private readonly TimeSpan _negativeTtl;
+    // Upper bound on _cache/_locks entries (#165). Without a cap, a malicious or churning peer
+    // querying distinct ASNs grows the dictionaries without limit. Exceeded → least-recently-used
+    // sweep before insert. The configured ASN universe is small (operator AsnLists), so a generous
+    // default does not constrain real deployments.
+    private readonly int _maxCacheEntries;
+    private readonly TimeProvider _timeProvider;
+    // asn → (prefix list, cached at, is negative). Negative entries (failed RIPEstat fetches) use
+    // _negativeTtl. The tuple is shaped to mirror PrefixSourceService so the resilience semantics
+    // (stale-on-failure, negative cache, bounded sweep) are identical across both caches.
+    private readonly ConcurrentDictionary<uint, (IReadOnlyList<(uint Prefix, byte Length)> Data, DateTime CachedAt, bool Negative)> _cache = new();
+    // asn → gate serializing the cache-miss fetch path (prevents thundering herd on cold/expired
+    // ASNs — #164).
+    private readonly ConcurrentDictionary<uint, SemaphoreSlim> _locks = new();
+
+    public RipeStatPrefixCache(
+        RipeStatProvider ripe,
+        ILogger<RipeStatPrefixCache>? logger = null,
+        TimeSpan? cacheTtl = null,
+        TimeSpan? negativeTtl = null,
+        int? maxCacheEntries = null,
+        TimeProvider? timeProvider = null)
+    {
+        _ripe = ripe;
+        _logger = logger;
+        _cacheTtl = cacheTtl ?? TimeSpan.FromHours(1);
+        _negativeTtl = negativeTtl ?? TimeSpan.FromSeconds(30);
+        // 2× a generous operator-configured ASN universe (a route server typically tracks tens to
+        // low-hundreds of origin ASNs). The cap defends against unbounded growth from adversarial /
+        // churn traffic, not normal operation.
+        _maxCacheEntries = maxCacheEntries ?? 4096;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
+    {
+        // Fast path: fresh entry (positive or negative within its TTL).
+        if (TryGetFresh(asn, out var fresh))
+            return fresh;
+
+        // Serialize per-ASN so concurrent callers share a single RIPEstat fetch — no thundering herd
+        // on a cold or just-expired ASN (#164).
+        var gate = _locks.GetOrAdd(asn, _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync(ct);
+        try
+        {
+            // Re-check after acquiring the lock: another caller may have just populated the entry.
+            if (TryGetFresh(asn, out var rechecked))
+                return rechecked;
+
+            IReadOnlyList<(uint Prefix, byte Length)> prefixes;
+            try
+            {
+                prefixes = await _ripe.GetPrefixesAsync(asn, ct);
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                // Stale-on-failure (#163): serve the last good copy regardless of its age so a
+                // transient RIPEstat outage (429/5xx/network) does not drop the ASN's routes the
+                // instant its TTL elapses.
+                if (_cache.TryGetValue(asn, out var stale) && !stale.Negative)
+                {
+                    _logger?.LogWarning(ex,
+                        "AS{Asn}: RIPEstat fetch failed; serving cached copy ({Count} prefixes).", asn, stale.Data.Count);
+                    return stale.Data;
+                }
+
+                // No cached copy: remember the failure briefly so repeated calls don't hammer RIPEstat.
+                EvictIfAtCapacity(asn);
+                _cache[asn] = ([], _timeProvider.GetUtcNow().UtcDateTime, Negative: true);
+                throw;
+            }
+
+            EvictIfAtCapacity(asn);
+            _cache[asn] = (prefixes, _timeProvider.GetUtcNow().UtcDateTime, Negative: false);
+            return prefixes;
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    /// <summary>True if <paramref name="asn"/> has a non-expired entry (positive within _cacheTtl,
+    /// negative within _negativeTtl).</summary>
+    private bool TryGetFresh(uint asn, out IReadOnlyList<(uint Prefix, byte Length)> data)
+    {
+        data = null!;
+        if (!_cache.TryGetValue(asn, out var entry)) return false;
+
+        var ttl = entry.Negative ? _negativeTtl : _cacheTtl;
+        if (_timeProvider.GetUtcNow().UtcDateTime - entry.CachedAt < ttl)
+        {
+            data = entry.Data;
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>Enforces the _maxCacheEntries bound (#165). Called before inserting a NEW key,
+    /// under the caller's per-ASN gate. Removes a few least-recently-cached entries (by CachedAt)
+    /// plus any expired entries it encounters, and drops the corresponding _locks entries. Under
+    /// the lock of the caller's per-ASN gate, so the sweep is serialized against itself;
+    /// ConcurrentDictionary enumeration is a snapshot and safe against concurrent writers.</summary>
+    private void EvictIfAtCapacity(uint insertingKey)
+    {
+        if (_cache.Count < _maxCacheEntries) return;
+        if (_cache.ContainsKey(insertingKey)) return; // already present, no insert coming
+
+        // Snapshot, drop expired entries first (cheapest eviction), then by oldest CachedAt.
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        var toEvict = new List<uint>();
+        foreach (var (key, entry) in _cache)
+        {
+            var ttl = entry.Negative ? _negativeTtl : _cacheTtl;
+            if (now - entry.CachedAt >= ttl)
+                toEvict.Add(key);
+        }
+        // If still at/over capacity after dropping expired, evict the oldest until below the cap.
+        if (_cache.Count - toEvict.Count >= _maxCacheEntries)
+        {
+            var oldest = _cache
+                .Where(kvp => !toEvict.Contains(kvp.Key))
+                .OrderBy(kvp => kvp.Value.CachedAt)
+                .Select(kvp => kvp.Key);
+            foreach (var key in oldest)
+            {
+                toEvict.Add(key);
+                if (_cache.Count - toEvict.Count < _maxCacheEntries) break;
+            }
+        }
+
+        foreach (var key in toEvict)
+        {
+            // TryUpdate/TryRemove under no per-key lock: a concurrent fetch for this key may be
+            // racing, but that's fine — it will re-populate the entry; losing a transient cache hit
+            // is acceptable, and never losing correctness.
+            if (_cache.TryRemove(key, out _))
+                _locks.TryRemove(key, out _);
+        }
+    }
+}

--- a/BGPLite.Tests/AsnPrefixProviderTests.cs
+++ b/BGPLite.Tests/AsnPrefixProviderTests.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Net.Http;
 using BGPLite.Configuration;
 using BGPLite.Providers;
 using Xunit;
@@ -16,5 +18,51 @@ public class AsnPrefixProviderTests
         var provider = new AsnPrefixProvider(null!, null!);
         var source = new PrefixSourceConfig { Name = "cloudflare", Kind = "asn" };
         await Assert.ThrowsAsync<InvalidOperationException>(() => provider.LoadAsync(source));
+    }
+
+    /// <summary>
+    /// #267 item 5: Kind:asn sources and the RipeStat.AsnLists/custom-ASN path share ONE per-ASN
+    /// cache — an ASN configured in both mechanisms is fetched from RIPEstat once. The old
+    /// direct-to-wire provider path fetched it twice with independent TTLs.
+    /// </summary>
+    private sealed class CountingRipeHandler : HttpMessageHandler
+    {
+        public int Calls { get; private set; }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Calls++;
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """{"status":"ok","data":{"resource":"65010","prefixes":{"v4":{"originating":["10.1.10.1/32"]},"v6":{"originating":[]}}}}""")
+            });
+        }
+    }
+
+    private sealed class StubFactory : IHttpClientFactory
+    {
+        private readonly HttpMessageHandler _handler;
+        public StubFactory(HttpMessageHandler handler) => _handler = handler;
+        public HttpClient CreateClient(string name) => new(_handler, disposeHandler: false);
+    }
+
+    [Fact]
+    public async Task SameAsn_BothMechanisms_SingleWireFetch()
+    {
+        var handler = new CountingRipeHandler();
+        var cache = new RipeStatPrefixCache(new RipeStatProvider(
+            new StubFactory(handler), NullLogger<RipeStatProvider>.Instance,
+            new RipeStatConfig { RetryAttempts = 0, RetryDelaySeconds = 0 }));
+        var service = new PrefixService(new AppConfig(), cache, null!, null!);
+        var provider = new AsnPrefixProvider(cache, NullLogger<AsnPrefixProvider>.Instance);
+
+        // Mechanism A: RipeStat.AsnLists / custom-ASN path.
+        var viaService = await service.GetPrefixesAsync(65010);
+        // Mechanism B: a PrefixSources entry of Kind: asn for the SAME ASN.
+        var viaSource = await provider.LoadAsync(new PrefixSourceConfig { Name = "x", Kind = "asn", Asn = 65010 });
+
+        Assert.Single(viaService);
+        Assert.Single(viaSource.Prefixes);
+        Assert.Equal(1, handler.Calls);   // RED on the old direct-to-wire provider: 2
     }
 }

--- a/BGPLite.Tests/CompositionContractTests.cs
+++ b/BGPLite.Tests/CompositionContractTests.cs
@@ -48,7 +48,7 @@ public class CompositionContractTests
     [InlineData(typeof(ManagementApi), "sessionManager")]
     // PrefixService.cs:14-15 — a null http provider made every per-peer user URL source resolve to
     // zero prefixes, and a null RIPEstat did the same for custom ASNs.
-    [InlineData(typeof(PrefixService), "ripeStat")]
+    [InlineData(typeof(PrefixService), "ripeStatCache")] // #267 item 5: renamed when the per-ASN cache became a shared component
     [InlineData(typeof(PrefixService), "httpProvider")]
     public void ProductionDependency_IsRequired(Type type, string parameterName)
     {

--- a/BGPLite.Tests/PrefixCacheRaceTests.cs
+++ b/BGPLite.Tests/PrefixCacheRaceTests.cs
@@ -111,10 +111,10 @@ public class PrefixCacheRaceTests
             // #263 made both required in production; neither is on the GetRuPrefixesAsync path this
             // fixture exercises, so the fake composition states that explicitly rather than relying
             // on a nullable parameter that production code could also leave unset.
-            ripeStat: null!,
+            null!, // RipeStatPrefixCache — not on the GetRuPrefixesAsync path
             prefixSources: source,
             httpProvider: null!,
-            cacheTtl: cacheTtl ?? TimeSpan.FromHours(1),
+            ruCacheTtl: cacheTtl ?? TimeSpan.FromHours(1),
             logger: NullLogger<PrefixService>.Instance,
             timeProvider: timeProvider);
 

--- a/BGPLite.Tests/PrefixServiceTests.cs
+++ b/BGPLite.Tests/PrefixServiceTests.cs
@@ -73,15 +73,17 @@ public class PrefixServiceTests
 
     private static PrefixService Service(PerAsnHandler handler, TimeSpan? cacheTtl = null, TimeSpan? negativeTtl = null, int? maxCacheEntries = null, int retryAttempts = 2, ILogger<PrefixService>? logger = null) =>
         new(new AppConfig(),
-            new RipeStatProvider(new StubFactory(handler),
-                NullLogger<RipeStatProvider>.Instance,
-                new RipeStatConfig { RetryAttempts = retryAttempts, RetryDelaySeconds = 0 }),
+            // #267 item 5: per-ASN TTL/negative-TTL/eviction knobs moved into the shared cache.
+            new RipeStatPrefixCache(
+                new RipeStatProvider(new StubFactory(handler),
+                    NullLogger<RipeStatProvider>.Instance,
+                    new RipeStatConfig { RetryAttempts = retryAttempts, RetryDelaySeconds = 0 }),
+                cacheTtl: cacheTtl,
+                negativeTtl: negativeTtl,
+                maxCacheEntries: maxCacheEntries),
             null!, // IPrefixSourceService is not on the GetPrefixesForAsns path
             null!, // HttpPrefixProvider is only on the per-peer user-source path (#263)
-            cacheTtl: cacheTtl ?? TimeSpan.FromHours(1),
-            logger: logger,
-            negativeTtl: negativeTtl,
-            maxCacheEntries: maxCacheEntries);
+            logger: logger);
 
     /// <summary>The single prefix uint that <see cref="PerAsnHandler"/> yields for a given ASN,
     /// computed through the same <see cref="BgpConstants.IPAddressToUint"/> the provider uses.</summary>

--- a/BGPLite/Program.cs
+++ b/BGPLite/Program.cs
@@ -158,14 +158,27 @@ builder.Services.AddSingleton(sp => new RipeStatProvider(
 
 // AS-originated prefix source (Kind: "asn") — fetches an AS's prefixes via RIPEstat through the
 // provider factory, so `Kind: asn` entries under PrefixSources load like any other source.
-builder.Services.AddSingleton<AsnPrefixProvider>();
+// #267 item 5: the ONE per-ASN RIPEstat cache — shared by PrefixService (RipeStat.AsnLists,
+// custom ASNs) and AsnPrefixProvider (Kind: asn sources), so an ASN configured in both
+// mechanisms is fetched and cached once.
+builder.Services.AddSingleton(sp => new RipeStatPrefixCache(
+    sp.GetRequiredService<RipeStatProvider>(),
+    sp.GetRequiredService<ILogger<RipeStatPrefixCache>>()));
+builder.Services.AddSingleton<AsnPrefixProvider>(sp => new AsnPrefixProvider(
+    sp.GetRequiredService<RipeStatPrefixCache>(),
+    sp.GetRequiredService<ILogger<AsnPrefixProvider>>()));
 builder.Services.AddSingleton<IPrefixSourceProvider>(sp => sp.GetRequiredService<AsnPrefixProvider>());
 
 builder.Services.AddSingleton<IPrefixService>(sp =>
 {
     var ripe = sp.GetRequiredService<RipeStatProvider>();
     var sources = sp.GetRequiredService<IPrefixSourceService>();
-    return new PrefixService(config, ripe, sources, sp.GetRequiredService<HttpPrefixProvider>(), logger: sp.GetRequiredService<ILogger<PrefixService>>());
+    return new PrefixService(
+        config,
+        sp.GetRequiredService<RipeStatPrefixCache>(),
+        sources,
+        sp.GetRequiredService<HttpPrefixProvider>(),
+        logger: sp.GetRequiredService<ILogger<PrefixService>>());
 });
 
 // #263: the BGP send path's dependencies are registered explicitly and resolved with


### PR DESCRIPTION
Split from #267 (item 5).

## Problem
The same ASN configured in both `RipeStat.AsnLists` (or a custom ASN) and a `PrefixSources` entry of `Kind: asn` was fetched and cached TWICE with independent TTLs: `PrefixService._cache` served one copy while `AsnPrefixProvider` called `RipeStatProvider` directly — a path with no cache at all, despite its doc comment claiming to share one. Double RIPEstat traffic; two snapshots that could disagree.

## Fix
Extract the per-ASN cache machinery VERBATIM into `RipeStatPrefixCache` (TTL, negative TTL, stale-on-failure #163, per-ASN gates #164, #165 eviction sweep — comments preserved) and inject ONE instance into both consumers; Program wires the single singleton. `PrefixService` keeps only the RU/default projection cache (`ruCacheTtl`) and delegates per-ASN work; `AsnPrefixProvider` now goes through the cache and its doc comment matches reality. #214 change-detection untouched — name-level content comparison in `PrefixSourceService` now sees the cache-served (stable) list, which only IMPROVES its signal (no phantom changes from two disagreeing fetches).

## Regression Test
`SameAsn_BothMechanisms_SingleWireFetch` — both mechanisms resolve one ASN with exactly one HTTP call. Red on the old direct-wire behavior (verified via a temporary bypass probe simulating it), green after.

## Verification
`dotnet format` / `dotnet build` (0 errors) / focused suites 2× green / full **851/851** (CompositionContract updated for the renamed ctor parameter — the executable-architecture net catching exactly what it exists for).

## RFC / Behavior Change
None on the wire. Deliberate: overlapping configs now serve from one fetch (the issue's own recommended fix); TTL knobs for per-ASN data moved from PrefixService's ctor into the cache's.

## Deviation from Issue Proposal
None — the 'share one cache keyed by ASN' branch of the issue's optional fix.