### PR TITLE
fix(providers): no eviction of an in-flight ASN's gate; drop post-create roundtrip (#267)

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -848,24 +848,24 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // (PeerId, Prefix, PrefixLength) key — returned 500 over an already-committed peer row and
         // left the user with a half-configured peer. Duplicates are now deduplicated inside the
         // store: a set of prefixes means the same thing whether a value appears once or twice.
-        var id = _store.SavePeerConfiguration(
+        // #267 item 6: the upsert returns (Id, Status, CreatedAt) from its RETURNING clause — no
+        // follow-up GetDbPeerById roundtrip for fields the caller already knows.
+        var saved = _store.SavePeerConfiguration(
             normalizedIp, data.Asn, data.Description, asnLists, customPrefixes, data.CustomAsns ?? []);
 
-        var peer = _store.GetDbPeerById(id);
-
         _logger.LogInformation("Created peer {Ip} AS{Asn} ({Id}): {Subs} lists, {Prefixes} custom prefixes, {Asns} custom AS",
-            normalizedIp, data.Asn, id, asnLists.Count, customPrefixes.Count, data.CustomAsns?.Count ?? 0);
+            normalizedIp, data.Asn, saved.Id, asnLists.Count, customPrefixes.Count, data.CustomAsns?.Count ?? 0);
 
         _ = _sessionManager.RefreshPeerAsync(normalizedIp, data.Asn);
 
         return ApiResponse.Ok(new
         {
-            id,
+            id = saved.Id,
             ip = normalizedIp,
             asn = data.Asn,
             description = data.Description,
-            status = peer?.Status ?? "inactive",
-            createdAt = peer?.CreatedAt,
+            status = saved.Status,
+            createdAt = saved.CreatedAt,
             lists = asnLists,
             customPrefixes = data.CustomPrefixes ?? [],
             customAsns = data.CustomAsns ?? []

--- a/BGPLite.Api/PeerStore.cs
+++ b/BGPLite.Api/PeerStore.cs
@@ -1,8 +1,14 @@
+using System.Globalization;
 using BGPLite.Api.Entities;
 using Microsoft.EntityFrameworkCore;
 using BGPLite.Contracts;
 
 namespace BGPLite.Api;
+
+/// <summary>The persisted state of a peer row right after an upsert (#267 item 6): everything the
+/// POST /api/peers response needs, returned from the upsert's RETURNING clause instead of a
+/// follow-up read.</summary>
+public sealed record SavedPeer(string Id, string Status, DateTime CreatedAt);
 
 public sealed class PeerStore : IPeerStore
 {
@@ -18,7 +24,7 @@ public sealed class PeerStore : IPeerStore
     public string CreatePeer(string ip, uint asn, string? description)
     {
         using var db = _dbFactory.CreateDbContext();
-        return UpsertPeerRow(db, ip, asn, description);
+        return UpsertPeerRow(db, ip, asn, description).Id;
     }
 
     /// <summary>
@@ -26,7 +32,7 @@ public sealed class PeerStore : IPeerStore
     /// an enclosing transaction (#259) instead of always committing on its own. Behaviour is
     /// unchanged from the #227 implementation this was extracted from.
     /// </summary>
-    private static string UpsertPeerRow(BgpDbContext db, string ip, uint asn, string? description)
+    private static SavedPeer UpsertPeerRow(BgpDbContext db, string ip, uint asn, string? description)
     {
         // #227: atomic SQLite upsert eliminates the read-then-write race on the composite unique
         // index UX_Peers_Ip_Asn. Two concurrent CreatePeer calls for the same (Ip, Asn) previously
@@ -38,8 +44,11 @@ public sealed class PeerStore : IPeerStore
         // (Microsoft.Data.Sqlite >= 6) — satisfied by the EF Core Sqlite 10 dependency.
         //
         // EF Core's SqlQuery<T> is documented only for SELECT/composable queries, so for a DML
-        // statement with RETURNING we go through the underlying ADO.NET connection (ExecuteScalar)
-        // — the documented path for a single scalar result from non-composable SQL.
+        // statement with RETURNING we go through the underlying ADO.NET connection — the documented
+        // path for results from non-composable SQL. #267 item 6: the statement returns the row's
+        // Status and CreatedAt alongside the Id so the caller can build its response without a
+        // follow-up roundtrip; neither column is touched by the ON CONFLICT branch, so the returned
+        // values describe the row exactly as it exists after the upsert.
         var id = Guid.NewGuid().ToString("N");
         var now = DateTime.UtcNow.ToString("O");
         var connection = db.Database.GetDbConnection();
@@ -56,14 +65,19 @@ public sealed class PeerStore : IPeerStore
                 "INSERT INTO Peers (Id, Ip, Asn, Description, Status, CreatedAt, LastSessionAt) " +
                 "VALUES (@id, @ip, @asn, @desc, 'inactive', @now, NULL) " +
                 "ON CONFLICT(Ip, Asn) DO UPDATE SET Description = excluded.Description " +
-                "RETURNING Id";
+                "RETURNING Id, Status, CreatedAt";
             AddParam(cmd, "@id", id);
             AddParam(cmd, "@ip", ip);
             AddParam(cmd, "@asn", (long)asn);
             AddParam(cmd, "@desc", (object?)description ?? DBNull.Value);
             AddParam(cmd, "@now", now);
-            var storedId = (string)cmd.ExecuteScalar()!;
-            return storedId;
+            using var reader = cmd.ExecuteReader();
+            reader.Read();
+            return new SavedPeer(
+                reader.GetString(0),
+                reader.GetString(1),
+                // CreatedAt is written in the "O" (round-trip) format above.
+                DateTime.Parse(reader.GetString(2), CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind));
         }
         finally
         {
@@ -303,7 +317,7 @@ public sealed class PeerStore : IPeerStore
     /// thing as asking once, and a user assembling a list in the UI produces repeats by pasting.
     /// </para>
     /// </summary>
-    public string SavePeerConfiguration(
+    public SavedPeer SavePeerConfiguration(
         string ip, uint asn, string? description,
         IReadOnlyList<string> asnListNames,
         IReadOnlyList<(string Prefix, byte Length)> customPrefixes,
@@ -312,14 +326,14 @@ public sealed class PeerStore : IPeerStore
         using var db = _dbFactory.CreateDbContext();
         using var tx = db.Database.BeginTransaction();
 
-        var id = UpsertPeerRow(db, ip, asn, description);
-        ReplaceSubscriptions(db, id, asnListNames);
-        ReplaceCustomPrefixes(db, id, customPrefixes);
-        ReplaceCustomAsns(db, id, customAsns);
+        var saved = UpsertPeerRow(db, ip, asn, description);
+        ReplaceSubscriptions(db, saved.Id, asnListNames);
+        ReplaceCustomPrefixes(db, saved.Id, customPrefixes);
+        ReplaceCustomAsns(db, saved.Id, customAsns);
         db.SaveChanges();
 
         tx.Commit();
-        return id;
+        return saved;
     }
 
     /// <summary>

--- a/BGPLite.Providers/RipeStatPrefixCache.cs
+++ b/BGPLite.Providers/RipeStatPrefixCache.cs
@@ -44,6 +44,12 @@ public sealed class RipeStatPrefixCache
     // asn → gate serializing the cache-miss fetch path (prevents thundering herd on cold/expired
     // ASNs — #164).
     private readonly ConcurrentDictionary<uint, SemaphoreSlim> _locks = new();
+    // #267 item 3: ASNs with a fetch currently in flight. The capacity sweep must never evict an
+    // in-flight ASN's entry + gate: the fetcher holds that gate, and removing it let a later
+    // GetOrAdd create a second semaphore — two concurrent RIPEstat fetches for one ASN, breaking
+    // the #164 invariant. Marked before the gate is taken and unmarked after it is released, so
+    // "holding the gate" always implies "in-flight".
+    private readonly ConcurrentDictionary<uint, byte> _inflight = new();
 
     public RipeStatPrefixCache(
         RipeStatProvider ripe,
@@ -72,6 +78,24 @@ public sealed class RipeStatPrefixCache
         if (TryGetFresh(asn, out var fresh, out var freshIsNegative) && (serveNegativeEntries || !freshIsNegative))
             return fresh;
 
+        // #267 item 3: mark in-flight BEFORE the gate is taken (and unmark only after it is
+        // released) so the capacity sweep can never drop the gate this caller is about to wait on
+        // or holds — see the _inflight note.
+        _inflight.TryAdd(asn, 0);
+        try
+        {
+            return await FetchThroughGateAsync(asn, ct, serveNegativeEntries);
+        }
+        finally
+        {
+            _inflight.TryRemove(asn, out _);
+        }
+    }
+
+    /// <summary>The gated fetch path of <see cref="GetPrefixesAsync"/> — runs under the caller's
+    /// in-flight mark, sharing a single RIPEstat fetch per ASN (#164).</summary>
+    private async Task<IReadOnlyList<(uint Prefix, byte Length)>> FetchThroughGateAsync(uint asn, CancellationToken ct, bool serveNegativeEntries)
+    {
         // Serialize per-ASN so concurrent callers share a single RIPEstat fetch — no thundering herd
         // on a cold or just-expired ASN (#164).
         var gate = _locks.GetOrAdd(asn, _ => new SemaphoreSlim(1, 1));
@@ -140,9 +164,10 @@ public sealed class RipeStatPrefixCache
 
     /// <summary>Enforces the _maxCacheEntries bound (#165). Called before inserting a NEW key,
     /// under the caller's per-ASN gate. Removes a few least-recently-cached entries (by CachedAt)
-    /// plus any expired entries it encounters, and drops the corresponding _locks entries. Under
-    /// the lock of the caller's per-ASN gate, so the sweep is serialized against itself;
-    /// ConcurrentDictionary enumeration is a snapshot and safe against concurrent writers.</summary>
+    /// plus any expired entries it encounters, and drops the corresponding _locks entries — never
+    /// for an in-flight ASN (#267 item 3). Under the lock of the caller's per-ASN gate, so the
+    /// sweep is serialized against itself; ConcurrentDictionary enumeration is a snapshot and safe
+    /// against concurrent writers.</summary>
     private void EvictIfAtCapacity(uint insertingKey)
     {
         if (_cache.Count < _maxCacheEntries) return;
@@ -150,7 +175,7 @@ public sealed class RipeStatPrefixCache
 
         // Snapshot, drop expired entries first (cheapest eviction), then by oldest CachedAt.
         var now = _timeProvider.GetUtcNow().UtcDateTime;
-        var toEvict = new List<uint>();
+        var toEvict = new HashSet<uint>();
         foreach (var (key, entry) in _cache)
         {
             var ttl = entry.Negative ? _negativeTtl : _cacheTtl;
@@ -173,9 +198,11 @@ public sealed class RipeStatPrefixCache
 
         foreach (var key in toEvict)
         {
-            // TryUpdate/TryRemove under no per-key lock: a concurrent fetch for this key may be
-            // racing, but that's fine — it will re-populate the entry; losing a transient cache hit
-            // is acceptable, and never losing correctness.
+            // #267 item 3: an in-flight ASN's entry is re-populated by its fetch — evicting both
+            // while the fetcher holds the gate made a later GetOrAdd mint a second semaphore and
+            // issue a duplicate concurrent fetch (#164). Skipping keeps the gate intact; losing a
+            // transient eviction slot is acceptable, never losing correctness.
+            if (_inflight.ContainsKey(key)) continue;
             if (_cache.TryRemove(key, out _))
                 _locks.TryRemove(key, out _);
         }

--- a/BGPLite.Tests/ApiHandlerBehaviorTests.cs
+++ b/BGPLite.Tests/ApiHandlerBehaviorTests.cs
@@ -78,7 +78,7 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
     public async Task ExportTxt_PlaintextBody_NotJsonQuoted()
     {
         var store = new PeerStore(new StaticOptionsFactory(new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(_connection).Options));
-        var id = store.SavePeerConfiguration("198.51.100.7", 65090, null, [], [("10.0.0.0", (byte)8)], []);
+        var id = store.SavePeerConfiguration("198.51.100.7", 65090, null, [], [("10.0.0.0", (byte)8)], []).Id;
         _port = await StartAsync(new AppConfig { Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" } });
         _client = new HttpClient();
 

--- a/BGPLite.Tests/PeerStoreConfigurationAtomicityTests.cs
+++ b/BGPLite.Tests/PeerStoreConfigurationAtomicityTests.cs
@@ -35,7 +35,7 @@ public class PeerStoreConfigurationAtomicityTests
         var id = store.SavePeerConfiguration(Ip, Asn, "dup prefixes",
             asnListNames: ["ru"],
             customPrefixes: [("10.0.0.0", 8), ("10.0.0.0", 8), ("192.0.2.0", 24)],
-            customAsns: [64512]);
+            customAsns: [64512]).Id;
 
         // A set of prefixes: announcing 10.0.0.0/8 twice is the same as once, so the duplicate is
         // dropped rather than rejected.
@@ -57,7 +57,7 @@ public class PeerStoreConfigurationAtomicityTests
         var id = store.SavePeerConfiguration(Ip, Asn, "dup lists and asns",
             asnListNames: ["ru", "ru", "cdn"],
             customPrefixes: [],
-            customAsns: [64512, 64512, 64513]);
+            customAsns: [64512, 64512, 64513]).Id;
 
         Assert.Equal(["cdn", "ru"], store.GetSubscriptions(id).Order().ToList());
         Assert.Equal([64512u, 64513u], store.GetCustomAsns(id).Order().ToList());
@@ -76,7 +76,7 @@ public class PeerStoreConfigurationAtomicityTests
         var id = store.SavePeerConfiguration(Ip, Asn, "full",
             asnListNames: ["ru"],
             customPrefixes: [("10.0.0.0", 8)],
-            customAsns: [64512]);
+            customAsns: [64512]).Id;
 
         // The failure #259 describes is a peer row committed with its child collections missing.
         // Assert the whole configuration is readable through the same view the send path uses.
@@ -118,7 +118,7 @@ public class PeerStoreConfigurationAtomicityTests
         var (store, connection, transactions) = NewStoreCountingTransactions();
         using var _ = connection;
         var id = store.SavePeerConfiguration(Ip, Asn, "initial",
-            asnListNames: ["ru"], customPrefixes: [("10.0.0.0", 8)], customAsns: [64512]);
+            asnListNames: ["ru"], customPrefixes: [("10.0.0.0", 8)], customAsns: [64512]).Id;
 
         transactions.Clear();
         store.UpdatePeerConfiguration(id, "changed",
@@ -138,7 +138,7 @@ public class PeerStoreConfigurationAtomicityTests
         var (store, connection) = NewStore();
         using var _ = connection;
         var id = store.SavePeerConfiguration(Ip, Asn, "initial",
-            asnListNames: ["ru"], customPrefixes: [("10.0.0.0", 8)], customAsns: [64512]);
+            asnListNames: ["ru"], customPrefixes: [("10.0.0.0", 8)], customAsns: [64512]).Id;
 
         // Only the prefixes are supplied; the rest must survive untouched, matching the PATCH
         // semantics the management API exposes.

--- a/BGPLite.Tests/PrefixServiceTests.cs
+++ b/BGPLite.Tests/PrefixServiceTests.cs
@@ -5,6 +5,7 @@ using BGPLite.Protocol;
 using Microsoft.Extensions.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
 using Xunit;
 
 namespace BGPLite.Tests;
@@ -395,6 +396,110 @@ public class PrefixServiceTests
         // throw and must correctly serialize (SemaphoreSlim is recreated via GetOrAdd).
         var result = await service.GetPrefixesAsync(100);
         Assert.Single(result);
+    }
+
+    /// <summary>
+    /// #267 item 3: the capacity sweep must not evict an ASN's entry + gate while a fetch for it is
+    /// in flight. Pre-fix, the sweep dropped the gate a fetcher held, so a concurrent caller minted
+    /// a SECOND semaphore via GetOrAdd and issued a duplicate concurrent RIPEstat fetch for the same
+    /// ASN — breaking the #164 invariant (one wire fetch per ASN at a time).
+    /// </summary>
+    [Fact]
+    public async Task Eviction_DoesNot_DuplicateFetch_While_Entry_InFlight()
+    {
+        var handler = new BlockingPerAsnHandler();
+        var clock = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        // Direct cache (not through PrefixService): the test needs a custom clock + blocking handler.
+        var cache = new RipeStatPrefixCache(
+            new RipeStatProvider(new StubFactory(handler), NullLogger<RipeStatProvider>.Instance,
+                new RipeStatConfig { RetryAttempts = 0, RetryDelaySeconds = 0 }),
+            cacheTtl: TimeSpan.FromHours(1),
+            maxCacheEntries: 1,
+            timeProvider: clock);
+
+        // 1. Populate ASN 1 — its fresh entry fills the cap of 1.
+        await cache.GetPrefixesAsync(1);
+        Assert.Equal(1, handler.CallsFor(1));
+
+        // 2. Expire it; start a slow refetch that is now inside ASN 1's gate (the stale entry is
+        // still in the cache, which is what made it sweepable mid-fetch).
+        clock.Advance(TimeSpan.FromHours(2));
+        handler.Block(1);
+        var slow = cache.GetPrefixesAsync(1);
+        await handler.WaitStarted(1);
+
+        // 3. A second ASN's insert triggers the sweep while ASN 1 is mid-refetch: ASN 1 is the only
+        // cache entry and it is expired — the pre-fix sweep evicted its entry AND its held gate.
+        await cache.GetPrefixesAsync(2);
+
+        // 4. A concurrent caller for ASN 1 must share slow's gate, not mint a second one.
+        var concurrent = cache.GetPrefixesAsync(1);
+
+        handler.Unblock(1);
+        await slow;
+        var result = await concurrent;
+
+        // Two fetches for ASN 1 are expected: the initial populate + the slow refetch. The
+        // concurrent caller served from the refetch's result. RED pre-fix: the sweep had evicted
+        // the held gate, so the concurrent caller minted a second one and fetched a third time.
+        Assert.Equal(2, handler.CallsFor(1));
+        Assert.Single(result);
+    }
+
+    /// <summary>Like <see cref="PerAsnHandler"/> but able to block a specific ASN's response until
+    /// released — models a slow RIPEstat fetch holding the per-ASN gate (#267 item 3).</summary>
+    private sealed class BlockingPerAsnHandler : HttpMessageHandler
+    {
+        private readonly object _sync = new();
+        private readonly Dictionary<uint, int> _calls = [];
+        private readonly Dictionary<uint, TaskCompletionSource> _blocks = [];
+        private readonly Dictionary<uint, TaskCompletionSource> _started = [];
+
+        public int CallsFor(uint asn) { lock (_sync) return _calls.TryGetValue(asn, out var c) ? c : 0; }
+
+        public void Block(uint asn)
+        {
+            lock (_sync)
+            {
+                _blocks[asn] = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                _started[asn] = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            }
+        }
+
+        public Task WaitStarted(uint asn) { lock (_sync) return _started[asn].Task; }
+
+        public void Unblock(uint asn) { lock (_sync) _blocks[asn].TrySetResult(); }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var asn = ExtractAsn(request.RequestUri!);
+            Task? gate;
+            lock (_sync)
+            {
+                _calls[asn] = (_calls.TryGetValue(asn, out var c) ? c : 0) + 1;
+                if (_started.TryGetValue(asn, out var started)) started.TrySetResult();
+                gate = _blocks.TryGetValue(asn, out var t) ? t.Task : null;
+            }
+            if (gate is not null)
+                await gate;
+
+            var hi = (int)((asn >> 8) & 0xFF);
+            var lo = (int)(asn & 0xFF);
+            var body = BodyTemplate
+                .Replace("__ASN__", asn.ToString())
+                .Replace("__CIDR__", $"10.{hi}.{lo}.1/32");
+            return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(body) };
+        }
+
+        private static uint ExtractAsn(Uri uri)
+        {
+            var s = uri.AbsoluteUri;
+            var marker = "resource=AS";
+            var i = s.IndexOf(marker, StringComparison.Ordinal) + marker.Length;
+            var end = s.IndexOf('&', i);
+            if (end < 0) end = s.Length;
+            return uint.Parse(s[i..end]);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #267

## Problem
The #267 grouping issue collected 6 LOW/MINOR providers/data findings from the 2026-08-26 audit. Items 1 (RIPEstat double buffering), 2 (pipeline timeout vs source.Timeout), 4 (dead Includes), and 5 (duplicate ASN caches) were **already fixed on dev** by commits `add9d93` (#321), `b428934` (#324), `494d6b0`, and `27bc22e`. This PR completes the two remaining sub-items.

## Root Cause
- **Item 3 (RipeStatPrefixCache.EvictIfAtCapacity):** the capacity sweep removed a `_locks` entry without knowing whether a fetcher held that semaphore. A later `GetOrAdd` then minted a second semaphore, and two concurrent RIPEstat fetches ran for the same ASN — breaking the #164 one-fetch-per-ASN invariant (cost: duplicate HTTP, not corruption). Also `toEvict.Contains` was O(n²) over a `List`.
- **Item 6:** `HandleCreatePeer` called `GetDbPeerById` right after `SavePeerConfiguration` — a 5th roundtrip for `Status`/`CreatedAt` the upsert already knows.

## Fix
- **Item 3:** ASNs are marked in-flight (`ConcurrentDictionary<uint, byte>`) **before** their gate is taken and unmarked **after** it is released, so "holding the gate" always implies "in-flight". The sweep skips in-flight keys — entry+gate are evicted only together and only when idle; a skipped in-flight ASN is simply re-populated by its own fetch. `toEvict` became a `HashSet<uint>` (O(1) Contains).
- **Item 6:** the atomic upsert's `RETURNING` clause now returns `Id, Status, CreatedAt` (neither column is touched by the ON CONFLICT branch, so the values describe the post-upsert row exactly). `SavePeerConfiguration` returns a `SavedPeer` record; `HandleCreatePeer` builds its response from it — no follow-up read.

## Regression Test
`Eviction_DoesNot_DuplicateFetch_While_Entry_InFlight` (new `BlockingPerAsnHandler` + `FakeTimeProvider`): ASN 1 populated → TTL expires → slow refetch holds ASN 1's gate → ASN 2's insert triggers the sweep → a concurrent ASN 1 caller joins. Asserts exactly **2** wire fetches for ASN 1 (initial + refetch). **Proven RED pre-fix**: with the cache fix stashed the count is 3 — the duplicate fetch the issue describes.

## Verification
- dotnet format / dotnet build BGPLite.sln (0 errors) / dotnet test BGPLite.sln: **884/884 passed** (baseline 883 on this branch point).
- Item 6 changes no external response shape: `status`/`createdAt` carry the same values (previously `peer?.Status ?? "inactive"` — the upsert's returned Status is the identical column value; CreatedAt is parsed from the same "O"-format string the row stores). Existing PeerStoreConfigurationAtomicity / ApiHandlerBehavior suites cover the path.

## RFC
none — no protocol surface.

## Behavior Change
None externally. Internal: `SavePeerConfiguration`/`UpsertPeerRow` signatures changed (concrete class, not on `IPeerStore`); eviction keeps gates of in-flight ASNs alive slightly longer (bounded by the fetch duration).

## Deviation from Issue Proposal
The issue's optional item-5 config-overlap warning is dropped as moot: since `27bc22e` both mechanisms share one cache, so there is no duplicate traffic left to warn about.
