### PR TITLE
fix: address the second-pass CodeRabbit findings on #377 (#306 hardening)

### DIFF
--- a/BGPLite.Protocol/AttributeHelper.cs
+++ b/BGPLite.Protocol/AttributeHelper.cs
@@ -127,8 +127,8 @@ public static class AttributeHelper
 
         var asn = BinaryPrimitives.ReadUInt32BigEndian(attr.Data);
 
-        // RFC 7607 §2 — AS 0 in AS4_AGGREGATOR is malformed; RFC 7606 §7.8 assigns attribute
-        // discard (#306).
+        // RFC 7607 §2 — AS 0 in AS4_AGGREGATOR is malformed, handled per RFC 6793 §6:
+        // attribute discard (#306; RFC 7606 §7.8 is COMMUNITY).
         if (asn == 0)
             throw new BgpParseException("Invalid AS4_AGGREGATOR attribute: AS 0 is reserved (RFC 7607)",
                 BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.OptionalAttributeError);

--- a/BGPLite.Protocol/UpdateCodec.cs
+++ b/BGPLite.Protocol/UpdateCodec.cs
@@ -169,14 +169,14 @@ public static class UpdateCodec
     /// Validates RFC 6793 AGGREGATOR/AS4_AGGREGATOR consistency: AS_TRANS in AGGREGATOR requires
     /// AS4_AGGREGATOR, and a lone AS4_AGGREGATOR without AGGREGATOR is malformed.
     /// </summary>
-    public static void ValidateAggregatorReconstruction(uint? aggregatorAsn, uint? as4AggregatorAsn, bool aggregatorDiscarded = false)
+    public static void ValidateAggregatorReconstruction(uint? aggregatorAsn, uint? as4AggregatorAsn, bool aggregatorDiscarded = false, bool as4AggregatorDiscarded = false)
     {
-        if (aggregatorAsn == BgpConstants.AsPath.AsTrans && as4AggregatorAsn is null)
+        // #306/#377 review: a discarded-malformed attribute must not penalize the pairing rules —
+        // the UPDATE carried it; it was dropped per RFC 7606 §7.7 (AGGREGATOR) / RFC 6793 §6
+        // (AS4_AGGREGATOR), and what remains satisfies everything the check exists for.
+        if (aggregatorAsn == BgpConstants.AsPath.AsTrans && as4AggregatorAsn is null && !as4AggregatorDiscarded)
             throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.OptionalAttributeError, "Missing AS4_AGGREGATOR for AGGREGATOR AS_TRANS");
 
-        // #306: an UPDATE that CARRIED an AGGREGATOR which was discarded as malformed must not be
-        // penalized for the pairing rule — the AS4 value alone satisfies everything BGPLite uses
-        // these attributes for (the consistency check itself).
         if (!aggregatorAsn.HasValue && as4AggregatorAsn.HasValue && !aggregatorDiscarded)
             throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.OptionalAttributeError, "Missing AGGREGATOR attribute for AS4_AGGREGATOR");
     }
@@ -299,12 +299,15 @@ public static class UpdateCodec
                     case BgpConstants.Attribute.LargeCommunity:
                         largeCommunities = AttributeHelper.ReadLargeCommunities(attr);
                         break;
-                    // #306 (RFC 7606 §7.7/§7.8): AGGREGATOR/AS4_AGGREGATOR malformations — wrong
-                    // length by session type, AS 0 (RFC 7607) — take ATTRIBUTE DISCARD, not
-                    // treat-as-withdraw: drop the attribute, keep processing the UPDATE. Both are
-                    // read solely for the RFC 6793 consistency check and never influence route
-                    // selection or installation, which is §2's constraint on this remedy. Flags
-                    // conflicts (ValidateAttributeShape above) stay treat-as-withdraw per §3.
+                    // #306: AGGREGATOR/AS4_AGGREGATOR malformations — wrong length by session
+                    // type, AS 0 (RFC 7607) — take ATTRIBUTE DISCARD, not treat-as-withdraw: drop
+                    // the attribute, keep processing the UPDATE. Citations differ per attribute:
+                    // AGGREGATOR per RFC 7606 §7.7; AS4_AGGREGATOR per RFC 6793 §6 ("the
+                    // AS4_AGGREGATOR is just informational, the 'attribute discard' approach is
+                    // chosen" — RFC 7606 §7.8 is COMMUNITY and §7 explicitly excludes attribute 18).
+                    // Both feed only the RFC 6793 consistency check and never influence route
+                    // selection/installation — RFC 7606 §2's constraint. Flags conflicts
+                    // (ValidateAttributeShape above) stay treat-as-withdraw per §3.
                     case BgpConstants.Attribute.Aggregator:
                         try { aggregatorAsn = AttributeHelper.ReadAggregatorAsn(attr, fourByteAsnSession); }
                         catch (BgpParseException ex) { discarded.Add((attr.TypeCode, ex.Message)); }
