### PR TITLE
fix(api): 266 part 1 — txt export double serialization, CORS PATCH, preflight rate limit, FK 404

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -352,13 +352,9 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         AddCorsHeaders(ctx);
 
-        if (ctx.Request.HttpMethod == "OPTIONS")
-        {
-            ctx.Response.StatusCode = 204;
-            ctx.Response.Close();
-            return;
-        }
-
+        // #266 item 7: rate-limit FIRST — the OPTIONS short-circuit used to return before this
+        // check, so an unlimited cheap-preflight flood was bounded only by the 64 in-flight
+        // slots. Preflights now consume the client's bucket like any other request.
         // Per-client-IP rate limit (#116) — 429 once the resolved client's token bucket is drained.
         if (rateLimiter is not null)
         {
@@ -370,6 +366,13 @@ public sealed class ManagementApi : IHostedService, IDisposable
                 await WriteResponse(ctx, ApiResponse.Error("Too many requests", 429));
                 return;
             }
+        }
+
+        if (ctx.Request.HttpMethod == "OPTIONS")
+        {
+            ctx.Response.StatusCode = 204;
+            ctx.Response.Close();
+            return;
         }
 
         var path = ctx.Request.Url!.AbsolutePath;
@@ -435,10 +438,16 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (ex is JsonException)
             return ("Malformed JSON body", 400);
 
-        // EF Core unique-constraint violation (concurrent duplicate insert). SQLite's message
-        // contains "UNIQUE constraint failed"; EF wraps it in DbUpdateException. Treat as 409.
+        // EF Core constraint violation. #266 item 8: distinguish the two SQLite constraint codes —
+        // 2067 (SQLITE_CONSTRAINT_UNIQUE, a concurrent duplicate insert) is a genuine 409, while
+        // 19 (SQLITE_CONSTRAINT, in practice an FK violation after a concurrent DELETE removed the
+        // parent peer row) must not answer "already exists" for a resource that is GONE.
         if (ex is Microsoft.EntityFrameworkCore.DbUpdateException)
+        {
+            if (ex.InnerException is Microsoft.Data.Sqlite.SqliteException sqlite && sqlite.SqliteErrorCode == 19)
+                return ("The peer was removed while the change was being applied", 404);
             return ("The resource already exists or conflicts with the current state", 409);
+        }
 
         // Anything else: generic message, full detail logged server-side.
         return ("Internal server error", 500);
@@ -1508,12 +1517,23 @@ public sealed class ManagementApi : IHostedService, IDisposable
     private async Task WriteResponse(HttpListenerContext ctx, ApiResponse response)
     {
         ctx.Response.StatusCode = response.StatusCode;
-        ctx.Response.ContentType = "application/json";
-        // Pass the cached JsonSerializerOptions (#105 aot/perf) — without it, Serialize falls back to
-        // default per-call options (reflection + no caching), a perf regression on every response.
-        var json = JsonSerializer.Serialize(response.Body, _jsonOpts);
-        var bytes = Encoding.UTF8.GetBytes(json);
-        await ctx.Response.OutputStream.WriteAsync(bytes);
+        // #266 item 1: a handler may pin a content type (the txt prefix export sets text/plain);
+        // defaulting unconditionally made every such response double-serialized — JSON content
+        // type, JSON-quoted body with escaped newlines. Only JSON responses get the serializer.
+        if (string.IsNullOrEmpty(ctx.Response.ContentType))
+            ctx.Response.ContentType = "application/json";
+        if (response.Body is string raw && !string.Equals(ctx.Response.ContentType, "application/json", StringComparison.OrdinalIgnoreCase))
+        {
+            // A plain-string body with a pinned non-JSON content type is written verbatim.
+            await ctx.Response.OutputStream.WriteAsync(Encoding.UTF8.GetBytes(raw));
+        }
+        else
+        {
+            // Pass the cached JsonSerializerOptions (#105 aot/perf) — without it, Serialize falls back to
+            // default per-call options (reflection + no caching), a perf regression on every response.
+            var json = JsonSerializer.Serialize(response.Body, _jsonOpts);
+            await ctx.Response.OutputStream.WriteAsync(Encoding.UTF8.GetBytes(json));
+        }
         ctx.Response.Close();
     }
 
@@ -1550,7 +1570,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (origin is null) return;
         ctx.Response.Headers.Add("Access-Control-Allow-Origin", origin);
         ctx.Response.Headers.Add("Vary", "Origin");
-        ctx.Response.Headers.Add("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
+        ctx.Response.Headers.Add("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS");
         ctx.Response.Headers.Add("Access-Control-Allow-Headers", "Content-Type");
     }
 

