### PR TITLE
chore: integrate dev — per-peer prefix limit, shared ASN cache, API hardening, legacy converger

### DIFF
--- a/BGPLite.Api/BgpDbContext.cs
+++ b/BGPLite.Api/BgpDbContext.cs
@@ -39,6 +39,10 @@ public class BgpDbContext : DbContext
         {
             if (TableExists("Peers") && !TableExists("__EFMigrationsHistory"))
             {
+                // #264: converge the Peers COLUMN set before stamping — the converger migration
+                // reconciles child tables and indexes, never Peers' own columns.
+                ConvergeLegacyPeersColumns(connection);
+
                 // Pre-Migrations deployment: create the history table and stamp Init as applied —
                 // LegacyEnsureCreated (not stamped) then converges the residual drift via Migrate.
                 var efVersion = typeof(DbContext).Assembly.GetName().Version!.ToString();
@@ -61,6 +65,53 @@ public class BgpDbContext : DbContext
         // every peer starts inactive. A single ExecuteUpdate is atomic under SQLite.
         db.Peers.Where(p => p.Status == "active").ExecuteUpdate(
             s => s.SetProperty(p => p.Status, "inactive"));
+    }
+
+    /// <summary>
+    /// Expected <c>Peers</c> columns with the Init-migration DDL (#264). Nullable/defaulted only —
+    /// a required column without a default cannot be ALTERed onto existing rows, and
+    /// <see cref="ConvergeLegacyPeersColumns"/> refuses loudly for it instead of stamping an
+    /// unusable schema.
+    /// </summary>
+    private static readonly (string Name, string Ddl)[] ExpectedPeersColumns =
+    [
+        ("Id", "\"Id\" TEXT NOT NULL"),
+        ("Ip", "\"Ip\" TEXT NOT NULL"),
+        ("Asn", "\"Asn\" INTEGER NULL"),
+        ("Description", "\"Description\" TEXT NULL"),
+        ("Status", "\"Status\" TEXT NOT NULL DEFAULT 'inactive'"),
+        ("CreatedAt", "\"CreatedAt\" TEXT NOT NULL"),
+        ("LastSessionAt", "\"LastSessionAt\" TEXT NULL"),
+    ];
+
+    /// <summary>
+    /// #264: before the legacy stamp, converge the <c>Peers</c> column set. The converger MIGRATION
+    /// reconciles child tables and indexes but never Peers' own columns, so an early EnsureCreated-era
+    /// build missing one would stamp Init and fail its first raw write at runtime ("no such column").
+    /// </summary>
+    private static void ConvergeLegacyPeersColumns(System.Data.Common.DbConnection connection)
+    {
+        var existing = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        using (var cmd = connection.CreateCommand())
+        {
+            cmd.CommandText = "PRAGMA table_info(\"Peers\")";
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+                existing.Add(reader.GetString(1)); // column 1 = name
+        }
+
+        foreach (var (name, ddl) in ExpectedPeersColumns)
+        {
+            if (existing.Contains(name))
+                continue;
+            if (ddl.Contains("NOT NULL") && !ddl.Contains("DEFAULT", StringComparison.OrdinalIgnoreCase))
+                throw new InvalidOperationException(
+                    $"Legacy database is missing required column 'Peers.{name}' that cannot be added without a backfill. " +
+                    "Restore the database from a backup or migrate it manually before upgrading.");
+            using var alter = connection.CreateCommand();
+            alter.CommandText = $"ALTER TABLE \"Peers\" ADD COLUMN {ddl}";
+            alter.ExecuteNonQuery();
+        }
     }
 
     private const string InitMigrationId = "20260826182256_Init";

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -793,6 +793,14 @@ public sealed class ManagementApi : IHostedService, IDisposable
         var asnLists = data.AsnLists ?? [];
         var customPrefixes = new List<(string Prefix, byte Length)>();
 
+        // #266 item 4: reject unknown subscription names at the boundary — a stored typo silently
+        // served zero prefixes from that list forever, with no signal on either side.
+        var unknownLists = FindUnknownSubscriptionNames(asnLists, _config);
+        if (unknownLists.Count > 0)
+            return ApiResponse.Error(
+                $"Unknown list name(s): {SanitizeForLog(string.Join(", ", unknownLists))}. " +
+                "See /api/asn-lists for the configured names.", 400);
+
         _logger.LogInformation("CreatePeer deserialized: AsnLists={Lists}, CustomPrefixes={Prefixes}, CustomAsns={Asns}",
             SanitizeForLog(string.Join(",", asnLists)), SanitizeForLog(string.Join(",", data.CustomPrefixes ?? [])),
             string.Join(",", data.CustomAsns ?? []));
@@ -908,6 +916,17 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // #259: one transaction for the whole update, same reasoning as the create path. A null
         // argument means "leave this alone" — the PATCH semantics this endpoint already had, now
         // expressed once in the store instead of as four conditional calls that each committed.
+        // #266 item 4: same boundary check on update — but only for names actually being SET
+        // (a null Lists field means "leave the subscriptions alone" and has nothing to validate).
+        if (data.Lists is not null)
+        {
+            var unknown = FindUnknownSubscriptionNames(data.Lists, _config);
+            if (unknown.Count > 0)
+                return ApiResponse.Error(
+                    $"Unknown list name(s): {SanitizeForLog(string.Join(", ", unknown))}. " +
+                    "See /api/asn-lists for the configured names.", 400);
+        }
+
         _store.UpdatePeerConfiguration(peerId, data.Description, data.Lists, parsedPrefixes, data.CustomAsns);
 
         _logger.LogInformation("Updated peer {Id}", SanitizeForLog(peerId));
@@ -1378,6 +1397,23 @@ public sealed class ManagementApi : IHostedService, IDisposable
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// #266 item 4: subscription names must match something actually configured — an unknown
+    /// name (typo, removed list) was stored and silently served zero prefixes forever. Returns
+    /// the unknown names, or an empty list when every name resolves against the configured
+    /// <c>RipeStat.AsnLists</c> or <c>PrefixSources</c>.
+    /// </summary>
+    internal static IReadOnlyList<string> FindUnknownSubscriptionNames(IEnumerable<string> names, AppConfig config)
+    {
+        var known = new HashSet<string>(StringComparer.Ordinal);
+        if (config.RipeStat?.AsnLists is { } lists)
+            foreach (var l in lists)
+                known.Add(l.Name);
+        foreach (var source in config.PrefixSources)
+            known.Add(source.Name);
+        return names.Where(n => !known.Contains(n)).Distinct(StringComparer.Ordinal).ToList();
     }
 
     /// <summary>

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -444,7 +444,10 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // parent peer row) must not answer "already exists" for a resource that is GONE.
         if (ex is Microsoft.EntityFrameworkCore.DbUpdateException)
         {
-            if (ex.InnerException is Microsoft.Data.Sqlite.SqliteException sqlite && sqlite.SqliteErrorCode == 19)
+            // #377 review: BOTH constraint classes report primary code 19 in SqliteErrorCode;
+            // the discriminator is the EXTENDED code — 787 (SQLITE_CONSTRAINT_FOREIGNKEY) is the
+            // concurrent-DELETE case, anything else (2067 unique, 19 bare) is a genuine conflict.
+            if (ex.InnerException is Microsoft.Data.Sqlite.SqliteException sqlite && sqlite.SqliteExtendedErrorCode == 787)
                 return ("The peer was removed while the change was being applied", 404);
             return ("The resource already exists or conflicts with the current state", 409);
         }

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -352,13 +352,9 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         AddCorsHeaders(ctx);
 
-        if (ctx.Request.HttpMethod == "OPTIONS")
-        {
-            ctx.Response.StatusCode = 204;
-            ctx.Response.Close();
-            return;
-        }
-
+        // #266 item 7: rate-limit FIRST — the OPTIONS short-circuit used to return before this
+        // check, so an unlimited cheap-preflight flood was bounded only by the 64 in-flight
+        // slots. Preflights now consume the client's bucket like any other request.
         // Per-client-IP rate limit (#116) — 429 once the resolved client's token bucket is drained.
         if (rateLimiter is not null)
         {
@@ -370,6 +366,13 @@ public sealed class ManagementApi : IHostedService, IDisposable
                 await WriteResponse(ctx, ApiResponse.Error("Too many requests", 429));
                 return;
             }
+        }
+
+        if (ctx.Request.HttpMethod == "OPTIONS")
+        {
+            ctx.Response.StatusCode = 204;
+            ctx.Response.Close();
+            return;
         }
 
         var path = ctx.Request.Url!.AbsolutePath;
@@ -435,10 +438,16 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (ex is JsonException)
             return ("Malformed JSON body", 400);
 
-        // EF Core unique-constraint violation (concurrent duplicate insert). SQLite's message
-        // contains "UNIQUE constraint failed"; EF wraps it in DbUpdateException. Treat as 409.
+        // EF Core constraint violation. #266 item 8: distinguish the two SQLite constraint codes —
+        // 2067 (SQLITE_CONSTRAINT_UNIQUE, a concurrent duplicate insert) is a genuine 409, while
+        // 19 (SQLITE_CONSTRAINT, in practice an FK violation after a concurrent DELETE removed the
+        // parent peer row) must not answer "already exists" for a resource that is GONE.
         if (ex is Microsoft.EntityFrameworkCore.DbUpdateException)
+        {
+            if (ex.InnerException is Microsoft.Data.Sqlite.SqliteException sqlite && sqlite.SqliteErrorCode == 19)
+                return ("The peer was removed while the change was being applied", 404);
             return ("The resource already exists or conflicts with the current state", 409);
+        }
 
         // Anything else: generic message, full detail logged server-side.
         return ("Internal server error", 500);
@@ -1508,12 +1517,23 @@ public sealed class ManagementApi : IHostedService, IDisposable
     private async Task WriteResponse(HttpListenerContext ctx, ApiResponse response)
     {
         ctx.Response.StatusCode = response.StatusCode;
-        ctx.Response.ContentType = "application/json";
-        // Pass the cached JsonSerializerOptions (#105 aot/perf) — without it, Serialize falls back to
-        // default per-call options (reflection + no caching), a perf regression on every response.
-        var json = JsonSerializer.Serialize(response.Body, _jsonOpts);
-        var bytes = Encoding.UTF8.GetBytes(json);
-        await ctx.Response.OutputStream.WriteAsync(bytes);
+        // #266 item 1: a handler may pin a content type (the txt prefix export sets text/plain);
+        // defaulting unconditionally made every such response double-serialized — JSON content
+        // type, JSON-quoted body with escaped newlines. Only JSON responses get the serializer.
+        if (string.IsNullOrEmpty(ctx.Response.ContentType))
+            ctx.Response.ContentType = "application/json";
+        if (response.Body is string raw && !string.Equals(ctx.Response.ContentType, "application/json", StringComparison.OrdinalIgnoreCase))
+        {
+            // A plain-string body with a pinned non-JSON content type is written verbatim.
+            await ctx.Response.OutputStream.WriteAsync(Encoding.UTF8.GetBytes(raw));
+        }
+        else
+        {
+            // Pass the cached JsonSerializerOptions (#105 aot/perf) — without it, Serialize falls back to
+            // default per-call options (reflection + no caching), a perf regression on every response.
+            var json = JsonSerializer.Serialize(response.Body, _jsonOpts);
+            await ctx.Response.OutputStream.WriteAsync(Encoding.UTF8.GetBytes(json));
+        }
         ctx.Response.Close();
     }
 
@@ -1550,7 +1570,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (origin is null) return;
         ctx.Response.Headers.Add("Access-Control-Allow-Origin", origin);
         ctx.Response.Headers.Add("Vary", "Origin");
-        ctx.Response.Headers.Add("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
+        ctx.Response.Headers.Add("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS");
         ctx.Response.Headers.Add("Access-Control-Allow-Headers", "Content-Type");
     }
 

--- a/BGPLite.Api/PeerStore.cs
+++ b/BGPLite.Api/PeerStore.cs
@@ -155,7 +155,6 @@ public sealed class PeerStore : IPeerStore
     {
         using var db = _dbFactory.CreateDbContext();
         return db.Peers.AsNoTracking()
-            .Include(p => p.Communities)
             .Where(p => p.Ip == ip)
             .Select(p => MapToInfo(p))
             .ToList();
@@ -387,11 +386,13 @@ public sealed class PeerStore : IPeerStore
             s => s.SetProperty(p => p.Description, description));
     }
 
-    // AsNoTracking is a read-only-intent marker here — a no-op for this scalar projection (no entities are materialized to track).
+    // AsNoTracking is a read-only-intent marker here — a no-op for this scalar projection (no
+    // entities are materialized to track). #267 item 4: no Include — SelectMany over the
+    // navigation composes in SQL on its own; the Include was redundant load-hint noise.
     public HashSet<uint> GetCommunities(string peerId)
     {
         using var db = _dbFactory.CreateDbContext();
-        return db.Peers.AsNoTracking().Include(p => p.Communities)
+        return db.Peers.AsNoTracking()
             .Where(p => p.Id == peerId)
             .SelectMany(p => p.Communities)
             .Select(c => (uint)c.Community)
@@ -402,7 +403,7 @@ public sealed class PeerStore : IPeerStore
     public HashSet<uint> GetCommunities(string ip, uint asn)
     {
         using var db = _dbFactory.CreateDbContext();
-        return db.Peers.AsNoTracking().Include(p => p.Communities)
+        return db.Peers.AsNoTracking()
             .Where(p => p.Ip == ip && p.Asn == asn)
             .SelectMany(p => p.Communities)
             .Select(c => (uint)c.Community)
@@ -413,7 +414,7 @@ public sealed class PeerStore : IPeerStore
     public HashSet<uint> GetCommunitiesByIp(string ip)
     {
         using var db = _dbFactory.CreateDbContext();
-        return db.Peers.AsNoTracking().Include(p => p.Communities)
+        return db.Peers.AsNoTracking()
             .Where(p => p.Ip == ip)
             .SelectMany(p => p.Communities)
             .Select(c => (uint)c.Community)

--- a/BGPLite.Configuration/BgpConfig.cs
+++ b/BGPLite.Configuration/BgpConfig.cs
@@ -60,6 +60,13 @@ public sealed class BgpConfig
     [YamlMember(Alias = "MaxAcceptsPerIpPerMinute")]
     public int MaxAcceptsPerIpPerMinute { get; init; } = 60;
 
+    /// <summary>#304: per-peer ceiling on prefixes installed from one session (distinct
+    /// NLRI this session currently owns); exceeding it tears the session down with
+    /// NOTIFICATION(Cease, MaxPrefixesExceeded) per RFC 4271 §6.7 / RFC 4486 §2.
+    /// 0 = unlimited (the convention of OpenTimeoutSeconds / MaxAcceptsPerIpPerMinute).</summary>
+    [YamlMember(Alias = "MaxPrefixesPerPeer")]
+    public int MaxPrefixesPerPeer { get; init; } = 0;
+
     public IPAddress GetRouterIdAddress() => IPAddress.Parse(RouterId);
 
     /// <summary>
@@ -116,5 +123,9 @@ public sealed class BgpConfig
         if (MaxAcceptsPerIpPerMinute < 0)
             throw new InvalidOperationException(
                 $"Invalid configuration: Bgp.MaxAcceptsPerIpPerMinute must be >= 0 (got {MaxAcceptsPerIpPerMinute}).");
+
+        if (MaxPrefixesPerPeer < 0)
+            throw new InvalidOperationException(
+                $"Invalid configuration: Bgp.MaxPrefixesPerPeer must be >= 0, 0 = unlimited (got {MaxPrefixesPerPeer}).");
     }
 }

--- a/BGPLite.Protocol/AttributeHelper.cs
+++ b/BGPLite.Protocol/AttributeHelper.cs
@@ -98,9 +98,18 @@ public static class AttributeHelper
             throw new BgpParseException($"Malformed AGGREGATOR attribute: expected {expectedLength} bytes on a {(fourByteAsn ? "4-octet" : "2-octet")}-AS session, got {attr.Data.Length}",
                 BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.OptionalAttributeError);
 
-        return fourByteAsn
+        var asn = fourByteAsn
             ? BinaryPrimitives.ReadUInt32BigEndian(attr.Data)
             : BinaryPrimitives.ReadUInt16BigEndian(attr.Data);
+
+        // RFC 7607 §2: "an UPDATE with AS 0 in the AGGREGATOR ... MUST be considered as malformed
+        // and be handled by the procedures specified in [RFC7606]" — for AGGREGATOR that remedy
+        // is attribute discard (#306; was deliberately deferred from #300 until discard existed).
+        if (asn == 0)
+            throw new BgpParseException("Invalid AGGREGATOR attribute: AS 0 is reserved (RFC 7607)",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.OptionalAttributeError);
+
+        return asn;
     }
 
     /// <summary>
