### PR TITLE
fix: address CodeRabbit findings on the fourth integration

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -444,7 +444,10 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // parent peer row) must not answer "already exists" for a resource that is GONE.
         if (ex is Microsoft.EntityFrameworkCore.DbUpdateException)
         {
-            if (ex.InnerException is Microsoft.Data.Sqlite.SqliteException sqlite && sqlite.SqliteErrorCode == 19)
+            // #377 review: BOTH constraint classes report primary code 19 in SqliteErrorCode;
+            // the discriminator is the EXTENDED code — 787 (SQLITE_CONSTRAINT_FOREIGNKEY) is the
+            // concurrent-DELETE case, anything else (2067 unique, 19 bare) is a genuine conflict.
+            if (ex.InnerException is Microsoft.Data.Sqlite.SqliteException sqlite && sqlite.SqliteExtendedErrorCode == 787)
                 return ("The peer was removed while the change was being applied", 404);
             return ("The resource already exists or conflicts with the current state", 409);
         }

--- a/BGPLite.Providers/AsnPrefixProvider.cs
+++ b/BGPLite.Providers/AsnPrefixProvider.cs
@@ -44,7 +44,9 @@ public sealed class AsnPrefixProvider : IPrefixSourceProvider
         if (!source.Asn.HasValue)
             throw new InvalidOperationException($"Prefix source '{source.Name}': Kind=asn requires an Asn.");
 
-        var prefixes = await _cache.GetPrefixesAsync(source.Asn.Value, ct);
+        // serveNegativeEntries: false (#377 review) — a cached failure must propagate (throw), not
+        // come back as an empty list the name-level cache would store as a POSITIVE result.
+        var prefixes = await _cache.GetPrefixesAsync(source.Asn.Value, ct, serveNegativeEntries: false);
         _logger.LogInformation(
             "Source '{Name}' (asn AS{Asn}): loaded {Count} prefixes via RIPEstat",
             source.Name, source.Asn.Value, prefixes.Count);

--- a/BGPLite.Providers/RipeStatPrefixCache.cs
+++ b/BGPLite.Providers/RipeStatPrefixCache.cs
@@ -13,6 +13,13 @@ namespace BGPLite.Providers;
 /// separate TTLs — an ASN configured in both doubled RIPEstat traffic and could serve
 /// disagreeing snapshots.
 /// <para>
+/// <para>
+/// #377 review: the negative-entry fast path serves [] to callers that accept the
+/// "nothing this cycle" semantic (the RouteAssembler fan-out). A SOURCE provider must pass
+/// <c>serveNegativeEntries: false</c> — wrapping a cached failure into SourceLoadResult.Ok([])
+/// would store a positive empty list in the name-level cache and mark the source changed,
+/// withdrawing a previously-good advertisement over a transient RIPEstat blip.
+/// </para>
 /// Shape (moved verbatim from <see cref="PrefixService"/>): per-ASN TTL cache with
 /// stale-on-failure (#163), short negative TTL for failed fetches, per-ASN fetch gates against
 /// thundering herds (#164), and a capacity cap with the #165 eviction sweep.
@@ -57,10 +64,12 @@ public sealed class RipeStatPrefixCache
         _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
-    public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
+    public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default, bool serveNegativeEntries = true)
     {
-        // Fast path: fresh entry (positive or negative within its TTL).
-        if (TryGetFresh(asn, out var fresh))
+        // Fast path: fresh entry (positive, or negative within its TTL when the caller accepts
+        // the []-on-recent-failure semantic — the RouteAssembler fan-out does; a source provider
+        // must NOT, see the class doc).
+        if (TryGetFresh(asn, out var fresh) && (serveNegativeEntries || !IsNegative(asn)))
             return fresh;
 
         // Serialize per-ASN so concurrent callers share a single RIPEstat fetch — no thundering herd
@@ -69,8 +78,10 @@ public sealed class RipeStatPrefixCache
         await gate.WaitAsync(ct);
         try
         {
-            // Re-check after acquiring the lock: another caller may have just populated the entry.
-            if (TryGetFresh(asn, out var rechecked))
+            // Re-check after acquiring the lock: another caller may have just populated the entry
+            // (with the same negative-entry discriminator as the outer fast path — #377 review:
+            // forgetting it here re-introduces exactly the Ok([]) hole the provider opts out of).
+            if (TryGetFresh(asn, out var rechecked) && (serveNegativeEntries || !IsNegative(asn)))
                 return rechecked;
 
             IReadOnlyList<(uint Prefix, byte Length)> prefixes;
@@ -106,6 +117,10 @@ public sealed class RipeStatPrefixCache
             gate.Release();
         }
     }