--- a/BGPLite.Tests/ApiHandlerBehaviorTests.cs
+++ b/BGPLite.Tests/ApiHandlerBehaviorTests.cs
@@ -1,0 +1,163 @@
+using System.Net;
+using BGPLite.Api;
+using BGPLite.Configuration;
+using BGPLite.Contracts;
+using BGPLite.Providers;
+using BGPLite.Routing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #266 handler-level behavior that needs a real listener: the txt prefix export must not be
+/// double-serialized (item 1), the CORS preflight must advertise PATCH (item 2), and OPTIONS
+/// preflights consume the client's rate bucket instead of bypassing it (item 7).
+/// </summary>
+public sealed class ApiHandlerBehaviorTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private ManagementApi? _api;
+    private HttpClient? _client;
+    private int _port;
+
+    public ApiHandlerBehaviorTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        using (var boot = new BgpDbContext(new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(_connection).Options))
+            BgpDbContext.Initialize(boot);
+    }
+
+    public void Dispose()
+    {
+        try { _api?.StopAsync(CancellationToken.None).Wait(TimeSpan.FromSeconds(5)); } catch { /* best-effort */ }
+        _api?.Dispose();
+        _client?.Dispose();
+        _connection.Dispose();
+    }
+
+    private async Task<int> StartAsync(AppConfig template)
+    {
+        for (var attempt = 0; ; attempt++)
+        {
+            var port = FreeTcpPort();
+            var config = new AppConfig
+            {
+                Bgp = template.Bgp,
+                CorsAllowedOrigins = template.CorsAllowedOrigins,
+                ApiRateLimit = template.ApiRateLimit,
+                ApiListen = "127.0.0.1",
+                ApiPort = port,
+            };
+            _api = new ManagementApi(
+                new PeerStore(new StaticOptionsFactory(new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(_connection).Options)),
+                new RouteTable(),
+                config,
+                new BgpMetrics(),
+                NullLogger<ManagementApi>.Instance,
+                new InertPrefixService(),
+                new InertPrefixSources(),
+                new InertSessions());
+            try
+            {
+                await _api.StartAsync(CancellationToken.None);
+                return port;
+            }
+            catch (HttpListenerException) when (attempt < 2)
+            {
+                _api.Dispose();
+                _api = null;
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ExportTxt_PlaintextBody_NotJsonQuoted()
+    {
+        var store = new PeerStore(new StaticOptionsFactory(new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(_connection).Options));
+        var id = store.SavePeerConfiguration("198.51.100.7", 65090, null, [], [("10.0.0.0", (byte)8)], []);
+        _port = await StartAsync(new AppConfig { Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" } });
+        _client = new HttpClient();
+
+        using var response = await _client.GetAsync($"http://127.0.0.1:{_port}/api/peers/{id}/prefixes?format=txt");
+        var body = await response.Content.ReadAsStringAsync();
+
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.Equal("text/plain", response.Content.Headers.ContentType?.MediaType);
+        Assert.Equal("10.0.0.0/8", body.TrimEnd());   // RED pre-fix: "\"10.0.0.0/8\\n\"" with application/json
+    }
+
+    [Fact]
+    public async Task OptionsPreflight_AdvertisesPatch_AndConsumesRateBucket()
+    {
+        var config = new AppConfig
+        {
+            Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" },
+            CorsAllowedOrigins = ["http://example.com"],
+            ApiRateLimit = new ApiRateLimitConfig { Enabled = true, TokenLimit = 2, TokensPerPeriod = 1000, PeriodSeconds = 3600 },
+        };
+        _port = await StartAsync(config);
+        _client = new HttpClient();
+
+        var preflight = new HttpRequestMessage(HttpMethod.Options, $"http://127.0.0.1:{_port}/api/peers");
+        preflight.Headers.Add("Origin", "http://example.com");
+        using var first = await _client.SendAsync(preflight);
+        Assert.Equal(HttpStatusCode.NoContent, first.StatusCode);
+        Assert.Contains("PATCH", first.Headers.GetValues("Access-Control-Allow-Methods").First()); // RED pre-fix: no PATCH
+
+        var second = new HttpRequestMessage(HttpMethod.Options, $"http://127.0.0.1:{_port}/api/peers");
+        second.Headers.Add("Origin", "http://example.com");
+        using var ok = await _client.SendAsync(second);
+        Assert.Equal(HttpStatusCode.NoContent, ok.StatusCode);   // 2nd — bucket still has tokens
+
+        var third = new HttpRequestMessage(HttpMethod.Options, $"http://127.0.0.1:{_port}/api/peers");
+        third.Headers.Add("Origin", "http://example.com");
+        using var limited = await _client.SendAsync(third);
+        Assert.Equal(HttpStatusCode.TooManyRequests, limited.StatusCode);   // RED pre-fix: 204 forever
+    }
+
+    private static int FreeTcpPort()
+    {
+        using var socket = new System.Net.Sockets.Socket(System.Net.Sockets.AddressFamily.InterNetwork, System.Net.Sockets.SocketType.Stream, System.Net.Sockets.ProtocolType.Tcp);
+        socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        return ((IPEndPoint)socket.LocalEndPoint!).Port;
+    }
+
+    private sealed class StaticOptionsFactory(DbContextOptions<BgpDbContext> options) : IDbContextFactory<BgpDbContext>
+    {
+        public BgpDbContext CreateDbContext() => new(options);
+    }
+
+    private sealed class InertPrefixService : IPrefixService
+    {
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default) => Task.FromResult(new List<(uint, byte, uint)>());
+        public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
+        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default) => Task.FromResult(new List<(uint, byte, uint)>());
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private sealed class InertPrefixSources : IPrefixSourceService
+    {
+        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>> LoadAllAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<(uint Prefix, byte Length)>)>>([]);
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetDefaultAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);
+        public bool SourceSupportsConditional(string sourceName) => false;
+    }
+
+    private sealed class InertSessions : ISessionManager
+    {
+        public Task RefreshPeerAsync(string peerIp, uint asn) => Task.CompletedTask;
+        public List<string> GetActivePeerIps() => [];
+        public Task TerminatePeerAsync(string peerIp, uint asn, CancellationToken ct = default) => Task.CompletedTask;
+        public int GetAdvertisedPrefixCount(string peerIp, uint asn) => 0;
+        public Task RefreshAllEstablishedAsync() => Task.CompletedTask;
+    }
+}

--- a/BGPLite.Tests/ExceptionMappingTests.cs
+++ b/BGPLite.Tests/ExceptionMappingTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Data.Sqlite;
 using System.Text.Json;
 using BGPLite.Api;
 using Microsoft.EntityFrameworkCore;
@@ -85,5 +86,30 @@ public class ExceptionMappingTests
         var (message, status) = ManagementApi.MapExceptionToResponse(new OperationCanceledException());
         Assert.Equal(500, status);
         Assert.Equal("Internal server error", message);
+    }
+
+    /// <summary>
+    /// #266 item 8: an FK violation (SQLite code 19) after a concurrent DELETE removed the parent
+    /// peer row must answer 404 "removed", not 409 "already exists" for a resource that is gone.
+    /// </summary>
+    [Fact]
+    public void DbUpdateException_FkViolation_MapsTo_404()
+    {
+        var ex = new DbUpdateException("constraint failed", new SqliteException("FK constraint failed", 19));
+        var (message, status) = ManagementApi.MapExceptionToResponse(ex);
+
+        Assert.Equal(404, status);
+        Assert.Contains("removed", message);
+    }
+
+    [Fact]
+    public void DbUpdateException_UniqueViolation_Still409()
+    {
+        // SQLITE_CONSTRAINT_UNIQUE — a concurrent duplicate insert remains a genuine conflict.
+        var ex = new DbUpdateException("unique", new SqliteException("UNIQUE constraint failed: Peers.Ip", 2067));
+        var (message, status) = ManagementApi.MapExceptionToResponse(ex);
+
+        Assert.Equal(409, status);
+        Assert.Contains("exists", message);
     }
 }


