### PR TITLE
fix(api): ignore X-Real-IP by default — opt-in via Api.TrustXRealIp (#256)

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -31,6 +31,13 @@ public sealed class ManagementApi : IHostedService, IDisposable
     // replenish Timer that GC never collects, so "let GC handle it" leaked one timer per reload.
     private readonly List<IDisposable> _retiredLimiters = [];
     private IReadOnlyList<string>? _corsAllowedOrigins;
+    // #256: X-Real-IP is attacker-controllable behind a proxy that passes the header through
+    // unmodified, so it is consulted only when the operator opts in via Api.TrustXRealIp.
+    // 0/1 (not bool) so ApplyConfig can swap it with Interlocked.Exchange like the fields above.
+    private int _trustXRealIp;
+    // #256: fires once when a trusted proxy yields no usable forwarding header — all its clients
+    // then share one identity (rate-limit bucket + /api/me data), which operators should see.
+    private int _warnedProxyWithoutClientIp;
     private readonly BgpMetrics _metrics;
     // #263: required, not optional. Each of these was a silent feature switch: without
     // _sessionManager a peer edited in the UI was persisted but never pushed to its live session,
@@ -103,6 +110,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         _concurrencyLimiter = config.ApiRateLimit is { Enabled: true, MaxConcurrentRequests: > 0 } limitCfg
             ? CreateConcurrencyLimiter(limitCfg) : null;
         _corsAllowedOrigins = config.CorsAllowedOrigins;
+        _trustXRealIp = config.TrustXRealIp ? 1 : 0;
     }
 
     /// <summary>
@@ -134,6 +142,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         var oldConcurrencyLimiter = Interlocked.Exchange(ref _concurrencyLimiter, concurrencyLimiter);
         Interlocked.Exchange(ref _trustedProxyNetworks, trusted);
         Interlocked.Exchange(ref _corsAllowedOrigins, newConfig.CorsAllowedOrigins);
+        Interlocked.Exchange(ref _trustXRealIp, newConfig.TrustXRealIp ? 1 : 0);
 
         // Old limiters cannot be disposed here — a concurrent HandleAsync may still be mid-acquire
         // on them (#137). Park them for StopAsync/Dispose, which run after the in-flight drain.
@@ -144,11 +153,12 @@ public sealed class ManagementApi : IHostedService, IDisposable
         }
 
         _logger.LogInformation(
-            "Soft config reloaded: trustedProxies={TrustedProxyCount}, corsOrigins={CorsOriginCount}, rateLimit={RateLimitEnabled}, concurrencyLimit={ConcurrencyEnabled}",
+            "Soft config reloaded: trustedProxies={TrustedProxyCount}, corsOrigins={CorsOriginCount}, rateLimit={RateLimitEnabled}, concurrencyLimit={ConcurrencyEnabled}, trustXRealIp={TrustXRealIp}",
             trusted.Count,
             newConfig.CorsAllowedOrigins?.Count ?? 0,
             rateLimiter is not null,
-            concurrencyLimiter is not null);
+            concurrencyLimiter is not null,
+            newConfig.TrustXRealIp);
     }
 
     /// <summary>
@@ -157,7 +167,12 @@ public sealed class ManagementApi : IHostedService, IDisposable
     /// Mirrors <see cref="GetClientIp"/>'s forwarding-header logic.
     /// </summary>
     internal string ResolveClientIpLive(IPAddress? remote, string? xForwardedFor, string? xRealIp) =>
-        ResolveClientIp(remote, xForwardedFor, xRealIp, Volatile.Read(ref _trustedProxyNetworks));
+        ResolveClientIp(
+            remote,
+            xForwardedFor,
+            xRealIp,
+            Volatile.Read(ref _trustedProxyNetworks),
+            Volatile.Read(ref _trustXRealIp) != 0);
 
     /// <summary>
     /// Resolves the CORS origin against the CURRENT live <c>_corsAllowedOrigins</c> (#136), for tests
@@ -200,6 +215,15 @@ public sealed class ManagementApi : IHostedService, IDisposable
                 "Management API is bound to {Address} (non-loopback) — ensure an authenticated reverse " +
                 "proxy (Caddy/nginx with TLS + auth) is in front, or the unauthenticated control plane " +
                 "is reachable from the network", _listenAddress);
