### PR TITLE
fix: providers/config audit minors — reload re-arm, redirect rejection, NAT64, RIPEstat bounds, async file reads, empty-YAML error, refresh teardown (#321)

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -107,7 +107,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
     /// <summary>
     /// Hot-reloads the SOFT (non-session-disrupting) part of the configuration (#136): the
-    /// trusted-proxy CIDR list (client-IP resolution), the CORS origin allowlist (via <c>_config</c>),
+    /// trusted-proxy CIDR list (client-IP resolution), the CORS origin allowlist (<c>_corsAllowedOrigins</c>),
     /// and the API rate / concurrency limiters. Each derived field is rebuilt from
     /// <paramref name="newConfig"/> and swapped atomically with <see cref="Interlocked.Exchange"/> so
     /// in-flight requests keep observing the previous state while subsequent requests pick up the new
@@ -160,8 +160,8 @@ public sealed class ManagementApi : IHostedService, IDisposable
         ResolveClientIp(remote, xForwardedFor, xRealIp, Volatile.Read(ref _trustedProxyNetworks));
 
     /// <summary>
-    /// Resolves the CORS origin against the CURRENT live <c>_config</c> (#136), for tests that need
-    /// to observe the effect of reloading <c>CorsAllowedOrigins</c> without an HttpListener. Mirrors
+    /// Resolves the CORS origin against the CURRENT live <c>_corsAllowedOrigins</c> (#136), for tests
+    /// that need to observe the effect of reloading <c>CorsAllowedOrigins</c> without an HttpListener. Mirrors
     /// <see cref="AddCorsHeaders"/>'s resolution.
     /// </summary>
     internal string? ResolveCorsOriginLive(string? requestOrigin) =>

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -127,7 +127,9 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         // Swap every reloadable field atomically. A request that has already captured the old
         // references into locals finishes against them; the next request reads the new ones.
-        // _config is swapped last so CORS / client-IP and the limiters always move together.
+        // NOTE (#321 item 8): _config itself is NOT swapped — request-path code that must observe
+        // reloads reads the derived fields above; the fields still reading _config (e.g.
+        // MaxRequestBodyBytes, RipeStat lists) are restart-required, tracked as #266 item 6.
         var oldRateLimiter = Interlocked.Exchange(ref _rateLimiter, rateLimiter);
         var oldConcurrencyLimiter = Interlocked.Exchange(ref _concurrencyLimiter, concurrencyLimiter);
         Interlocked.Exchange(ref _trustedProxyNetworks, trusted);

--- a/BGPLite.Configuration/ConfigLoader.cs
+++ b/BGPLite.Configuration/ConfigLoader.cs
@@ -13,11 +13,15 @@ public static class ConfigLoader
     public static AppConfig Load(string path)
     {
         var yaml = File.ReadAllText(path);
-        return Deserializer.Deserialize<AppConfig>(yaml);
+        return LoadFromText(yaml);
     }
 
     public static AppConfig LoadFromText(string yaml) =>
-        Deserializer.Deserialize<AppConfig>(yaml);
+        // YamlDotNet returns null for an empty/whitespace document ("", "   ", "---") — fail loud
+        // with a clear message instead of an NRE at the first config use (#321 item 6). The
+        // hot-reload path logs it and keeps the previous config, as with any other bad edit.
+        Deserializer.Deserialize<AppConfig>(yaml)
+            ?? throw new InvalidOperationException("The configuration is empty — nothing to load.");
 
     private static readonly ISerializer Serializer = new SerializerBuilder()
         .Build();

--- a/BGPLite.Providers/FilePrefixProvider.cs
+++ b/BGPLite.Providers/FilePrefixProvider.cs
@@ -13,7 +13,7 @@ public sealed class FilePrefixProvider(ILogger<FilePrefixProvider> logger) : IPr
     /// <summary>File mtime comparison is a zero-cost conditional check (#214).</summary>
     public bool SupportsConditionalRequests => true;
 
-    public Task<SourceLoadResult> LoadAsync(
+    public async Task<SourceLoadResult> LoadAsync(
         PrefixSourceConfig source,
         string? etag = null,
         DateTimeOffset? lastModified = null,
@@ -35,11 +35,15 @@ public sealed class FilePrefixProvider(ILogger<FilePrefixProvider> logger) : IPr
         if (lastModified is not null && fileMtime == lastModified)
         {
             logger.LogDebug("Source '{Name}' (file): unchanged (mtime match)", source.Name);
-            return Task.FromResult(SourceLoadResult.NotModifiedResult(lastModified: fileMtime));
+            return SourceLoadResult.NotModifiedResult(lastModified: fileMtime);
         }
 
-        var prefixes = PrefixListParser.Parse(File.ReadAllText(fullPath));
+        // #321 item 5: async read with the caller's token — the sync ReadAllText held a threadpool
+        // thread under the per-source gate for the whole file. The metadata probes above stay
+        // sync: they are single stat calls, not reads.
+        var text = await File.ReadAllTextAsync(fullPath, ct);
+        var prefixes = PrefixListParser.Parse(text);
         logger.LogInformation("Source '{Name}' (file): loaded {Count} prefixes from {Path}", source.Name, prefixes.Count, fullPath);
-        return Task.FromResult(SourceLoadResult.Ok(prefixes, lastModified: fileMtime));
+        return SourceLoadResult.Ok(prefixes, lastModified: fileMtime);
     }
 }

--- a/BGPLite.Providers/HttpPrefixProvider.cs
+++ b/BGPLite.Providers/HttpPrefixProvider.cs
@@ -110,6 +110,14 @@ public sealed class HttpPrefixProvider(
                 return SourceLoadResult.NotModifiedResult(updatedEtag ?? etag, updatedLm ?? lastModified);
             }
 
+            // #321: redirects are not followed (AllowAutoRedirect=false on the named client) — the
+            // handler would re-send every per-source header except Authorization to the target
+            // host, so a 3xx is an operator-fixable configuration error, not something to chase.
+            if (response.StatusCode is >= HttpStatusCode.MultipleChoices and < HttpStatusCode.BadRequest)
+                throw new InvalidOperationException(
+                    $"Prefix source '{source.Name}': the URL redirects ({(int)response.StatusCode}) — " +
+                    "redirects are not followed; configure the final URL.");
+
             response.EnsureSuccessStatusCode();
 
             // Extract validators from the 200 response for next time (#214).

--- a/BGPLite.Providers/PrefixSourceUrlValidator.cs
+++ b/BGPLite.Providers/PrefixSourceUrlValidator.cs
@@ -37,6 +37,8 @@ public static class PrefixSourceUrlValidator
         IPNetwork.Parse("2001::/32"),           // Teredo — can embed private IPv4 in the last 32 bits
         IPNetwork.Parse("::ffff:0:0/96"),       // IPv4-mapped (also caught by IsIPv4MappedToIPv6, defense in depth)
         IPNetwork.Parse("::/96"),               // IPv4-compatible (deprecated ::a.b.c.d form)
+        IPNetwork.Parse("64:ff9b::/96"),        // NAT64 well-known — a DNS64 name can embed any IPv4 here (#321)
+        IPNetwork.Parse("64:ff8:1::/96"),       // NAT64 well-known, local scope (RFC 6052 §2.1 alternate)
     ];
 
     /// <summary>Per-address connect budget so one blackholed candidate can't consume the whole
