### PR TITLE
feat(protocol): RFC 7606 attribute discard — malformed AGGREGATOR/AS4_AGGREGATOR keeps the routes

### DIFF
--- a/BGPLite.Protocol/AttributeHelper.cs
+++ b/BGPLite.Protocol/AttributeHelper.cs
@@ -98,9 +98,18 @@ public static class AttributeHelper
             throw new BgpParseException($"Malformed AGGREGATOR attribute: expected {expectedLength} bytes on a {(fourByteAsn ? "4-octet" : "2-octet")}-AS session, got {attr.Data.Length}",
                 BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.OptionalAttributeError);
 
-        return fourByteAsn
+        var asn = fourByteAsn
             ? BinaryPrimitives.ReadUInt32BigEndian(attr.Data)
             : BinaryPrimitives.ReadUInt16BigEndian(attr.Data);
+
+        // RFC 7607 §2: "an UPDATE with AS 0 in the AGGREGATOR ... MUST be considered as malformed
+        // and be handled by the procedures specified in [RFC7606]" — for AGGREGATOR that remedy
+        // is attribute discard (#306; was deliberately deferred from #300 until discard existed).
+        if (asn == 0)
+            throw new BgpParseException("Invalid AGGREGATOR attribute: AS 0 is reserved (RFC 7607)",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.OptionalAttributeError);
+
+        return asn;
     }
 
     /// <summary>
@@ -116,7 +125,15 @@ public static class AttributeHelper
             throw new BgpParseException($"Malformed AS4_AGGREGATOR attribute: expected 8 bytes, got {attr.Data.Length}",
                 BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.OptionalAttributeError);
 
-        return BinaryPrimitives.ReadUInt32BigEndian(attr.Data);
+        var asn = BinaryPrimitives.ReadUInt32BigEndian(attr.Data);
+
+        // RFC 7607 §2 — AS 0 in AS4_AGGREGATOR is malformed; RFC 7606 §7.8 assigns attribute
+        // discard (#306).
+        if (asn == 0)
+            throw new BgpParseException("Invalid AS4_AGGREGATOR attribute: AS 0 is reserved (RFC 7607)",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.OptionalAttributeError);
+
+        return asn;
     }
 
     public static PathAttribute WriteNextHop(uint nextHop)

--- a/BGPLite.Protocol/UpdateCodec.cs
+++ b/BGPLite.Protocol/UpdateCodec.cs
@@ -169,12 +169,15 @@ public static class UpdateCodec
     /// Validates RFC 6793 AGGREGATOR/AS4_AGGREGATOR consistency: AS_TRANS in AGGREGATOR requires
     /// AS4_AGGREGATOR, and a lone AS4_AGGREGATOR without AGGREGATOR is malformed.
     /// </summary>
-    public static void ValidateAggregatorReconstruction(uint? aggregatorAsn, uint? as4AggregatorAsn)
+    public static void ValidateAggregatorReconstruction(uint? aggregatorAsn, uint? as4AggregatorAsn, bool aggregatorDiscarded = false)
     {
         if (aggregatorAsn == BgpConstants.AsPath.AsTrans && as4AggregatorAsn is null)
             throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.OptionalAttributeError, "Missing AS4_AGGREGATOR for AGGREGATOR AS_TRANS");
 
-        if (!aggregatorAsn.HasValue && as4AggregatorAsn.HasValue)
+        // #306: an UPDATE that CARRIED an AGGREGATOR which was discarded as malformed must not be
+        // penalized for the pairing rule — the AS4 value alone satisfies everything BGPLite uses
+        // these attributes for (the consistency check itself).
+        if (!aggregatorAsn.HasValue && as4AggregatorAsn.HasValue && !aggregatorDiscarded)
             throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.OptionalAttributeError, "Missing AGGREGATOR attribute for AS4_AGGREGATOR");
     }
 
@@ -191,7 +194,8 @@ public static class UpdateCodec
         uint[] AsPath,
         uint NextHop,
         uint[] Communities,
-        (uint Global, uint Local1, uint Local2)[] LargeCommunities);
+        (uint Global, uint Local1, uint Local2)[] LargeCommunities,
+        IReadOnlyList<byte> DiscardedAttributes = null!);
 
     /// <summary>
     /// Parses and validates the path attributes of an announcing UPDATE per RFC 4271 §6.3 /