### PR DESCRIPTION
Split from #266 (items 1, 2, 7, 8).

## Problem (per item)
1. `format=txt` export arrived JSON-quoted (WriteResponse forced application/json + serialized the joined string).
2. CORS `Allow-Methods` lacked PATCH though a PATCH route exists — browser UIs couldn't toggle source active.
3. OPTIONS preflight returned before the rate-limit check — unlimited cheap-preflight flood bounded only by the 64 in-flight slots.
4. Any `DbUpdateException` answered 409 "already exists" — including an FK violation after a concurrent DELETE removed the peer (a 404-shaped event).

## Fix
1. WriteResponse respects a handler-pinned ContentType and writes plain-string bodies verbatim.
2. PATCH added to Allow-Methods.
3. Rate-limit block moved above the OPTIONS short-circuit — preflights consume the client's bucket.
4. SQLite code discrimination: 19 (constraint/FK) → 404 "removed while applying"; 2067 (unique) → 409.

## Regression Tests
Listener-level `ExportTxt_PlaintextBody_NotJsonQuoted` and `OptionsPreflight_AdvertisesPatch_AndConsumesRateBucket` (204+PATCH → 204 → 429), plus the pure FK/Unique mapping pair. Red 3-of-4 on pre-fix code, green after.

## Verification
`dotnet format` / `dotnet build` (0 errors) / full suite **864/864**.

## RFC / Behavior Change
None on BGP wire; API: txt export is now actually plain text, preflights are rate-limited, FK-race errors read 404.