@@ -65,7 +67,8 @@ public static class PrefixSourceUrlValidator
     /// SocketsHttpHandler.ConnectCallback: resolves DNS, validates ALL resolved IPs are public,
     /// then connects with a matching-family socket per address (IPv4 preferred) until one succeeds.
     /// No TOCTOU — every address is validated above and the connected IP is one of them.
-    /// SocketsHttpHandler does NOT follow redirects (no 302-to-internal-IP bypass).
+    /// Redirects are not followed (AllowAutoRedirect=false in Program.cs, #321); any connection a
+    /// redirect would have opened re-enters this callback anyway, so the gate holds per hop.
     /// </summary>
     public static async ValueTask<Stream> CreateValidatedConnectionAsync(
         SocketsHttpConnectionContext context, CancellationToken ct)

--- a/BGPLite.Providers/RipeStatProvider.cs
+++ b/BGPLite.Providers/RipeStatProvider.cs
@@ -12,6 +12,9 @@ public sealed class RipeStatProvider
     /// <summary>Named-client key registered with <c>IHttpClientFactory</c>.</summary>
     public const string ClientName = "ripestat";
 
+    /// <summary>Maximum response body size (10 MB) — same bound as HttpPrefixProvider (#144/#321).</summary>
+    internal const int MaxResponseBytes = 10 * 1024 * 1024;
+
     private readonly IHttpClientFactory _httpFactory;
     private readonly ILogger<RipeStatProvider> _logger;
     private readonly RipeStatConfig _config;