+        }
+        // #256: state the hard proxy requirement at startup — a trusted proxy that neither appends
+        // X-Forwarded-For nor overwrites X-Real-IP lets clients forge their identity.
+        if (_trustedProxyNetworks.Count > 0)
+        {
+            _logger.LogWarning(
+                "TrustedProxies configured — the proxy MUST append X-Forwarded-For (real client on the " +
+                "right-most non-trusted hop); X-Real-IP is ignored unless Api.TrustXRealIp is true and " +
+                "the proxy overwrites it. A pass-through proxy lets clients spoof their IP");
         }
         _listenTask = ListenAsync(_cts.Token);
         return Task.CompletedTask;
@@ -1432,12 +1456,39 @@ public sealed class ManagementApi : IHostedService, IDisposable
         catch (FormatException) { return false; }
     }
 
-    private string GetClientIp(HttpListenerContext ctx) =>
-        ResolveClientIp(
-            ctx.Request.RemoteEndPoint?.Address,
+    private string GetClientIp(HttpListenerContext ctx)
+    {
+        var remote = ctx.Request.RemoteEndPoint?.Address;
+        var resolved = ResolveClientIp(
+            remote,
             ctx.Request.Headers["X-Forwarded-For"],
             ctx.Request.Headers["X-Real-IP"],
-            Volatile.Read(ref _trustedProxyNetworks));
+            Volatile.Read(ref _trustedProxyNetworks),
+            Volatile.Read(ref _trustXRealIp) != 0);
+        WarnWhenProxyHidesClientIp(remote, resolved);
+        return resolved;
+    }
+
+    /// <summary>
+    /// #256: a trusted proxy whose request carries no usable <c>X-Forwarded-For</c> hop (and no
+    /// opted-in <c>X-Real-IP</c>) collapses all its traffic into one client identity — the proxy
+    /// address: every client behind it shares a rate-limit bucket and <c>/api/me</c> data. Logs a
+    /// warning once so a misconfigured proxy is visible without spamming every request.
+    /// </summary>
+    private void WarnWhenProxyHidesClientIp(IPAddress? remote, string resolved)
+    {
+        if (remote is null) return;
+        var normalized = remote.IsIPv4MappedToIPv6 ? remote.MapToIPv4() : remote;
+        var trusted = Volatile.Read(ref _trustedProxyNetworks);
+        if (trusted.Count == 0 || !trusted.Any(n => n.Contains(normalized))) return;
+        if (!string.Equals(resolved, normalized.ToString(), StringComparison.Ordinal)) return;
+        if (Interlocked.Exchange(ref _warnedProxyWithoutClientIp, 1) != 0) return;
+        _logger.LogWarning(
+            "Trusted-proxy request from {Remote} carries no usable X-Forwarded-For / X-Real-IP — all its " +
+            "clients share one rate-limit bucket and /api/me identity. Configure the proxy to append " +
+            "X-Forwarded-For (or to overwrite X-Real-IP and set Api.TrustXRealIp: true).",
+            normalized.ToString());
+    }
 
     /// <summary>
     /// Builds the per-client-IP token-bucket rate limiter for the management API (#116). Each distinct
@@ -1484,10 +1535,12 @@ public sealed class ManagementApi : IHostedService, IDisposable
     /// Forwarding headers are honored ONLY when the immediate peer (<paramref name="remote"/>) is a
     /// configured trusted proxy (#91) — a direct client cannot inject <c>X-Forwarded-For</c> /
     /// <c>X-Real-IP</c>. <c>X-Forwarded-For</c> is walked right-to-left and the first hop that is not
-    /// itself a trusted proxy is returned, defeating injection through the proxy. Extracted as a pure
-    /// function so the security logic is unit-testable without an HttpListener.
+    /// itself a trusted proxy is returned, defeating injection through the proxy. <c>X-Real-IP</c> is
+    /// consulted only when <paramref name="trustXRealIp"/> is set (#256) — unlike XFF its value cannot
+    /// be verified against the trusted-hop chain. Extracted as a pure function so the security logic
+    /// is unit-testable without an HttpListener.
     /// </summary>