+
+    /// <summary>True when the fresh entry for <paramref name="asn"/> is a NEGATIVE (recent-failure) one.</summary>
+    private bool IsNegative(uint asn) =>
+        _cache.TryGetValue(asn, out var entry) && entry.Negative;
 
     /// <summary>True if <paramref name="asn"/> has a non-expired entry (positive within _cacheTtl,
     /// negative within _negativeTtl).</summary>

--- a/BGPLite.Routing/RouteTable.cs
+++ b/BGPLite.Routing/RouteTable.cs
@@ -67,9 +67,25 @@ public sealed class RouteTable
             }
             if (_routes.TryGetValue(route.Key, out var existing) &&
                 _routes.TryUpdate(route.Key, entry, existing))
+            {
+                // #377 review: ownership transferred — the PREVIOUS owner's session bookkeeping
+                // (e.g. the #304 per-peer prefix set) must learn it no longer holds this key,
+                // or its count drifts upward on overlaps and can trip the cap it no longer owns.
+                // Raised AFTER the swap wins; a stale previous-owner read only means a late
+                // notification, which the remove-if-present handlers tolerate.
+                if (!ReferenceEquals(existing.Owner, owner) && existing.Owner is not null)
+                    EntryOwnershipLost?.Invoke(existing.Owner, route.Key);
                 return false; // replaced an entry that was still present — no count transition
+            }
         }
     }
+
+    /// <summary>
+    /// Fired (on the replacing caller's thread) after an <see cref="AddOrUpdate"/> swap takes a
+    /// key away from a previous owner (#377 review). Subscribers must tolerate invocation from
+    /// any thread and duplicate/late notifications — treat it as "you MIGHT have lost this key".
+    /// </summary>
+    public event Action<object, (uint Prefix, byte Length)>? EntryOwnershipLost;
 
     /// <summary>Unconditional removal, regardless of owner — administrative paths only.</summary>
     public bool Remove(uint prefix, byte length)

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -68,8 +68,11 @@ public sealed class BgpSession : IDisposable
     private ushort _negotiatedHoldTime;
     private List<IpPrefix> _advertisedPrefixes = [];
     // #304: distinct NLRI this session currently owns in the shared table — drives the per-peer
-    // prefix cap (Bgp.MaxPrefixesPerPeer) and its 75% warning.
-    private readonly HashSet<IpPrefix> _installedPrefixes = [];
+    // prefix cap (Bgp.MaxPrefixesPerPeer) and its 75% warning. #377 review: ConcurrentDictionary,
+    // not HashSet — ownership can be taken over by ANOTHER session's install (the
+    // RouteTable.EntryOwnershipLost handler below runs on that session's thread), and the
+    // per-announce cap check reads the count on this session's read loop.
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<IpPrefix, byte> _installedPrefixes = new();
     private bool _maxPrefixesWarned;
     // #212: actual count sent on the wire (after aggregation + dedup). Updated at the end of
     // SendRoutesAsync. Read via AdvertisedPrefixCount for the management API/UI so operators see
@@ -272,6 +275,11 @@ public sealed class BgpSession : IDisposable
         // (test-only) composition, so it gets a real, named implementation that says so out loud —
         // not a RouteAssembler quietly holding nulls.
         _routeAssembler = routeAssembler ?? new SharedTableRouteAssembler(_routeTable, _routeFilter, logger);
+
+        // #377 review: when another session takes over a key this one installed, drop it from the
+        // per-peer prefix set — otherwise the cap count drifts upward on overlapping NLRI and can
+        // trip a reset for prefixes this session no longer owns. Any thread; remove-if-present.
+        _routeTable.EntryOwnershipLost += OnEntryOwnershipLost;
     }
 
     public async Task RunAsync(CancellationToken cancellationToken = default)
@@ -975,11 +983,11 @@ public sealed class BgpSession : IDisposable
                     // BgpNotificationException handler, which sends the NOTIFICATION and tears the
                     // session down (owned routes are flushed by the finally, RFC 4271 §8.2.2).
                     var cap = _bgpConfig.MaxPrefixesPerPeer;