@@ -34,11 +37,34 @@ public sealed class RipeStatProvider
     {
         var url = $"https://stat.ripe.net/data/ris-prefixes/data.json?resource=AS{asn}&list_prefixes=true";
         var http = _httpFactory.CreateClient(ClientName);
-        using var response = await http.GetAsync(url, ct);
+        using var response = await http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct);
         response.EnsureSuccessStatusCode();
 
-        var json = await response.Content.ReadAsStringAsync(ct);
-        using var doc = JsonDocument.Parse(json);
+        // #321 item 4: bound the body like every other fetch path (HttpPrefixProvider caps URL
+        // sources at 10 MB, #144) — ReadAsStringAsync would fully buffer whatever arrives before
+        // parsing. Fast Content-Length check first, then a hard cap while streaming.
+        if (response.Content.Headers.ContentLength is long declared && declared > MaxResponseBytes)
+            throw new InvalidOperationException(
+                $"RIPEstat response for AS{asn} too large ({declared} bytes, max {MaxResponseBytes}).");
+        // #324 parity: the resilience pipeline clips at the response headers
+        // (ResponseHeadersRead), so the body loop needs its own deadline — a slow-dripping origin
+        // must not hold the fetch open; size alone bounds memory, not time.
+        using var bodyCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        // Math.Max mirrors the pipeline's clamp (Program.cs) — a configured 0/negative must mean
+        // "the minimum", not CancelAfter(0) silently cancelling every body read (#321 review).
+        bodyCts.CancelAfter(TimeSpan.FromSeconds(Math.Max(10, _config.TimeoutSeconds)));
+        await using var stream = await response.Content.ReadAsStreamAsync(bodyCts.Token);
+        using var buffered = new MemoryStream();
+        var readBuffer = new byte[8192];
+        int read;
+        while ((read = await stream.ReadAsync(readBuffer, bodyCts.Token)) > 0)
+        {
+            buffered.Write(readBuffer, 0, read);
+            if (buffered.Length > MaxResponseBytes)
+                throw new InvalidOperationException(
+                    $"RIPEstat response for AS{asn} exceeded {MaxResponseBytes} bytes during stream.");
+        }
+        using var doc = JsonDocument.Parse(new ReadOnlyMemory<byte>(buffered.GetBuffer(), 0, (int)buffered.Length));
 
         var prefixes = doc.RootElement
             .GetProperty("data")

--- a/BGPLite.Tests/ConfigurationTests.cs
+++ b/BGPLite.Tests/ConfigurationTests.cs
@@ -4,6 +4,18 @@ namespace BGPLite.Tests;
 
 public class ConfigurationTests
 {
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("---")]
+    public void LoadFromText_EmptyDocument_ThrowsClearError(string yaml)
+    {
+        // #321 item 6: YamlDotNet deserializes an empty/whitespace document to null — previously
+        // that surfaced as an opaque NRE at the first config use instead of a clear message.
+        var ex = Assert.Throws<InvalidOperationException>(() => ConfigLoader.LoadFromText(yaml));
+        Assert.Contains("empty", ex.Message);
+    }
+
     [Fact]
     public void LoadFromText_UnknownKey_Throws()
     {

--- a/BGPLite.Tests/HttpPrefixProviderTests.cs
+++ b/BGPLite.Tests/HttpPrefixProviderTests.cs
@@ -283,6 +283,23 @@ public class HttpPrefixProviderTests
             provider.LoadAsync(HttpSource("https://raw.githubusercontent.com/o/r/main/x.txt")));
     }
 