-    internal static string ResolveClientIp(IPAddress? remote, string? xForwardedFor, string? xRealIp, IReadOnlyList<IPNetwork> trustedProxies)
+    internal static string ResolveClientIp(IPAddress? remote, string? xForwardedFor, string? xRealIp, IReadOnlyList<IPNetwork> trustedProxies, bool trustXRealIp)
     {
         if (remote is null) return "unknown";
 
@@ -1519,10 +1572,13 @@ public sealed class ManagementApi : IHostedService, IDisposable
             }
         }
 
-        // Single-hop proxies commonly set X-Real-IP instead of (or alongside) X-Forwarded-For.
-        // Validate + normalize so a malformed header can't surface garbage (e.g. newlines for log
-        // forging) — fall back to the proxy address if it isn't a parseable IP.
-        if (!string.IsNullOrWhiteSpace(xRealIp) && IPAddress.TryParse(xRealIp.Trim(), out var realAddr))
+        // Single-hop proxies commonly set X-Real-IP instead of (or alongside) X-Forwarded-For. Unlike
+        // XFF, the value cannot be verified against the trusted-hop chain — a proxy that passes the
+        // header through instead of overwriting it turns it into an attacker-controlled input (#256),
+        // so it is consulted only when the operator opts in via Api.TrustXRealIp. Validate + normalize
+        // so a malformed header can't surface garbage (e.g. newlines for log forging) — fall back to
+        // the proxy address if it isn't a parseable IP.
+        if (trustXRealIp && !string.IsNullOrWhiteSpace(xRealIp) && IPAddress.TryParse(xRealIp.Trim(), out var realAddr))
             return Normalize(realAddr).ToString();
 
         return remote.ToString();

--- a/BGPLite.Configuration/AppConfig.cs
+++ b/BGPLite.Configuration/AppConfig.cs
@@ -55,6 +55,18 @@ public sealed class AppConfig
     [YamlMember(Alias = "TrustedProxies")]
     public List<string> TrustedProxies { get; init; } = [];
 
+    /// <summary>
+    /// Opt-in (#256): when <c>true</c>, a trusted proxy's <c>X-Real-IP</c> header is accepted as a
+    /// client-IP source when no <c>X-Forwarded-For</c> hop resolves. Default <c>false</c> — unlike
+    /// X-Forwarded-For, an X-Real-IP value cannot be verified against the trusted-hop chain, so a
+    /// proxy that passes the header through instead of overwriting it (plain nginx without
+    /// <c>proxy_set_header X-Real-IP $remote_addr;</c>) turns it into an attacker-controlled input:
+    /// fresh rate-limit buckets per request and a forged <c>/api/me</c> identity. Enable only for
+    /// proxies guaranteed to overwrite the header. Hot-reloadable (applies to new requests).
+    /// </summary>
+    [YamlMember(Alias = "TrustXRealIp")]
+    public bool TrustXRealIp { get; init; }
+
     /// <summary>Per-client-IP rate limiting for the management API (#116). Null = defaults applied.</summary>
     [YamlMember(Alias = "ApiRateLimit")]
     public ApiRateLimitConfig? ApiRateLimit { get; init; }

--- a/BGPLite.Tests/ClientIpResolverTests.cs
+++ b/BGPLite.Tests/ClientIpResolverTests.cs
@@ -6,7 +6,9 @@ namespace BGPLite.Tests;
 /// <summary>
 /// Unit tests for <see cref="ManagementApi.ResolveClientIp"/> (#91): forwarding headers are honored
 /// only when the immediate peer is a configured trusted proxy, and X-Forwarded-For is walked
-/// right-to-left past trusted hops so client injection on the left is defeated.
+/// right-to-left past trusted hops so client injection on the left is defeated. X-Real-IP is
+/// consulted only behind the Api.TrustXRealIp opt-in (#256) — its value cannot be verified against
+/// the trusted-hop chain, so a pass-through proxy would otherwise let clients forge their identity.
 /// </summary>
 public class ClientIpResolverTests
 {
@@ -19,17 +21,17 @@ public class ClientIpResolverTests
     [Fact]
     public void DirectClient_Ignores_XForwardedFor() =>
         Assert.Equal("203.0.113.9",
-            ManagementApi.ResolveClientIp(IPAddress.Parse("203.0.113.9"), "198.51.100.5", null, Proxy));
+            ManagementApi.ResolveClientIp(IPAddress.Parse("203.0.113.9"), "198.51.100.5", null, Proxy, trustXRealIp: false));
 
     [Fact]