@@ -324,8 +327,9 @@ public static class UpdateCodec
             if (nextHopSeen)
                 ValidateNextHopSemantics(nextHop, localRouterId);
             asPath = MergeAsPathWithAs4Path(asPath, as4Path);
-            var aggregatorDiscarded = discarded.Any(d => d.TypeCode == BgpConstants.Attribute.Aggregator);
-            ValidateAggregatorReconstruction(aggregatorAsn, as4AggregatorAsn, aggregatorDiscarded);
+            ValidateAggregatorReconstruction(aggregatorAsn, as4AggregatorAsn,
+                aggregatorDiscarded: discarded.Any(d => d.TypeCode == BgpConstants.Attribute.Aggregator),
+                as4AggregatorDiscarded: discarded.Any(d => d.TypeCode == BgpConstants.Attribute.As4Aggregator));
 
             return new RouteAttributes(asPath, nextHop, communities, largeCommunities,
                 discarded.Select(d => d.TypeCode).ToArray());

--- a/BGPLite.Providers/RipeStatPrefixCache.cs
+++ b/BGPLite.Providers/RipeStatPrefixCache.cs
@@ -69,7 +69,7 @@ public sealed class RipeStatPrefixCache
         // Fast path: fresh entry (positive, or negative within its TTL when the caller accepts
         // the []-on-recent-failure semantic — the RouteAssembler fan-out does; a source provider
         // must NOT, see the class doc).
-        if (TryGetFresh(asn, out var fresh) && (serveNegativeEntries || !IsNegative(asn)))
+        if (TryGetFresh(asn, out var fresh, out var freshIsNegative) && (serveNegativeEntries || !freshIsNegative))
             return fresh;
 
         // Serialize per-ASN so concurrent callers share a single RIPEstat fetch — no thundering herd
@@ -81,7 +81,7 @@ public sealed class RipeStatPrefixCache
             // Re-check after acquiring the lock: another caller may have just populated the entry
             // (with the same negative-entry discriminator as the outer fast path — #377 review:
             // forgetting it here re-introduces exactly the Ok([]) hole the provider opts out of).
-            if (TryGetFresh(asn, out var rechecked) && (serveNegativeEntries || !IsNegative(asn)))
+            if (TryGetFresh(asn, out var rechecked, out var recheckIsNegative) && (serveNegativeEntries || !recheckIsNegative))
                 return rechecked;
 
             IReadOnlyList<(uint Prefix, byte Length)> prefixes;
@@ -118,21 +118,21 @@ public sealed class RipeStatPrefixCache
         }
     }
 
-    /// <summary>True when the fresh entry for <paramref name="asn"/> is a NEGATIVE (recent-failure) one.</summary>
-    private bool IsNegative(uint asn) =>
-        _cache.TryGetValue(asn, out var entry) && entry.Negative;
-
     /// <summary>True if <paramref name="asn"/> has a non-expired entry (positive within _cacheTtl,