@@ -218,6 +222,8 @@ public static class UpdateCodec
             uint[] as4Path = [];
             uint? aggregatorAsn = null;
             uint? as4AggregatorAsn = null;
+            // (typeCode, reason) per RFC 7606 attribute-discard — surfaced for the session's log/metric.
+            var discarded = new List<(byte TypeCode, string Reason)>();
 
             // RFC 7606 §3 (revising RFC 4271 §6.3): "If any other attribute (whether recognized or
             // unrecognized) appears more than once in an UPDATE message, then all the occurrences of
@@ -293,11 +299,19 @@ public static class UpdateCodec
                     case BgpConstants.Attribute.LargeCommunity:
                         largeCommunities = AttributeHelper.ReadLargeCommunities(attr);
                         break;
+                    // #306 (RFC 7606 §7.7/§7.8): AGGREGATOR/AS4_AGGREGATOR malformations — wrong
+                    // length by session type, AS 0 (RFC 7607) — take ATTRIBUTE DISCARD, not
+                    // treat-as-withdraw: drop the attribute, keep processing the UPDATE. Both are
+                    // read solely for the RFC 6793 consistency check and never influence route
+                    // selection or installation, which is §2's constraint on this remedy. Flags
+                    // conflicts (ValidateAttributeShape above) stay treat-as-withdraw per §3.
                     case BgpConstants.Attribute.Aggregator:
-                        aggregatorAsn = AttributeHelper.ReadAggregatorAsn(attr, fourByteAsnSession);
+                        try { aggregatorAsn = AttributeHelper.ReadAggregatorAsn(attr, fourByteAsnSession); }
+                        catch (BgpParseException ex) { discarded.Add((attr.TypeCode, ex.Message)); }
                         break;
                     case BgpConstants.Attribute.As4Aggregator when !fourByteAsnSession:
-                        as4AggregatorAsn = AttributeHelper.ReadAs4AggregatorAsn(attr);
+                        try { as4AggregatorAsn = AttributeHelper.ReadAs4AggregatorAsn(attr); }
+                        catch (BgpParseException ex) { discarded.Add((attr.TypeCode, ex.Message)); }
                         break;
                 }
             }
@@ -310,9 +324,11 @@ public static class UpdateCodec
             if (nextHopSeen)
                 ValidateNextHopSemantics(nextHop, localRouterId);
             asPath = MergeAsPathWithAs4Path(asPath, as4Path);
-            ValidateAggregatorReconstruction(aggregatorAsn, as4AggregatorAsn);
+            var aggregatorDiscarded = discarded.Any(d => d.TypeCode == BgpConstants.Attribute.Aggregator);
+            ValidateAggregatorReconstruction(aggregatorAsn, as4AggregatorAsn, aggregatorDiscarded);
 
-            return new RouteAttributes(asPath, nextHop, communities, largeCommunities);
+            return new RouteAttributes(asPath, nextHop, communities, largeCommunities,
+                discarded.Select(d => d.TypeCode).ToArray());
         }
         catch (BgpParseException ex)
         {

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -944,6 +944,13 @@ public sealed class BgpSession : IDisposable
                 throw;
             }
 
+            // #306: RFC 7606 attribute-discard surfaced — the UPDATE is otherwise fine and its
+            // routes install; a Warning shows WHICH attributes were dropped (the session stays up,
+            // so this is the only trace an operator gets).
+            if (attrs.DiscardedAttributes is { Count: > 0 } dropped)
+                _logger.LogWarning("Discarded malformed attribute(s) [{Types}] from {Peer} — routes kept (RFC 7606 attribute discard)",
+                    string.Join(",", dropped), _peer);
+
             var filterPeerConfig = GetFilterPeerConfig();
 
             foreach (var nlri in update.Nlri)

--- a/BGPLite.Tests/BgpSessionRfc6793Tests.cs
+++ b/BGPLite.Tests/BgpSessionRfc6793Tests.cs
@@ -122,6 +122,103 @@ public class BgpSessionRfc6793Tests
         Assert.Contains(expected, ex.Message);
     }
 