-    public void DirectClient_Ignores_XRealIp() =>
+    public void DirectClient_Ignores_XRealIp_Even_When_OptedIn() =>
         Assert.Equal("203.0.113.9",
-            ManagementApi.ResolveClientIp(IPAddress.Parse("203.0.113.9"), null, "198.51.100.5", Proxy));
+            ManagementApi.ResolveClientIp(IPAddress.Parse("203.0.113.9"), null, "198.51.100.5", Proxy, trustXRealIp: true));
 
     [Fact]
     public void TrustedProxy_Uses_XForwardedFor_Client() =>
         Assert.Equal("198.51.100.5",
-            ManagementApi.ResolveClientIp(IPAddress.Parse("127.0.0.1"), "198.51.100.5", null, Proxy));
+            ManagementApi.ResolveClientIp(IPAddress.Parse("127.0.0.1"), "198.51.100.5", null, Proxy, trustXRealIp: false));
 
     [Fact]
     public void TrustedProxy_LeftInjection_Is_Defeated()
@@ -37,7 +39,7 @@ public class ClientIpResolverTests
         // Attacker spoofs a left entry; the proxy appends the real client on the right.
         // Right-to-left walk returns the rightmost untrusted hop = the real client.
         Assert.Equal("198.51.100.5",
-            ManagementApi.ResolveClientIp(IPAddress.Parse("127.0.0.1"), "spoofed, 198.51.100.5", null, Proxy));
+            ManagementApi.ResolveClientIp(IPAddress.Parse("127.0.0.1"), "spoofed, 198.51.100.5", null, Proxy, trustXRealIp: false));
     }
 
     [Fact]
@@ -46,31 +48,53 @@ public class ClientIpResolverTests
         // client -> trusted proxy (10.x) -> us (127.x). XFF = "client, 10.0.0.1" — 10.0.0.1 is
         // trusted (skipped), so the client is returned.
         Assert.Equal("198.51.100.5",
-            ManagementApi.ResolveClientIp(IPAddress.Parse("127.0.0.1"), "198.51.100.5, 10.0.0.1", null, Proxy));
+            ManagementApi.ResolveClientIp(IPAddress.Parse("127.0.0.1"), "198.51.100.5, 10.0.0.1", null, Proxy, trustXRealIp: false));
     }
 
     [Fact]
-    public void TrustedProxy_FallsBack_To_XRealIp() =>
+    public void TrustedProxy_Ignores_XRealIp_By_Default()
+    {
+        // #256 secure default: a spoofed X-Real-IP behind a pass-through proxy must not become the
+        // client identity — the proxy address is returned instead.
+        Assert.Equal("127.0.0.1",
+            ManagementApi.ResolveClientIp(IPAddress.Parse("127.0.0.1"), null, "198.51.100.5", Proxy, trustXRealIp: false));
+    }
+
+    [Fact]
+    public void TrustedProxy_TrustXRealIp_True_Uses_Fallback()
+    {
+        // Opt-in restores the single-hop-proxy fallback for deployments whose proxy overwrites
+        // X-Real-IP but does not append X-Forwarded-For.
         Assert.Equal("198.51.100.5",
-            ManagementApi.ResolveClientIp(IPAddress.Parse("127.0.0.1"), null, "198.51.100.5", Proxy));
+            ManagementApi.ResolveClientIp(IPAddress.Parse("127.0.0.1"), null, "198.51.100.5", Proxy, trustXRealIp: true));
+    }
+
+    [Fact]
+    public void TrustedProxy_TrustXRealIp_True_Xff_Still_Wins()
+    {
+        // X-Real-IP is a fallback: when the XFF walk resolves, X-Real-IP is not consulted even when
+        // opted in (an attacker-supplied X-Real-IP cannot override a proxy-attested XFF client).
+        Assert.Equal("198.51.100.5",
+            ManagementApi.ResolveClientIp(IPAddress.Parse("127.0.0.1"), "198.51.100.5", "6.6.6.6", Proxy, trustXRealIp: true));
+    }
 
     [Fact]
     public void TrustedProxy_Malformed_XRealIp_FallsBack_To_Remote()
     {
         // A garbage X-Real-IP (e.g. with log-forging newlines) must not be returned verbatim.
         Assert.Equal("127.0.0.1",
-            ManagementApi.ResolveClientIp(IPAddress.Parse("127.0.0.1"), null, "not-an-ip\nFAKE", Proxy));
+            ManagementApi.ResolveClientIp(IPAddress.Parse("127.0.0.1"), null, "not-an-ip\nFAKE", Proxy, trustXRealIp: true));
     }
 
     [Fact]