-    /// negative within _negativeTtl).</summary>
-    private bool TryGetFresh(uint asn, out IReadOnlyList<(uint Prefix, byte Length)> data)
+    /// negative within _negativeTtl). #377 review: the negative flag comes out of the SAME read —
+    /// a separate IsNegative lookup could miss an eviction racing between the two and serve a
+    /// captured [] to a caller that opted out of negatives.</summary>
+    private bool TryGetFresh(uint asn, out IReadOnlyList<(uint Prefix, byte Length)> data, out bool isNegative)
     {
         data = null!;
+        isNegative = false;
         if (!_cache.TryGetValue(asn, out var entry)) return false;
 
         var ttl = entry.Negative ? _negativeTtl : _cacheTtl;
         if (_timeProvider.GetUtcNow().UtcDateTime - entry.CachedAt < ttl)
         {
             data = entry.Data;
+            isNegative = entry.Negative;
             return true;
         }
         return false;

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -994,17 +994,24 @@ public sealed class BgpSession : IDisposable
                         throw new BgpNotificationException(
                             BgpConstants.Error.Cease, BgpConstants.SubError.CeaseMaxPrefixes,
                             $"Peer {_peer} exceeded the per-peer prefix limit ({cap}); session reset per RFC 4486");
-                    if (cap > 0 && !_maxPrefixesWarned && _installedPrefixes.Count >= MaxPrefixWarningThreshold(cap))
-                    {
-                        _maxPrefixesWarned = true;
-                        _logger.LogWarning("Peer {Peer} at {Count}/{Cap} of the per-peer prefix limit", _peer, _installedPrefixes.Count, cap);
-                    }
+                    // #377 review: record membership BEFORE publishing — a concurrent takeover
+                    // fires EntryOwnershipLost synchronously inside AddOrUpdate, and the handler's
+                    // remove would no-op against a key not yet recorded, leaving this session
+                    // counting a prefix it no longer owns.
+                    _installedPrefixes.TryAdd(nlri, 0);
 
                     // Tagged with this session as the owner, so only this peer's own withdrawal can
                     // remove it (#289). A route the filter dropped is never installed and therefore
                     // never owned, so a later withdrawal for it removes nothing.
                     _routeTable.AddOrUpdate(route, owner: this);
-                    _installedPrefixes.TryAdd(nlri, 0);
+
+                    // #377 review: warn AFTER the install with the actual count — the pre-install
+                    // count logged "0/1" for the very first route under cap=1 (threshold floor 0).
+                    if (cap > 0 && !_maxPrefixesWarned && _installedPrefixes.Count >= MaxPrefixWarningThreshold(cap))
+                    {
+                        _maxPrefixesWarned = true;
+                        _logger.LogWarning("Peer {Peer} at {Count}/{Cap} of the per-peer prefix limit", _peer, _installedPrefixes.Count, cap);
+                    }
                     // #85: guard the UintToIPAddress allocation behind IsEnabled — LogDebug
                     // evaluates the arg eagerly even when Debug is filtered out.
                     if (_logger.IsEnabled(LogLevel.Debug))

--- a/BGPLite.Tests/BgpSessionHoldTimerTests.cs
+++ b/BGPLite.Tests/BgpSessionHoldTimerTests.cs
@@ -700,6 +700,7 @@ public class BgpSessionHoldTimerTests
     [InlineData(2, 1)]
     [InlineData(100, 75)]
     [InlineData(int.MaxValue, 1610612735)]    // exact 75% via widened arithmetic — no wrap, no saturation
+    [InlineData(1, 0)]                        // floor: with post-install logging this reads "at 1/1"
     [InlineData(1_500_000_000, 1_125_000_000)] // would wrap as int*3
     public void MaxPrefixWarningThreshold_NoOverflow(int cap, int expected)
         => Assert.Equal(expected, BgpSession.MaxPrefixWarningThreshold(cap));

--- a/BGPLite.Tests/BgpSessionRfc6793Tests.cs
+++ b/BGPLite.Tests/BgpSessionRfc6793Tests.cs
@@ -185,7 +185,8 @@ public class BgpSessionRfc6793Tests
                 AttributeHelper.WriteAsPath([65001u], fourByteAsn: false),
                 AttributeHelper.WriteNextHop(0x0A000001),
                 new PathAttribute { Flags = 0xC0, TypeCode = BgpConstants.Attribute.Aggregator, Data = new byte[5] },     // malformed → discarded
-                new PathAttribute { Flags = 0xC0, TypeCode = BgpConstants.Attribute.As4Aggregator, Data = new byte[8] },  // valid, AS 65001
+                new PathAttribute { Flags = 0xC0, TypeCode = BgpConstants.Attribute.As4Aggregator,
+                    Data = [0x00, 0x00, 0xFD, 0xE9, 0x00, 0x00, 0x00, 0x00] },                                            // valid, AS 65001
             ],
             Nlri = [new IpPrefix(0x0A000000, 24)]
         };
@@ -193,6 +194,35 @@ public class BgpSessionRfc6793Tests
         var attrs = UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: false);   // RED pre-fix: 3/9 pairing error
 
         Assert.Contains(BgpConstants.Attribute.Aggregator, attrs.DiscardedAttributes);
