### PR TITLE
fix(api): hot-reload MaxRequestBodyBytes + sanitize CustomAsns log (#266)

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -38,6 +38,9 @@ public sealed class ManagementApi : IHostedService, IDisposable
     // #256: fires once when a trusted proxy yields no usable forwarding header — all its clients
     // then share one identity (rate-limit bucket + /api/me data), which operators should see.
     private int _warnedProxyWithoutClientIp;
+    // #266 item 6: the body-size cap is read on every mutating request (ReadBodyAsync) — swapped
+    // atomically so a reload applies to subsequent requests instead of requiring a restart.
+    private long _maxRequestBodyBytes;
     private readonly BgpMetrics _metrics;
     // #263: required, not optional. Each of these was a silent feature switch: without
     // _sessionManager a peer edited in the UI was persisted but never pushed to its live session,
@@ -111,6 +114,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
             ? CreateConcurrencyLimiter(limitCfg) : null;
         _corsAllowedOrigins = config.CorsAllowedOrigins;
         _trustXRealIp = config.TrustXRealIp ? 1 : 0;
+        _maxRequestBodyBytes = config.MaxRequestBodyBytes;
     }
 
     /// <summary>
@@ -136,13 +140,14 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // Swap every reloadable field atomically. A request that has already captured the old
         // references into locals finishes against them; the next request reads the new ones.
         // NOTE (#321 item 8): _config itself is NOT swapped — request-path code that must observe
-        // reloads reads the derived fields above; the fields still reading _config (e.g.
-        // MaxRequestBodyBytes, RipeStat lists) are restart-required, tracked as #266 item 6.
+        // reloads reads the derived fields swapped below; the remaining _config readers (RipeStat
+        // lists, CustomPrefixCommunity) are restart-required (#266 item 6 covered MaxRequestBodyBytes).
         var oldRateLimiter = Interlocked.Exchange(ref _rateLimiter, rateLimiter);
         var oldConcurrencyLimiter = Interlocked.Exchange(ref _concurrencyLimiter, concurrencyLimiter);
         Interlocked.Exchange(ref _trustedProxyNetworks, trusted);
         Interlocked.Exchange(ref _corsAllowedOrigins, newConfig.CorsAllowedOrigins);
         Interlocked.Exchange(ref _trustXRealIp, newConfig.TrustXRealIp ? 1 : 0);
+        Interlocked.Exchange(ref _maxRequestBodyBytes, newConfig.MaxRequestBodyBytes);
 
         // Old limiters cannot be disposed here — a concurrent HandleAsync may still be mid-acquire
         // on them (#137). Park them for StopAsync/Dispose, which run after the in-flight drain.
@@ -153,12 +158,13 @@ public sealed class ManagementApi : IHostedService, IDisposable
         }
 
         _logger.LogInformation(
-            "Soft config reloaded: trustedProxies={TrustedProxyCount}, corsOrigins={CorsOriginCount}, rateLimit={RateLimitEnabled}, concurrencyLimit={ConcurrencyEnabled}, trustXRealIp={TrustXRealIp}",
+            "Soft config reloaded: trustedProxies={TrustedProxyCount}, corsOrigins={CorsOriginCount}, rateLimit={RateLimitEnabled}, concurrencyLimit={ConcurrencyEnabled}, trustXRealIp={TrustXRealIp}, maxRequestBodyBytes={MaxRequestBodyBytes}",
             trusted.Count,
             newConfig.CorsAllowedOrigins?.Count ?? 0,
             rateLimiter is not null,
             concurrencyLimiter is not null,
-            newConfig.TrustXRealIp);
+            newConfig.TrustXRealIp,
+            newConfig.MaxRequestBodyBytes);
     }
 
     /// <summary>
@@ -184,6 +190,9 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
     /// <summary>Whether a per-client rate limiter is currently active — exposed for hot-reload tests.</summary>
     internal bool IsRateLimitingEnabled => Volatile.Read(ref _rateLimiter) is not null;
+
+    /// <summary>Live body-size cap (<see cref="AppConfig.MaxRequestBodyBytes"/>) — exposed for hot-reload tests (#266 item 6).</summary>
+    internal long MaxRequestBodyBytesLive => Volatile.Read(ref _maxRequestBodyBytes);
 
     /// <summary>Whether a global concurrency limiter is currently active — exposed for hot-reload tests.</summary>
     internal bool IsConcurrencyLimitEnabled => Volatile.Read(ref _concurrencyLimiter) is not null;