@@ -116,7 +125,15 @@ public static class AttributeHelper
             throw new BgpParseException($"Malformed AS4_AGGREGATOR attribute: expected 8 bytes, got {attr.Data.Length}",
                 BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.OptionalAttributeError);
 
-        return BinaryPrimitives.ReadUInt32BigEndian(attr.Data);
+        var asn = BinaryPrimitives.ReadUInt32BigEndian(attr.Data);
+
+        // RFC 7607 §2 — AS 0 in AS4_AGGREGATOR is malformed; RFC 7606 §7.8 assigns attribute
+        // discard (#306).
+        if (asn == 0)
+            throw new BgpParseException("Invalid AS4_AGGREGATOR attribute: AS 0 is reserved (RFC 7607)",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.OptionalAttributeError);
+
+        return asn;
     }
 
     public static PathAttribute WriteNextHop(uint nextHop)

--- a/BGPLite.Protocol/AttributeHelper.cs
+++ b/BGPLite.Protocol/AttributeHelper.cs
@@ -127,8 +127,8 @@ public static class AttributeHelper
 
         var asn = BinaryPrimitives.ReadUInt32BigEndian(attr.Data);
 
-        // RFC 7607 §2 — AS 0 in AS4_AGGREGATOR is malformed; RFC 7606 §7.8 assigns attribute
-        // discard (#306).
+        // RFC 7607 §2 — AS 0 in AS4_AGGREGATOR is malformed, handled per RFC 6793 §6:
+        // attribute discard (#306; RFC 7606 §7.8 is COMMUNITY).
         if (asn == 0)
             throw new BgpParseException("Invalid AS4_AGGREGATOR attribute: AS 0 is reserved (RFC 7607)",
                 BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.OptionalAttributeError);

--- a/BGPLite.Protocol/UpdateCodec.cs
+++ b/BGPLite.Protocol/UpdateCodec.cs
@@ -169,12 +169,15 @@ public static class UpdateCodec
     /// Validates RFC 6793 AGGREGATOR/AS4_AGGREGATOR consistency: AS_TRANS in AGGREGATOR requires
     /// AS4_AGGREGATOR, and a lone AS4_AGGREGATOR without AGGREGATOR is malformed.
     /// </summary>
-    public static void ValidateAggregatorReconstruction(uint? aggregatorAsn, uint? as4AggregatorAsn)
+    public static void ValidateAggregatorReconstruction(uint? aggregatorAsn, uint? as4AggregatorAsn, bool aggregatorDiscarded = false)
     {
         if (aggregatorAsn == BgpConstants.AsPath.AsTrans && as4AggregatorAsn is null)
             throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.OptionalAttributeError, "Missing AS4_AGGREGATOR for AGGREGATOR AS_TRANS");
 
-        if (!aggregatorAsn.HasValue && as4AggregatorAsn.HasValue)
+        // #306: an UPDATE that CARRIED an AGGREGATOR which was discarded as malformed must not be
+        // penalized for the pairing rule — the AS4 value alone satisfies everything BGPLite uses
+        // these attributes for (the consistency check itself).
+        if (!aggregatorAsn.HasValue && as4AggregatorAsn.HasValue && !aggregatorDiscarded)
             throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.OptionalAttributeError, "Missing AGGREGATOR attribute for AS4_AGGREGATOR");
     }
 
@@ -191,7 +194,8 @@ public static class UpdateCodec
         uint[] AsPath,
         uint NextHop,
         uint[] Communities,
-        (uint Global, uint Local1, uint Local2)[] LargeCommunities);
+        (uint Global, uint Local1, uint Local2)[] LargeCommunities,
+        IReadOnlyList<byte> DiscardedAttributes = null!);
 
     /// <summary>
     /// Parses and validates the path attributes of an announcing UPDATE per RFC 4271 §6.3 /
@@ -218,6 +222,8 @@ public static class UpdateCodec
             uint[] as4Path = [];
             uint? aggregatorAsn = null;
             uint? as4AggregatorAsn = null;
+            // (typeCode, reason) per RFC 7606 attribute-discard — surfaced for the session's log/metric.
+            var discarded = new List<(byte TypeCode, string Reason)>();
 
             // RFC 7606 §3 (revising RFC 4271 §6.3): "If any other attribute (whether recognized or
             // unrecognized) appears more than once in an UPDATE message, then all the occurrences of
@@ -293,11 +299,19 @@ public static class UpdateCodec
                     case BgpConstants.Attribute.LargeCommunity:
                         largeCommunities = AttributeHelper.ReadLargeCommunities(attr);
                         break;
+                    // #306 (RFC 7606 §7.7/§7.8): AGGREGATOR/AS4_AGGREGATOR malformations — wrong
+                    // length by session type, AS 0 (RFC 7607) — take ATTRIBUTE DISCARD, not
+                    // treat-as-withdraw: drop the attribute, keep processing the UPDATE. Both are
+                    // read solely for the RFC 6793 consistency check and never influence route
+                    // selection or installation, which is §2's constraint on this remedy. Flags
+                    // conflicts (ValidateAttributeShape above) stay treat-as-withdraw per §3.
                     case BgpConstants.Attribute.Aggregator:
-                        aggregatorAsn = AttributeHelper.ReadAggregatorAsn(attr, fourByteAsnSession);
+                        try { aggregatorAsn = AttributeHelper.ReadAggregatorAsn(attr, fourByteAsnSession); }
+                        catch (BgpParseException ex) { discarded.Add((attr.TypeCode, ex.Message)); }
                         break;
                     case BgpConstants.Attribute.As4Aggregator when !fourByteAsnSession:
-                        as4AggregatorAsn = AttributeHelper.ReadAs4AggregatorAsn(attr);
+                        try { as4AggregatorAsn = AttributeHelper.ReadAs4AggregatorAsn(attr); }
+                        catch (BgpParseException ex) { discarded.Add((attr.TypeCode, ex.Message)); }
                         break;
                 }
             }
@@ -310,9 +324,11 @@ public static class UpdateCodec
             if (nextHopSeen)
                 ValidateNextHopSemantics(nextHop, localRouterId);
             asPath = MergeAsPathWithAs4Path(asPath, as4Path);
-            ValidateAggregatorReconstruction(aggregatorAsn, as4AggregatorAsn);
+            var aggregatorDiscarded = discarded.Any(d => d.TypeCode == BgpConstants.Attribute.Aggregator);
+            ValidateAggregatorReconstruction(aggregatorAsn, as4AggregatorAsn, aggregatorDiscarded);
 
-            return new RouteAttributes(asPath, nextHop, communities, largeCommunities);
+            return new RouteAttributes(asPath, nextHop, communities, largeCommunities,
+                discarded.Select(d => d.TypeCode).ToArray());
         }
         catch (BgpParseException ex)
         {

--- a/BGPLite.Protocol/UpdateCodec.cs
+++ b/BGPLite.Protocol/UpdateCodec.cs
@@ -169,14 +169,14 @@ public static class UpdateCodec
     /// Validates RFC 6793 AGGREGATOR/AS4_AGGREGATOR consistency: AS_TRANS in AGGREGATOR requires
     /// AS4_AGGREGATOR, and a lone AS4_AGGREGATOR without AGGREGATOR is malformed.
     /// </summary>
-    public static void ValidateAggregatorReconstruction(uint? aggregatorAsn, uint? as4AggregatorAsn, bool aggregatorDiscarded = false)
+    public static void ValidateAggregatorReconstruction(uint? aggregatorAsn, uint? as4AggregatorAsn, bool aggregatorDiscarded = false, bool as4AggregatorDiscarded = false)
     {
-        if (aggregatorAsn == BgpConstants.AsPath.AsTrans && as4AggregatorAsn is null)
+        // #306/#377 review: a discarded-malformed attribute must not penalize the pairing rules —
+        // the UPDATE carried it; it was dropped per RFC 7606 §7.7 (AGGREGATOR) / RFC 6793 §6
+        // (AS4_AGGREGATOR), and what remains satisfies everything the check exists for.
+        if (aggregatorAsn == BgpConstants.AsPath.AsTrans && as4AggregatorAsn is null && !as4AggregatorDiscarded)
             throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.OptionalAttributeError, "Missing AS4_AGGREGATOR for AGGREGATOR AS_TRANS");
 
-        // #306: an UPDATE that CARRIED an AGGREGATOR which was discarded as malformed must not be
-        // penalized for the pairing rule — the AS4 value alone satisfies everything BGPLite uses
-        // these attributes for (the consistency check itself).
         if (!aggregatorAsn.HasValue && as4AggregatorAsn.HasValue && !aggregatorDiscarded)
             throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.OptionalAttributeError, "Missing AGGREGATOR attribute for AS4_AGGREGATOR");
     }
@@ -299,12 +299,15 @@ public static class UpdateCodec
                     case BgpConstants.Attribute.LargeCommunity:
                         largeCommunities = AttributeHelper.ReadLargeCommunities(attr);
                         break;
-                    // #306 (RFC 7606 §7.7/§7.8): AGGREGATOR/AS4_AGGREGATOR malformations — wrong
-                    // length by session type, AS 0 (RFC 7607) — take ATTRIBUTE DISCARD, not
-                    // treat-as-withdraw: drop the attribute, keep processing the UPDATE. Both are
-                    // read solely for the RFC 6793 consistency check and never influence route
-                    // selection or installation, which is §2's constraint on this remedy. Flags
-                    // conflicts (ValidateAttributeShape above) stay treat-as-withdraw per §3.
+                    // #306: AGGREGATOR/AS4_AGGREGATOR malformations — wrong length by session
+                    // type, AS 0 (RFC 7607) — take ATTRIBUTE DISCARD, not treat-as-withdraw: drop
+                    // the attribute, keep processing the UPDATE. Citations differ per attribute:
+                    // AGGREGATOR per RFC 7606 §7.7; AS4_AGGREGATOR per RFC 6793 §6 ("the
+                    // AS4_AGGREGATOR is just informational, the 'attribute discard' approach is
+                    // chosen" — RFC 7606 §7.8 is COMMUNITY and §7 explicitly excludes attribute 18).
+                    // Both feed only the RFC 6793 consistency check and never influence route
+                    // selection/installation — RFC 7606 §2's constraint. Flags conflicts
+                    // (ValidateAttributeShape above) stay treat-as-withdraw per §3.
                     case BgpConstants.Attribute.Aggregator:
                         try { aggregatorAsn = AttributeHelper.ReadAggregatorAsn(attr, fourByteAsnSession); }
                         catch (BgpParseException ex) { discarded.Add((attr.TypeCode, ex.Message)); }
@@ -324,8 +327,9 @@ public static class UpdateCodec
             if (nextHopSeen)
                 ValidateNextHopSemantics(nextHop, localRouterId);
             asPath = MergeAsPathWithAs4Path(asPath, as4Path);
-            var aggregatorDiscarded = discarded.Any(d => d.TypeCode == BgpConstants.Attribute.Aggregator);
-            ValidateAggregatorReconstruction(aggregatorAsn, as4AggregatorAsn, aggregatorDiscarded);
+            ValidateAggregatorReconstruction(aggregatorAsn, as4AggregatorAsn,
+                aggregatorDiscarded: discarded.Any(d => d.TypeCode == BgpConstants.Attribute.Aggregator),
+                as4AggregatorDiscarded: discarded.Any(d => d.TypeCode == BgpConstants.Attribute.As4Aggregator));
 
             return new RouteAttributes(asPath, nextHop, communities, largeCommunities,
                 discarded.Select(d => d.TypeCode).ToArray());

--- a/BGPLite.Providers/AsnPrefixProvider.cs
+++ b/BGPLite.Providers/AsnPrefixProvider.cs
@@ -5,21 +5,24 @@ namespace BGPLite.Providers;
 
 /// <summary>
 /// Loads the prefixes originated by a single AS via RIPEstat (Kind = <c>"asn"</c>).
-/// Requires <see cref="PrefixSourceConfig.Asn"/>. Shares the RIPEstat client, retry, and per-ASN
-/// caching of <see cref="RipeStatProvider"/>/PrefixService, so adding it as a <c>Kind: asn</c>
-/// source under <c>PrefixSources</c> does not multiply RIPEstat traffic.
+/// Requires <see cref="PrefixSourceConfig.Asn"/>. Goes through the SHARED per-ASN cache
+/// (<see cref="RipeStatPrefixCache"/>, #267 item 5) — the same instance PrefixService uses for
+/// <c>RipeStat.AsnLists</c> and custom ASNs — so an ASN configured in both mechanisms is fetched
+/// and cached once (the previous direct-to-wire path doubled RIPEstat traffic and served
+/// disagreeing snapshots with independent TTLs).
 /// <para>RIPEstat does not support ETag / Last-Modified — the <paramref name="etag"/> and
 /// <paramref name="lastModified"/> parameters are ignored. Content-change detection for auto-refresh
-/// (#214) is handled by hash comparison in <see cref="PrefixSourceService"/> (the cache layer).</para>
+/// (#214) stays at the source-NAME level: hash comparison in <see cref="PrefixSourceService"/> over
+/// this provider's (cache-served) result.</para>
 /// </summary>
 public sealed class AsnPrefixProvider : IPrefixSourceProvider
 {
-    private readonly RipeStatProvider _ripe;
+    private readonly RipeStatPrefixCache _cache;
     private readonly ILogger<AsnPrefixProvider> _logger;
 
-    public AsnPrefixProvider(RipeStatProvider ripe, ILogger<AsnPrefixProvider> logger)
+    public AsnPrefixProvider(RipeStatPrefixCache cache, ILogger<AsnPrefixProvider> logger)
     {
-        _ripe = ripe;
+        _cache = cache;
         _logger = logger;
     }
 
@@ -41,10 +44,10 @@ public sealed class AsnPrefixProvider : IPrefixSourceProvider
         if (!source.Asn.HasValue)
             throw new InvalidOperationException($"Prefix source '{source.Name}': Kind=asn requires an Asn.");
 
-        var prefixes = await _ripe.GetPrefixesAsync(source.Asn.Value, ct);
+        var prefixes = await _cache.GetPrefixesAsync(source.Asn.Value, ct);
         _logger.LogInformation(
             "Source '{Name}' (asn AS{Asn}): loaded {Count} prefixes via RIPEstat",
             source.Name, source.Asn.Value, prefixes.Count);
-        return SourceLoadResult.Ok(prefixes.Select(p => (Prefix: p.Prefix, Length: p.PrefixLength)).ToList());
+        return SourceLoadResult.Ok(prefixes.Select(p => (Prefix: p.Prefix, Length: p.Length)).ToList());
     }
 }

