### PR TITLE
fix(api): converge legacy Peers columns before the Init stamp

### DIFF
--- a/BGPLite.Api/BgpDbContext.cs
+++ b/BGPLite.Api/BgpDbContext.cs
@@ -39,6 +39,10 @@ public class BgpDbContext : DbContext
         {
             if (TableExists("Peers") && !TableExists("__EFMigrationsHistory"))
             {
+                // #264: converge the Peers COLUMN set before stamping — the converger migration
+                // reconciles child tables and indexes, never Peers' own columns.
+                ConvergeLegacyPeersColumns(connection);
+
                 // Pre-Migrations deployment: create the history table and stamp Init as applied —
                 // LegacyEnsureCreated (not stamped) then converges the residual drift via Migrate.
                 var efVersion = typeof(DbContext).Assembly.GetName().Version!.ToString();
@@ -61,6 +65,53 @@ public class BgpDbContext : DbContext
         // every peer starts inactive. A single ExecuteUpdate is atomic under SQLite.
         db.Peers.Where(p => p.Status == "active").ExecuteUpdate(
             s => s.SetProperty(p => p.Status, "inactive"));
+    }
+
+    /// <summary>
+    /// Expected <c>Peers</c> columns with the Init-migration DDL (#264). Nullable/defaulted only —
+    /// a required column without a default cannot be ALTERed onto existing rows, and
+    /// <see cref="ConvergeLegacyPeersColumns"/> refuses loudly for it instead of stamping an
+    /// unusable schema.
+    /// </summary>
+    private static readonly (string Name, string Ddl)[] ExpectedPeersColumns =
+    [
+        ("Id", "\"Id\" TEXT NOT NULL"),
+        ("Ip", "\"Ip\" TEXT NOT NULL"),
+        ("Asn", "\"Asn\" INTEGER NULL"),
+        ("Description", "\"Description\" TEXT NULL"),
+        ("Status", "\"Status\" TEXT NOT NULL DEFAULT 'inactive'"),
+        ("CreatedAt", "\"CreatedAt\" TEXT NOT NULL"),
+        ("LastSessionAt", "\"LastSessionAt\" TEXT NULL"),
+    ];
+
+    /// <summary>
+    /// #264: before the legacy stamp, converge the <c>Peers</c> column set. The converger MIGRATION
+    /// reconciles child tables and indexes but never Peers' own columns, so an early EnsureCreated-era
+    /// build missing one would stamp Init and fail its first raw write at runtime ("no such column").
+    /// </summary>
+    private static void ConvergeLegacyPeersColumns(System.Data.Common.DbConnection connection)
+    {
+        var existing = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        using (var cmd = connection.CreateCommand())
+        {
+            cmd.CommandText = "PRAGMA table_info(\"Peers\")";
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+                existing.Add(reader.GetString(1)); // column 1 = name
+        }
+
+        foreach (var (name, ddl) in ExpectedPeersColumns)
+        {
+            if (existing.Contains(name))
+                continue;
+            if (ddl.Contains("NOT NULL") && !ddl.Contains("DEFAULT", StringComparison.OrdinalIgnoreCase))
+                throw new InvalidOperationException(
+                    $"Legacy database is missing required column 'Peers.{name}' that cannot be added without a backfill. " +
+                    "Restore the database from a backup or migrate it manually before upgrading.");
+            using var alter = connection.CreateCommand();
+            alter.CommandText = $"ALTER TABLE \"Peers\" ADD COLUMN {ddl}";
+            alter.ExecuteNonQuery();
+        }
     }
 
     private const string InitMigrationId = "20260826182256_Init";

--- a/BGPLite.Tests/PeerStoreKeyingTests.cs
+++ b/BGPLite.Tests/PeerStoreKeyingTests.cs
@@ -259,6 +259,58 @@ public class PeerStoreKeyingTests
     }
 
     /// <summary>
+    /// #264: a legacy EnsureCreated-era database MISSING expected Peers columns (an early build
+    /// without Description/LastSessionAt) must be converged at Initialize — the stamp alone left
+    /// the first runtime write failing with "no such column".
+    /// </summary>
+    [Fact]
+    public void Initialize_LegacyDbMissingPeersColumns_ConvergesBeforeStamp()
+    {
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        // Early-build shape: no Description, no LastSessionAt, no Status default concerns.
+        using (var cmd = connection.CreateCommand())
+        {
+            cmd.CommandText =
+                "CREATE TABLE Peers (" +
+                "\"Id\" TEXT NOT NULL PRIMARY KEY, \"Ip\" TEXT NOT NULL, \"Asn\" INTEGER NULL, " +
+                "\"Status\" TEXT NOT NULL DEFAULT 'inactive', \"CreatedAt\" TEXT NOT NULL)";
+            cmd.ExecuteNonQuery();
+        }
+        var options = new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(connection).Options;
+
+        using (var boot = new BgpDbContext(options))
+            BgpDbContext.Initialize(boot);   // RED pre-fix: stamps without converging
+
+        // The columns now exist and a session-status write (the first raw write to touch
+        // LastSessionAt) succeeds instead of throwing "no such column".
+        string[] Columns()
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "PRAGMA table_info(\"Peers\")";
+            using var reader = cmd.ExecuteReader();
+            var names = new List<string>();
+            while (reader.Read())
+                names.Add(reader.GetString(1));
+            return [.. names];
+        }
+        Assert.Contains("Description", Columns());
+        Assert.Contains("LastSessionAt", Columns());
+
+        using (var db = new BgpDbContext(options))
+        {
+            db.Peers.Add(new BGPLite.Api.Entities.Peer { Id = "p1", Ip = "198.51.100.1", Asn = 65001, Description = "converged", LastSessionAt = DateTime.UtcNow });
+            db.SaveChanges();
+        }
+        using (var check = new BgpDbContext(options))
+        {
+            var peer = check.Peers.AsNoTracking().Single();
+            Assert.Equal("converged", peer.Description);
+            Assert.NotNull(peer.LastSessionAt);
+        }
+    }
+
+    /// <summary>
     /// #237: Initialize runs the EF migration pipeline — a fresh database gets Init +
     /// LegacyEnsureCreated applied in order and recorded in __EFMigrationsHistory, and a second
     /// startup is an idempotent no-op (Migrate() finds nothing pending).


### PR DESCRIPTION
Closes #264   # linkage; closure lands with the integration PR

## Problem
The legacy path stamped Init for ANY database with a Peers table and no \`__EFMigrationsHistory\`; the converger migration reconciles child tables and indexes — never Peers' own columns. An early build missing a column stamped cleanly and failed its first raw write at runtime ("no such column").

## Fix
`ConvergeLegacyPeersColumns` before the stamp: `PRAGMA table_info` against the expected Init-migration column set, guarded `ALTER TABLE ADD COLUMN` per missing column (all nullable/defaulted — safe for existing rows). A required-no-default column (none today) refuses loudly with a backup/restore pointer.

## Regression Test
`Initialize_LegacyDbMissingPeersColumns_ConvergesBeforeStamp` — early-build shape converges at Initialize; the first write touching both added columns succeeds. Red on stamp-only code.

## Verification
`dotnet format` / `dotnet build` (0 errors) / full suite **866/866** (fresh-db and idempotency tests unchanged).

## RFC / Behavior Change
None on the wire; startup: legacy DBs missing Peers columns now converge instead of failing at first write.