-                    if (cap > 0 && !_installedPrefixes.Contains(nlri) && _installedPrefixes.Count >= cap)
+                    if (cap > 0 && !_installedPrefixes.ContainsKey(nlri) && _installedPrefixes.Count >= cap)
                         throw new BgpNotificationException(
                             BgpConstants.Error.Cease, BgpConstants.SubError.CeaseMaxPrefixes,
                             $"Peer {_peer} exceeded the per-peer prefix limit ({cap}); session reset per RFC 4486");
-                    if (cap > 0 && !_maxPrefixesWarned && _installedPrefixes.Count >= cap * 3 / 4)
+                    if (cap > 0 && !_maxPrefixesWarned && _installedPrefixes.Count >= MaxPrefixWarningThreshold(cap))
                     {
                         _maxPrefixesWarned = true;
                         _logger.LogWarning("Peer {Peer} at {Count}/{Cap} of the per-peer prefix limit", _peer, _installedPrefixes.Count, cap);
@@ -989,7 +997,7 @@ public sealed class BgpSession : IDisposable
                     // remove it (#289). A route the filter dropped is never installed and therefore
                     // never owned, so a later withdrawal for it removes nothing.
                     _routeTable.AddOrUpdate(route, owner: this);
-                    _installedPrefixes.Add(nlri);
+                    _installedPrefixes.TryAdd(nlri, 0);
                     // #85: guard the UintToIPAddress allocation behind IsEnabled — LogDebug
                     // evaluates the arg eagerly even when Debug is filtered out.
                     if (_logger.IsEnabled(LogLevel.Debug))
@@ -1008,6 +1016,27 @@ public sealed class BgpSession : IDisposable
     /// one of its own that another peer has since replaced. A withdrawal that owns nothing is logged
     /// and ignored — not a protocol error, since a stale withdrawal after a reconverge is ordinary.
     /// </summary>
+    /// <summary>
+    /// #377 review: another session took over a key we installed — stop counting it. Runs on the
+    /// REPLACING session's thread (see RouteTable.EntryOwnershipLost); the concurrent set makes
+    /// that safe, and a late/duplicate notification only removes an entry already gone.
+    /// </summary>
+    private void OnEntryOwnershipLost(object previousOwner, (uint Prefix, byte Length) key)
+    {
+        if (!ReferenceEquals(previousOwner, this))
+            return;
+        _installedPrefixes.TryRemove(new IpPrefix(key.Prefix, key.Length), out _);
+    }
+
+    /// <summary>
+    /// 75% of the per-peer prefix cap, overflow-safe (#377 review): cap*3 in int arithmetic
+    /// overflows for large caps and can arm the warning at a wrong (even zero) count. 75% of any
+    /// positive int always fits int (¾·MaxValue &lt; MaxValue), so a widened multiply is exact —
+    /// no saturation branch.
+    /// </summary>
+    internal static int MaxPrefixWarningThreshold(int cap) =>
+        (int)((long)cap * 3 / 4);
+
     private void WithdrawIfOwned(IpPrefix prefix, string reason)
     {
         if (!_routeTable.RemoveOwnedBy(prefix.Address, prefix.Length, this))
@@ -1018,7 +1047,8 @@ public sealed class BgpSession : IDisposable
         }
 
         // #304: the cap counts what this session currently owns — a withdrawal frees budget.
-        _installedPrefixes.Remove(prefix);
+        // (A takeover already removed it via the ownership handler; TryRemove tolerates that.)
+        _installedPrefixes.TryRemove(prefix, out _);
 
         if (_logger.IsEnabled(LogLevel.Debug))
             _logger.LogDebug("{Reason}: {Prefix}", reason, prefix);
@@ -1510,6 +1540,7 @@ public sealed class BgpSession : IDisposable
         // #341: wake any send parked on _sendLock BEFORE the semaphore (and its waiter queue)
         // goes away — SendMessageAsync abandons such waits and reports "not sent".
         _sendLockDisposed.TrySetResult();
+        _routeTable.EntryOwnershipLost -= OnEntryOwnershipLost;
         _cts.Cancel();
         _connection.Dispose();   // owns the socket (SocketBgpConnection wraps NetworkStream ownsSocket:true)
         _cts.Dispose();

--- a/BGPLite.Tests/AsnPrefixProviderTests.cs
+++ b/BGPLite.Tests/AsnPrefixProviderTests.cs
@@ -65,4 +65,47 @@ public class AsnPrefixProviderTests
         Assert.Single(viaSource.Prefixes);
         Assert.Equal(1, handler.Calls);   // RED on the old direct-to-wire provider: 2
     }