--- a/BGPLite.Providers/AsnPrefixProvider.cs
+++ b/BGPLite.Providers/AsnPrefixProvider.cs
@@ -44,7 +44,9 @@ public sealed class AsnPrefixProvider : IPrefixSourceProvider
         if (!source.Asn.HasValue)
             throw new InvalidOperationException($"Prefix source '{source.Name}': Kind=asn requires an Asn.");
 
-        var prefixes = await _cache.GetPrefixesAsync(source.Asn.Value, ct);
+        // serveNegativeEntries: false (#377 review) — a cached failure must propagate (throw), not
+        // come back as an empty list the name-level cache would store as a POSITIVE result.
+        var prefixes = await _cache.GetPrefixesAsync(source.Asn.Value, ct, serveNegativeEntries: false);
         _logger.LogInformation(
             "Source '{Name}' (asn AS{Asn}): loaded {Count} prefixes via RIPEstat",
             source.Name, source.Asn.Value, prefixes.Count);

--- a/BGPLite.Providers/PrefixService.cs
+++ b/BGPLite.Providers/PrefixService.cs
@@ -7,24 +7,16 @@ namespace BGPLite.Providers;
 
 public sealed class PrefixService : IPrefixService
 {
-    private readonly RipeStatProvider _ripeStat;
+    // #267 item 5: the per-ASN RIPEstat cache is a shared component — PrefixService (RipeStat
+    // AsnLists + custom ASNs) and AsnPrefixProvider (Kind: asn sources) consume ONE instance, so
+    // an ASN configured in both mechanisms is fetched and cached once. TTL/stale-on-failure/
+    // negative-cache/eviction (#163/#164/#165) live there now.
+    private readonly RipeStatPrefixCache _ripeStatCache;
     private readonly IPrefixSourceService _prefixSources;
     private readonly AppConfig _config;
     private readonly HttpPrefixProvider _httpProvider;
-    // asn → (prefix list, cached at, is negative). Negative entries (failed RIPEstat fetches) use
-    // _negativeTtl. The tuple is shaped to mirror PrefixSourceService so the resilience semantics
-    // (stale-on-failure, negative cache, bounded sweep) are identical across both caches.
-    private readonly ConcurrentDictionary<uint, (IReadOnlyList<(uint Prefix, byte Length)> Data, DateTime CachedAt, bool Negative)> _cache = new();
-    // asn → gate serializing the cache-miss fetch path (prevents thundering herd on cold/expired
-    // ASNs — #164). Mirrors PrefixSourceService._locks.
-    private readonly ConcurrentDictionary<uint, SemaphoreSlim> _locks = new();
-    private readonly TimeSpan _cacheTtl;
-    private readonly TimeSpan _negativeTtl;
-    // Upper bound on _cache/_locks entries (#165). Without a cap, a malicious or churning peer
-    // querying distinct ASNs grows the dictionaries without limit. Exceeded → least-recently-used
-    // sweep before insert. The configured ASN universe is small (operator AsnLists), so a generous
-    // default does not constrain real deployments.
-    private readonly int _maxCacheEntries;
+    // Freshness of the RU/default projection cache below (the per-ASN TTL moved to the shared cache).
+    private readonly TimeSpan _ruCacheTtl;
     private readonly ILogger<PrefixService>? _logger;
     private readonly TimeProvider _timeProvider;
     private readonly UserSourceCache _userSourceCache;
@@ -34,18 +26,13 @@ public sealed class PrefixService : IPrefixService
     // when the TTL elapses. Mirrors the per-ASN gate pattern in GetPrefixesAsync.
     private readonly SemaphoreSlim _ruGate = new(1, 1);
 
-    public PrefixService(AppConfig config, RipeStatProvider ripeStat, IPrefixSourceService prefixSources, HttpPrefixProvider httpProvider, TimeSpan? cacheTtl = null, ILogger<PrefixService>? logger = null, TimeSpan? negativeTtl = null, int? maxCacheEntries = null, TimeProvider? timeProvider = null, int? userSourceTimeoutSeconds = null)
+    public PrefixService(AppConfig config, RipeStatPrefixCache ripeStatCache, IPrefixSourceService prefixSources, HttpPrefixProvider httpProvider, TimeSpan? ruCacheTtl = null, ILogger<PrefixService>? logger = null, TimeProvider? timeProvider = null, int? userSourceTimeoutSeconds = null)
     {
         _config = config;
-        _ripeStat = ripeStat;
+        _ripeStatCache = ripeStatCache;
         _prefixSources = prefixSources;
         _httpProvider = httpProvider;
-        _cacheTtl = cacheTtl ?? TimeSpan.FromHours(1);
-        _negativeTtl = negativeTtl ?? TimeSpan.FromSeconds(30);
-        // 2× a generous operator-configured ASN universe (a route server typically tracks tens to
-        // low-hundreds of origin ASNs). The cap defends against unbounded growth from adversarial /
-        // churn traffic, not normal operation.
-        _maxCacheEntries = maxCacheEntries ?? 4096;
+        _ruCacheTtl = ruCacheTtl ?? TimeSpan.FromHours(1);
         _logger = logger;
         _timeProvider = timeProvider ?? TimeProvider.System;
         // #320: fetch budget for peer-supplied URL sources — generous for a real prefix list
@@ -94,115 +81,11 @@ public sealed class PrefixService : IPrefixService
         }, ct);
     }
 
-    public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
-    {
-        // Fast path: fresh entry (positive or negative within its TTL).
-        if (TryGetFresh(asn, out var fresh))
-            return fresh;
-
-        // Serialize per-ASN so concurrent callers share a single RIPEstat fetch — no thundering herd
-        // on a cold or just-expired ASN (#164). Mirrors PrefixSourceService.LoadCachedAsync.
-        var gate = _locks.GetOrAdd(asn, _ => new SemaphoreSlim(1, 1));
-        await gate.WaitAsync(ct);
-        try
-        {
-            // Re-check after acquiring the lock: another caller may have just populated the entry.
-            if (TryGetFresh(asn, out var rechecked))
-                return rechecked;
-
-            IReadOnlyList<(uint Prefix, byte Length)> prefixes;
-            try
-            {
-                prefixes = await _ripeStat.GetPrefixesAsync(asn, ct);
-            }
-            catch (OperationCanceledException) { throw; }
-            catch (Exception ex)
-            {
-                // Stale-on-failure (#163): serve the last good copy regardless of its age so a
-                // transient RIPEstat outage (429/5xx/network) does not drop the ASN's routes the
-                // instant its TTL elapses. Asymmetric with the old behavior — previously the throw
-                // propagated and (via GetPrefixesForAsns) the ASN's prefixes vanished from peers.
-                if (_cache.TryGetValue(asn, out var stale) && !stale.Negative)
-                {
-                    _logger?.LogWarning(ex,
-                        "AS{Asn}: RIPEstat fetch failed; serving cached copy ({Count} prefixes).", asn, stale.Data.Count);
-                    return stale.Data;
-                }
-
-                // No cached copy: remember the failure briefly so repeated calls don't hammer RIPEstat.
-                EvictIfAtCapacity(asn);
-                _cache[asn] = ([], _timeProvider.GetUtcNow().UtcDateTime, Negative: true);
-                throw;
-            }
-
-            EvictIfAtCapacity(asn);
-            _cache[asn] = (prefixes, _timeProvider.GetUtcNow().UtcDateTime, Negative: false);
-            return prefixes;
-        }
-        finally
-        {
-            gate.Release();
-        }
-    }
-
-    /// <summary>True if <paramref name="asn"/> has a non-expired entry (positive within _cacheTtl,
-    /// negative within _negativeTtl).</summary>
-    private bool TryGetFresh(uint asn, out IReadOnlyList<(uint Prefix, byte Length)> data)
-    {
-        data = null!;
-        if (!_cache.TryGetValue(asn, out var entry)) return false;
-
-        var ttl = entry.Negative ? _negativeTtl : _cacheTtl;
-        if (_timeProvider.GetUtcNow().UtcDateTime - entry.CachedAt < ttl)
-        {
-            data = entry.Data;
-            return true;
-        }
-        return false;
-    }
-
-    /// <summary>Enforces the _maxCacheEntries bound (#165). Called before inserting a NEW key.
-    /// Removes a few least-recently-cached entries (by CachedAt) plus any expired entries it
-    /// encounters, and drops the corresponding _locks entries. Under the lock of the caller's
-    /// per-ASN gate, so the sweep is serialized against itself; ConcurrentDictionary enumeration
-    /// is a snapshot and safe against concurrent writers.</summary>
-    private void EvictIfAtCapacity(uint insertingKey)
-    {
-        if (_cache.Count < _maxCacheEntries) return;
-        if (_cache.ContainsKey(insertingKey)) return; // already present, no insert coming
-
-        // Snapshot, drop expired entries first (cheapest eviction), then by oldest CachedAt.
-        var now = _timeProvider.GetUtcNow().UtcDateTime;
-        var toEvict = new List<uint>();
-        foreach (var (key, entry) in _cache)
-        {
-            var ttl = entry.Negative ? _negativeTtl : _cacheTtl;
-            if (now - entry.CachedAt >= ttl)
-                toEvict.Add(key);
-        }
-        // If still at/over capacity after dropping expired, evict the oldest until below the cap.
-        if (_cache.Count - toEvict.Count >= _maxCacheEntries)
-        {
-            var oldest = _cache
-                .Where(kvp => !toEvict.Contains(kvp.Key))
-                .OrderBy(kvp => kvp.Value.CachedAt)
-                .Select(kvp => kvp.Key);
-            foreach (var key in oldest)
-            {
-                toEvict.Add(key);
-                if (_cache.Count - toEvict.Count < _maxCacheEntries) break;
-            }
-        }
-
-        foreach (var key in toEvict)
-        {
-            // TryUpdate/TryRemove under no per-key lock: a concurrent fetch for this key may be
-            // racing, but that's fine — it will re-populate the entry; losing a transient cache hit
-            // is acceptable, and never losing correctness.
-            if (_cache.TryRemove(key, out _))
-                _locks.TryRemove(key, out _);
-        }
-    }
+    public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
+        // Per-ASN caching, stale-on-failure, negative TTL, fetch gates, and the #165 eviction
+        // sweep all live in the shared cache (#267 item 5) — one wire fetch per ASN regardless
+        // of which mechanism asked.
+        => _ripeStatCache.GetPrefixesAsync(asn, ct);
 
     /// <summary>Bounds how many ASNs are resolved against RIPEstat concurrently on a cold cache
     /// (warm traffic is cache-flat). Keeps cold-start fan-out from tripping RIPEstat rate limits.</summary>
@@ -302,7 +185,7 @@ public sealed class PrefixService : IPrefixService
         // Fast path: fresh entry. A single Volatile.Read of the immutable entry reference gives a
         // consistent (projection, ticks) snapshot — no two-field torn read.
         var cached = Volatile.Read(ref _ruCache);
-        if (cached is not null && _timeProvider.GetUtcNow().UtcDateTime.Ticks - cached.CachedAtTicks < _cacheTtl.Ticks)
+        if (cached is not null && _timeProvider.GetUtcNow().UtcDateTime.Ticks - cached.CachedAtTicks < _ruCacheTtl.Ticks)
             return cached.Projected;
 
         // Serialize the cache-miss fetch so concurrent callers share one default-source fetch
@@ -312,7 +195,7 @@ public sealed class PrefixService : IPrefixService
         {
             // Re-check under the lock: another caller may have just populated the entry.
             cached = Volatile.Read(ref _ruCache);
-            if (cached is not null && _timeProvider.GetUtcNow().UtcDateTime.Ticks - cached.CachedAtTicks < _cacheTtl.Ticks)
+            if (cached is not null && _timeProvider.GetUtcNow().UtcDateTime.Ticks - cached.CachedAtTicks < _ruCacheTtl.Ticks)
                 return cached.Projected;
 
             List<(uint Prefix, byte Length, uint Asn)> projected;

--- a/BGPLite.Providers/RipeStatPrefixCache.cs
+++ b/BGPLite.Providers/RipeStatPrefixCache.cs
@@ -13,6 +13,13 @@ namespace BGPLite.Providers;
 /// separate TTLs — an ASN configured in both doubled RIPEstat traffic and could serve
 /// disagreeing snapshots.
 /// <para>
+/// <para>
+/// #377 review: the negative-entry fast path serves [] to callers that accept the
+/// "nothing this cycle" semantic (the RouteAssembler fan-out). A SOURCE provider must pass
+/// <c>serveNegativeEntries: false</c> — wrapping a cached failure into SourceLoadResult.Ok([])
+/// would store a positive empty list in the name-level cache and mark the source changed,
+/// withdrawing a previously-good advertisement over a transient RIPEstat blip.
+/// </para>
 /// Shape (moved verbatim from <see cref="PrefixService"/>): per-ASN TTL cache with
 /// stale-on-failure (#163), short negative TTL for failed fetches, per-ASN fetch gates against
 /// thundering herds (#164), and a capacity cap with the #165 eviction sweep.
@@ -57,10 +64,12 @@ public sealed class RipeStatPrefixCache
         _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
-    public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
+    public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default, bool serveNegativeEntries = true)
     {
-        // Fast path: fresh entry (positive or negative within its TTL).
-        if (TryGetFresh(asn, out var fresh))
+        // Fast path: fresh entry (positive, or negative within its TTL when the caller accepts
+        // the []-on-recent-failure semantic — the RouteAssembler fan-out does; a source provider
+        // must NOT, see the class doc).
+        if (TryGetFresh(asn, out var fresh) && (serveNegativeEntries || !IsNegative(asn)))
             return fresh;
 
         // Serialize per-ASN so concurrent callers share a single RIPEstat fetch — no thundering herd
@@ -69,8 +78,10 @@ public sealed class RipeStatPrefixCache
         await gate.WaitAsync(ct);
         try
         {
-            // Re-check after acquiring the lock: another caller may have just populated the entry.
-            if (TryGetFresh(asn, out var rechecked))
+            // Re-check after acquiring the lock: another caller may have just populated the entry
+            // (with the same negative-entry discriminator as the outer fast path — #377 review:
+            // forgetting it here re-introduces exactly the Ok([]) hole the provider opts out of).
+            if (TryGetFresh(asn, out var rechecked) && (serveNegativeEntries || !IsNegative(asn)))
                 return rechecked;
 
             IReadOnlyList<(uint Prefix, byte Length)> prefixes;
@@ -106,6 +117,10 @@ public sealed class RipeStatPrefixCache
             gate.Release();
         }
     }