+    /// <summary>
+    /// #306 (RFC 7606 §7.7): a malformed AGGREGATOR takes ATTRIBUTE DISCARD — the attribute is
+    /// dropped and the UPDATE's routes stay. Pre-fix this was treat-as-withdraw (D3): a wrong
+    /// length (5 bytes on a 2-octet session) withdrew routes a conformant implementation installs.
+    /// </summary>
+    [Fact]
+    public void ParseRouteAttributes_MalformedAggregator_AttributeDiscarded_RouteKept()
+    {
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+                AttributeHelper.WriteAsPath([65001u], fourByteAsn: true),
+                AttributeHelper.WriteNextHop(0x0A000001),
+                new PathAttribute { Flags = 0xC0, TypeCode = BgpConstants.Attribute.Aggregator, Data = new byte[5] }, // 5 bytes — neither 6 nor 8
+            ],
+            Nlri = [new IpPrefix(0x0A000000, 24)]
+        };
+
+        var attrs = UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: true);   // RED pre-fix: threw 3/9
+
+        Assert.Equal(0x0A000001u, attrs.NextHop);                    // route data intact
+        Assert.Equal([BgpConstants.Attribute.Aggregator], attrs.DiscardedAttributes); // ...with the attribute reported discarded
+    }
+
+    /// <summary>RFC 7607 §2 (the half #300 deferred): AS 0 in AGGREGATOR is malformed → discarded, routes kept.</summary>
+    [Fact]
+    public void ParseRouteAttributes_AsZeroAggregator_Discarded_RouteKept()
+    {
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+                AttributeHelper.WriteAsPath([65001u], fourByteAsn: true),
+                AttributeHelper.WriteNextHop(0x0A000001),
+                new PathAttribute { Flags = 0xC0, TypeCode = BgpConstants.Attribute.Aggregator, Data = new byte[8] }, // AS 0 + 0.0.0.0
+            ],
+            Nlri = [new IpPrefix(0x0A000000, 24)]
+        };
+
+        var attrs = UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: true);
+
+        Assert.Equal([BgpConstants.Attribute.Aggregator], attrs.DiscardedAttributes);
+        Assert.Equal(0x0A000001u, attrs.NextHop);
+    }
+
+    /// <summary>
+    /// #306 interplay: a discarded AGGREGATOR must not trip "Missing AGGREGATOR for AS4_AGGREGATOR"
+    /// for an UPDATE that carried one — the consistency check tolerates the discard.
+    /// </summary>
+    [Fact]
+    public void ParseRouteAttributes_DiscardedAggregator_WithAs4Aggregator_NoPairingError()
+    {
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+                AttributeHelper.WriteAsPath([65001u], fourByteAsn: false),
+                AttributeHelper.WriteNextHop(0x0A000001),
+                new PathAttribute { Flags = 0xC0, TypeCode = BgpConstants.Attribute.Aggregator, Data = new byte[5] },     // malformed → discarded
+                new PathAttribute { Flags = 0xC0, TypeCode = BgpConstants.Attribute.As4Aggregator, Data = new byte[8] },  // valid, AS 65001
+            ],
+            Nlri = [new IpPrefix(0x0A000000, 24)]
+        };
+
+        var attrs = UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: false);   // RED pre-fix: 3/9 pairing error
+
+        Assert.Contains(BgpConstants.Attribute.Aggregator, attrs.DiscardedAttributes);
+    }
+
+    /// <summary>
+    /// Boundary: attribute discard applies to VALUE/LENGTH malformation only — a FLAGS conflict on
+    /// AGGREGATOR stays treat-as-withdraw per RFC 7606 §3 (flags errors are never discard-eligible).
+    /// </summary>
+    [Fact]
+    public void ParseRouteAttributes_AggregatorFlagsConflict_StillTreatAsWithdraw()
+    {
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+                AttributeHelper.WriteAsPath([65001u], fourByteAsn: true),
+                AttributeHelper.WriteNextHop(0x0A000001),
+                new PathAttribute { Flags = 0x40, TypeCode = BgpConstants.Attribute.Aggregator, Data = new byte[8] }, // well-known — flags conflict
+            ],
+            Nlri = [new IpPrefix(0x0A000000, 24)]
+        };
+
+        var ex = Assert.Throws<BgpNotificationException>(
+            () => UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: true));
+        Assert.Equal(BgpConstants.SubError.AttributeFlagsError, ex.SubErrorCode);
+    }
+
     [Fact]
     public void ParseRouteAttributes_ValidNextHop_Accepted()
     {

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -26,13 +26,18 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
   deviation is recorded in `ReadLoopAsync` and here.
 - **Tracker:** documented in code (#222); intentionally kept.
 
-### D3. Malformed AGGREGATOR withdraws the whole UPDATE (temporary)
-- **Decision:** a malformed AGGREGATOR (length ≠ 6/8 by session type) is handled as treat-as-withdraw.
-- **Context:** RFC 7606 §7.7 prescribes *attribute discard* (keep the routes); BGPLite has no
-  attribute-discard mechanism yet.
-- **Consequence:** BGPLite is stricter than the RFC — routes a conformant implementation installs are
-  lost. Also blocks AS-0 rejection in AGGREGATOR (RFC 7607) from landing correctly.
-- **Tracker:** #306 (open).
+### D3. Malformed AGGREGATOR/AS4_AGGREGATOR takes attribute discard (RESOLVED)
+- **Decision:** a malformed AGGREGATOR or AS4_AGGREGATOR (length ≠ 6/8 by session type, or AS 0 per
+  RFC 7607) is DISCARDED per RFC 7606 §7.7/§7.8 — the attribute is dropped, the UPDATE's routes stay,
+  a Warning names the dropped type codes.
+- **Context:** was temporarily treat-as-withdraw (stricter than the RFC — routes a conformant
+  implementation installs were lost) until the attribute-discard mechanism existed (#306). Flags
+  conflicts on these attributes REMAIN treat-as-withdraw per RFC 7606 §3 — discard is reserved for
+  value/length malformation of attributes with no route-selection effect (§2).
+- **Consequence:** the deferred RFC 7607 half (AS 0 in both aggregator attributes) landed with the
+  mechanism; ValidateAggregatorReconstruction tolerates a discarded AGGREGATOR so a carried-but-malformed
+  one does not trip the pairing rule.
+- **Tracker:** #306.
 
 ### D4. Per-type minimum message lengths classified as body errors
 - **Decision:** too-short OPEN/UPDATE/NOTIFICATION/ROUTE_REFRESH frames surface as Open/Update


### PR DESCRIPTION
Closes #306   # linkage; closure lands with the integration PR. Also resolves D3 (catalog updated in-PR).

## Problem
No attribute-discard remedy existed; a malformed AGGREGATOR (length ≠ 6/8 by session type) withdrew the whole UPDATE where RFC 7606 §7.7 prescribes discarding only the attribute — stricter than the RFC, losing installable routes (D3, recorded temporary).

## RFC
RFC 7606 §2 (attribute discard; the §2 constraint — 'no effect on route selection or installation' — is why AGGREGATOR/AS4_AGGREGATOR qualify and nothing else), §7.7/§7.8 (per-attribute remedy), §3 (flags conflicts remain treat-as-withdraw). RFC 7607 §2 — AS 0 in both aggregator attributes is malformed; with discard existing, the half #300 deferred lands correctly.

## Fix
Per-attribute guard around the two aggregator readers in `ParseRouteAttributes`; drops recorded in `RouteAttributes.DiscardedAttributes`; session logs a Warning naming the type codes. `ValidateAggregatorReconstruction` gains `aggregatorDiscarded` so a carried-but-malformed AGGREGATOR cannot trip the pairing rule. AS-0 checks added to both readers.

## Regression Tests
4 tests: malformed-length discard w/ routes kept (red: 3/9), AS-0 discard, discarded+valid-AS4 pairing tolerance (red: 3/9), flags-conflict boundary (still withdraw).

## Verification
`dotnet format` / `dotnet build` (0 errors) / full suite **877/877**.

## Behavior Change
Deliberate: UPDATEs with malformed aggregator attributes now install their routes (attribute dropped + Warning) instead of being withdrawn.

## Deviation from Issue Proposal
None — the issue's suggested shape implemented, including both design points (eligibility limited to §7.7/§7.8 attributes; reconstruction tolerance).

Note: HELD for dev-merge until #377 lands (its reviewed head must stay stable).