-    public void NoTrustedProxies_Always_Returns_Remote() =>
+    public void NoTrustedProxies_Always_Returns_Remote_Even_When_OptedIn() =>
         Assert.Equal("203.0.113.9",
-            ManagementApi.ResolveClientIp(IPAddress.Parse("203.0.113.9"), "198.51.100.5", "1.2.3.4", Array.Empty<IPNetwork>()));
+            ManagementApi.ResolveClientIp(IPAddress.Parse("203.0.113.9"), "198.51.100.5", "1.2.3.4", Array.Empty<IPNetwork>(), trustXRealIp: true));
 
     [Fact]
     public void Null_Remote_Returns_Unknown() =>
         Assert.Equal("unknown",
-            ManagementApi.ResolveClientIp(null, "198.51.100.5", null, Proxy));
+            ManagementApi.ResolveClientIp(null, "198.51.100.5", null, Proxy, trustXRealIp: false));
 
     [Fact]
     public void IPv4MappedIPv6_Remote_Normalized_For_TrustCheck()
@@ -81,6 +105,6 @@ public class ClientIpResolverTests
         var mapped = IPAddress.Parse("::ffff:127.0.0.1");
         Assert.True(mapped.IsIPv4MappedToIPv6);
         Assert.Equal("198.51.100.5",
-            ManagementApi.ResolveClientIp(mapped, "198.51.100.5", null, Proxy));
+            ManagementApi.ResolveClientIp(mapped, "198.51.100.5", null, Proxy, trustXRealIp: false));
     }
 }

--- a/BGPLite.Tests/ConfigHotReloadTests.cs
+++ b/BGPLite.Tests/ConfigHotReloadTests.cs
@@ -58,6 +58,24 @@ public class ConfigHotReloadTests
             harness.Api.ResolveClientIpLive(IPAddress.Parse("127.0.0.1"), "198.51.100.5", null));
     }
 
+    // --- ManagementApi.ApplyConfig: X-Real-IP opt-in (#256) --------------------------------------
+
+    [Fact]
+    public void ApplyConfig_Swaps_TrustXRealIp()
+    {
+        using var harness = NewApi(Config(trustedProxies: ["127.0.0.0/8"]));
+
+        // Secure default: a spoofed X-Real-IP is ignored even behind a trusted proxy.
+        Assert.Equal("127.0.0.1",
+            harness.Api.ResolveClientIpLive(IPAddress.Parse("127.0.0.1"), null, "198.51.100.5"));
+
+        harness.Api.ApplyConfig(Config(trustedProxies: ["127.0.0.0/8"], trustXRealIp: true));
+
+        // Reload flipped the opt-in on; no restart required.
+        Assert.Equal("198.51.100.5",
+            harness.Api.ResolveClientIpLive(IPAddress.Parse("127.0.0.1"), null, "198.51.100.5"));
+    }
+
     // --- ManagementApi.ApplyConfig: rate limiter -----------------------------------------------
 
     [Fact]
@@ -147,6 +165,28 @@ public class ConfigHotReloadTests
         finally { TryDelete(path); }
     }
 
+    [Fact]
+    public void Reload_Valid_Config_Applies_TrustXRealIp()
+    {
+        var path = TempConfigPath();
+        try
+        {
+            File.WriteAllText(path, Yaml(trustedProxies: ["127.0.0.0/8"], trustXRealIp: true));
+            using var harness = NewApi(Config(trustedProxies: ["127.0.0.0/8"]));
+            var reloader = new ConfigReloader(path, harness.Api, new CapturingLogger<ConfigReloader>());
+
+            // Initial state: opt-in off, the spoofed X-Real-IP is ignored.
+            Assert.Equal("127.0.0.1",
+                harness.Api.ResolveClientIpLive(IPAddress.Parse("127.0.0.1"), null, "198.51.100.5"));
+
+            reloader.Reload();
+
+            Assert.Equal("198.51.100.5",
+                harness.Api.ResolveClientIpLive(IPAddress.Parse("127.0.0.1"), null, "198.51.100.5"));
+        }
+        finally { TryDelete(path); }
+    }
+
     // --- ConfigReloader.Reload: invalid edits never crash, keep previous -----------------------
 
     [Fact]