+
+    /// <summary>True when the fresh entry for <paramref name="asn"/> is a NEGATIVE (recent-failure) one.</summary>
+    private bool IsNegative(uint asn) =>
+        _cache.TryGetValue(asn, out var entry) && entry.Negative;
 
     /// <summary>True if <paramref name="asn"/> has a non-expired entry (positive within _cacheTtl,
     /// negative within _negativeTtl).</summary>

--- a/BGPLite.Providers/RipeStatPrefixCache.cs
+++ b/BGPLite.Providers/RipeStatPrefixCache.cs
@@ -69,7 +69,7 @@ public sealed class RipeStatPrefixCache
         // Fast path: fresh entry (positive, or negative within its TTL when the caller accepts
         // the []-on-recent-failure semantic — the RouteAssembler fan-out does; a source provider
         // must NOT, see the class doc).
-        if (TryGetFresh(asn, out var fresh) && (serveNegativeEntries || !IsNegative(asn)))
+        if (TryGetFresh(asn, out var fresh, out var freshIsNegative) && (serveNegativeEntries || !freshIsNegative))
             return fresh;
 
         // Serialize per-ASN so concurrent callers share a single RIPEstat fetch — no thundering herd
@@ -81,7 +81,7 @@ public sealed class RipeStatPrefixCache
             // Re-check after acquiring the lock: another caller may have just populated the entry
             // (with the same negative-entry discriminator as the outer fast path — #377 review:
             // forgetting it here re-introduces exactly the Ok([]) hole the provider opts out of).
-            if (TryGetFresh(asn, out var rechecked) && (serveNegativeEntries || !IsNegative(asn)))
+            if (TryGetFresh(asn, out var rechecked, out var recheckIsNegative) && (serveNegativeEntries || !recheckIsNegative))
                 return rechecked;
 
             IReadOnlyList<(uint Prefix, byte Length)> prefixes;
@@ -118,21 +118,21 @@ public sealed class RipeStatPrefixCache
         }
     }
 
-    /// <summary>True when the fresh entry for <paramref name="asn"/> is a NEGATIVE (recent-failure) one.</summary>
-    private bool IsNegative(uint asn) =>
-        _cache.TryGetValue(asn, out var entry) && entry.Negative;
-
     /// <summary>True if <paramref name="asn"/> has a non-expired entry (positive within _cacheTtl,