+        Assert.DoesNotContain(BgpConstants.Attribute.As4Aggregator, attrs.DiscardedAttributes);   // #377 review: the AS4 side is VALID — not silently discarded too
+    }
+
+    /// <summary>
+    /// #377 review: a valid AGGREGATOR (AS_TRANS) + malformed AS4_AGGREGATOR must not trip the
+    /// "Missing AS4_AGGREGATOR for AGGREGATOR AS_TRANS" pairing rule — the UPDATE CARRIED an
+    /// AS4_AGGREGATOR and it was discarded per RFC 6793 §6; routes stay.
+    /// </summary>
+    [Fact]
+    public void ParseRouteAttributes_AsTransAggregator_MalformedAs4Aggregator_NoPairingError()
+    {
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+                AttributeHelper.WriteAsPath([65001u], fourByteAsn: false),
+                AttributeHelper.WriteNextHop(0x0A000001),
+                new PathAttribute { Flags = 0xC0, TypeCode = BgpConstants.Attribute.Aggregator,
+                    Data = [0x5B, 0xA0, 0x00, 0x00, 0x00, 0x00] },                        // AS_TRANS (23456 = 0x5BA0) 2-octet form
+                new PathAttribute { Flags = 0xC0, TypeCode = BgpConstants.Attribute.As4Aggregator, Data = new byte[5] }, // malformed length
+            ],
+            Nlri = [new IpPrefix(0x0A000000, 24)]
+        };
+
+        var attrs = UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: false);   // RED pre-fix: 3/9 pairing error
+
+        Assert.Contains(BgpConstants.Attribute.As4Aggregator, attrs.DiscardedAttributes);
+        Assert.Equal(0x0A000001u, attrs.NextHop);
     }
 
     /// <summary>

--- a/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
+++ b/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
@@ -666,10 +666,24 @@ public class BgpSessionRouteOwnershipTests
         aConn.EnqueueFrame(AnnounceFrame(8, 0x0A));
         await SettleAsync(aConn, () => routeTable.Count == 1);
 
-        // B takes the SAME prefix over — A no longer owns it.
-        bConn.EnqueueFrame(AnnounceFrame(8, 0x0A));
-        await SettleAsync(bConn, () => routeTable.Get(TenSlashEight, 8) is not null);
-        await Task.Delay(50);   // let the ownership-lost notification land
+        // B takes the SAME prefix over — A no longer owns it. #377 review: await the
+        // ownership-loss callback deterministically instead of a fixed delay.
+        var aLostOwnership = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        void OnLost(object owner, (uint Prefix, byte Length) key)
+        {
+            if (ReferenceEquals(owner, a) && key.Prefix == TenSlashEight)
+                aLostOwnership.TrySetResult();
+        }
+        routeTable.EntryOwnershipLost += OnLost;
+        try
+        {
+            bConn.EnqueueFrame(AnnounceFrame(8, 0x0A));
+            await aLostOwnership.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            routeTable.EntryOwnershipLost -= OnLost;
+        }
 
         // A announces a DIFFERENT prefix with cap=1 — pre-fix this tripped the cap (A still
         // counted the taken-over 10/8) and reset A; post-fix A owns only the new prefix.

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -28,7 +28,8 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
 
 ### D3. Malformed AGGREGATOR/AS4_AGGREGATOR takes attribute discard (RESOLVED)
 - **Decision:** a malformed AGGREGATOR or AS4_AGGREGATOR (length ≠ 6/8 by session type, or AS 0 per
-  RFC 7607) is DISCARDED per RFC 7606 §7.7/§7.8 — the attribute is dropped, the UPDATE's routes stay,
+  RFC 7607) is DISCARDED per RFC 7606 §7.7 (AGGREGATOR) / RFC 6793 §6 (AS4_AGGREGATOR — RFC 7606 §7.8
+  is COMMUNITY and §7 excludes attribute 18) — the attribute is dropped, the UPDATE's routes stay,
   a Warning names the dropped type codes.
 - **Context:** was temporarily treat-as-withdraw (stricter than the RFC — routes a conformant
   implementation installs were lost) until the attribute-discard mechanism existed (#306). Flags


### PR DESCRIPTION
Second-pass review response — seven findings, all verified (incl. a fact-check of the RFC citations against rfc-editor): correct §7.8→RFC 6793 §6 citations; AS_TRANS + discarded-AS4 pairing suppression; atomic freshness/negativity read; membership-before-publish ordering; post-install 75% warning; two test defects (vacuous AS-0 encoding, Delay→TCS). Red/green on the new AS_TRANS regression; suite 879/879. Lands on dev and re-triggers #377's review on the new head.