@@ -574,7 +583,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
     /// </summary>
     private async Task<(string? Body, ApiResponse? Error)> ReadBodyAsync(HttpListenerContext ctx)
     {
-        var maxBytes = _config.MaxRequestBodyBytes;
+        var maxBytes = Volatile.Read(ref _maxRequestBodyBytes);
 
         // Fast path: Content-Length present and already over the cap → reject without reading.
         if (ctx.Request.ContentLength64 > maxBytes)
@@ -830,7 +839,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         _logger.LogInformation("CreatePeer deserialized: AsnLists={Lists}, CustomPrefixes={Prefixes}, CustomAsns={Asns}",
             SanitizeForLog(string.Join(",", asnLists)), SanitizeForLog(string.Join(",", data.CustomPrefixes ?? [])),
-            string.Join(",", data.CustomAsns ?? []));
+            SanitizeForLog(string.Join(",", data.CustomAsns ?? [])));
 
         if (data.CustomPrefixes is not null)
         {

--- a/BGPLite.Tests/ApiHandlerBehaviorTests.cs
+++ b/BGPLite.Tests/ApiHandlerBehaviorTests.cs
@@ -1,4 +1,6 @@
 using System.Net;
+using System.Text;
+using System.Text.Json;
 using BGPLite.Api;
 using BGPLite.Configuration;
 using BGPLite.Contracts;
@@ -13,8 +15,9 @@ namespace BGPLite.Tests;
 
 /// <summary>
 /// #266 handler-level behavior that needs a real listener: the txt prefix export must not be
-/// double-serialized (item 1), the CORS preflight must advertise PATCH (item 2), and OPTIONS
-/// preflights consume the client's rate bucket instead of bypassing it (item 7).
+/// double-serialized (item 1), the CORS preflight must advertise PATCH (item 2), OPTIONS
+/// preflights consume the client's rate bucket instead of bypassing it (item 7), and a reloaded
+/// MaxRequestBodyBytes applies to subsequent requests without a restart (item 6).
 /// </summary>
 public sealed class ApiHandlerBehaviorTests : IDisposable
 {
@@ -117,6 +120,36 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
         third.Headers.Add("Origin", "http://example.com");
         using var limited = await _client.SendAsync(third);
         Assert.Equal(HttpStatusCode.TooManyRequests, limited.StatusCode);   // RED pre-fix: 204 forever
+    }
+
+    [Fact]
+    public async Task MaxRequestBodyBytes_HotReloaded_AppliesToSubsequentRequests()
+    {
+        var config = new AppConfig { Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" } };
+        _port = await StartAsync(config);
+        _client = new HttpClient();
+
+        // ~4 KB body — comfortably under the 1 MiB startup cap. The padding rides in an unknown
+        // JSON field (ignored by deserialization) so the request stays semantically valid while
+        // the reloaded cap rejects it by size alone.
+        var body = JsonSerializer.Serialize(new Dictionary<string, object>
+        {
+            ["ip"] = "198.51.100.5",
+            ["asn"] = 65010,
+            ["description"] = "hot-reload probe",
+            ["padding"] = new string('x', 4096)
+        });
+        using (var ok = await _client.PostAsync($"http://127.0.0.1:{_port}/api/peers",
+            new StringContent(body, Encoding.UTF8, "application/json")))
+            Assert.Equal(HttpStatusCode.OK, ok.StatusCode);
+
+        // Shrink the cap below the body size; the NEXT request is rejected with 413 — no restart.
+        _api!.ApplyConfig(new AppConfig { Bgp = config.Bgp, ApiPort = _port, MaxRequestBodyBytes = 1024 });
+
+        using var tooLarge = await _client.PostAsync($"http://127.0.0.1:{_port}/api/peers",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+        // RED pre-fix: ReadBodyAsync kept reading the startup _config, so the same POST returned 200.
+        Assert.Equal(HttpStatusCode.RequestEntityTooLarge, tooLarge.StatusCode);
     }
 
     private static int FreeTcpPort()

--- a/BGPLite.Tests/ConfigHotReloadTests.cs
+++ b/BGPLite.Tests/ConfigHotReloadTests.cs
@@ -76,6 +76,21 @@ public class ConfigHotReloadTests
             harness.Api.ResolveClientIpLive(IPAddress.Parse("127.0.0.1"), null, "198.51.100.5"));
     }
 
+    // --- ManagementApi.ApplyConfig: body-size cap (#266 item 6) -----------------------------------
+
+    [Fact]
+    public void ApplyConfig_Swaps_MaxRequestBodyBytes()
+    {
+        using var harness = NewApi(Config()); // default 1 MiB
+
+        Assert.Equal(1024 * 1024, harness.Api.MaxRequestBodyBytesLive);
+
+        harness.Api.ApplyConfig(Config(maxBodyBytes: 4096));
+
+        // ReadBodyAsync reads the same live field — the new cap applies without a restart.
+        Assert.Equal(4096, harness.Api.MaxRequestBodyBytesLive);
+    }
+
     // --- ManagementApi.ApplyConfig: rate limiter -----------------------------------------------
 
     [Fact]
@@ -256,14 +271,16 @@ public class ConfigHotReloadTests
         List<string>? trustedProxies = null,
         ApiRateLimitConfig? rateLimit = null,
         List<string>? corsOrigins = null,
-        bool trustXRealIp = false) => new()
+        bool trustXRealIp = false,
+        long maxBodyBytes = 1024 * 1024) => new()
         {
             Bgp = new BgpConfig { Asn = 65001, RouterId = "10.0.0.1", HoldTime = 180, KeepAlive = 60 },
             ApiPort = 5001,
             TrustedProxies = trustedProxies ?? [],
             ApiRateLimit = rateLimit,
             CorsAllowedOrigins = corsOrigins,
-            TrustXRealIp = trustXRealIp
+            TrustXRealIp = trustXRealIp,
+            MaxRequestBodyBytes = maxBodyBytes
         };
 
     /// <summary>Renders a VALID <c>appsettings.yml</c>-style document with the given soft fields.</summary>