+    [Theory]
+    [InlineData(HttpStatusCode.Found)]             // 302 — the classic redirect
+    [InlineData(HttpStatusCode.MultipleChoices)]   // 300 — the boundary of the 3xx class (#321 review)
+    public async Task Redirect_IsRejected_WithClearError(HttpStatusCode status)
+    {
+        // #321: redirects are not followed (AllowAutoRedirect=false on the named client) — the
+        // handler would re-send per-source headers except Authorization to the target host. The
+        // provider must surface a 3xx as an operator-fixable error naming the actual behavior.
+        var provider = Provider(new StubHandler(status, ""));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            provider.LoadAsync(HttpSource("https://example.com/moved.txt")));
+
+        Assert.Contains("redirects are not followed", ex.Message);
+        Assert.Contains("final URL", ex.Message);
+    }
+
     [Fact]
     public async Task MissingUrlThrowsInvalidOperation()
     {

--- a/BGPLite.Tests/PrefixServiceTests.cs
+++ b/BGPLite.Tests/PrefixServiceTests.cs
@@ -125,6 +125,71 @@ public class PrefixServiceTests
     }
 
     [Fact]
+    public async Task OversizedRipeStatResponse_IsRejectedFromHeaders()
+    {
+        // #321 item 4: the RIPEstat body is bounded like every other fetch path — a huge declared
+        // ContentLength is rejected from the response headers, before any buffering.
+        var provider = new RipeStatProvider(
+            new StubFactory(new OversizedHandler()), NullLogger<RipeStatProvider>.Instance);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => provider.GetPrefixesAsync(65001));
+
+        Assert.Contains("too large", ex.Message);
+    }
+
+    [Fact]
+    public async Task OversizedChunkedRipeStatResponse_IsRejectedDuringStream()
+    {
+        // #321 item 4: a server that LIES in its headers (no ContentLength) is caught by the
+        // streaming cap — the only bound a malicious origin cannot dodge.
+        var provider = new RipeStatProvider(
+            new StubFactory(new EndlessBodyHandler()), NullLogger<RipeStatProvider>.Instance);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => provider.GetPrefixesAsync(65001));
+
+        Assert.Contains("exceeded", ex.Message);
+    }
+
+    private sealed class OversizedHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{}") };
+            response.Content.Headers.ContentLength = 10 * 1024 * 1024 + 1;  // just past the 10 MB cap
+            return Task.FromResult(response);
+        }
+    }
+
+    private sealed class EndlessBodyHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StreamContent(new EndlessXStream())   // no ContentLength declared
+            });
+    }
+
+    private sealed class EndlessXStream : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => 0; set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            buffer.AsSpan(offset, count).Fill((byte)'x');
+            return count;
+        }
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => Task.FromResult(Read(buffer, offset, count));
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    [Fact]
     public async Task GetPrefixesForAsns_FailedAsn_LogsWarning()
     {
         // #330: a transient RIPEstat failure for one ASN must not be silent — its prefixes vanish

--- a/BGPLite.Tests/PrefixSourceUrlValidatorTests.cs
+++ b/BGPLite.Tests/PrefixSourceUrlValidatorTests.cs
@@ -140,6 +140,8 @@ public class PrefixSourceUrlValidatorTests
     [InlineData("2001:0:5ef5:79fd:d8c6:e8e9:ac10:0001")] // Teredo-style embedding 172.16.0.1
     [InlineData("::192.168.1.1")]       // IPv4-compatible (deprecated ::a.b.c.d form)
     [InlineData("::ffff:10.0.0.1")]     // IPv4-mapped private (also caught by normalize, defense in depth)
+    [InlineData("64:ff9b::0a00:0001")]  // NAT64 well-known embedding 10.0.0.1 (#321)
+    [InlineData("64:ff8:1::c0a8:0101")] // NAT64 local-scope embedding 192.168.1.1 (#321)
     public void IsBlockedAddress_Rejects_IPv4EmbeddingForms(string ip)
     {
         // Without the #158 ranges, an attacker controlling DNS returns one of these IPv6 addresses

--- a/BGPLite/ConfigReloader.cs
+++ b/BGPLite/ConfigReloader.cs
@@ -29,6 +29,10 @@ public sealed class ConfigReloader : IHostedService, IDisposable
     private Timer? _debounceTimer;
     private int _reloading; // 0 = idle, 1 = a reload is in progress (Interlocked)
     private int _stopped;    // 1 after StopAsync — a queued debounce callback must not start a reload
+    // Gate making {stop-latch, reload admission} atomic relative to each other, plus the drain task
+    // StopAsync awaits so an admitted reload finishes before the host disposes ManagementApi.
+    private readonly object _gate = new();
+    private Task _reloadDrain = Task.CompletedTask;
 
     public ConfigReloader(string configPath, ManagementApi managementApi, ILogger<ConfigReloader> logger)
     {
@@ -96,25 +100,28 @@ public sealed class ConfigReloader : IHostedService, IDisposable
         // At most one reload at a time: a slow reload (large YAML) should not overlap with a second
         // one triggered by another save during the first. ApplyConfig is itself thread-safe, but the
         // guard keeps the log output and the load+validate sequence coherent.
-        if (Volatile.Read(ref _stopped) != 0)
-            return;
-        if (Interlocked.CompareExchange(ref _reloading, 1, 0) != 0)
+        lock (_gate)
         {
-            // A save landed while a reload is still running: the one-shot debounce fired, we lost
-            // the CAS, and without re-arming the timer that save would never be applied until the
-            // NEXT save (#321 item 1). Push the fire time past the in-flight reload instead.
-            try { _debounceTimer?.Change(DebounceMs, Timeout.Infinite); }
-            catch (ObjectDisposedException) { /* StopAsync raced us — shutting down */ }
-            return;
-        }
+            if (Volatile.Read(ref _stopped) != 0)
+                return;
+            if (Interlocked.CompareExchange(ref _reloading, 1, 0) != 0)
+            {
+                // A save landed while a reload is still running: the one-shot debounce fired, we
+                // lost the CAS, and without re-arming the timer that save would never be applied
+                // until the NEXT save (#321 item 1). Push the fire time past the in-flight reload.
+                try { _debounceTimer?.Change(DebounceMs, Timeout.Infinite); }
+                catch (ObjectDisposedException) { /* StopAsync raced us — shutting down */ }
+                return;
+            }
 
-        try
-        {
-            Reload();
-        }
-        finally
-        {
-            Volatile.Write(ref _reloading, 0);
+            // Off the timer thread, and observable: StopAsync awaits _reloadDrain so an admitted
+            // reload finishes before the host tears ManagementApi down. Reload never throws by
+            // contract; the continuation only keeps a hypothetical fault from going unobserved.
+            _reloadDrain = Task.Run(() =>
+            {
+                try { Reload(); }
+                finally { Volatile.Write(ref _reloading, 0); }
+            });
         }
     }
 
@@ -153,16 +160,24 @@ public sealed class ConfigReloader : IHostedService, IDisposable
         }
     }
 