-    /// negative within _negativeTtl).</summary>
-    private bool TryGetFresh(uint asn, out IReadOnlyList<(uint Prefix, byte Length)> data)
+    /// negative within _negativeTtl). #377 review: the negative flag comes out of the SAME read —
+    /// a separate IsNegative lookup could miss an eviction racing between the two and serve a
+    /// captured [] to a caller that opted out of negatives.</summary>
+    private bool TryGetFresh(uint asn, out IReadOnlyList<(uint Prefix, byte Length)> data, out bool isNegative)
     {
         data = null!;
+        isNegative = false;
         if (!_cache.TryGetValue(asn, out var entry)) return false;
 
         var ttl = entry.Negative ? _negativeTtl : _cacheTtl;
         if (_timeProvider.GetUtcNow().UtcDateTime - entry.CachedAt < ttl)
         {
             data = entry.Data;
+            isNegative = entry.Negative;
             return true;
         }
         return false;

--- a/BGPLite.Providers/RipeStatPrefixCache.cs
+++ b/BGPLite.Providers/RipeStatPrefixCache.cs
@@ -1,0 +1,168 @@
+using System.Collections.Concurrent;
+using BGPLite.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace BGPLite.Providers;
+
+/// <summary>
+/// The single per-ASN RIPEstat prefix cache (#267 item 5). Every consumer of RIPEstat
+/// per-ASN data goes through one instance of this class — the legacy
+/// <c>RipeStat.AsnLists</c>/custom-ASN path (<see cref="PrefixService"/>) and
+/// <c>PrefixSources</c> entries of <c>Kind: asn</c> (<see cref="AsnPrefixProvider"/>).
+/// Before it existed the two mechanisms fetched and cached the same ASN independently with
+/// separate TTLs — an ASN configured in both doubled RIPEstat traffic and could serve
+/// disagreeing snapshots.
+/// <para>
+/// Shape (moved verbatim from <see cref="PrefixService"/>): per-ASN TTL cache with
+/// stale-on-failure (#163), short negative TTL for failed fetches, per-ASN fetch gates against
+/// thundering herds (#164), and a capacity cap with the #165 eviction sweep.
+/// </para>
+/// </summary>
+public sealed class RipeStatPrefixCache
+{
+    private readonly RipeStatProvider _ripe;
+    private readonly ILogger<RipeStatPrefixCache>? _logger;
+    private readonly TimeSpan _cacheTtl;
+    private readonly TimeSpan _negativeTtl;
+    // Upper bound on _cache/_locks entries (#165). Without a cap, a malicious or churning peer
+    // querying distinct ASNs grows the dictionaries without limit. Exceeded → least-recently-used
+    // sweep before insert. The configured ASN universe is small (operator AsnLists), so a generous
+    // default does not constrain real deployments.
+    private readonly int _maxCacheEntries;
+    private readonly TimeProvider _timeProvider;
+    // asn → (prefix list, cached at, is negative). Negative entries (failed RIPEstat fetches) use
+    // _negativeTtl. The tuple is shaped to mirror PrefixSourceService so the resilience semantics
+    // (stale-on-failure, negative cache, bounded sweep) are identical across both caches.
+    private readonly ConcurrentDictionary<uint, (IReadOnlyList<(uint Prefix, byte Length)> Data, DateTime CachedAt, bool Negative)> _cache = new();
+    // asn → gate serializing the cache-miss fetch path (prevents thundering herd on cold/expired
+    // ASNs — #164).
+    private readonly ConcurrentDictionary<uint, SemaphoreSlim> _locks = new();
+
+    public RipeStatPrefixCache(
+        RipeStatProvider ripe,
+        ILogger<RipeStatPrefixCache>? logger = null,
+        TimeSpan? cacheTtl = null,
+        TimeSpan? negativeTtl = null,
+        int? maxCacheEntries = null,
+        TimeProvider? timeProvider = null)
+    {
+        _ripe = ripe;
+        _logger = logger;
+        _cacheTtl = cacheTtl ?? TimeSpan.FromHours(1);
+        _negativeTtl = negativeTtl ?? TimeSpan.FromSeconds(30);
+        // 2× a generous operator-configured ASN universe (a route server typically tracks tens to
+        // low-hundreds of origin ASNs). The cap defends against unbounded growth from adversarial /
+        // churn traffic, not normal operation.
+        _maxCacheEntries = maxCacheEntries ?? 4096;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
+    {
+        // Fast path: fresh entry (positive or negative within its TTL).
+        if (TryGetFresh(asn, out var fresh))
+            return fresh;
+
+        // Serialize per-ASN so concurrent callers share a single RIPEstat fetch — no thundering herd
+        // on a cold or just-expired ASN (#164).
+        var gate = _locks.GetOrAdd(asn, _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync(ct);
+        try
+        {
+            // Re-check after acquiring the lock: another caller may have just populated the entry.
+            if (TryGetFresh(asn, out var rechecked))
+                return rechecked;
+
+            IReadOnlyList<(uint Prefix, byte Length)> prefixes;
+            try
+            {
+                prefixes = await _ripe.GetPrefixesAsync(asn, ct);
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                // Stale-on-failure (#163): serve the last good copy regardless of its age so a
+                // transient RIPEstat outage (429/5xx/network) does not drop the ASN's routes the
+                // instant its TTL elapses.
+                if (_cache.TryGetValue(asn, out var stale) && !stale.Negative)
+                {
+                    _logger?.LogWarning(ex,
+                        "AS{Asn}: RIPEstat fetch failed; serving cached copy ({Count} prefixes).", asn, stale.Data.Count);
+                    return stale.Data;
+                }
+
+                // No cached copy: remember the failure briefly so repeated calls don't hammer RIPEstat.
+                EvictIfAtCapacity(asn);
+                _cache[asn] = ([], _timeProvider.GetUtcNow().UtcDateTime, Negative: true);
+                throw;
+            }
+
+            EvictIfAtCapacity(asn);
+            _cache[asn] = (prefixes, _timeProvider.GetUtcNow().UtcDateTime, Negative: false);
+            return prefixes;
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    /// <summary>True if <paramref name="asn"/> has a non-expired entry (positive within _cacheTtl,
+    /// negative within _negativeTtl).</summary>
+    private bool TryGetFresh(uint asn, out IReadOnlyList<(uint Prefix, byte Length)> data)
+    {
+        data = null!;
+        if (!_cache.TryGetValue(asn, out var entry)) return false;
+
+        var ttl = entry.Negative ? _negativeTtl : _cacheTtl;
+        if (_timeProvider.GetUtcNow().UtcDateTime - entry.CachedAt < ttl)
+        {
+            data = entry.Data;
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>Enforces the _maxCacheEntries bound (#165). Called before inserting a NEW key,
+    /// under the caller's per-ASN gate. Removes a few least-recently-cached entries (by CachedAt)
+    /// plus any expired entries it encounters, and drops the corresponding _locks entries. Under
+    /// the lock of the caller's per-ASN gate, so the sweep is serialized against itself;
+    /// ConcurrentDictionary enumeration is a snapshot and safe against concurrent writers.</summary>
+    private void EvictIfAtCapacity(uint insertingKey)
+    {
+        if (_cache.Count < _maxCacheEntries) return;
+        if (_cache.ContainsKey(insertingKey)) return; // already present, no insert coming
+
+        // Snapshot, drop expired entries first (cheapest eviction), then by oldest CachedAt.
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        var toEvict = new List<uint>();
+        foreach (var (key, entry) in _cache)
+        {
+            var ttl = entry.Negative ? _negativeTtl : _cacheTtl;
+            if (now - entry.CachedAt >= ttl)
+                toEvict.Add(key);
+        }
+        // If still at/over capacity after dropping expired, evict the oldest until below the cap.
+        if (_cache.Count - toEvict.Count >= _maxCacheEntries)
+        {
+            var oldest = _cache
+                .Where(kvp => !toEvict.Contains(kvp.Key))
+                .OrderBy(kvp => kvp.Value.CachedAt)
+                .Select(kvp => kvp.Key);
+            foreach (var key in oldest)
+            {
+                toEvict.Add(key);
+                if (_cache.Count - toEvict.Count < _maxCacheEntries) break;
+            }
+        }
+
+        foreach (var key in toEvict)
+        {
+            // TryUpdate/TryRemove under no per-key lock: a concurrent fetch for this key may be
+            // racing, but that's fine — it will re-populate the entry; losing a transient cache hit
+            // is acceptable, and never losing correctness.
+            if (_cache.TryRemove(key, out _))
+                _locks.TryRemove(key, out _);
+        }
+    }
+}

--- a/BGPLite.Routing/RouteTable.cs
+++ b/BGPLite.Routing/RouteTable.cs
@@ -67,9 +67,25 @@ public sealed class RouteTable
             }
             if (_routes.TryGetValue(route.Key, out var existing) &&
                 _routes.TryUpdate(route.Key, entry, existing))
+            {
+                // #377 review: ownership transferred — the PREVIOUS owner's session bookkeeping
+                // (e.g. the #304 per-peer prefix set) must learn it no longer holds this key,
+                // or its count drifts upward on overlaps and can trip the cap it no longer owns.
+                // Raised AFTER the swap wins; a stale previous-owner read only means a late
+                // notification, which the remove-if-present handlers tolerate.
+                if (!ReferenceEquals(existing.Owner, owner) && existing.Owner is not null)
+                    EntryOwnershipLost?.Invoke(existing.Owner, route.Key);
                 return false; // replaced an entry that was still present — no count transition
+            }
         }
     }
+
+    /// <summary>
+    /// Fired (on the replacing caller's thread) after an <see cref="AddOrUpdate"/> swap takes a
+    /// key away from a previous owner (#377 review). Subscribers must tolerate invocation from
+    /// any thread and duplicate/late notifications — treat it as "you MIGHT have lost this key".
+    /// </summary>
+    public event Action<object, (uint Prefix, byte Length)>? EntryOwnershipLost;
 
     /// <summary>Unconditional removal, regardless of owner — administrative paths only.</summary>
     public bool Remove(uint prefix, byte length)

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -67,6 +67,10 @@ public sealed class BgpSession : IDisposable
     private bool _localFourByteAsn; // derived from negotiated OPEN capability (RFC 6793)
     private ushort _negotiatedHoldTime;
     private List<IpPrefix> _advertisedPrefixes = [];
+    // #304: distinct NLRI this session currently owns in the shared table — drives the per-peer
+    // prefix cap (Bgp.MaxPrefixesPerPeer) and its 75% warning.
+    private readonly HashSet<IpPrefix> _installedPrefixes = [];
+    private bool _maxPrefixesWarned;
     // #212: actual count sent on the wire (after aggregation + dedup). Updated at the end of
     // SendRoutesAsync. Read via AdvertisedPrefixCount for the management API/UI so operators see
     // the real number their peer's router receives, not the raw pre-aggregation count.
@@ -963,10 +967,29 @@ public sealed class BgpSession : IDisposable
 
                 if (_routeFilter.AcceptIncoming(route, filterPeerConfig))
                 {
+                    // #304: per-peer prefix ceiling (RFC 4271 §6.7 / RFC 4486 §2) — counted on the
+                    // distinct NLRI this session currently owns; replacements of an owned prefix
+                    // do not grow the count, withdrawals shrink it. Exceeding the cap throws
+                    // Cease/MaxPrefixesExceeded: deliberately NOT UpdateMessageError, so the read
+                    // loop's treat-as-withdraw filter does not swallow it — it unwinds to RunAsync's
+                    // BgpNotificationException handler, which sends the NOTIFICATION and tears the
+                    // session down (owned routes are flushed by the finally, RFC 4271 §8.2.2).
+                    var cap = _bgpConfig.MaxPrefixesPerPeer;
+                    if (cap > 0 && !_installedPrefixes.Contains(nlri) && _installedPrefixes.Count >= cap)
+                        throw new BgpNotificationException(
+                            BgpConstants.Error.Cease, BgpConstants.SubError.CeaseMaxPrefixes,
+                            $"Peer {_peer} exceeded the per-peer prefix limit ({cap}); session reset per RFC 4486");
+                    if (cap > 0 && !_maxPrefixesWarned && _installedPrefixes.Count >= cap * 3 / 4)
+                    {
+                        _maxPrefixesWarned = true;
+                        _logger.LogWarning("Peer {Peer} at {Count}/{Cap} of the per-peer prefix limit", _peer, _installedPrefixes.Count, cap);
+                    }
+
                     // Tagged with this session as the owner, so only this peer's own withdrawal can
                     // remove it (#289). A route the filter dropped is never installed and therefore
                     // never owned, so a later withdrawal for it removes nothing.
                     _routeTable.AddOrUpdate(route, owner: this);
+                    _installedPrefixes.Add(nlri);
                     // #85: guard the UintToIPAddress allocation behind IsEnabled — LogDebug
                     // evaluates the arg eagerly even when Debug is filtered out.
                     if (_logger.IsEnabled(LogLevel.Debug))
@@ -993,6 +1016,9 @@ public sealed class BgpSession : IDisposable
                 _logger.LogDebug("Ignoring withdrawal of {Prefix} from {Peer}: not owned by this session", prefix, _peer);
             return;
         }
+
+        // #304: the cap counts what this session currently owns — a withdrawal frees budget.
+        _installedPrefixes.Remove(prefix);
 
         if (_logger.IsEnabled(LogLevel.Debug))
             _logger.LogDebug("{Reason}: {Prefix}", reason, prefix);

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -944,6 +944,13 @@ public sealed class BgpSession : IDisposable
                 throw;
             }
 
+            // #306: RFC 7606 attribute-discard surfaced — the UPDATE is otherwise fine and its
+            // routes install; a Warning shows WHICH attributes were dropped (the session stays up,
+            // so this is the only trace an operator gets).
+            if (attrs.DiscardedAttributes is { Count: > 0 } dropped)
+                _logger.LogWarning("Discarded malformed attribute(s) [{Types}] from {Peer} — routes kept (RFC 7606 attribute discard)",
+                    string.Join(",", dropped), _peer);
+
             var filterPeerConfig = GetFilterPeerConfig();
 
             foreach (var nlri in update.Nlri)

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -994,17 +994,24 @@ public sealed class BgpSession : IDisposable
                         throw new BgpNotificationException(
                             BgpConstants.Error.Cease, BgpConstants.SubError.CeaseMaxPrefixes,
                             $"Peer {_peer} exceeded the per-peer prefix limit ({cap}); session reset per RFC 4486");
-                    if (cap > 0 && !_maxPrefixesWarned && _installedPrefixes.Count >= MaxPrefixWarningThreshold(cap))
-                    {
-                        _maxPrefixesWarned = true;
-                        _logger.LogWarning("Peer {Peer} at {Count}/{Cap} of the per-peer prefix limit", _peer, _installedPrefixes.Count, cap);
-                    }
+                    // #377 review: record membership BEFORE publishing — a concurrent takeover
+                    // fires EntryOwnershipLost synchronously inside AddOrUpdate, and the handler's
+                    // remove would no-op against a key not yet recorded, leaving this session
+                    // counting a prefix it no longer owns.
+                    _installedPrefixes.TryAdd(nlri, 0);
 
                     // Tagged with this session as the owner, so only this peer's own withdrawal can
                     // remove it (#289). A route the filter dropped is never installed and therefore
                     // never owned, so a later withdrawal for it removes nothing.
                     _routeTable.AddOrUpdate(route, owner: this);
-                    _installedPrefixes.TryAdd(nlri, 0);
+
+                    // #377 review: warn AFTER the install with the actual count — the pre-install
+                    // count logged "0/1" for the very first route under cap=1 (threshold floor 0).
+                    if (cap > 0 && !_maxPrefixesWarned && _installedPrefixes.Count >= MaxPrefixWarningThreshold(cap))
+                    {
+                        _maxPrefixesWarned = true;
+                        _logger.LogWarning("Peer {Peer} at {Count}/{Cap} of the per-peer prefix limit", _peer, _installedPrefixes.Count, cap);
+                    }
                     // #85: guard the UintToIPAddress allocation behind IsEnabled — LogDebug
                     // evaluates the arg eagerly even when Debug is filtered out.
                     if (_logger.IsEnabled(LogLevel.Debug))

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -68,8 +68,11 @@ public sealed class BgpSession : IDisposable
     private ushort _negotiatedHoldTime;
     private List<IpPrefix> _advertisedPrefixes = [];
     // #304: distinct NLRI this session currently owns in the shared table — drives the per-peer
-    // prefix cap (Bgp.MaxPrefixesPerPeer) and its 75% warning.
-    private readonly HashSet<IpPrefix> _installedPrefixes = [];
+    // prefix cap (Bgp.MaxPrefixesPerPeer) and its 75% warning. #377 review: ConcurrentDictionary,
+    // not HashSet — ownership can be taken over by ANOTHER session's install (the
+    // RouteTable.EntryOwnershipLost handler below runs on that session's thread), and the
+    // per-announce cap check reads the count on this session's read loop.
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<IpPrefix, byte> _installedPrefixes = new();
     private bool _maxPrefixesWarned;
     // #212: actual count sent on the wire (after aggregation + dedup). Updated at the end of
     // SendRoutesAsync. Read via AdvertisedPrefixCount for the management API/UI so operators see
@@ -272,6 +275,11 @@ public sealed class BgpSession : IDisposable
         // (test-only) composition, so it gets a real, named implementation that says so out loud —
         // not a RouteAssembler quietly holding nulls.
         _routeAssembler = routeAssembler ?? new SharedTableRouteAssembler(_routeTable, _routeFilter, logger);
+
+        // #377 review: when another session takes over a key this one installed, drop it from the
+        // per-peer prefix set — otherwise the cap count drifts upward on overlapping NLRI and can
+        // trip a reset for prefixes this session no longer owns. Any thread; remove-if-present.
+        _routeTable.EntryOwnershipLost += OnEntryOwnershipLost;
     }
 
     public async Task RunAsync(CancellationToken cancellationToken = default)
@@ -975,11 +983,11 @@ public sealed class BgpSession : IDisposable
                     // BgpNotificationException handler, which sends the NOTIFICATION and tears the
                     // session down (owned routes are flushed by the finally, RFC 4271 §8.2.2).
                     var cap = _bgpConfig.MaxPrefixesPerPeer;
-                    if (cap > 0 && !_installedPrefixes.Contains(nlri) && _installedPrefixes.Count >= cap)
+                    if (cap > 0 && !_installedPrefixes.ContainsKey(nlri) && _installedPrefixes.Count >= cap)
                         throw new BgpNotificationException(
                             BgpConstants.Error.Cease, BgpConstants.SubError.CeaseMaxPrefixes,
                             $"Peer {_peer} exceeded the per-peer prefix limit ({cap}); session reset per RFC 4486");
-                    if (cap > 0 && !_maxPrefixesWarned && _installedPrefixes.Count >= cap * 3 / 4)
+                    if (cap > 0 && !_maxPrefixesWarned && _installedPrefixes.Count >= MaxPrefixWarningThreshold(cap))
                     {
                         _maxPrefixesWarned = true;
                         _logger.LogWarning("Peer {Peer} at {Count}/{Cap} of the per-peer prefix limit", _peer, _installedPrefixes.Count, cap);
@@ -989,7 +997,7 @@ public sealed class BgpSession : IDisposable
                     // remove it (#289). A route the filter dropped is never installed and therefore
                     // never owned, so a later withdrawal for it removes nothing.
                     _routeTable.AddOrUpdate(route, owner: this);
-                    _installedPrefixes.Add(nlri);
+                    _installedPrefixes.TryAdd(nlri, 0);
                     // #85: guard the UintToIPAddress allocation behind IsEnabled — LogDebug
                     // evaluates the arg eagerly even when Debug is filtered out.
                     if (_logger.IsEnabled(LogLevel.Debug))
@@ -1008,6 +1016,27 @@ public sealed class BgpSession : IDisposable
     /// one of its own that another peer has since replaced. A withdrawal that owns nothing is logged
     /// and ignored — not a protocol error, since a stale withdrawal after a reconverge is ordinary.
     /// </summary>
+    /// <summary>
+    /// #377 review: another session took over a key we installed — stop counting it. Runs on the
+    /// REPLACING session's thread (see RouteTable.EntryOwnershipLost); the concurrent set makes
+    /// that safe, and a late/duplicate notification only removes an entry already gone.
+    /// </summary>
+    private void OnEntryOwnershipLost(object previousOwner, (uint Prefix, byte Length) key)
+    {
+        if (!ReferenceEquals(previousOwner, this))
+            return;
+        _installedPrefixes.TryRemove(new IpPrefix(key.Prefix, key.Length), out _);
+    }
+
+    /// <summary>
+    /// 75% of the per-peer prefix cap, overflow-safe (#377 review): cap*3 in int arithmetic
+    /// overflows for large caps and can arm the warning at a wrong (even zero) count. 75% of any
+    /// positive int always fits int (¾·MaxValue &lt; MaxValue), so a widened multiply is exact —
+    /// no saturation branch.
+    /// </summary>
+    internal static int MaxPrefixWarningThreshold(int cap) =>
+        (int)((long)cap * 3 / 4);
+
     private void WithdrawIfOwned(IpPrefix prefix, string reason)
     {
         if (!_routeTable.RemoveOwnedBy(prefix.Address, prefix.Length, this))
@@ -1018,7 +1047,8 @@ public sealed class BgpSession : IDisposable
         }
 
         // #304: the cap counts what this session currently owns — a withdrawal frees budget.
-        _installedPrefixes.Remove(prefix);
+        // (A takeover already removed it via the ownership handler; TryRemove tolerates that.)
+        _installedPrefixes.TryRemove(prefix, out _);
 
         if (_logger.IsEnabled(LogLevel.Debug))
             _logger.LogDebug("{Reason}: {Prefix}", reason, prefix);
@@ -1510,6 +1540,7 @@ public sealed class BgpSession : IDisposable
         // #341: wake any send parked on _sendLock BEFORE the semaphore (and its waiter queue)
         // goes away — SendMessageAsync abandons such waits and reports "not sent".
         _sendLockDisposed.TrySetResult();
+        _routeTable.EntryOwnershipLost -= OnEntryOwnershipLost;
         _cts.Cancel();
         _connection.Dispose();   // owns the socket (SocketBgpConnection wraps NetworkStream ownsSocket:true)
         _cts.Dispose();

--- a/BGPLite.Tests/ApiHandlerBehaviorTests.cs
+++ b/BGPLite.Tests/ApiHandlerBehaviorTests.cs
@@ -1,0 +1,163 @@
+using System.Net;
+using BGPLite.Api;
+using BGPLite.Configuration;
+using BGPLite.Contracts;
+using BGPLite.Providers;
+using BGPLite.Routing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #266 handler-level behavior that needs a real listener: the txt prefix export must not be
+/// double-serialized (item 1), the CORS preflight must advertise PATCH (item 2), and OPTIONS
+/// preflights consume the client's rate bucket instead of bypassing it (item 7).
+/// </summary>
+public sealed class ApiHandlerBehaviorTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private ManagementApi? _api;
+    private HttpClient? _client;
+    private int _port;
+
+    public ApiHandlerBehaviorTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        using (var boot = new BgpDbContext(new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(_connection).Options))
+            BgpDbContext.Initialize(boot);
+    }
+
+    public void Dispose()
+    {
+        try { _api?.StopAsync(CancellationToken.None).Wait(TimeSpan.FromSeconds(5)); } catch { /* best-effort */ }
+        _api?.Dispose();
+        _client?.Dispose();
+        _connection.Dispose();
+    }
+
+    private async Task<int> StartAsync(AppConfig template)
+    {
+        for (var attempt = 0; ; attempt++)
+        {
+            var port = FreeTcpPort();
+            var config = new AppConfig
+            {
+                Bgp = template.Bgp,
+                CorsAllowedOrigins = template.CorsAllowedOrigins,
+                ApiRateLimit = template.ApiRateLimit,
+                ApiListen = "127.0.0.1",
+                ApiPort = port,
+            };
+            _api = new ManagementApi(
+                new PeerStore(new StaticOptionsFactory(new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(_connection).Options)),
+                new RouteTable(),
+                config,
+                new BgpMetrics(),
+                NullLogger<ManagementApi>.Instance,
+                new InertPrefixService(),
+                new InertPrefixSources(),
+                new InertSessions());
+            try
+            {
+                await _api.StartAsync(CancellationToken.None);
+                return port;
+            }
+            catch (HttpListenerException) when (attempt < 2)
+            {
+                _api.Dispose();
+                _api = null;
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ExportTxt_PlaintextBody_NotJsonQuoted()
+    {
+        var store = new PeerStore(new StaticOptionsFactory(new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(_connection).Options));
+        var id = store.SavePeerConfiguration("198.51.100.7", 65090, null, [], [("10.0.0.0", (byte)8)], []);
+        _port = await StartAsync(new AppConfig { Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" } });
+        _client = new HttpClient();
+
+        using var response = await _client.GetAsync($"http://127.0.0.1:{_port}/api/peers/{id}/prefixes?format=txt");
+        var body = await response.Content.ReadAsStringAsync();
+
+        Assert.True(response.IsSuccessStatusCode);
+        Assert.Equal("text/plain", response.Content.Headers.ContentType?.MediaType);
+        Assert.Equal("10.0.0.0/8", body.TrimEnd());   // RED pre-fix: "\"10.0.0.0/8\\n\"" with application/json
+    }
+
+    [Fact]
+    public async Task OptionsPreflight_AdvertisesPatch_AndConsumesRateBucket()
+    {
+        var config = new AppConfig
+        {
+            Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" },
+            CorsAllowedOrigins = ["http://example.com"],
+            ApiRateLimit = new ApiRateLimitConfig { Enabled = true, TokenLimit = 2, TokensPerPeriod = 1000, PeriodSeconds = 3600 },
+        };
+        _port = await StartAsync(config);
+        _client = new HttpClient();
+
+        var preflight = new HttpRequestMessage(HttpMethod.Options, $"http://127.0.0.1:{_port}/api/peers");
+        preflight.Headers.Add("Origin", "http://example.com");
+        using var first = await _client.SendAsync(preflight);
+        Assert.Equal(HttpStatusCode.NoContent, first.StatusCode);
+        Assert.Contains("PATCH", first.Headers.GetValues("Access-Control-Allow-Methods").First()); // RED pre-fix: no PATCH
+
+        var second = new HttpRequestMessage(HttpMethod.Options, $"http://127.0.0.1:{_port}/api/peers");
+        second.Headers.Add("Origin", "http://example.com");
+        using var ok = await _client.SendAsync(second);
+        Assert.Equal(HttpStatusCode.NoContent, ok.StatusCode);   // 2nd — bucket still has tokens
+
+        var third = new HttpRequestMessage(HttpMethod.Options, $"http://127.0.0.1:{_port}/api/peers");
+        third.Headers.Add("Origin", "http://example.com");
+        using var limited = await _client.SendAsync(third);
+        Assert.Equal(HttpStatusCode.TooManyRequests, limited.StatusCode);   // RED pre-fix: 204 forever
+    }
+
+    private static int FreeTcpPort()
+    {
+        using var socket = new System.Net.Sockets.Socket(System.Net.Sockets.AddressFamily.InterNetwork, System.Net.Sockets.SocketType.Stream, System.Net.Sockets.ProtocolType.Tcp);
+        socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        return ((IPEndPoint)socket.LocalEndPoint!).Port;
+    }
+
+    private sealed class StaticOptionsFactory(DbContextOptions<BgpDbContext> options) : IDbContextFactory<BgpDbContext>
+    {
+        public BgpDbContext CreateDbContext() => new(options);
+    }
+
+    private sealed class InertPrefixService : IPrefixService
+    {
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default) => Task.FromResult(new List<(uint, byte, uint)>());
+        public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
+        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default) => Task.FromResult(new List<(uint, byte, uint)>());
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private sealed class InertPrefixSources : IPrefixSourceService
+    {
+        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>> LoadAllAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<(uint Prefix, byte Length)>)>>([]);
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetDefaultAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);
+        public bool SourceSupportsConditional(string sourceName) => false;
+    }
+
+    private sealed class InertSessions : ISessionManager
+    {
+        public Task RefreshPeerAsync(string peerIp, uint asn) => Task.CompletedTask;
+        public List<string> GetActivePeerIps() => [];
+        public Task TerminatePeerAsync(string peerIp, uint asn, CancellationToken ct = default) => Task.CompletedTask;
+        public int GetAdvertisedPrefixCount(string peerIp, uint asn) => 0;
+        public Task RefreshAllEstablishedAsync() => Task.CompletedTask;
+    }
+}

--- a/BGPLite.Tests/AsnPrefixProviderTests.cs
+++ b/BGPLite.Tests/AsnPrefixProviderTests.cs
@@ -65,4 +65,47 @@ public class AsnPrefixProviderTests
         Assert.Single(viaSource.Prefixes);
         Assert.Equal(1, handler.Calls);   // RED on the old direct-to-wire provider: 2
     }
+
+    /// <summary>
+    /// #377 review (negative-cache regression of #370): a cached RIPEstat failure must PROPAGATE
+    /// from the provider path — Ok([]) would store a positive empty list in the name-level cache
+    /// and mark the source changed, withdrawing a good advertisement over a transient blip.
+    /// The RouteAssembler path keeps its []-on-recent-failure semantic.
+    /// </summary>
+    private sealed class FailingRipeHandler : HttpMessageHandler
+    {
+        public int Calls { get; private set; }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Calls++;
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.ServiceUnavailable) { Content = new StringContent("blip") });
+        }
+    }
+
+    [Fact]
+    public async Task CachedFailure_PropagatesFromProvider_ServesEmptyToAssemblerPath()
+    {
+        var handler = new FailingRipeHandler();
+        var ripe = new RipeStatProvider(new StubFactory(handler), NullLogger<RipeStatProvider>.Instance,
+            new RipeStatConfig { RetryAttempts = 0, RetryDelaySeconds = 0 });
+        var cache = new RipeStatPrefixCache(ripe, negativeTtl: TimeSpan.FromSeconds(30));
+        var service = new PrefixService(new AppConfig(), cache, null!, null!);
+        var provider = new AsnPrefixProvider(cache, NullLogger<AsnPrefixProvider>.Instance);
+
+        // Prime the negative entry through the assembler path: the first fetch FAILS (no stale
+        // copy exists yet, so it throws and negative-caches), the second serves [] per that path's
+        // documented semantic.
+        await Assert.ThrowsAnyAsync<Exception>(() => service.GetPrefixesAsync(65010));
+        var viaService = await service.GetPrefixesAsync(65010);
+        Assert.Empty(viaService);
+        var primedCalls = handler.Calls;
+
+        // Provider path: the cached failure must THROW, not come back as Ok([]) — Ok would store a
+        // positive empty list in the name-level cache and mark the source changed. The provider
+        // re-fetches (one wire attempt per load — matching its pre-#370 behavior); throttling for
+        // sources lives at the NAME level (PrefixSourceService stale/negative), not here.
+        await Assert.ThrowsAnyAsync<Exception>(() =>
+            provider.LoadAsync(new PrefixSourceConfig { Name = "x", Kind = "asn", Asn = 65010 }));
+        Assert.Equal(primedCalls + 1, handler.Calls);   // exactly one provider-driven wire attempt
+    }
 }