@@ -215,20 +255,23 @@ public class ConfigHotReloadTests
     private static AppConfig Config(
         List<string>? trustedProxies = null,
         ApiRateLimitConfig? rateLimit = null,
-        List<string>? corsOrigins = null) => new()
+        List<string>? corsOrigins = null,
+        bool trustXRealIp = false) => new()
         {
             Bgp = new BgpConfig { Asn = 65001, RouterId = "10.0.0.1", HoldTime = 180, KeepAlive = 60 },
             ApiPort = 5001,
             TrustedProxies = trustedProxies ?? [],
             ApiRateLimit = rateLimit,
-            CorsAllowedOrigins = corsOrigins
+            CorsAllowedOrigins = corsOrigins,
+            TrustXRealIp = trustXRealIp
         };
 
     /// <summary>Renders a VALID <c>appsettings.yml</c>-style document with the given soft fields.</summary>
     private static string Yaml(
         List<string>? trustedProxies = null,
         List<string>? corsOrigins = null,
-        int apiPort = 5001)
+        int apiPort = 5001,
+        bool trustXRealIp = false)
     {
         var sb = new StringBuilder();
         sb.AppendLine("Bgp:");
@@ -242,6 +285,7 @@ public class ConfigHotReloadTests
             sb.AppendLine("TrustedProxies:");
             foreach (var p in trustedProxies) sb.AppendLine($"  - \"{p}\"");
         }