-    public Task StopAsync(CancellationToken cancellationToken)
+    public async Task StopAsync(CancellationToken cancellationToken)
     {
         // Set the stop latch BEFORE disarming the timer: a debounce callback already queued can
         // still run TriggerReload, which would re-arm and start a reload during shutdown (#321
         // review). The latch makes both the entry and the re-arm branch no-ops.
-        Volatile.Write(ref _stopped, 1);
+        Task drain;
+        lock (_gate)
+        {
+            Volatile.Write(ref _stopped, 1);
+            drain = _reloadDrain;
+        }
         _debounceTimer?.Change(Timeout.Infinite, Timeout.Infinite);
         if (_watcher is not null)
             _watcher.EnableRaisingEvents = false;
-        return Task.CompletedTask;
+        // An already-admitted reload may still be applying config — let it finish (bounded by the
+        // host token) so ApplyConfig cannot race ManagementApi.Dispose (#321 CodeRabbit review).
+        try { await drain.WaitAsync(cancellationToken); }
+        catch { /* host grace elapsed or the reload faulted — previous config stays */ }
     }
 
     public void Dispose()

--- a/BGPLite/ConfigReloader.cs
+++ b/BGPLite/ConfigReloader.cs
@@ -28,6 +28,7 @@ public sealed class ConfigReloader : IHostedService, IDisposable
     private FileSystemWatcher? _watcher;
     private Timer? _debounceTimer;
     private int _reloading; // 0 = idle, 1 = a reload is in progress (Interlocked)