--- a/BGPLite.Tests/AsnPrefixProviderTests.cs
+++ b/BGPLite.Tests/AsnPrefixProviderTests.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Net.Http;
 using BGPLite.Configuration;
 using BGPLite.Providers;
 using Xunit;
@@ -16,5 +18,51 @@ public class AsnPrefixProviderTests
         var provider = new AsnPrefixProvider(null!, null!);
         var source = new PrefixSourceConfig { Name = "cloudflare", Kind = "asn" };
         await Assert.ThrowsAsync<InvalidOperationException>(() => provider.LoadAsync(source));
+    }
+
+    /// <summary>
+    /// #267 item 5: Kind:asn sources and the RipeStat.AsnLists/custom-ASN path share ONE per-ASN
+    /// cache — an ASN configured in both mechanisms is fetched from RIPEstat once. The old
+    /// direct-to-wire provider path fetched it twice with independent TTLs.
+    /// </summary>
+    private sealed class CountingRipeHandler : HttpMessageHandler
+    {
+        public int Calls { get; private set; }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Calls++;
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """{"status":"ok","data":{"resource":"65010","prefixes":{"v4":{"originating":["10.1.10.1/32"]},"v6":{"originating":[]}}}}""")
+            });
+        }
+    }
+
+    private sealed class StubFactory : IHttpClientFactory
+    {
+        private readonly HttpMessageHandler _handler;
+        public StubFactory(HttpMessageHandler handler) => _handler = handler;
+        public HttpClient CreateClient(string name) => new(_handler, disposeHandler: false);
+    }
+
+    [Fact]
+    public async Task SameAsn_BothMechanisms_SingleWireFetch()
+    {
+        var handler = new CountingRipeHandler();
+        var cache = new RipeStatPrefixCache(new RipeStatProvider(
+            new StubFactory(handler), NullLogger<RipeStatProvider>.Instance,
+            new RipeStatConfig { RetryAttempts = 0, RetryDelaySeconds = 0 }));
+        var service = new PrefixService(new AppConfig(), cache, null!, null!);
+        var provider = new AsnPrefixProvider(cache, NullLogger<AsnPrefixProvider>.Instance);
+
+        // Mechanism A: RipeStat.AsnLists / custom-ASN path.
+        var viaService = await service.GetPrefixesAsync(65010);
+        // Mechanism B: a PrefixSources entry of Kind: asn for the SAME ASN.
+        var viaSource = await provider.LoadAsync(new PrefixSourceConfig { Name = "x", Kind = "asn", Asn = 65010 });
+
+        Assert.Single(viaService);
+        Assert.Single(viaSource.Prefixes);
+        Assert.Equal(1, handler.Calls);   // RED on the old direct-to-wire provider: 2
     }
 }

--- a/BGPLite.Tests/BgpSessionHoldTimerTests.cs
+++ b/BGPLite.Tests/BgpSessionHoldTimerTests.cs
@@ -700,6 +700,7 @@ public class BgpSessionHoldTimerTests
     [InlineData(2, 1)]
     [InlineData(100, 75)]
     [InlineData(int.MaxValue, 1610612735)]    // exact 75% via widened arithmetic — no wrap, no saturation
+    [InlineData(1, 0)]                        // floor: with post-install logging this reads "at 1/1"
     [InlineData(1_500_000_000, 1_125_000_000)] // would wrap as int*3
     public void MaxPrefixWarningThreshold_NoOverflow(int cap, int expected)
         => Assert.Equal(expected, BgpSession.MaxPrefixWarningThreshold(cap));

--- a/BGPLite.Tests/BgpSessionHoldTimerTests.cs
+++ b/BGPLite.Tests/BgpSessionHoldTimerTests.cs
@@ -692,6 +692,19 @@ public class BgpSessionHoldTimerTests
     }
 
     /// <summary>
+    /// #377 review: the 75% warning threshold must not overflow — cap*3 in int arithmetic wraps
+    /// for large caps and can arm the warning at a wrong (even tiny) count.
+    /// </summary>
+    [Theory]
+    [InlineData(4, 3)]
+    [InlineData(2, 1)]
+    [InlineData(100, 75)]
+    [InlineData(int.MaxValue, 1610612735)]    // exact 75% via widened arithmetic — no wrap, no saturation
+    [InlineData(1_500_000_000, 1_125_000_000)] // would wrap as int*3
+    public void MaxPrefixWarningThreshold_NoOverflow(int cap, int expected)
+        => Assert.Equal(expected, BgpSession.MaxPrefixWarningThreshold(cap));
+
+    /// <summary>
     /// #341: a blocked writer (a refresh send parked inside WriteAsync — the slow-peer holder of
     /// the issue) holds <c>_sendLock</c>; the next keepalive tick queues on the semaphore with NO
     /// token of its own; <c>Dispose</c> cancels <c>_cts</c> and then disposes the semaphore.

--- a/BGPLite.Tests/BgpSessionRfc6793Tests.cs
+++ b/BGPLite.Tests/BgpSessionRfc6793Tests.cs
@@ -185,7 +185,8 @@ public class BgpSessionRfc6793Tests
                 AttributeHelper.WriteAsPath([65001u], fourByteAsn: false),
                 AttributeHelper.WriteNextHop(0x0A000001),
                 new PathAttribute { Flags = 0xC0, TypeCode = BgpConstants.Attribute.Aggregator, Data = new byte[5] },     // malformed → discarded
-                new PathAttribute { Flags = 0xC0, TypeCode = BgpConstants.Attribute.As4Aggregator, Data = new byte[8] },  // valid, AS 65001
+                new PathAttribute { Flags = 0xC0, TypeCode = BgpConstants.Attribute.As4Aggregator,
+                    Data = [0x00, 0x00, 0xFD, 0xE9, 0x00, 0x00, 0x00, 0x00] },                                            // valid, AS 65001
             ],
             Nlri = [new IpPrefix(0x0A000000, 24)]
         };
@@ -193,6 +194,35 @@ public class BgpSessionRfc6793Tests
         var attrs = UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: false);   // RED pre-fix: 3/9 pairing error
 
         Assert.Contains(BgpConstants.Attribute.Aggregator, attrs.DiscardedAttributes);
+        Assert.DoesNotContain(BgpConstants.Attribute.As4Aggregator, attrs.DiscardedAttributes);   // #377 review: the AS4 side is VALID — not silently discarded too
+    }
+
+    /// <summary>
+    /// #377 review: a valid AGGREGATOR (AS_TRANS) + malformed AS4_AGGREGATOR must not trip the
+    /// "Missing AS4_AGGREGATOR for AGGREGATOR AS_TRANS" pairing rule — the UPDATE CARRIED an
+    /// AS4_AGGREGATOR and it was discarded per RFC 6793 §6; routes stay.
+    /// </summary>
+    [Fact]
+    public void ParseRouteAttributes_AsTransAggregator_MalformedAs4Aggregator_NoPairingError()
+    {
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+                AttributeHelper.WriteAsPath([65001u], fourByteAsn: false),
+                AttributeHelper.WriteNextHop(0x0A000001),
+                new PathAttribute { Flags = 0xC0, TypeCode = BgpConstants.Attribute.Aggregator,
+                    Data = [0x5B, 0xA0, 0x00, 0x00, 0x00, 0x00] },                        // AS_TRANS (23456 = 0x5BA0) 2-octet form
+                new PathAttribute { Flags = 0xC0, TypeCode = BgpConstants.Attribute.As4Aggregator, Data = new byte[5] }, // malformed length
+            ],
+            Nlri = [new IpPrefix(0x0A000000, 24)]
+        };
+
+        var attrs = UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: false);   // RED pre-fix: 3/9 pairing error
+
+        Assert.Contains(BgpConstants.Attribute.As4Aggregator, attrs.DiscardedAttributes);
+        Assert.Equal(0x0A000001u, attrs.NextHop);
     }
 
     /// <summary>

--- a/BGPLite.Tests/BgpSessionRfc6793Tests.cs
+++ b/BGPLite.Tests/BgpSessionRfc6793Tests.cs
@@ -122,6 +122,103 @@ public class BgpSessionRfc6793Tests
         Assert.Contains(expected, ex.Message);
     }
 
+    /// <summary>
+    /// #306 (RFC 7606 §7.7): a malformed AGGREGATOR takes ATTRIBUTE DISCARD — the attribute is
+    /// dropped and the UPDATE's routes stay. Pre-fix this was treat-as-withdraw (D3): a wrong
+    /// length (5 bytes on a 2-octet session) withdrew routes a conformant implementation installs.
+    /// </summary>
+    [Fact]
+    public void ParseRouteAttributes_MalformedAggregator_AttributeDiscarded_RouteKept()
+    {
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+                AttributeHelper.WriteAsPath([65001u], fourByteAsn: true),
+                AttributeHelper.WriteNextHop(0x0A000001),
+                new PathAttribute { Flags = 0xC0, TypeCode = BgpConstants.Attribute.Aggregator, Data = new byte[5] }, // 5 bytes — neither 6 nor 8
+            ],
+            Nlri = [new IpPrefix(0x0A000000, 24)]
+        };
+
+        var attrs = UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: true);   // RED pre-fix: threw 3/9
+
+        Assert.Equal(0x0A000001u, attrs.NextHop);                    // route data intact
+        Assert.Equal([BgpConstants.Attribute.Aggregator], attrs.DiscardedAttributes); // ...with the attribute reported discarded
+    }
+
+    /// <summary>RFC 7607 §2 (the half #300 deferred): AS 0 in AGGREGATOR is malformed → discarded, routes kept.</summary>
+    [Fact]
+    public void ParseRouteAttributes_AsZeroAggregator_Discarded_RouteKept()
+    {
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+                AttributeHelper.WriteAsPath([65001u], fourByteAsn: true),
+                AttributeHelper.WriteNextHop(0x0A000001),
+                new PathAttribute { Flags = 0xC0, TypeCode = BgpConstants.Attribute.Aggregator, Data = new byte[8] }, // AS 0 + 0.0.0.0
+            ],
+            Nlri = [new IpPrefix(0x0A000000, 24)]
+        };
+
+        var attrs = UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: true);
+
+        Assert.Equal([BgpConstants.Attribute.Aggregator], attrs.DiscardedAttributes);
+        Assert.Equal(0x0A000001u, attrs.NextHop);
+    }
+
+    /// <summary>
+    /// #306 interplay: a discarded AGGREGATOR must not trip "Missing AGGREGATOR for AS4_AGGREGATOR"
+    /// for an UPDATE that carried one — the consistency check tolerates the discard.
+    /// </summary>
+    [Fact]
+    public void ParseRouteAttributes_DiscardedAggregator_WithAs4Aggregator_NoPairingError()
+    {
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+                AttributeHelper.WriteAsPath([65001u], fourByteAsn: false),
+                AttributeHelper.WriteNextHop(0x0A000001),
+                new PathAttribute { Flags = 0xC0, TypeCode = BgpConstants.Attribute.Aggregator, Data = new byte[5] },     // malformed → discarded
+                new PathAttribute { Flags = 0xC0, TypeCode = BgpConstants.Attribute.As4Aggregator, Data = new byte[8] },  // valid, AS 65001
+            ],
+            Nlri = [new IpPrefix(0x0A000000, 24)]
+        };
+
+        var attrs = UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: false);   // RED pre-fix: 3/9 pairing error
+
+        Assert.Contains(BgpConstants.Attribute.Aggregator, attrs.DiscardedAttributes);
+    }
+
+    /// <summary>
+    /// Boundary: attribute discard applies to VALUE/LENGTH malformation only — a FLAGS conflict on
+    /// AGGREGATOR stays treat-as-withdraw per RFC 7606 §3 (flags errors are never discard-eligible).
+    /// </summary>
+    [Fact]
+    public void ParseRouteAttributes_AggregatorFlagsConflict_StillTreatAsWithdraw()
+    {
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+                AttributeHelper.WriteAsPath([65001u], fourByteAsn: true),
+                AttributeHelper.WriteNextHop(0x0A000001),
+                new PathAttribute { Flags = 0x40, TypeCode = BgpConstants.Attribute.Aggregator, Data = new byte[8] }, // well-known — flags conflict
+            ],
+            Nlri = [new IpPrefix(0x0A000000, 24)]
+        };
+
+        var ex = Assert.Throws<BgpNotificationException>(
+            () => UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: true));
+        Assert.Equal(BgpConstants.SubError.AttributeFlagsError, ex.SubErrorCode);
+    }
+
     [Fact]
     public void ParseRouteAttributes_ValidNextHop_Accepted()
     {

--- a/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
+++ b/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
@@ -666,10 +666,24 @@ public class BgpSessionRouteOwnershipTests
         aConn.EnqueueFrame(AnnounceFrame(8, 0x0A));
         await SettleAsync(aConn, () => routeTable.Count == 1);
 
-        // B takes the SAME prefix over — A no longer owns it.
-        bConn.EnqueueFrame(AnnounceFrame(8, 0x0A));
-        await SettleAsync(bConn, () => routeTable.Get(TenSlashEight, 8) is not null);
-        await Task.Delay(50);   // let the ownership-lost notification land
+        // B takes the SAME prefix over — A no longer owns it. #377 review: await the
+        // ownership-loss callback deterministically instead of a fixed delay.
+        var aLostOwnership = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        void OnLost(object owner, (uint Prefix, byte Length) key)
+        {
+            if (ReferenceEquals(owner, a) && key.Prefix == TenSlashEight)
+                aLostOwnership.TrySetResult();
+        }
+        routeTable.EntryOwnershipLost += OnLost;
+        try
+        {
+            bConn.EnqueueFrame(AnnounceFrame(8, 0x0A));
+            await aLostOwnership.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            routeTable.EntryOwnershipLost -= OnLost;
+        }
 
         // A announces a DIFFERENT prefix with cap=1 — pre-fix this tripped the cap (A still
         // counted the taken-over 10/8) and reset A; post-fix A owns only the new prefix.

--- a/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
+++ b/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
@@ -622,6 +622,88 @@ public class BgpSessionRouteOwnershipTests
         Assert.Contains(store.StatusWrites, w => !w.Active);
     }
 