### PR DESCRIPTION
Closes #266

## Problem
The #266 grouping issue collected 8 LOW/MINOR management-API findings from the 2026-08-26 audit. Items 1 (txt export double serialization), 2 (CORS PATCH), 3 (community validation), 4 (unknown subscription names), 7 (OPTIONS pre-rate-limit), and 8 (misleading 409) were **already fixed on dev** by commits `a5bf2e2`, `338c46f`, `30fc838` with their own red/green tests. This PR completes the two remaining sub-items.

## Root Cause
- **Item 6:** `ReadBodyAsync` read `_config.MaxRequestBodyBytes` from the startup AppConfig object; `ApplyConfig` deliberately never swaps `_config` (its own comment listed the field as restart-required). A reloaded body cap silently never applied.
- **Item 5:** the `CustomAsns` join in the CreatePeer log line was the only unsanitized neighbor in an otherwise-sanitized structured log.

## Fix
- **Item 6:** `MaxRequestBodyBytes` became its own hot-reloadable field in the `ApplyConfig` `Interlocked.Exchange` batch (same pattern as the four existing soft fields), read via `Volatile.Read` in `ReadBodyAsync`. The reload log carries the new value; the stale restart-required comment is updated.
- **Item 5:** `SanitizeForLog` wrap on the CustomAsns join (cosmetic — `List<uint>` is provably digits; applied for consistency).

## Regression Test
- `MaxRequestBodyBytes_HotReloaded_AppliesToSubsequentRequests` (real listener): POST succeeds under the startup 1 MiB cap; `ApplyConfig(MaxRequestBodyBytes: 1024)`; the identical POST is now 413. **Proven RED pre-fix**: with the `ManagementApi.cs` change stashed the test fails (the cap stayed at the startup value).
- `ApplyConfig_Swaps_MaxRequestBodyBytes` (unit, via new `MaxRequestBodyBytesLive` test observer).

## Verification
- dotnet format / dotnet build BGPLite.sln (0 errors) / dotnet test BGPLite.sln: **885/885 passed** (baseline 883/883 on this branch point).
- Item 5 needs no focused test: `CustomAsns` is `List<uint>` (JSON deserialization rejects non-numeric input → 400), so log forging is impossible; the wrap is consistency with the neighboring sanitized joins.

## RFC
none — no protocol surface.

## Behavior Change
Intentional per the issue: `MaxRequestBodyBytes` now hot-reloads (previously documented as restart-required). Operators reloading config with a changed cap get the new cap on subsequent requests without a restart.

## Deviation from Issue Proposal
None on items 5–6. The issue's alternative for item 6 ("fix the comment and document as restart-required") was already partially in place; this PR implements the preferred option (hot swap) instead of settling for documentation.