+    private int _stopped;    // 1 after StopAsync — a queued debounce callback must not start a reload
 
     public ConfigReloader(string configPath, ManagementApi managementApi, ILogger<ConfigReloader> logger)
     {
@@ -95,8 +96,17 @@ public sealed class ConfigReloader : IHostedService, IDisposable
         // At most one reload at a time: a slow reload (large YAML) should not overlap with a second
         // one triggered by another save during the first. ApplyConfig is itself thread-safe, but the
         // guard keeps the log output and the load+validate sequence coherent.
-        if (Interlocked.CompareExchange(ref _reloading, 1, 0) != 0)
+        if (Volatile.Read(ref _stopped) != 0)
             return;
+        if (Interlocked.CompareExchange(ref _reloading, 1, 0) != 0)
+        {
+            // A save landed while a reload is still running: the one-shot debounce fired, we lost
+            // the CAS, and without re-arming the timer that save would never be applied until the
+            // NEXT save (#321 item 1). Push the fire time past the in-flight reload instead.
+            try { _debounceTimer?.Change(DebounceMs, Timeout.Infinite); }
+            catch (ObjectDisposedException) { /* StopAsync raced us — shutting down */ }
+            return;
+        }
 
         try
         {
@@ -145,6 +155,10 @@ public sealed class ConfigReloader : IHostedService, IDisposable
 
     public Task StopAsync(CancellationToken cancellationToken)
     {
+        // Set the stop latch BEFORE disarming the timer: a debounce callback already queued can
+        // still run TriggerReload, which would re-arm and start a reload during shutdown (#321
+        // review). The latch makes both the entry and the re-arm branch no-ops.
+        Volatile.Write(ref _stopped, 1);
         _debounceTimer?.Change(Timeout.Infinite, Timeout.Infinite);
         if (_watcher is not null)
             _watcher.EnableRaisingEvents = false;

--- a/BGPLite/PrefixAutoRefreshService.cs
+++ b/BGPLite/PrefixAutoRefreshService.cs
@@ -94,13 +94,24 @@ internal sealed class PrefixAutoRefreshService : IHostedService, IDisposable
     public async Task StopAsync(CancellationToken cancellationToken)
     {
         _cts.Cancel();
-        _timer?.Dispose();
+        // Wait for the loop BEFORE disposing the timer: the loop may be parked in
+        // WaitForNextTickAsync on this very timer, and disposing it first faults that wait with
+        // ObjectDisposedException — the generic "loop faulted" log noise on every affected
+        // shutdown (#321 item 7). Cancellation above unwinds the wait; a stopped loop leaves no
+        // waiter behind.
         if (_loopTask is not null)
         {
             try { await _loopTask.WaitAsync(cancellationToken); }
             catch (OperationCanceledException) { }
             catch (Exception ex) { _logger.LogWarning(ex, "Auto-refresh loop faulted on shutdown"); }
+            // The host token may have fired while the loop was still parked — give it a brief
+            // token-less chance to observe _cts and exit before the timer goes away, or disposing
+            // the timer faults the parked wait with an unobserved ObjectDisposedException (#321
+            // review). It only fails to exit if cancellation itself is wedged.
+            try { await _loopTask.WaitAsync(TimeSpan.FromSeconds(5)); }
+            catch { /* loop faulted or still parked — best effort before disposal */ }
         }
+        _timer?.Dispose();
     }
 
     private async Task LoopAsync(CancellationToken ct)

--- a/BGPLite/Program.cs
+++ b/BGPLite/Program.cs
@@ -104,9 +104,14 @@ builder.Services.AddHttpClient(HttpPrefixProvider.ClientName, c =>
 })
 .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
 {
-    // SSRF defense (#144): validate DNS resolution at the socket level — no TOCTOU race, no
-    // redirect bypass (SocketsHttpHandler does not follow redirects, unlike HttpClientHandler).
-    ConnectCallback = PrefixSourceUrlValidator.CreateValidatedConnectionAsync
+    // SSRF defense (#144): validate DNS resolution at the socket level — no TOCTOU race (every
+    // hop of any redirect re-enters ConnectCallback, so the target IP/port are re-checked).
+    // Redirects are NOT followed (#321): SocketsHttpHandler's AllowAutoRedirect defaults to true
+    // and re-sends all per-source headers except Authorization to the redirect target — an
+    // X-API-Key on a source whose host has an open redirect would leak to the attacker's origin.
+    // A 3xx is surfaced to HttpPrefixProvider and rejected there; operators list the final URL.
+    ConnectCallback = PrefixSourceUrlValidator.CreateValidatedConnectionAsync,
+    AllowAutoRedirect = false
 })
 // #107: resilience handler — retry transient HTTP failures (429/5xx/timeouts/network errors)
 // with exponential backoff + jitter, plus a circuit breaker. A transient blip on a prefix-source


### PR DESCRIPTION
Closes #321

## Items (all eight; item 4's parse-robustness half landed with the #319 fix — this adds the size/time bounds)

1. **Reload lost-update** — the one-shot debounce timer re-arms on CAS failure: a save during an in-flight reload is applied once the reload finishes instead of being silently dropped. A `_stopped` latch (set before the timer is disarmed in StopAsync) keeps a queued callback from starting a reload during shutdown.
2. **Redirects** — `AllowAutoRedirect = false` on the named http handler. Verified against MS docs: the default is **true**, and on redirect the handler re-sends every per-source header except `Authorization` — an `X-API-Key` on a source whose host has an open redirect leaked to the attacker's origin. The SSRF gate itself held per hop (each connection re-enters `ConnectCallback`); the leak was the residual risk. `HttpPrefixProvider` now rejects 3xx (300–399, boundary-tested) with an operator-fixable "configure the final URL" error, and the three comments claiming "SocketsHttpHandler does not follow redirects" state reality.
3. **NAT64** — `64:ff9b::/96` and `64:ff8:1::/96` join the SSRF blocklist (a DNS64-resolved name can embed any internal IPv4; same class as the #158 6to4 bypass). Theory-extended.
4. **RIPEstat bounds** — the body is capped at 10 MB (fast ContentLength check + a hard streaming cap that catches a header-lying origin mid-stream — both tested) and time-bounded by a body deadline mirroring #324 (the resilience pipeline clips at headers under `ResponseHeadersRead`), clamped to a 10 s minimum like the pipeline so a misconfigured `TimeoutSeconds: 0` degrades to the minimum instead of cancelling every read.
5. **File reads** — `ReadAllTextAsync(ct)`; the sync read held a threadpool thread under the per-source gate.
6. **Empty YAML** — "configuration is empty" instead of an NRE; theory over `""` / `"   "` / `"---"`.
7. **Refresh teardown** — StopAsync awaits the loop (host-token-bounded, then a token-less 5 s join closing the host-grace race) before disposing the timer; the parked `WaitForNextTickAsync` no longer faults with an unobserved ODE.
8. **ApplyConfig comment** — no longer describes a `_config` swap that never happens (points at #266 item 6 for the restart-required fields).

## Verification

- `dotnet test` — **855/855** (9 new cases: redirect 302/300, NAT64 ×2, empty-YAML ×3, RIPEstat header-cap and streaming-cap).
- Internal reviewer: two passes — the first found five MINORs (3xx boundary at 300, the missing RIPEstat body deadline, the host-grace dispose race, an untested streaming path, the shutdown re-arm race); all fixed; the second confirmed everything closed except the `TimeoutSeconds: 0` clamp, applied after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Empty configuration files now produce a clear error.
  - Configuration reloads are more reliable during rapid edits and shutdown.
  - Application shutdown no longer generates misleading reload errors.
  - HTTP redirects from prefix sources are rejected clearly and are not followed automatically.

- **Security**
  - Expanded protection against SSRF attacks involving NAT64 addresses.
  - RIPEstat responses are limited to 10 MB to prevent excessive memory use.

- **Performance**
  - File-based configuration sources now load asynchronously with cancellation support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->