+
+    /// <summary>
+    /// #377 review (negative-cache regression of #370): a cached RIPEstat failure must PROPAGATE
+    /// from the provider path — Ok([]) would store a positive empty list in the name-level cache
+    /// and mark the source changed, withdrawing a good advertisement over a transient blip.
+    /// The RouteAssembler path keeps its []-on-recent-failure semantic.
+    /// </summary>
+    private sealed class FailingRipeHandler : HttpMessageHandler
+    {
+        public int Calls { get; private set; }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Calls++;
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.ServiceUnavailable) { Content = new StringContent("blip") });
+        }
+    }
+
+    [Fact]
+    public async Task CachedFailure_PropagatesFromProvider_ServesEmptyToAssemblerPath()
+    {
+        var handler = new FailingRipeHandler();
+        var ripe = new RipeStatProvider(new StubFactory(handler), NullLogger<RipeStatProvider>.Instance,
+            new RipeStatConfig { RetryAttempts = 0, RetryDelaySeconds = 0 });
+        var cache = new RipeStatPrefixCache(ripe, negativeTtl: TimeSpan.FromSeconds(30));
+        var service = new PrefixService(new AppConfig(), cache, null!, null!);
+        var provider = new AsnPrefixProvider(cache, NullLogger<AsnPrefixProvider>.Instance);
+
+        // Prime the negative entry through the assembler path: the first fetch FAILS (no stale
+        // copy exists yet, so it throws and negative-caches), the second serves [] per that path's
+        // documented semantic.
+        await Assert.ThrowsAnyAsync<Exception>(() => service.GetPrefixesAsync(65010));
+        var viaService = await service.GetPrefixesAsync(65010);
+        Assert.Empty(viaService);
+        var primedCalls = handler.Calls;
+
+        // Provider path: the cached failure must THROW, not come back as Ok([]) — Ok would store a
+        // positive empty list in the name-level cache and mark the source changed. The provider
+        // re-fetches (one wire attempt per load — matching its pre-#370 behavior); throttling for
+        // sources lives at the NAME level (PrefixSourceService stale/negative), not here.
+        await Assert.ThrowsAnyAsync<Exception>(() =>
+            provider.LoadAsync(new PrefixSourceConfig { Name = "x", Kind = "asn", Asn = 65010 }));
+        Assert.Equal(primedCalls + 1, handler.Calls);   // exactly one provider-driven wire attempt
+    }
 }

--- a/BGPLite.Tests/BgpSessionHoldTimerTests.cs
+++ b/BGPLite.Tests/BgpSessionHoldTimerTests.cs
@@ -692,6 +692,19 @@ public class BgpSessionHoldTimerTests
     }
 
     /// <summary>
+    /// #377 review: the 75% warning threshold must not overflow — cap*3 in int arithmetic wraps
+    /// for large caps and can arm the warning at a wrong (even tiny) count.
+    /// </summary>
+    [Theory]
+    [InlineData(4, 3)]
+    [InlineData(2, 1)]
+    [InlineData(100, 75)]
+    [InlineData(int.MaxValue, 1610612735)]    // exact 75% via widened arithmetic — no wrap, no saturation
+    [InlineData(1_500_000_000, 1_125_000_000)] // would wrap as int*3
+    public void MaxPrefixWarningThreshold_NoOverflow(int cap, int expected)
+        => Assert.Equal(expected, BgpSession.MaxPrefixWarningThreshold(cap));
+
+    /// <summary>
     /// #341: a blocked writer (a refresh send parked inside WriteAsync — the slow-peer holder of
     /// the issue) holds <c>_sendLock</c>; the next keepalive tick queues on the semaphore with NO
     /// token of its own; <c>Dispose</c> cancels <c>_cts</c> and then disposes the semaphore.

--- a/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
+++ b/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
@@ -627,6 +627,62 @@ public class BgpSessionRouteOwnershipTests
     /// (Cease, MaxPrefixesExceeded) per RFC 4271 §6.7 / RFC 4486 §2, and the finally flushes
     /// the peer's owned routes (RFC 4271 §8.2.2) — the table does not keep the attacker's rows.
     /// </summary>
