### PR TITLE
feat(routing): custom prefixes suppress the source prefixes they cover (#220)

### DIFF
--- a/BGPLite.Server/RouteAssembler.cs
+++ b/BGPLite.Server/RouteAssembler.cs
@@ -184,6 +184,7 @@ public sealed class RouteAssembler : IRouteAssembler
             // write time (ParseCustomPrefix), but a corrupt row or a write path that bypassed the
             // API must not throw a FormatException out of the BGP send path — skip + log instead.
             var customPrefixComms = _communityResolver.Resolve(new CommunitySource(CommunitySourceKind.Custom));
+            var customRanges = new List<(uint Network, byte Length)>();
             foreach (var cidr in customPrefixes)
             {
                 if (!PrefixCidr.TryParse(cidr, out var prefix, out var length))
@@ -191,6 +192,7 @@ public sealed class RouteAssembler : IRouteAssembler
                     _logger.LogWarning("Skipping malformed custom prefix '{Cidr}' for {Peer}", cidr, peerLabel);
                     continue;
                 }
+                customRanges.Add((prefix, length));
                 routes.Add(MakeRoute(prefix, length, nextHop, null, customPrefixComms));
             }
 
@@ -218,6 +220,19 @@ public sealed class RouteAssembler : IRouteAssembler
             {
                 await AddUserSourceRoutesAsync(
                     routes, source, nextHop, _prefixService, _communityResolver, _logger, peerLabel, ct);
+            }
+
+            // #220 "suppress more-specifics": a custom prefix is an explicit operator override, so
+            // any other route it covers is dropped before aggregation — the operator's broader
+            // prefix wins over the source lists.
+            if (customRanges.Count > 0)
+            {
+                var before = routes.Count;
+                routes = SuppressCoveredByCustomPrefixes(routes, customRanges);
+                if (routes.Count < before)
+                    _logger.LogInformation(
+                        "Suppressed {Suppressed} source prefixes covered by custom prefixes for {Peer}",
+                        before - routes.Count, peerLabel);
             }
 
             _logger.LogInformation("Sending {Count} total routes to {Peer}", routes.Count, peerLabel);
@@ -281,6 +296,28 @@ public sealed class RouteAssembler : IRouteAssembler
         // Resolve the community allow-set ONCE for the whole send — not once per route (#79).
         var allowSet = _routeFilter.ResolveOutgoingAllowSet(filterPeerConfig);
         return routes.Where(r => _routeFilter.AcceptOutgoing(r, filterPeerConfig, allowSet)).ToList();
+    }
+
+    /// <summary>
+    /// #220 "suppress more-specifics": a custom prefix is an explicit operator override, so any
+    /// route covered by one is dropped from the outbound list, regardless of its source or
+    /// community set. Coverage is strictly-more-specific — an exact custom==source duplicate stays
+    /// in the list and gets its communities unioned by <c>BgpSession.MergeDuplicatePrefixes</c>
+    /// (#209), which is the desired exact-match behavior. Runs on the flat per-peer list BEFORE the
+    /// per-community-set aggregator sees it. Extracted as a pure function for unit tests.
+    /// </summary>
+    internal static List<Route> SuppressCoveredByCustomPrefixes(
+        List<Route> routes, List<(uint Network, byte Length)> customRanges)
+    {
+        // A route is covered when its length is strictly greater than the custom prefix's and its
+        // network, masked to the custom length, equals the (already host-bit-normalized) custom
+        // network — the repo's masking idiom (PrefixCidr, ExactUnionPrefixAggregator).
+        // Mask(0) must be 0, not 0xFFFFFFFF << 32 (a shift-by-32 is a no-op on uint, not a wipe).
+        static uint Mask(byte length) => length == 0 ? 0u : 0xFFFFFFFFu << (32 - length);
+        return routes
+            .Where(r => !customRanges.Any(cr => r.PrefixLength > cr.Length
+                                                && (r.Prefix & Mask(cr.Length)) == cr.Network))
+            .ToList();
     }
 
     /// <summary>