+        if (trustXRealIp) sb.AppendLine("TrustXRealIp: true");
         if (corsOrigins is { Count: > 0 })
         {
             sb.AppendLine("CorsAllowedOrigins:");

--- a/appsettings.Example.yml
+++ b/appsettings.Example.yml
@@ -75,12 +75,17 @@ DefaultPrefixSource: ru
 # X-Forwarded-For / X-Real-IP are honored ONLY when the immediate TCP peer is one of these trusted
 # CIDRs; otherwise the direct RemoteEndPoint is used and any client-supplied forwarding header is
 # ignored (secure default). X-Forwarded-For is walked right-to-left past trusted hops, so spoofed
-# entries injected on the left are defeated. When the API runs behind a reverse proxy, list the
-# proxy's CIDR here so /api/me (and future per-IP rate limiting, #116) see the real client.
+# entries injected on the left are defeated — the proxy MUST append the real client to
+# X-Forwarded-For (nginx: proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;). A proxy
+# that passes headers through unmodified lets clients forge their IP: fresh rate-limit buckets per
+# request and a spoofed /api/me identity (#256). X-Real-IP is ignored even from trusted proxies
+# unless you opt in via TrustXRealIp — enable it only if your proxy OVERWRITES the header
+# (nginx: proxy_set_header X-Real-IP $remote_addr;).
 # Empty/absent = never trust forwarding headers.
 # TrustedProxies:
 #   - "127.0.0.0/8"
 #   - "10.0.0.0/8"
+# TrustXRealIp: false
 
 # Management API — per-client-IP rate limiting (#116). Opt-in: absent = no limiting (live behavior
 # unchanged). When present, each resolved client IP (via TrustedProxies) gets a token bucket; a

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -189,3 +189,21 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
   silently dropped (log Warning + `UpdatesRejected` metric) instead of a session reset; operators
   comparing against RFC-strict speakers will see BGPLite retain sessions others would close.
 - **Tracker:** #94, #222, #284, #288, #322 (closed); recorded via #344.
+
+## Management API
+
+### D18. `X-Real-IP` is ignored by default, even behind trusted proxies
+- **Decision:** a trusted proxy's `X-Real-IP` header is consulted only when the operator sets
+  `Api.TrustXRealIp: true` (hot-reloadable). `X-Forwarded-For` handling is unchanged: walked
+  right-to-left past trusted hops. Startup warns about the proxy requirements when TrustedProxies is
+  configured; a runtime warning (once) fires when a trusted proxy yields no usable forwarding header.
+- **Context:** unlike XFF, an X-Real-IP value cannot be verified against the trusted-hop chain — a
+  proxy that passes the header through instead of overwriting it (plain nginx without
+  `proxy_set_header X-Real-IP $remote_addr;`) turns it into an attacker-controlled input: fresh
+  rate-limit buckets per request (#116 bypass) and a forged `/api/me` identity, which may surface
+  token-bearing prefix-source URLs (#149). Direct (non-trusted) connections were already hardened by
+  #117 — this closes the trusted-proxy hole (#256).
+- **Consequence:** deployments that relied on an X-Real-IP-only proxy must set `TrustXRealIp: true`
+  (intentional behavior change, secure by default); such a proxy is otherwise attributed to the
+  proxy address, with the one-shot runtime warning pointing at the misconfiguration.
+- **Tracker:** #256.


### PR DESCRIPTION
Closes #256

## Problem
A trusted proxy that does not overwrite `X-Real-IP` (plain nginx without `proxy_set_header X-Real-IP $remote_addr;`) and does not append its own XFF hop lets clients forge their identity: unlimited fresh per-IP rate-limit buckets (#116 bypass), `GET /api/me` returning another client's peer data (including token-bearing prefix-source URLs, #149), and forged log attribution.

## Root Cause
`ResolveClientIp` accepts `X-Real-IP` from any trusted-proxy peer with no way to verify the value against the trusted-hop chain (unlike XFF, which is walked right-to-left past trusted hops). #117 already hardened direct (non-trusted) connections; the trusted-proxy hole remained, with no opt-out and no documentation of the proxy requirement.

## Fix
- New `Api.TrustXRealIp` config flag (default **false**, hot-reloadable): `X-Real-IP` is consulted only when opted in. XFF walk unchanged; direct connections unchanged.
- Startup warning when `TrustedProxies` is configured documenting the hard proxy requirement.
- One-shot runtime warning when a trusted proxy yields no usable forwarding header (all its clients collapse into one identity: shared rate-limit bucket + shared /api/me data).
- `appsettings.Example.yml` + `docs/DESIGN_DECISIONS.md` (new **D18**) document the requirement and the decision.

## Correctness
Resolution order per request: untrusted remote → remote address (unchanged); trusted remote → XFF right-most non-trusted hop (unchanged) → `X-Real-IP` only if `TrustXRealIp` (validated + normalized) → proxy address. The flag is swapped atomically in `ApplyConfig` (Interlocked) and read via `Volatile.Read`, matching the established hot-reload pattern.

## Regression Test
- `ClientIpResolverTests`: `TrustedProxy_Ignores_XRealIp_By_Default` (the new secure default — the pre-fix code fails this by construction: the old `TrustedProxy_FallsBack_To_XRealIp` asserted exactly the opposite and was rewritten), `TrustedProxy_TrustXRealIp_True_Uses_Fallback`, `TrustedProxy_TrustXRealIp_True_Xff_Still_Wins`, `DirectClient_Ignores_XRealIp_Even_When_OptedIn`, `NoTrustedProxies_Always_Returns_Remote_Even_When_OptedIn`.
- `ConfigHotReloadTests`: `ApplyConfig_Swaps_TrustXRealIp` (hot reload without restart), `Reload_Valid_Config_Applies_TrustXRealIp` (YAML binding through ConfigReloader).

## Verification
- dotnet format / dotnet build BGPLite.sln (0 errors) / dotnet test BGPLite.sln: **883/883 passed** (baseline before change: 879/879).
- Targeted: ClientIpResolverTests + ConfigHotReloadTests 24/24.
- Issue acceptance: spoofed `X-Real-IP` cannot influence buckets/identity with the flag off (covered by new tests); `/api/me` from an untrusted direct connection returns only the true remote IP (pre-existing since #117, covered by `DirectClient_*` tests).

## RFC
none — no protocol surface (management-API client-IP resolution only).

## Behavior Change
**Yes, intentional (secure by default):** deployments with `TrustedProxies` relying on an `X-Real-IP`-only proxy now resolve clients to the proxy address unless they set `Api.TrustXRealIp: true`. A one-shot runtime warning points at the misconfiguration. Documented in D18.

## Deviation from Issue Proposal
The issue proposed warning "at startup when a trusted-proxy request arrives with neither a valid XFF chain nor X-Real-IP" — requests cannot be observed at startup, so this is split: a startup config-level warning (proxy requirements) + a one-shot per-process runtime warning on the first such request.