+    /// <summary>
+    /// #377 review: a session's per-peer prefix set must stay aligned with route-table OWNERSHIP —
+    /// when session B takes over a key session A installed, A stops counting it; otherwise A's
+    /// cap count drifts upward on overlaps and trips a reset for prefixes it no longer owns.
+    /// </summary>
+    private static async Task<(BgpSession Session, Task Run, ScriptedConnection Conn)> EstablishCappedAsync(RouteTable routeTable, int cap, uint routerId)
+    {
+        var conn = new ScriptedConnection();
+        var config = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0, MaxPrefixesPerPeer = cap };
+        var session = new BgpSession(
+            conn, new PeerConfig { Address = "127.0.0.1" }, config, routeTable,
+            AllowAllFilter.Instance, new BgpMetrics(), NullLogger<BgpSession>.Instance);
+        var run = session.RunAsync();
+        conn.EnqueueMessage(new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = 0,
+            RouterId = routerId,
+            Capabilities = [BgpCapabilityInfo.FourOctetAsn(65002)],
+        });
+        conn.EnqueueMessage(BgpKeepaliveMessage.Instance);
+        for (var i = 0; i < 200 && !session.IsEstablished; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        Assert.True(session.IsEstablished, "session must reach Established");
+        return (session, run, conn);
+    }
+
+    [Fact]
+    public async Task TakenOverPrefix_FreesTheOriginalOwnersCapBudget()
+    {
+        var routeTable = new RouteTable();
+        var (a, aRun, aConn) = await EstablishCappedAsync(routeTable, cap: 1, routerId: 0x0A000002);
+        var (b, bRun, bConn) = await EstablishCappedAsync(routeTable, cap: 0, routerId: 0x0A000003);
+
+        // A installs 10/8 (its single budget slot).
+        aConn.EnqueueFrame(AnnounceFrame(8, 0x0A));
+        await SettleAsync(aConn, () => routeTable.Count == 1);
+
+        // B takes the SAME prefix over — A no longer owns it.
+        bConn.EnqueueFrame(AnnounceFrame(8, 0x0A));
+        await SettleAsync(bConn, () => routeTable.Get(TenSlashEight, 8) is not null);
+        await Task.Delay(50);   // let the ownership-lost notification land
+
+        // A announces a DIFFERENT prefix with cap=1 — pre-fix this tripped the cap (A still
+        // counted the taken-over 10/8) and reset A; post-fix A owns only the new prefix.
+        aConn.EnqueueFrame(AnnounceFrame(24, 0xC0, 0x00, 0x02));
+        await SettleAsync(aConn, () => routeTable.Count == 2);
+
+        Assert.True(a.IsEstablished, "the taken-over prefix must not count against A's cap");   // RED pre-fix
+        Assert.Equal(2, routeTable.Count);
+
+        await TeardownAsync(a, aRun);
+        await TeardownAsync(b, bRun);
+    }
+
     private static async Task<(BgpSession Session, Task Run, ScriptedConnection Conn, RouteTable Table)> EstablishCappedAsync(int cap)
     {
         var routeTable = new RouteTable();

--- a/BGPLite.Tests/ExceptionMappingTests.cs
+++ b/BGPLite.Tests/ExceptionMappingTests.cs
@@ -95,7 +95,7 @@ public class ExceptionMappingTests
     [Fact]
     public void DbUpdateException_FkViolation_MapsTo_404()
     {
-        var ex = new DbUpdateException("constraint failed", new SqliteException("FK constraint failed", 19));
+        var ex = new DbUpdateException("constraint failed", new SqliteException("FK constraint failed", 19, 787));
         var (message, status) = ManagementApi.MapExceptionToResponse(ex);
 
         Assert.Equal(404, status);
@@ -106,7 +106,9 @@ public class ExceptionMappingTests
     public void DbUpdateException_UniqueViolation_Still409()
     {
         // SQLITE_CONSTRAINT_UNIQUE — a concurrent duplicate insert remains a genuine conflict.
-        var ex = new DbUpdateException("unique", new SqliteException("UNIQUE constraint failed: Peers.Ip", 2067));
+        // Realistic shape: BOTH classes report primary 19; the discriminator is the EXTENDED
+        // code (2067 = SQLITE_CONSTRAINT_UNIQUE).
+        var ex = new DbUpdateException("unique", new SqliteException("UNIQUE constraint failed: Peers.Ip", 19, 2067));
         var (message, status) = ManagementApi.MapExceptionToResponse(ex);
 
         Assert.Equal(409, status);


### PR DESCRIPTION
Review response to #377's four findings — all verified real, all fixed: negative-cache Ok([]) propagation through the provider path (a #370 regression, incl. the under-gate re-check hole), per-peer prefix set vs route ownership (takeover event + concurrent set), 75%-threshold int overflow (exact widened arithmetic), FK/UNIQUE extended-code discrimination. Red/green per finding; suite 873/873. Lands on dev and re-triggers the #377 review on the new head.