+    /// <summary>
+    /// #304: exceeding Bgp.MaxPrefixesPerPeer tears the session down with NOTIFICATION
+    /// (Cease, MaxPrefixesExceeded) per RFC 4271 §6.7 / RFC 4486 §2, and the finally flushes
+    /// the peer's owned routes (RFC 4271 §8.2.2) — the table does not keep the attacker's rows.
+    /// </summary>
+    private static async Task<(BgpSession Session, Task Run, ScriptedConnection Conn, RouteTable Table)> EstablishCappedAsync(int cap)
+    {
+        var routeTable = new RouteTable();
+        var conn = new ScriptedConnection();
+        var config = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0, MaxPrefixesPerPeer = cap };
+        var session = new BgpSession(
+            conn, new PeerConfig { Address = "127.0.0.1" }, config, routeTable,
+            AllowAllFilter.Instance, new BgpMetrics(), NullLogger<BgpSession>.Instance);
+        var run = session.RunAsync();
+        conn.EnqueueMessage(new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = 0,
+            RouterId = 0x0A000002,
+            Capabilities = [BgpCapabilityInfo.FourOctetAsn(65002)],
+        });
+        conn.EnqueueMessage(BgpKeepaliveMessage.Instance);
+        for (var i = 0; i < 200 && !session.IsEstablished; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        Assert.True(session.IsEstablished, "session must reach Established");
+        return (session, run, conn, routeTable);
+    }
+
+    [Fact]
+    public async Task ExceedingMaxPrefixes_SendsCeaseMaxPrefixes_AndFlushesOwned()
+    {
+        var (session, run, conn, routeTable) = await EstablishCappedAsync(cap: 2);
+
+        conn.EnqueueFrame(AnnounceFrame(8, 0x0A));          // 1/2
+        conn.EnqueueFrame(AnnounceFrame(24, 0xC0, 0x00, 0x02)); // 2/2 — at the limit, still up
+        await SettleAsync(conn, () => routeTable.Count == 2);
+        Assert.True(session.IsEstablished, "at exactly the limit the session stays up");
+
+        conn.EnqueueFrame(AnnounceFrame(16, 0xC0, 0x01));   // 3rd distinct prefix — over
+        var completed = await Task.WhenAny(run, Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.Same(run, completed);                        // RED pre-fix: session keeps running
+        Assert.False(session.IsEstablished);
+
+        var notif = conn.Sent
+            .Select(b => BgpMessageReader.ReadMessage(b.AsSpan()))
+            .OfType<BgpNotificationMessage>()
+            .SingleOrDefault(n => n.ErrorCode == BgpConstants.Error.Cease);
+        Assert.NotNull(notif);
+        Assert.Equal(BgpConstants.SubError.CeaseMaxPrefixes, notif.SubErrorCode);
+        Assert.Equal(0, routeTable.Count);                  // owned routes flushed by the finally
+    }
+
+    [Fact]
+    public async Task AtLimitWithdrawal_FreesBudget()
+    {
+        var (session, run, conn, routeTable) = await EstablishCappedAsync(cap: 1);
+        conn.EnqueueFrame(AnnounceFrame(8, 0x0A));
+        await SettleAsync(conn, () => routeTable.Count == 1);
+
+        // Withdraw it — the budget frees — then a DIFFERENT prefix installs without a reset.
+        conn.EnqueueFrame(WithdrawFrame([8, 0x0A]));
+        await SettleAsync(conn, () => routeTable.Count == 0);
+        conn.EnqueueFrame(AnnounceFrame(24, 0xC0, 0x00, 0x02));
+        await SettleAsync(conn, () => routeTable.Count == 1);
+        Assert.True(session.IsEstablished, "withdrawals free prefix budget");
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task ZeroCap_IsUnlimited()
+    {
+        var (session, run, conn, routeTable) = await EstablishCappedAsync(cap: 0);
+        for (var i = 0; i < 5; i++)
+            conn.EnqueueFrame(AnnounceFrame(24, 0xC0, 0x00, (byte)(10 + i)));
+        await SettleAsync(conn, () => routeTable.Count == 5);
+        Assert.True(session.IsEstablished, "cap 0 = unlimited");
+
+        await TeardownAsync(session, run);
+    }
+
     private sealed class RejectAllIncomingFilter : IRouteFilter
     {
         private static readonly IReadOnlySet<uint> Empty = new HashSet<uint>();

--- a/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
+++ b/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
@@ -627,6 +627,62 @@ public class BgpSessionRouteOwnershipTests
     /// (Cease, MaxPrefixesExceeded) per RFC 4271 §6.7 / RFC 4486 §2, and the finally flushes
     /// the peer's owned routes (RFC 4271 §8.2.2) — the table does not keep the attacker's rows.
     /// </summary>
+    /// <summary>
+    /// #377 review: a session's per-peer prefix set must stay aligned with route-table OWNERSHIP —
+    /// when session B takes over a key session A installed, A stops counting it; otherwise A's
+    /// cap count drifts upward on overlaps and trips a reset for prefixes it no longer owns.
+    /// </summary>
+    private static async Task<(BgpSession Session, Task Run, ScriptedConnection Conn)> EstablishCappedAsync(RouteTable routeTable, int cap, uint routerId)
+    {
+        var conn = new ScriptedConnection();
+        var config = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0, MaxPrefixesPerPeer = cap };
+        var session = new BgpSession(
+            conn, new PeerConfig { Address = "127.0.0.1" }, config, routeTable,
+            AllowAllFilter.Instance, new BgpMetrics(), NullLogger<BgpSession>.Instance);
+        var run = session.RunAsync();
+        conn.EnqueueMessage(new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = 0,
+            RouterId = routerId,
+            Capabilities = [BgpCapabilityInfo.FourOctetAsn(65002)],
+        });
+        conn.EnqueueMessage(BgpKeepaliveMessage.Instance);
+        for (var i = 0; i < 200 && !session.IsEstablished; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        Assert.True(session.IsEstablished, "session must reach Established");
+        return (session, run, conn);
+    }
+
+    [Fact]
+    public async Task TakenOverPrefix_FreesTheOriginalOwnersCapBudget()
+    {
+        var routeTable = new RouteTable();
+        var (a, aRun, aConn) = await EstablishCappedAsync(routeTable, cap: 1, routerId: 0x0A000002);
+        var (b, bRun, bConn) = await EstablishCappedAsync(routeTable, cap: 0, routerId: 0x0A000003);
+
+        // A installs 10/8 (its single budget slot).
+        aConn.EnqueueFrame(AnnounceFrame(8, 0x0A));
+        await SettleAsync(aConn, () => routeTable.Count == 1);
+
+        // B takes the SAME prefix over — A no longer owns it.
+        bConn.EnqueueFrame(AnnounceFrame(8, 0x0A));
+        await SettleAsync(bConn, () => routeTable.Get(TenSlashEight, 8) is not null);
+        await Task.Delay(50);   // let the ownership-lost notification land
+
+        // A announces a DIFFERENT prefix with cap=1 — pre-fix this tripped the cap (A still
+        // counted the taken-over 10/8) and reset A; post-fix A owns only the new prefix.
+        aConn.EnqueueFrame(AnnounceFrame(24, 0xC0, 0x00, 0x02));
+        await SettleAsync(aConn, () => routeTable.Count == 2);
+
+        Assert.True(a.IsEstablished, "the taken-over prefix must not count against A's cap");   // RED pre-fix
+        Assert.Equal(2, routeTable.Count);
+
+        await TeardownAsync(a, aRun);
+        await TeardownAsync(b, bRun);
+    }
+
     private static async Task<(BgpSession Session, Task Run, ScriptedConnection Conn, RouteTable Table)> EstablishCappedAsync(int cap)
     {
         var routeTable = new RouteTable();

--- a/BGPLite.Tests/CompositionContractTests.cs
+++ b/BGPLite.Tests/CompositionContractTests.cs
@@ -48,7 +48,7 @@ public class CompositionContractTests
     [InlineData(typeof(ManagementApi), "sessionManager")]
     // PrefixService.cs:14-15 — a null http provider made every per-peer user URL source resolve to
     // zero prefixes, and a null RIPEstat did the same for custom ASNs.
-    [InlineData(typeof(PrefixService), "ripeStat")]
+    [InlineData(typeof(PrefixService), "ripeStatCache")] // #267 item 5: renamed when the per-ASN cache became a shared component
     [InlineData(typeof(PrefixService), "httpProvider")]
     public void ProductionDependency_IsRequired(Type type, string parameterName)
     {

--- a/BGPLite.Tests/ConfigValidationTests.cs
+++ b/BGPLite.Tests/ConfigValidationTests.cs
@@ -8,7 +8,7 @@ public class ConfigValidationTests
     // under test. Defaults match appsettings.Example.yml: a known-good baseline.
     private static BgpConfig Bgp(
         uint asn = 65001, string routerId = "10.0.0.1", int keepAlive = 60, int holdTime = 180,
-        int openTimeoutSeconds = 30, int maxAcceptsPerIpPerMinute = 60)
+        int openTimeoutSeconds = 30, int maxAcceptsPerIpPerMinute = 60, int maxPrefixesPerPeer = 0)
         => new()
         {
             Asn = asn,
@@ -16,7 +16,8 @@ public class ConfigValidationTests
             KeepAlive = keepAlive,
             HoldTime = holdTime,
             OpenTimeoutSeconds = openTimeoutSeconds,
-            MaxAcceptsPerIpPerMinute = maxAcceptsPerIpPerMinute
+            MaxAcceptsPerIpPerMinute = maxAcceptsPerIpPerMinute,
+            MaxPrefixesPerPeer = maxPrefixesPerPeer
         };
 
     private static AppConfig Config(BgpConfig? bgp = null, int apiPort = 5001, List<PeerConfig>? peers = null,
@@ -309,6 +310,16 @@ public class ConfigValidationTests
         var ex = Assert.Throws<InvalidOperationException>(() => config.Validate());
         Assert.Contains("Bgp.HoldTime", ex.Message);
         Assert.Contains("65535", ex.Message);
+    }
+
+    /// <summary>#304: the per-peer prefix cap validates like the other 0=unlimited knobs.</summary>
+    [Fact]
+    public void Validate_RejectsNegativeMaxPrefixesPerPeer()
+    {
+        var config = Config(Bgp(maxPrefixesPerPeer: -1));
+
+        var ex = Assert.Throws<InvalidOperationException>(() => config.Validate());
+        Assert.Contains("MaxPrefixesPerPeer", ex.Message);
     }
 
     [Fact]

--- a/BGPLite.Tests/ExceptionMappingTests.cs
+++ b/BGPLite.Tests/ExceptionMappingTests.cs
@@ -95,7 +95,7 @@ public class ExceptionMappingTests
     [Fact]
     public void DbUpdateException_FkViolation_MapsTo_404()
     {
-        var ex = new DbUpdateException("constraint failed", new SqliteException("FK constraint failed", 19));
+        var ex = new DbUpdateException("constraint failed", new SqliteException("FK constraint failed", 19, 787));
         var (message, status) = ManagementApi.MapExceptionToResponse(ex);
 
         Assert.Equal(404, status);
@@ -106,7 +106,9 @@ public class ExceptionMappingTests
     public void DbUpdateException_UniqueViolation_Still409()
     {
         // SQLITE_CONSTRAINT_UNIQUE — a concurrent duplicate insert remains a genuine conflict.
-        var ex = new DbUpdateException("unique", new SqliteException("UNIQUE constraint failed: Peers.Ip", 2067));
+        // Realistic shape: BOTH classes report primary 19; the discriminator is the EXTENDED
+        // code (2067 = SQLITE_CONSTRAINT_UNIQUE).
+        var ex = new DbUpdateException("unique", new SqliteException("UNIQUE constraint failed: Peers.Ip", 19, 2067));
         var (message, status) = ManagementApi.MapExceptionToResponse(ex);
 
         Assert.Equal(409, status);

--- a/BGPLite.Tests/ExceptionMappingTests.cs
+++ b/BGPLite.Tests/ExceptionMappingTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Data.Sqlite;
 using System.Text.Json;
 using BGPLite.Api;
 using Microsoft.EntityFrameworkCore;
@@ -85,5 +86,30 @@ public class ExceptionMappingTests
         var (message, status) = ManagementApi.MapExceptionToResponse(new OperationCanceledException());
         Assert.Equal(500, status);
         Assert.Equal("Internal server error", message);
+    }
+
+    /// <summary>
+    /// #266 item 8: an FK violation (SQLite code 19) after a concurrent DELETE removed the parent
+    /// peer row must answer 404 "removed", not 409 "already exists" for a resource that is gone.
+    /// </summary>
+    [Fact]
+    public void DbUpdateException_FkViolation_MapsTo_404()
+    {
+        var ex = new DbUpdateException("constraint failed", new SqliteException("FK constraint failed", 19));
+        var (message, status) = ManagementApi.MapExceptionToResponse(ex);
+
+        Assert.Equal(404, status);
+        Assert.Contains("removed", message);
+    }
+
+    [Fact]
+    public void DbUpdateException_UniqueViolation_Still409()
+    {
+        // SQLITE_CONSTRAINT_UNIQUE — a concurrent duplicate insert remains a genuine conflict.
+        var ex = new DbUpdateException("unique", new SqliteException("UNIQUE constraint failed: Peers.Ip", 2067));
+        var (message, status) = ManagementApi.MapExceptionToResponse(ex);
+
+        Assert.Equal(409, status);
+        Assert.Contains("exists", message);
     }
 }

--- a/BGPLite.Tests/PeerInputValidationTests.cs
+++ b/BGPLite.Tests/PeerInputValidationTests.cs
@@ -1,3 +1,4 @@
+using BGPLite.Configuration;
 using BGPLite.Api;
 
 namespace BGPLite.Tests;
@@ -115,5 +116,27 @@ public class PeerInputValidationTests
     public void IsConfigurablePeerAsn_ReservedValuesDoNotBleedIntoNeighbours(uint asn)
     {
         Assert.True(ManagementApi.IsConfigurablePeerAsn(asn));
+    }
+
+    /// <summary>
+    /// #266 item 4: subscription names must resolve against the configured lists — an unknown
+    /// name was stored and silently served zero prefixes forever. Both config surfaces count as
+    /// known: RipeStat.AsnLists and PrefixSources.
+    /// </summary>
+    [Fact]
+    public void FindUnknownSubscriptionNames_FlagsTypos_KnowsBothSurfaces()
+    {
+        var config = new AppConfig
+        {
+            Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" },
+            RipeStat = new RipeStatConfig { AsnLists = [new AsnList { Name = "ru" }] },
+            PrefixSources = [new PrefixSourceConfig { Name = "cloud", Kind = "http", Url = "https://example.com/x" }],
+        };
+
+        Assert.Empty(ManagementApi.FindUnknownSubscriptionNames(["ru", "cloud"], config));
+        Assert.Empty(ManagementApi.FindUnknownSubscriptionNames([], config));
+
+        var unknown = ManagementApi.FindUnknownSubscriptionNames(["ru", "ru-backup", "Cloud"], config);
+        Assert.Equal(["ru-backup", "Cloud"], unknown);   // case-sensitive + typo both flagged
     }
 }

--- a/BGPLite.Tests/PeerStoreKeyingTests.cs
+++ b/BGPLite.Tests/PeerStoreKeyingTests.cs
@@ -259,6 +259,58 @@ public class PeerStoreKeyingTests
     }
 
     /// <summary>
+    /// #264: a legacy EnsureCreated-era database MISSING expected Peers columns (an early build
+    /// without Description/LastSessionAt) must be converged at Initialize — the stamp alone left
+    /// the first runtime write failing with "no such column".
+    /// </summary>
+    [Fact]
+    public void Initialize_LegacyDbMissingPeersColumns_ConvergesBeforeStamp()
+    {
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        // Early-build shape: no Description, no LastSessionAt, no Status default concerns.
+        using (var cmd = connection.CreateCommand())
+        {
+            cmd.CommandText =
+                "CREATE TABLE Peers (" +
+                "\"Id\" TEXT NOT NULL PRIMARY KEY, \"Ip\" TEXT NOT NULL, \"Asn\" INTEGER NULL, " +
+                "\"Status\" TEXT NOT NULL DEFAULT 'inactive', \"CreatedAt\" TEXT NOT NULL)";
+            cmd.ExecuteNonQuery();
+        }
+        var options = new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(connection).Options;
+
+        using (var boot = new BgpDbContext(options))
+            BgpDbContext.Initialize(boot);   // RED pre-fix: stamps without converging
+
+        // The columns now exist and a session-status write (the first raw write to touch
+        // LastSessionAt) succeeds instead of throwing "no such column".
+        string[] Columns()
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "PRAGMA table_info(\"Peers\")";
+            using var reader = cmd.ExecuteReader();
+            var names = new List<string>();
+            while (reader.Read())
+                names.Add(reader.GetString(1));
+            return [.. names];
+        }
+        Assert.Contains("Description", Columns());
+        Assert.Contains("LastSessionAt", Columns());
+
+        using (var db = new BgpDbContext(options))
+        {
+            db.Peers.Add(new BGPLite.Api.Entities.Peer { Id = "p1", Ip = "198.51.100.1", Asn = 65001, Description = "converged", LastSessionAt = DateTime.UtcNow });
+            db.SaveChanges();
+        }
+        using (var check = new BgpDbContext(options))
+        {
+            var peer = check.Peers.AsNoTracking().Single();
+            Assert.Equal("converged", peer.Description);
+            Assert.NotNull(peer.LastSessionAt);
+        }
+    }
+
+    /// <summary>
     /// #237: Initialize runs the EF migration pipeline — a fresh database gets Init +
     /// LegacyEnsureCreated applied in order and recorded in __EFMigrationsHistory, and a second
     /// startup is an idempotent no-op (Migrate() finds nothing pending).