--- a/BGPLite.Tests/RouteAssemblerSuppressionTests.cs
+++ b/BGPLite.Tests/RouteAssemblerSuppressionTests.cs
@@ -1,0 +1,167 @@
+using System.Net;
+using BGPLite.Configuration;
+using BGPLite.Contracts;
+using BGPLite.Protocol;
+using BGPLite.Routing;
+using BGPLite.Server;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #220 "suppress more-specifics": a custom prefix is the operator's explicit override, so source
+/// routes it covers (strictly more specific) are dropped from the outbound list; source prefixes
+/// NOT covered are sent normally, and an exact custom==source duplicate stays for the #209
+/// community-union merge. Suppression runs in the assembler, before the per-community-set
+/// aggregator — so it covers every trigger (initial dump, ROUTE_REFRESH, API-triggered refresh),
+/// which all rebuild the list through <see cref="RouteAssembler.BuildOutboundRoutesAsync"/>.
+/// </summary>
+public class RouteAssemblerSuppressionTests
+{
+    private static uint Net(string ip) => BgpConstants.IPAddressToUint(IPAddress.Parse(ip));
+
+    private static Route R(string ip, byte length) => new()
+    {
+        Prefix = Net(ip),
+        PrefixLength = length,
+        NextHop = Net("10.0.0.1"),
+        Communities = [65001u << 16 | 770]
+    };
+
+    // --- pure helper -----------------------------------------------------------------------------
+
+    [Fact]
+    public void Custom24_Covers_Source25_SourceSuppressed()
+    {
+        var customs = new List<(uint, byte)> { (Net("1.2.3.0"), 24) };
+        var routes = new List<Route> { R("1.2.3.0", 24), R("1.2.3.0", 25) };
+
+        var result = RouteAssembler.SuppressCoveredByCustomPrefixes(routes, customs);
+
+        // RED pre-fix: both were sent — the /16-style override did not suppress the covered /25.
+        Assert.Equal([(Net("1.2.3.0"), (byte)24)], result.Select(r => (r.Prefix, r.PrefixLength)));
+    }
+
+    [Fact]
+    public void Custom8_Covers_DeeperSourcePrefixes()
+    {
+        var customs = new List<(uint, byte)> { (Net("10.0.0.0"), 8) };
+        var routes = new List<Route> { R("10.1.0.0", 16), R("10.2.3.0", 24), R("10.0.0.0", 8) };
+
+        var result = RouteAssembler.SuppressCoveredByCustomPrefixes(routes, customs);
+
+        Assert.Equal([(Net("10.0.0.0"), (byte)8)], result.Select(r => (r.Prefix, r.PrefixLength)));
+    }
+
+    [Fact]
+    public void NonOverlappingPrefixes_AllKept()
+    {
+        var customs = new List<(uint, byte)> { (Net("1.2.3.0"), 24) };
+        var routes = new List<Route> { R("1.2.4.0", 24), R("1.2.3.0", 23) /* shorter, not covered */ };
+
+        var result = RouteAssembler.SuppressCoveredByCustomPrefixes(routes, customs);
+
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public void NoCustomPrefixes_UnchangedBehavior()
+    {
+        var routes = new List<Route> { R("1.2.3.0", 24), R("10.0.0.0", 8) };
+
+        var result = RouteAssembler.SuppressCoveredByCustomPrefixes(routes, []);
+
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public void ExactCustomEqualsSource_NotSuppressed_LeftToUnionMerge()
+    {
+        // The exact match is handled by BgpSession.MergeDuplicatePrefixes (#209), which unions the
+        // custom and source communities — suppressing it here would drop the source's tags.
+        var customs = new List<(uint, byte)> { (Net("1.2.3.0"), 24) };
+        var routes = new List<Route> { R("1.2.3.0", 24) };
+
+        var result = RouteAssembler.SuppressCoveredByCustomPrefixes(routes, customs);
+
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public void ZeroLengthCustom_Covers_Everything()
+    {
+        var customs = new List<(uint, byte)> { (Net("0.0.0.0"), 0) };
+        var routes = new List<Route> { R("1.2.3.0", 24), R("203.0.113.0", 24) };
+
+        var result = RouteAssembler.SuppressCoveredByCustomPrefixes(routes, customs);
+
+        Assert.Empty(result);
+    }
+
+    // --- end-to-end through BuildOutboundRoutesAsync ----------------------------------------------
+
+    [Fact]
+    public async Task BuildOutboundRoutes_CustomPrefix_SuppressesCoveredSourcePrefixes()
+    {
+        // The issue's scenario: a custom 91.108.0.0/16 overrides a YouTube-like source whose /22s
+        // (arriving here through the custom-ASN path) sit inside it.
+        var config = new AppConfig { Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" } };
+        var assembler = new RouteAssembler(
+            new StubPrefixService(),
+            new ConfiguredPeerStore(["91.108.0.0/16"], [64512]),
+            new ConfigCommunityResolver(config, config.Bgp),
+            AllowAllFilter.Instance,
+            config,
+            config.Bgp,
+            NullLogger<RouteAssembler>.Instance);
+
+        var routes = await assembler.BuildOutboundRoutesAsync(
+            "203.0.113.9", 65002, new PeerConfig { Address = "203.0.113.9" }, "203.0.113.9",
+            CancellationToken.None);
+
+        Assert.Equal([(Net("91.108.0.0"), (byte)16)], routes.Select(r => ((uint)r.Prefix, (byte)r.PrefixLength)));
+    }
+
+    /// <summary>Serves two YouTube-like /22s for the custom ASN; nothing else.</summary>
+    private sealed class StubPrefixService : IPrefixService
+    {
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
+            => Task.FromResult(new List<(uint, byte, uint)>
+            {
+                (Net("91.108.4.0"), 22, 64512),
+                (Net("91.108.8.0"), 22, 64512)
+            });
+        public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
+        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
+            => Task.FromResult(new List<(uint, byte, uint)>());
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    /// <summary>Resolves to a configured peer carrying one custom prefix + one custom ASN.</summary>
+    private sealed class ConfiguredPeerStore(List<string> customPrefixes, List<uint> customAsns) : IPeerStore
+    {
+        public string CreatePeer(string ip, uint asn, string? description) => "id";
+        public void UpsertPeer(string ip, uint asn) { }
+        public void UpdateSessionStatus(string ip, uint asn, bool active) { }
+        public void DeletePeer(string id) { }
+        public PeerInfo? GetPeerByIp(string ip) => null;
+        public PeerInfo? GetPeer(string ip, uint asn) => null;
+        public PeerInfo? GetPeerById(string id) => null;
+        public List<string> GetSubscriptions(string peerId) => [];
+        public List<string> GetCustomPrefixes(string peerId) => customPrefixes;
+        public List<uint> GetCustomAsns(string peerId) => customAsns;
+        public HashSet<uint> GetCommunities(string peerId) => [];
+        public HashSet<uint> GetCommunities(string ip, uint asn) => [];
+        public void SetCommunities(string peerId, HashSet<uint> communities) { }
+        public void ClearCommunities(string peerId) { }
+        public void SetDescription(string id, string description) { }
+        public PeerRoutingView? LoadPeerRoutingView(string ip, uint asn)
+            => new("id", [], customPrefixes, customAsns, []);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ DefaultPrefixSource: ru        # served to unconfigured/auto-registered peers
 2. The peer connects over BGP to port 179.
 3. On session establishment the server resolves the peer's subscription:
    - known peer — fetches prefixes for its subscriptions (cached) plus custom prefixes and advertises them;
+     a custom prefix overrides the source prefixes it covers: covered more-specifics are not sent (#220);
    - unknown peer — auto-registers it and advertises the default prefix source.
 4. Peer status and session timestamps are updated in the store.
 

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -190,6 +190,22 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
   comparing against RFC-strict speakers will see BGPLite retain sessions others would close.
 - **Tracker:** #94, #222, #284, #288, #322 (closed); recorded via #344.
 
+### D19. Custom prefixes suppress the source prefixes they cover
+- **Decision:** a custom prefix is the operator's explicit override: any route STRICTLY more specific
+  than one is dropped from the peer's outbound list, regardless of its source or community set. An
+  exact custom==source duplicate is NOT suppressed — `MergeDuplicatePrefixes` (#209) unions the
+  communities, so the source's tags survive. Suppression runs in the assembler on the flat per-peer
+  list, BEFORE the per-community-set aggregation — `ExactUnionPrefixAggregator` (D15, #82) itself is
+  untouched and never merges across community sets.
+- **Context:** operators add a broader custom prefix (e.g. a /16) to override a source list whose
+  more-specifics (e.g. /24s in different communities) were still advertised alongside it — the two
+  land in different aggregator groups and both went out (#220).
+- **Consequence:** suppressed source prefixes lose their community tags on the wire — the receiving
+  peer sees the custom-prefix community; that is the override's intent. Per-send log line reports the
+  suppressed count. Idempotent across refreshes: every rebuild of the list applies the same
+  deterministic filter, so `_advertisedPrefixes` stays consistent for withdrawals.
+- **Tracker:** #220.
+
 ## Management API
 
 ### D18. `X-Real-IP` is ignored by default, even behind trusted proxies


### PR DESCRIPTION
Closes #220

## Problem
An operator's custom prefix (e.g. `91.108.0.0/16`, community `<Asn>:100`) did not override the source prefixes it covers: `ExactUnionPrefixAggregator` groups by community set, so the custom `/16` and a source list's `/22`s (community `<Asn>:770`) landed in different groups and were ALL advertised. The operator's override did not override.

## Root Cause
Grouping-by-community-set is correct route-server semantics for aggregation, but nothing upstream told the pipeline that a custom prefix is an explicit operator override. The issue's suggested post-aggregation placement has an identification problem (post-`MergeDuplicatePrefixes`, a custom==source route has *unioned* communities, so "identify custom" breaks there); the correct point is upstream of aggregation, where custom prefixes are still identifiable as such.

## Fix
`RouteAssembler.BuildOutboundRoutesAsync`, after all route collection and BEFORE the per-community-set aggregation: any route **strictly more specific** than a custom prefix (masked-network containment — the repo's `PrefixCidr`/`ExactUnionPrefixAggregator` masking idiom) is dropped, regardless of its source or community set. Details:
- **Exact custom==source duplicate is NOT suppressed** — `MergeDuplicatePrefixes` (#209) unions the communities, keeping the source's tags for the exact-match case (the issue's test case 5).
- `/0` edge guarded (`Mask(0)=0`; a shift-by-32 on uint is a no-op, not a wipe).
- Per-send log line reports the suppressed count. `suppressedPrefixCount` API field deferred (see Deviations).
- Every trigger (initial dump, ROUTE_REFRESH, API-triggered refresh) rebuilds through the same deterministic filter, so `_advertisedPrefixes` stays consistent for withdrawals; idempotent across refreshes.
- No opt-in, per the issue's recommendation: adding a broader custom prefix IS the opt-in.

## Regression Test
`RouteAssemblerSuppressionTests` — the issue's five cases as pure-helper unit tests (cover `/24`⊃`/25`; `/8`⊃`/16`+`/24`; non-overlap kept; no-customs unchanged; exact-match kept) plus the `/0` edge, and an end-to-end `BuildOutboundRoutesAsync` test (custom `/16` over two source `/22s` through a stub store + prefix service). **Proven RED pre-fix**: with the assembler change stashed the e2e test fails with the actual outbound list `[1533804544/16, 1533805568/22, 1533806592/22]` — the covered /22s rode along.

## Verification
- dotnet format / dotnet build BGPLite.sln (0 errors) / dotnet test BGPLite.sln: **893/893 passed** (baseline 886 on this branch point).
- Suppression is a pure function of (fetched prefixes, `PeerRoutingView.CustomPrefixes`) — no state, no timers.

## RFC
none — this is an operator-intent routing policy, not a protocol surface; all announcements remain valid IPv4 NLRI. Aggregation semantics (D15/#82) untouched.

## Behavior Change
**Yes, intentional (the feature):** peers with custom prefixes now receive ONLY the custom prefix where previously they also received covered source more-specifics. Peers without custom prefixes see zero change.

## Deviation from Issue Proposal
- Placement: **before** aggregation inside the assembler (the issue's own first snippet's location), not "after MergeDuplicatePrefixes" — pre-aggregation placement makes the "aggregation interaction" caveat moot and avoids the post-union identification problem.
- `GET /api/peers/{id}` `suppressedPrefixCount` deferred: computing it on demand re-runs the whole prefix fetch per detail call; the assembler logs the per-send count instead. Can follow up as an observability item if wanted.
- Config: no opt-in flag, following the issue's own recommendation ("custom prefixes always suppress").
