### PR TITLE
fix(api): reject unknown subscription list names at the boundary

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -793,6 +793,14 @@ public sealed class ManagementApi : IHostedService, IDisposable
         var asnLists = data.AsnLists ?? [];
         var customPrefixes = new List<(string Prefix, byte Length)>();
 
+        // #266 item 4: reject unknown subscription names at the boundary — a stored typo silently
+        // served zero prefixes from that list forever, with no signal on either side.
+        var unknownLists = FindUnknownSubscriptionNames(asnLists, _config);
+        if (unknownLists.Count > 0)
+            return ApiResponse.Error(
+                $"Unknown list name(s): {SanitizeForLog(string.Join(", ", unknownLists))}. " +
+                "See /api/asn-lists for the configured names.", 400);
+
         _logger.LogInformation("CreatePeer deserialized: AsnLists={Lists}, CustomPrefixes={Prefixes}, CustomAsns={Asns}",
             SanitizeForLog(string.Join(",", asnLists)), SanitizeForLog(string.Join(",", data.CustomPrefixes ?? [])),
             string.Join(",", data.CustomAsns ?? []));
@@ -908,6 +916,17 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // #259: one transaction for the whole update, same reasoning as the create path. A null
         // argument means "leave this alone" — the PATCH semantics this endpoint already had, now
         // expressed once in the store instead of as four conditional calls that each committed.
+        // #266 item 4: same boundary check on update — but only for names actually being SET
+        // (a null Lists field means "leave the subscriptions alone" and has nothing to validate).
+        if (data.Lists is not null)
+        {
+            var unknown = FindUnknownSubscriptionNames(data.Lists, _config);
+            if (unknown.Count > 0)
+                return ApiResponse.Error(
+                    $"Unknown list name(s): {SanitizeForLog(string.Join(", ", unknown))}. " +
+                    "See /api/asn-lists for the configured names.", 400);
+        }
+
         _store.UpdatePeerConfiguration(peerId, data.Description, data.Lists, parsedPrefixes, data.CustomAsns);
 
         _logger.LogInformation("Updated peer {Id}", SanitizeForLog(peerId));
@@ -1378,6 +1397,23 @@ public sealed class ManagementApi : IHostedService, IDisposable
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// #266 item 4: subscription names must match something actually configured — an unknown
+    /// name (typo, removed list) was stored and silently served zero prefixes forever. Returns
+    /// the unknown names, or an empty list when every name resolves against the configured
+    /// <c>RipeStat.AsnLists</c> or <c>PrefixSources</c>.
+    /// </summary>
+    internal static IReadOnlyList<string> FindUnknownSubscriptionNames(IEnumerable<string> names, AppConfig config)
+    {
+        var known = new HashSet<string>(StringComparer.Ordinal);
+        if (config.RipeStat?.AsnLists is { } lists)
+            foreach (var l in lists)
+                known.Add(l.Name);
+        foreach (var source in config.PrefixSources)
+            known.Add(source.Name);
+        return names.Where(n => !known.Contains(n)).Distinct(StringComparer.Ordinal).ToList();
     }
 
     /// <summary>

--- a/BGPLite.Tests/PeerInputValidationTests.cs
+++ b/BGPLite.Tests/PeerInputValidationTests.cs
@@ -1,3 +1,4 @@
+using BGPLite.Configuration;
 using BGPLite.Api;
 
 namespace BGPLite.Tests;
@@ -115,5 +116,27 @@ public class PeerInputValidationTests
     public void IsConfigurablePeerAsn_ReservedValuesDoNotBleedIntoNeighbours(uint asn)
     {
         Assert.True(ManagementApi.IsConfigurablePeerAsn(asn));
+    }
+
+    /// <summary>
+    /// #266 item 4: subscription names must resolve against the configured lists — an unknown
+    /// name was stored and silently served zero prefixes forever. Both config surfaces count as
+    /// known: RipeStat.AsnLists and PrefixSources.
+    /// </summary>
+    [Fact]
+    public void FindUnknownSubscriptionNames_FlagsTypos_KnowsBothSurfaces()
+    {
+        var config = new AppConfig
+        {
+            Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" },
+            RipeStat = new RipeStatConfig { AsnLists = [new AsnList { Name = "ru" }] },
+            PrefixSources = [new PrefixSourceConfig { Name = "cloud", Kind = "http", Url = "https://example.com/x" }],
+        };
+
+        Assert.Empty(ManagementApi.FindUnknownSubscriptionNames(["ru", "cloud"], config));
+        Assert.Empty(ManagementApi.FindUnknownSubscriptionNames([], config));
+
+        var unknown = ManagementApi.FindUnknownSubscriptionNames(["ru", "ru-backup", "Cloud"], config);
+        Assert.Equal(["ru-backup", "Cloud"], unknown);   // case-sensitive + typo both flagged
     }
 }


### PR DESCRIPTION
Split from #266 (item 4 — with this, every code item of the umbrella is handled; verdicts for 5/6 in the issue comment).

## Problem
Unknown subscription names (typo, renamed list) were stored and silently served zero prefixes forever — no error on either side.

## Fix
`FindUnknownSubscriptionNames` (internal, pure) resolves against both configured surfaces — `RipeStat.AsnLists` + `PrefixSources`, case-sensitive ordinal; CreatePeer and UpdatePeer answer 400 naming the unknown entries with a pointer to /api/asn-lists. UpdatePeer validates only a non-null Lists (null = leave alone).

## Regression Test
`FindUnknownSubscriptionNames_FlagsTypos_KnowsBothSurfaces` — red on an always-empty shim, green after.

## Verification
`dotnet format` / `dotnet build` (0 errors) / full suite 865/865.