--- a/BGPLite.Tests/PrefixCacheRaceTests.cs
+++ b/BGPLite.Tests/PrefixCacheRaceTests.cs
@@ -111,10 +111,10 @@ public class PrefixCacheRaceTests
             // #263 made both required in production; neither is on the GetRuPrefixesAsync path this
             // fixture exercises, so the fake composition states that explicitly rather than relying
             // on a nullable parameter that production code could also leave unset.
-            ripeStat: null!,
+            null!, // RipeStatPrefixCache — not on the GetRuPrefixesAsync path
             prefixSources: source,
             httpProvider: null!,
-            cacheTtl: cacheTtl ?? TimeSpan.FromHours(1),
+            ruCacheTtl: cacheTtl ?? TimeSpan.FromHours(1),
             logger: NullLogger<PrefixService>.Instance,
             timeProvider: timeProvider);
 

--- a/BGPLite.Tests/PrefixServiceTests.cs
+++ b/BGPLite.Tests/PrefixServiceTests.cs
@@ -73,15 +73,17 @@ public class PrefixServiceTests
 
     private static PrefixService Service(PerAsnHandler handler, TimeSpan? cacheTtl = null, TimeSpan? negativeTtl = null, int? maxCacheEntries = null, int retryAttempts = 2, ILogger<PrefixService>? logger = null) =>
         new(new AppConfig(),
-            new RipeStatProvider(new StubFactory(handler),
-                NullLogger<RipeStatProvider>.Instance,
-                new RipeStatConfig { RetryAttempts = retryAttempts, RetryDelaySeconds = 0 }),
+            // #267 item 5: per-ASN TTL/negative-TTL/eviction knobs moved into the shared cache.
+            new RipeStatPrefixCache(
+                new RipeStatProvider(new StubFactory(handler),
+                    NullLogger<RipeStatProvider>.Instance,
+                    new RipeStatConfig { RetryAttempts = retryAttempts, RetryDelaySeconds = 0 }),
+                cacheTtl: cacheTtl,
+                negativeTtl: negativeTtl,
+                maxCacheEntries: maxCacheEntries),
             null!, // IPrefixSourceService is not on the GetPrefixesForAsns path
             null!, // HttpPrefixProvider is only on the per-peer user-source path (#263)
-            cacheTtl: cacheTtl ?? TimeSpan.FromHours(1),
-            logger: logger,
-            negativeTtl: negativeTtl,
-            maxCacheEntries: maxCacheEntries);
+            logger: logger);
 
     /// <summary>The single prefix uint that <see cref="PerAsnHandler"/> yields for a given ASN,
     /// computed through the same <see cref="BgpConstants.IPAddressToUint"/> the provider uses.</summary>

--- a/BGPLite/Program.cs
+++ b/BGPLite/Program.cs
@@ -158,14 +158,27 @@ builder.Services.AddSingleton(sp => new RipeStatProvider(
 
 // AS-originated prefix source (Kind: "asn") — fetches an AS's prefixes via RIPEstat through the
 // provider factory, so `Kind: asn` entries under PrefixSources load like any other source.
-builder.Services.AddSingleton<AsnPrefixProvider>();
+// #267 item 5: the ONE per-ASN RIPEstat cache — shared by PrefixService (RipeStat.AsnLists,
+// custom ASNs) and AsnPrefixProvider (Kind: asn sources), so an ASN configured in both
+// mechanisms is fetched and cached once.
+builder.Services.AddSingleton(sp => new RipeStatPrefixCache(
+    sp.GetRequiredService<RipeStatProvider>(),
+    sp.GetRequiredService<ILogger<RipeStatPrefixCache>>()));
+builder.Services.AddSingleton<AsnPrefixProvider>(sp => new AsnPrefixProvider(
+    sp.GetRequiredService<RipeStatPrefixCache>(),
+    sp.GetRequiredService<ILogger<AsnPrefixProvider>>()));
 builder.Services.AddSingleton<IPrefixSourceProvider>(sp => sp.GetRequiredService<AsnPrefixProvider>());
 
 builder.Services.AddSingleton<IPrefixService>(sp =>
 {
     var ripe = sp.GetRequiredService<RipeStatProvider>();
     var sources = sp.GetRequiredService<IPrefixSourceService>();
-    return new PrefixService(config, ripe, sources, sp.GetRequiredService<HttpPrefixProvider>(), logger: sp.GetRequiredService<ILogger<PrefixService>>());
+    return new PrefixService(
+        config,
+        sp.GetRequiredService<RipeStatPrefixCache>(),
+        sources,
+        sp.GetRequiredService<HttpPrefixProvider>(),
+        logger: sp.GetRequiredService<ILogger<PrefixService>>());
 });
 
 // #263: the BGP send path's dependencies are registered explicitly and resolved with

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -28,7 +28,8 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
 
 ### D3. Malformed AGGREGATOR/AS4_AGGREGATOR takes attribute discard (RESOLVED)
 - **Decision:** a malformed AGGREGATOR or AS4_AGGREGATOR (length ≠ 6/8 by session type, or AS 0 per
-  RFC 7607) is DISCARDED per RFC 7606 §7.7/§7.8 — the attribute is dropped, the UPDATE's routes stay,
+  RFC 7607) is DISCARDED per RFC 7606 §7.7 (AGGREGATOR) / RFC 6793 §6 (AS4_AGGREGATOR — RFC 7606 §7.8
+  is COMMUNITY and §7 excludes attribute 18) — the attribute is dropped, the UPDATE's routes stay,
   a Warning names the dropped type codes.
 - **Context:** was temporarily treat-as-withdraw (stricter than the RFC — routes a conformant
   implementation installs were lost) until the attribute-discard mechanism existed (#306). Flags

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -26,13 +26,18 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
   deviation is recorded in `ReadLoopAsync` and here.
 - **Tracker:** documented in code (#222); intentionally kept.
 
-### D3. Malformed AGGREGATOR withdraws the whole UPDATE (temporary)
-- **Decision:** a malformed AGGREGATOR (length ≠ 6/8 by session type) is handled as treat-as-withdraw.
-- **Context:** RFC 7606 §7.7 prescribes *attribute discard* (keep the routes); BGPLite has no
-  attribute-discard mechanism yet.
-- **Consequence:** BGPLite is stricter than the RFC — routes a conformant implementation installs are
-  lost. Also blocks AS-0 rejection in AGGREGATOR (RFC 7607) from landing correctly.
-- **Tracker:** #306 (open).
+### D3. Malformed AGGREGATOR/AS4_AGGREGATOR takes attribute discard (RESOLVED)
+- **Decision:** a malformed AGGREGATOR or AS4_AGGREGATOR (length ≠ 6/8 by session type, or AS 0 per
+  RFC 7607) is DISCARDED per RFC 7606 §7.7/§7.8 — the attribute is dropped, the UPDATE's routes stay,
+  a Warning names the dropped type codes.
+- **Context:** was temporarily treat-as-withdraw (stricter than the RFC — routes a conformant
+  implementation installs were lost) until the attribute-discard mechanism existed (#306). Flags
+  conflicts on these attributes REMAIN treat-as-withdraw per RFC 7606 §3 — discard is reserved for
+  value/length malformation of attributes with no route-selection effect (§2).
+- **Consequence:** the deferred RFC 7607 half (AS 0 in both aggregator attributes) landed with the
+  mechanism; ValidateAggregatorReconstruction tolerates a discarded AGGREGATOR so a carried-but-malformed
+  one does not trip the pairing rule.
+- **Tracker:** #306.
 
 ### D4. Per-type minimum message lengths classified as body errors
 - **Decision:** too-short OPEN/UPDATE/NOTIFICATION/ROUTE_REFRESH frames surface as Open/Update


### PR DESCRIPTION
Fourth integration of `dev` into `main`: seven commits — one feature, two refactors, three API-hardening fixes, one sync merge (pulling #373's #321 fixes into dev after that PR landed on main from a main-based branch). Each landed on `dev` as its own CI-green squash commit with red/green coverage (details in the linked PRs).

Closes #304
Closes #264
Closes #306

`#265`/`#266`/`#267` stay open — umbrella issues whose items are all dispositioned (see the status comments); closing them is the owner's call.

## What ships

| Area | Summary | PR |
|---|---|---|
| server, config | **#304** — `Bgp.MaxPrefixesPerPeer` (0 = unlimited default): distinct-owned-NLRI counting, breach → NOTIFICATION Cease/1 (RFC 4486) outside the treat-as-withdraw path, owned routes flushed, 75% one-shot warning | #368 |
| providers | **#267 item 4** — four dead Includes removed (projection queries) | #369 |
| providers | **#267 item 5** — ONE shared per-ASN `RipeStatPrefixCache` for both mechanisms (AsnLists + Kind:asn sources); the doc-comment lie fixed; #214 change-detection steadier | #370 |
| api | **#266 items 1/2/7/8** — txt export not double-serialized; CORS Allow-Methods + PATCH; OPTIONS preflights rate-limited; FK (19) → 404 vs UNIQUE (2067) → 409 | #374 |
| api | **#266 item 4** — unknown subscription names rejected with 400 (both config surfaces) | #375 |
| api | **#264** — legacy DBs missing Peers columns converge via guarded ALTER before the Init stamp; required-no-default refuses loudly | #376 |
| — | sync merge of #373's #321 fixes into dev (no new content vs main) | — |

## Verification
- Full suite on `dev` head: **866/866** (845 at the last integration + 21 new tests).
- This PR runs the full main-gate: CI + CodeQL + CodeRabbit (batched review for the delta).

## Behavior changes (all deliberate, documented per PR)
- Opt-in prefix cap (default off — unlimited, unchanged for existing deployments).
- API: txt export is genuinely plain text; preflights consume the rate bucket; FK-race errors read 404; unknown subscription names get 400; legacy DBs converge instead of failing at first write.
- Providers: an ASN configured in both mechanisms is fetched once.

## RFCs touched
RFC 4271 §6.7 + RFC 4486 §2 (max-prefix Cease/1); §8.2.2 (flush on teardown). No wire-format changes elsewhere.

## Risks
Recorded per-PR; the notable one: #267 item 5 renames a PrefixService ctor parameter (ripeStat → ripeStatCache) — CompositionContract covers it, standalone package consumers would see a compile break (the package is not shipped separately yet).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable per-peer prefix limits, warnings at 75% capacity, and session termination when limits are exceeded.
  - Added shared ASN prefix caching to reduce duplicate RIPEstat requests.
  - Added PATCH support in CORS preflight responses.

- **Bug Fixes**
  - Plain-text exports remain unquoted.
  - Unknown subscription names are rejected.
  - Legacy databases receive missing peer fields automatically.
  - Corrected database responses for removed records and conflicts.
  - OPTIONS requests now respect rate limits.
  - Malformed aggregator attributes are discarded while valid routes remain usable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
