### PR TITLE
refactor(api): async-only IPeerStore — expand-contract of the persistence contract (#262)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,7 @@ Deliberate deviations from the RFCs are catalogued in `docs/DESIGN_DECISIONS.md`
 
 - `BgpServer` owns live session state; callers should receive snapshots, not shared mutable pointers.
 - Do not hold the session lock while sending data or writing to listeners.
-- Avoid blocking synchronous I/O on BGP session threads (the send/read paths are async end-to-end; the known exception — sync `PeerStore` — is tracked in #262, don't add more).
+- Avoid blocking synchronous I/O on BGP session threads (the send/read paths are async end-to-end, including the persistence contract: `IPeerStore` is async-only since #262 — keep new store members async).
 - CancellationToken must propagate through long-running network and background operations; OCE from caller cancellation is never swallowed or cached as a failure (#114/#225/#254).
 - Timer callbacks and session shutdown must be safe when executed concurrently — cross-thread teardown coordination goes through atomic latches (see the `_teardownReason` CAS in `BgpSession`), not read-then-write flags.
 - Session disposal must be idempotent — use the `Interlocked.Exchange` test-and-set pattern (`BgpSession.Dispose`, `SocketBgpConnection.Dispose`); a second `Dispose` must be a no-op, not a double-release.

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -497,7 +497,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         // /api/me
         if (IsGet(method, segments, "api", "me"))
-            return HandleGetMe(ctx);
+            return await HandleGetMe(ctx);
 
         // /api/peers
         if (IsPost(method, segments, "api", "peers"))
@@ -505,7 +505,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         // /api/peers/{id}
         if (segments.Length == 3 && segments[0] == "api" && segments[1] == "peers" && method == "GET")
-            return HandleGetPeer(segments[2]);
+            return await HandleGetPeer(segments[2]);
         if (segments.Length == 3 && segments[0] == "api" && segments[1] == "peers" && method == "PUT")
             return await HandleUpdatePeer(segments[2], ctx);
         if (segments.Length == 3 && segments[0] == "api" && segments[1] == "peers" && method == "DELETE")
@@ -519,7 +519,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (segments.Length == 4 && segments[0] == "api" && segments[1] == "peers" && segments[3] == "sources")
         {
             if (method == "GET")
-                return HandleGetSources(segments[2]);
+                return await HandleGetSources(segments[2]);
             if (method == "POST")
                 return await HandleAddSource(segments[2], ctx);
         }
@@ -528,7 +528,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (segments.Length == 5 && segments[0] == "api" && segments[1] == "peers" && segments[3] == "sources")
         {
             if (method == "DELETE")
-                return HandleDeleteSource(segments[2], segments[4]);
+                return await HandleDeleteSource(segments[2], segments[4]);
             if (method == "PATCH")
                 return await HandlePatchSource(segments[2], segments[4], ctx);
         }
@@ -736,7 +736,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
     #region GET /api/me
 
-    private ApiResponse HandleGetMe(HttpListenerContext ctx)
+    private async Task<ApiResponse> HandleGetMe(HttpListenerContext ctx)
     {
         var clientIp = GetClientIp(ctx);
 
@@ -753,24 +753,25 @@ public sealed class ManagementApi : IHostedService, IDisposable
         {
             if (!uint.TryParse(asnQuery, out var asn))
                 return ApiResponse.Error($"Invalid 'asn' query parameter: '{asnQuery}'. Must be a non-negative integer.", 400);
-            var single = _store.GetPeer(clientIp, asn);
+            var single = await _store.GetPeerAsync(clientIp, asn);
             peerInfos = single is null ? [] : [single];
         }
         else
         {
-            peerInfos = _store.GetPeersByIp(clientIp);
+            peerInfos = await _store.GetPeersByIpAsync(clientIp);
         }
 
-        var details = peerInfos.Select(p => BuildPeerDetail(p.Id)).Where(d => d is not null).ToList()!;
+        var details = (await Task.WhenAll(peerInfos.Select(p => BuildPeerDetail(p.Id))))
+            .Where(d => d is not null).ToList()!;
         return ApiResponse.Ok(new { ip = clientIp, peers = details });
     }
 
     /// <summary>Builds the peer-detail anonymous object for /api/me. Returns null if the peer vanished.</summary>
-    private object? BuildPeerDetail(string peerId)
+    private async Task<object?> BuildPeerDetail(string peerId)
     {
         // #228: single DbContext roundtrip via PeerStore.GetPeerDetail (was 5 separate DbContexts:
         // GetDbPeerById + GetSubscriptions + GetCustomPrefixes + GetCustomAsns + GetCommunities).
-        var peer = _store.GetPeerDetail(peerId);
+        var peer = await _store.GetPeerDetailAsync(peerId);
         if (peer is null) return null;
 
         // #212: actual advertised count from the live session (post-aggregation, post-dedup).
@@ -859,7 +860,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // store: a set of prefixes means the same thing whether a value appears once or twice.
         // #267 item 6: the upsert returns (Id, Status, CreatedAt) from its RETURNING clause — no
         // follow-up GetDbPeerById roundtrip for fields the caller already knows.
-        var saved = _store.SavePeerConfiguration(
+        var saved = await _store.SavePeerConfigurationAsync(
             normalizedIp, data.Asn, data.Description, asnLists, customPrefixes, data.CustomAsns ?? []);
 
         _logger.LogInformation("Created peer {Ip} AS{Asn} ({Id}): {Subs} lists, {Prefixes} custom prefixes, {Asns} custom AS",
@@ -881,10 +882,10 @@ public sealed class ManagementApi : IHostedService, IDisposable
         });
     }
 
-    private ApiResponse HandleGetPeer(string peerId)
+    private async Task<ApiResponse> HandleGetPeer(string peerId)
     {
         // #228: single DbContext roundtrip via PeerStore.GetPeerDetail (was 6 separate DbContexts).
-        var peer = _store.GetPeerDetail(peerId);
+        var peer = await _store.GetPeerDetailAsync(peerId);
         if (peer is null)
             return ApiResponse.Error("Peer not found", 404);
 
@@ -913,7 +914,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
     /// </summary>
     private async Task<ApiResponse> HandleUpdatePeer(string peerId, HttpListenerContext ctx)
     {
-        var peer = _store.GetDbPeerById(peerId);
+        var peer = await _store.GetDbPeerByIdAsync(peerId);
         if (peer is null)
             return ApiResponse.Error("Peer not found", 404);
 
@@ -963,18 +964,18 @@ public sealed class ManagementApi : IHostedService, IDisposable
                     "See /api/asn-lists for the configured names.", 400);
         }
 
-        _store.UpdatePeerConfiguration(peerId, data.Description, data.Lists, parsedPrefixes, data.CustomAsns);
+        await _store.UpdatePeerConfigurationAsync(peerId, data.Description, data.Lists, parsedPrefixes, data.CustomAsns);
 
         _logger.LogInformation("Updated peer {Id}", SanitizeForLog(peerId));
 
         _ = _sessionManager.RefreshPeerAsync(peer.Ip, peer.Asn ?? 0);
 
-        return HandleGetPeer(peerId);
+        return await HandleGetPeer(peerId);
     }
 
     internal async Task<ApiResponse> HandleDeletePeer(string peerId)
     {
-        var peer = _store.GetDbPeerById(peerId);
+        var peer = await _store.GetDbPeerByIdAsync(peerId);
         if (peer is null)
             return ApiResponse.Error("Peer not found", 404);
 
@@ -988,7 +989,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         using var bound = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         await _sessionManager.TerminatePeerAsync(peer.Ip, peer.Asn ?? 0, bound.Token);
 
-        _store.DeletePeer(peerId);
+        await _store.DeletePeerAsync(peerId);
         _logger.LogInformation("Deleted peer {Id} ({Ip})", SanitizeForLog(peerId), peer.Ip);
         return ApiResponse.Ok(new { id = peerId, deleted = true });
     }
@@ -997,18 +998,18 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
     #region /api/peers/{id}/sources (#143)
 
-    private ApiResponse HandleGetSources(string peerId)
+    private async Task<ApiResponse> HandleGetSources(string peerId)
     {
-        if (_store.GetDbPeerById(peerId) is null)
+        if (await _store.GetDbPeerByIdAsync(peerId) is null)
             return ApiResponse.Error("Peer not found", 404);
 
-        var sources = _store.GetCustomSources(peerId);
+        var sources = await _store.GetCustomSourcesAsync(peerId);
         return ApiResponse.Ok(sources.Select(s => new { id = s.Id, name = s.Name, url = s.Url, community = s.Community, active = s.Active }));
     }
 
     private async Task<ApiResponse> HandleAddSource(string peerId, HttpListenerContext ctx)
     {
-        var peer = _store.GetDbPeerById(peerId);
+        var peer = await _store.GetDbPeerByIdAsync(peerId);
         if (peer is null)
             return ApiResponse.Error("Peer not found", 404);
 
@@ -1062,7 +1063,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
             return ApiResponse.Error($"Invalid URL: the host could not be reached or is not allowed", 400);
         }
 
-        var source = _store.AddCustomSource(peerId, data.Name, data.Url, data.Community);
+        var source = await _store.AddCustomSourceAsync(peerId, data.Name, data.Url, data.Community);
 
         // Trigger refresh so the peer receives the new source's prefixes immediately —
         // same pattern as CreatePeer/UpdatePeer. Pass ASN so shared-IP peers aren't refreshed (#200).
@@ -1073,13 +1074,13 @@ public sealed class ManagementApi : IHostedService, IDisposable
         return ApiResponse.Ok(new { id = source.Id, name = source.Name, url = source.Url, community = source.Community, active = source.Active });
     }
 
-    private ApiResponse HandleDeleteSource(string peerId, string sourceId)
+    private async Task<ApiResponse> HandleDeleteSource(string peerId, string sourceId)
     {
-        var peer = _store.GetDbPeerById(peerId);
+        var peer = await _store.GetDbPeerByIdAsync(peerId);
         if (peer is null)
             return ApiResponse.Error("Peer not found", 404);
 
-        if (!_store.DeleteCustomSource(peerId, sourceId))
+        if (!await _store.DeleteCustomSourceAsync(peerId, sourceId))
             return ApiResponse.Error($"Source '{sourceId}' not found", 404);
 
         // Trigger refresh so the source's prefixes are withdrawn immediately (#200: ASN-scoped).
@@ -1091,7 +1092,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
     private async Task<ApiResponse> HandlePatchSource(string peerId, string sourceId, HttpListenerContext ctx)
     {
-        var peer = _store.GetDbPeerById(peerId);
+        var peer = await _store.GetDbPeerByIdAsync(peerId);
         if (peer is null)
             return ApiResponse.Error("Peer not found", 404);
 
@@ -1102,7 +1103,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (data is null || data.Active is null)
             return ApiResponse.Error("PATCH body must contain { \"active\": true/false }", 400);
 
-        if (!_store.SetSourceActive(peerId, sourceId, data.Active.Value))
+        if (!await _store.SetSourceActiveAsync(peerId, sourceId, data.Active.Value))
             return ApiResponse.Error($"Source '{sourceId}' not found", 404);
 
         // Trigger refresh so toggling active/inactive takes effect immediately (#200: ASN-scoped).
@@ -1118,7 +1119,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
     private async Task<ApiResponse> HandleExportPrefixes(string peerId, HttpListenerContext ctx)
     {
-        var peer = _store.GetDbPeerById(peerId);
+        var peer = await _store.GetDbPeerByIdAsync(peerId);
         if (peer is null)
             return ApiResponse.Error("Peer not found", 404);
 
@@ -1137,9 +1138,9 @@ public sealed class ManagementApi : IHostedService, IDisposable
         var prefixes = new List<string>();
 
         // Custom prefixes
-        prefixes.AddRange(_store.GetCustomPrefixes(peerId));
+        prefixes.AddRange(await _store.GetCustomPrefixesAsync(peerId, ct));
 
-        var subscriptions = _store.GetSubscriptions(peerId);
+        var subscriptions = await _store.GetSubscriptionsAsync(peerId, ct);
         var subscribedLists = _config.RipeStat?.AsnLists
             .Where(l => subscriptions.Contains(l.Name))
             .ToList() ?? [];

--- a/BGPLite.Api/PeerStore.cs
+++ b/BGPLite.Api/PeerStore.cs
@@ -18,13 +18,13 @@ public sealed class PeerStore : IPeerStore
 
     /// <summary>
     /// Creates or upserts the peer row alone. Callers configuring a peer in full should use
-    /// <see cref="SavePeerConfiguration"/> instead, so the row and its collections commit together
+    /// <see cref="SavePeerConfigurationAsync"/> instead, so the row and its collections commit together
     /// (#259).
     /// </summary>
-    public string CreatePeer(string ip, uint asn, string? description)
+    public async Task<string> CreatePeerAsync(string ip, uint asn, string? description, CancellationToken ct = default)
     {
         using var db = _dbFactory.CreateDbContext();
-        return UpsertPeerRow(db, ip, asn, description).Id;
+        return (await UpsertPeerRowAsync(db, ip, asn, description, ct)).Id;
     }
 
     /// <summary>
@@ -32,7 +32,7 @@ public sealed class PeerStore : IPeerStore
     /// an enclosing transaction (#259) instead of always committing on its own. Behaviour is
     /// unchanged from the #227 implementation this was extracted from.
     /// </summary>
-    private static SavedPeer UpsertPeerRow(BgpDbContext db, string ip, uint asn, string? description)
+    private static async Task<SavedPeer> UpsertPeerRowAsync(BgpDbContext db, string ip, uint asn, string? description, CancellationToken ct)
     {
         // #227: atomic SQLite upsert eliminates the read-then-write race on the composite unique
         // index UX_Peers_Ip_Asn. Two concurrent CreatePeer calls for the same (Ip, Asn) previously
@@ -71,8 +71,8 @@ public sealed class PeerStore : IPeerStore
             AddParam(cmd, "@asn", (long)asn);
             AddParam(cmd, "@desc", (object?)description ?? DBNull.Value);
             AddParam(cmd, "@now", now);
-            using var reader = cmd.ExecuteReader();
-            reader.Read();
+            using var reader = await cmd.ExecuteReaderAsync(ct);
+            await reader.ReadAsync(ct);
             return new SavedPeer(
                 reader.GetString(0),
                 reader.GetString(1),
@@ -93,21 +93,21 @@ public sealed class PeerStore : IPeerStore
         cmd.Parameters.Add(p);
     }
 
-    public void UpsertPeer(string ip, uint asn)
+    public async Task UpsertPeerAsync(string ip, uint asn, CancellationToken ct = default)
     {
         using var db = _dbFactory.CreateDbContext();
-        // #227: atomic upsert — see CreatePeer. UpsertPeer is called from the BGP connect path
+        // #227: atomic upsert — see CreatePeerAsync. UpsertPeer is called from the BGP connect path
         // (Program.cs _onPeerIdentified), where there is no HTTP caller to receive a 409, so the
         // previous read-then-write race could throw DbUpdateException into the session handler.
         var id = Guid.NewGuid().ToString("N");
         var now = DateTime.UtcNow.ToString("O");
-        db.Database.ExecuteSqlInterpolated($@"
+        await db.Database.ExecuteSqlInterpolatedAsync($@"
             INSERT INTO Peers (Id, Ip, Asn, Description, Status, CreatedAt, LastSessionAt)
             VALUES ({id}, {ip}, {asn}, NULL, 'active', {now}, {now})
-            ON CONFLICT(Ip, Asn) DO UPDATE SET Status = 'active', LastSessionAt = {now}");
+            ON CONFLICT(Ip, Asn) DO UPDATE SET Status = 'active', LastSessionAt = {now}", ct);
     }
 
-    public void UpdateSessionStatus(string ip, uint asn, bool active)
+    public async Task UpdateSessionStatusAsync(string ip, uint asn, bool active, CancellationToken ct = default)
     {
         using var db = _dbFactory.CreateDbContext();
         // #227: single-statement UPDATE avoids the read-then-write race and is a no-op (0 rows
@@ -116,48 +116,28 @@ public sealed class PeerStore : IPeerStore
         var now = DateTime.UtcNow.ToString("O");
         if (active)
         {
-            db.Database.ExecuteSqlInterpolated($@"
+            await db.Database.ExecuteSqlInterpolatedAsync($@"
                 UPDATE Peers SET Status = {status}, LastSessionAt = {now}
-                WHERE Ip = {ip} AND Asn = {asn}");
+                WHERE Ip = {ip} AND Asn = {asn}", ct);
         }
         else
         {
-            db.Database.ExecuteSqlInterpolated($@"
+            await db.Database.ExecuteSqlInterpolatedAsync($@"
                 UPDATE Peers SET Status = {status}
-                WHERE Ip = {ip} AND Asn = {asn}");
+                WHERE Ip = {ip} AND Asn = {asn}", ct);
         }
     }
 
-    public void DeletePeer(string id)
+    public async Task DeletePeerAsync(string id, CancellationToken ct = default)
     {
         using var db = _dbFactory.CreateDbContext();
-        db.Peers.Where(p => p.Id == id).ExecuteDelete();
+        await db.Peers.Where(p => p.Id == id).ExecuteDeleteAsync(ct);
     }
 
-    public List<Peer> GetAllPeers()
+    public async Task<Peer?> GetDbPeerByIdAsync(string id, CancellationToken ct = default)
     {
         using var db = _dbFactory.CreateDbContext();
-        return db.Peers.AsNoTracking().Include(p => p.Communities).ToList();
-    }
-
-    public Peer? GetDbPeerById(string id)
-    {
-        using var db = _dbFactory.CreateDbContext();
-        return db.Peers.AsNoTracking().Include(p => p.Communities).FirstOrDefault(p => p.Id == id);
-    }
-
-    PeerInfo? IPeerStore.GetPeerById(string id)
-    {
-        using var db = _dbFactory.CreateDbContext();
-        var peer = db.Peers.AsNoTracking().Include(p => p.Communities).FirstOrDefault(p => p.Id == id);
-        return peer is null ? null : MapToInfo(peer);
-    }
-
-    public PeerInfo? GetPeerByIp(string ip)
-    {
-        using var db = _dbFactory.CreateDbContext();
-        var peer = db.Peers.AsNoTracking().Include(p => p.Communities).FirstOrDefault(p => p.Ip == ip);
-        return peer is null ? null : MapToInfo(peer);
+        return await db.Peers.AsNoTracking().Include(p => p.Communities).FirstOrDefaultAsync(p => p.Id == id, ct);
     }
 
     /// <summary>
@@ -165,24 +145,24 @@ public sealed class PeerStore : IPeerStore
     /// each is a distinct record with its own Id, subscriptions, and communities. Used by /api/me
     /// to return a multi-peer array when disambiguation is needed.
     /// </summary>
-    public List<PeerInfo> GetPeersByIp(string ip)
+    public async Task<List<PeerInfo>> GetPeersByIpAsync(string ip, CancellationToken ct = default)
     {
         using var db = _dbFactory.CreateDbContext();
-        return db.Peers.AsNoTracking()
+        return await db.Peers.AsNoTracking()
             .Where(p => p.Ip == ip)
             .Select(p => MapToInfo(p))
-            .ToList();
+            .ToListAsync(ct);
     }
 
     /// <summary>
     /// Resolves a peer by its durable identity <c>(Ip, Asn)</c> — the form a BGP session knows once
     /// it has parsed the peer's OPEN (issue #19). Several peers may share a source IP with distinct
-    /// AS; this returns the specific one, unlike the Ip-only <see cref="GetPeerByIp"/>.
+    /// AS; this returns the specific one, unlike the Ip-only lookup.
     /// </summary>
-    public PeerInfo? GetPeer(string ip, uint asn)
+    public async Task<PeerInfo?> GetPeerAsync(string ip, uint asn, CancellationToken ct = default)
     {
         using var db = _dbFactory.CreateDbContext();
-        var peer = db.Peers.AsNoTracking().Include(p => p.Communities).FirstOrDefault(p => p.Ip == ip && p.Asn == asn);
+        var peer = await db.Peers.AsNoTracking().Include(p => p.Communities).FirstOrDefaultAsync(p => p.Ip == ip && p.Asn == asn, ct);
         return peer is null ? null : MapToInfo(peer);
     }
 
@@ -196,7 +176,7 @@ public sealed class PeerStore : IPeerStore
     /// so the whole read+update is one connection (six statements on five connections → two
     /// statements on one). The returned collection shapes match the standalone getters exactly.
     /// </summary>
-    public PeerRoutingView? LoadPeerRoutingView(string ip, uint asn)
+    public async Task<PeerRoutingView?> LoadPeerRoutingViewAsync(string ip, uint asn, CancellationToken ct = default)
     {
         using var db = _dbFactory.CreateDbContext();
 
@@ -215,25 +195,25 @@ public sealed class PeerStore : IPeerStore
         // and a UI edit landing between them would advertise a mixed configuration. SQLite runs in
         // WAL here (#95), so a read transaction takes no write lock and does not block writers.
         Peer? peer;
-        using (var read = db.Database.BeginTransaction())
+        using (var read = await db.Database.BeginTransactionAsync(ct))
         {
-            peer = db.Peers.AsNoTracking()
+            peer = await db.Peers.AsNoTracking()
                 .Include(p => p.Subscriptions)
                 .Include(p => p.CustomPrefixes)
                 .Include(p => p.CustomAsns)
                 .Include(p => p.CustomSources.Where(c => c.Active))
                 .AsSplitQuery()
-                .FirstOrDefault(p => p.Ip == ip && p.Asn == asn);
-            read.Commit();
+                .FirstOrDefaultAsync(p => p.Ip == ip && p.Asn == asn, ct);
+            await read.CommitAsync(ct);
         }
         if (peer is null) return null;
 
         // Fold the status update (was UpdateSessionStatus(active:true) on its own DbContext) into
         // this one. ExecuteUpdate is scoped by (Ip, Asn) — identical effect, no extra connection.
-        db.Peers.Where(p => p.Ip == ip && p.Asn == asn)
-            .ExecuteUpdate(s => s
+        await db.Peers.Where(p => p.Ip == ip && p.Asn == asn)
+            .ExecuteUpdateAsync(s => s
                 .SetProperty(p => p.Status, "active")
-                .SetProperty(p => p.LastSessionAt, DateTime.UtcNow));
+                .SetProperty(p => p.LastSessionAt, DateTime.UtcNow), ct);
 
         return new PeerRoutingView(
             peer.Id,
@@ -267,14 +247,14 @@ public sealed class PeerStore : IPeerStore
     /// does NOT fold a status update (the GET path does not mutate). Returns null if the peer does
     /// not exist. Field shapes match the prior standalone getters byte-for-byte.
     /// </summary>
-    public PeerDetailDto? GetPeerDetail(string peerId)
+    public async Task<PeerDetailDto?> GetPeerDetailAsync(string peerId, CancellationToken ct = default)
     {
         using var db = _dbFactory.CreateDbContext();
         // AsSplitQuery is what makes each collection its own SELECT — a projection alone does not
-        // split (#260). Read transaction for the same reason as LoadPeerRoutingView: the six
+        // split (#260). Read transaction for the same reason as LoadPeerRoutingViewAsync: the six
         // statements must see one snapshot, and in WAL a read transaction blocks nobody.
-        using var read = db.Database.BeginTransaction();
-        var detail = db.Peers.AsNoTracking()
+        using var read = await db.Database.BeginTransactionAsync(ct);
+        var detail = await db.Peers.AsNoTracking()
             .Where(p => p.Id == peerId)
             .Select(p => new PeerDetailDto(
                 p.Id,
@@ -294,8 +274,8 @@ public sealed class PeerStore : IPeerStore
                 // Communities stored as long (PeerCommunity.Community); the API formats to "ASN:VAL".
                 p.Communities.Select(c => c.Community).ToList()))
             .AsSplitQuery()
-            .FirstOrDefault();
-        read.Commit();
+            .FirstOrDefaultAsync(ct);
+        await read.CommitAsync(ct);
         return detail;
     }
 
@@ -317,22 +297,22 @@ public sealed class PeerStore : IPeerStore
     /// thing as asking once, and a user assembling a list in the UI produces repeats by pasting.
     /// </para>
     /// </summary>
-    public SavedPeer SavePeerConfiguration(
+    public async Task<SavedPeer> SavePeerConfigurationAsync(
         string ip, uint asn, string? description,
         IReadOnlyList<string> asnListNames,
         IReadOnlyList<(string Prefix, byte Length)> customPrefixes,
-        IReadOnlyList<uint> customAsns)
+        IReadOnlyList<uint> customAsns, CancellationToken ct = default)
     {
         using var db = _dbFactory.CreateDbContext();
-        using var tx = db.Database.BeginTransaction();
+        using var tx = await db.Database.BeginTransactionAsync(ct);
 
-        var saved = UpsertPeerRow(db, ip, asn, description);
-        ReplaceSubscriptions(db, saved.Id, asnListNames);
-        ReplaceCustomPrefixes(db, saved.Id, customPrefixes);
-        ReplaceCustomAsns(db, saved.Id, customAsns);
-        db.SaveChanges();
+        var saved = await UpsertPeerRowAsync(db, ip, asn, description, ct);
+        await ReplaceSubscriptionsAsync(db, saved.Id, asnListNames, ct);
+        await ReplaceCustomPrefixesAsync(db, saved.Id, customPrefixes, ct);
+        await ReplaceCustomAsnsAsync(db, saved.Id, customAsns, ct);
+        await db.SaveChangesAsync(ct);
 
-        tx.Commit();
+        await tx.CommitAsync(ct);
         return saved;
     }
 
@@ -341,26 +321,26 @@ public sealed class PeerStore : IPeerStore
     /// this alone", matching the PATCH semantics the management API exposes — an empty list means
     /// "clear it", which is a different request and is honoured as such.
     /// </summary>
-    public void UpdatePeerConfiguration(
+    public async Task UpdatePeerConfigurationAsync(
         string peerId, string? description,
         IReadOnlyList<string>? asnListNames,
         IReadOnlyList<(string Prefix, byte Length)>? customPrefixes,
-        IReadOnlyList<uint>? customAsns)
+        IReadOnlyList<uint>? customAsns, CancellationToken ct = default)
     {
         using var db = _dbFactory.CreateDbContext();
-        using var tx = db.Database.BeginTransaction();
+        using var tx = await db.Database.BeginTransactionAsync(ct);
 
         if (description is not null)
         {
-            db.Peers.Where(p => p.Id == peerId)
-                .ExecuteUpdate(s => s.SetProperty(p => p.Description, description));
+            await db.Peers.Where(p => p.Id == peerId)
+                .ExecuteUpdateAsync(s => s.SetProperty(p => p.Description, description), ct);
         }
-        if (asnListNames is not null) ReplaceSubscriptions(db, peerId, asnListNames);
-        if (customPrefixes is not null) ReplaceCustomPrefixes(db, peerId, customPrefixes);
-        if (customAsns is not null) ReplaceCustomAsns(db, peerId, customAsns);
-        db.SaveChanges();
+        if (asnListNames is not null) await ReplaceSubscriptionsAsync(db, peerId, asnListNames, ct);
+        if (customPrefixes is not null) await ReplaceCustomPrefixesAsync(db, peerId, customPrefixes, ct);
+        if (customAsns is not null) await ReplaceCustomAsnsAsync(db, peerId, customAsns, ct);
+        await db.SaveChangesAsync(ct);
 
-        tx.Commit();
+        await tx.CommitAsync(ct);
     }
 
     // The Replace* helpers stage a delete + insert on the CALLER's DbContext without committing, so
@@ -368,174 +348,161 @@ public sealed class PeerStore : IPeerStore
     // Set* methods keep their own DbContext + transaction for single-field callers.
 
     /// <summary>Stages the subscription set, deduplicated — keyed <c>(PeerId, AsnListName)</c>.</summary>
-    private static void ReplaceSubscriptions(BgpDbContext db, string peerId, IReadOnlyList<string> names)
+    private static async Task ReplaceSubscriptionsAsync(BgpDbContext db, string peerId, IReadOnlyList<string> names, CancellationToken ct)
     {
-        db.Set<PeerSubscription>().Where(s => s.PeerId == peerId).ExecuteDelete();
+        await db.Set<PeerSubscription>().Where(s => s.PeerId == peerId).ExecuteDeleteAsync(ct);
         db.Set<PeerSubscription>().AddRange(
             names.Distinct(StringComparer.Ordinal)
                  .Select(n => new PeerSubscription { PeerId = peerId, AsnListName = n }));
     }
 
     /// <summary>Stages the custom-prefix set, deduplicated — keyed <c>(PeerId, Prefix, PrefixLength)</c>.</summary>
-    private static void ReplaceCustomPrefixes(BgpDbContext db, string peerId, IReadOnlyList<(string Prefix, byte Length)> prefixes)
+    private static async Task ReplaceCustomPrefixesAsync(BgpDbContext db, string peerId, IReadOnlyList<(string Prefix, byte Length)> prefixes, CancellationToken ct)
     {
-        db.Set<PeerCustomPrefix>().Where(c => c.PeerId == peerId).ExecuteDelete();
+        await db.Set<PeerCustomPrefix>().Where(c => c.PeerId == peerId).ExecuteDeleteAsync(ct);
         db.Set<PeerCustomPrefix>().AddRange(
             prefixes.Distinct()
                     .Select(p => new PeerCustomPrefix { PeerId = peerId, Prefix = p.Prefix, PrefixLength = p.Length }));
     }
 
     /// <summary>Stages the custom-ASN set, deduplicated — keyed <c>(PeerId, Asn)</c>.</summary>
-    private static void ReplaceCustomAsns(BgpDbContext db, string peerId, IReadOnlyList<uint> asns)
+    private static async Task ReplaceCustomAsnsAsync(BgpDbContext db, string peerId, IReadOnlyList<uint> asns, CancellationToken ct)
     {
-        db.Set<PeerCustomAsn>().Where(c => c.PeerId == peerId).ExecuteDelete();
+        await db.Set<PeerCustomAsn>().Where(c => c.PeerId == peerId).ExecuteDeleteAsync(ct);
         db.Set<PeerCustomAsn>().AddRange(
             asns.Distinct().Select(a => new PeerCustomAsn { PeerId = peerId, Asn = a }));
-    }
-
-    public void SetDescription(string id, string description)
-    {
-        using var db = _dbFactory.CreateDbContext();
-        db.Peers.Where(p => p.Id == id).ExecuteUpdate(
-            s => s.SetProperty(p => p.Description, description));
     }
 
     // AsNoTracking is a read-only-intent marker here — a no-op for this scalar projection (no
     // entities are materialized to track). #267 item 4: no Include — SelectMany over the
     // navigation composes in SQL on its own; the Include was redundant load-hint noise.
-    public HashSet<uint> GetCommunities(string peerId)
+    public async Task<HashSet<uint>> GetCommunitiesAsync(string peerId, CancellationToken ct = default)
     {
         using var db = _dbFactory.CreateDbContext();
-        return db.Peers.AsNoTracking()
+        return await db.Peers.AsNoTracking()
             .Where(p => p.Id == peerId)
             .SelectMany(p => p.Communities)
             .Select(c => (uint)c.Community)
-            .ToHashSet();
+            .ToHashSetAsync(ct);
     }
 
     // AsNoTracking is a read-only-intent marker here — a no-op for this scalar projection (no entities are materialized to track).
-    public HashSet<uint> GetCommunities(string ip, uint asn)
+    public async Task<HashSet<uint>> GetCommunitiesAsync(string ip, uint asn, CancellationToken ct = default)
     {
         using var db = _dbFactory.CreateDbContext();
-        return db.Peers.AsNoTracking()
+        return await db.Peers.AsNoTracking()
             .Where(p => p.Ip == ip && p.Asn == asn)
             .SelectMany(p => p.Communities)
             .Select(c => (uint)c.Community)
-            .ToHashSet();
+            .ToHashSetAsync(ct);
     }
 
     // AsNoTracking is a read-only-intent marker here — a no-op for this scalar projection (no entities are materialized to track).
-    public HashSet<uint> GetCommunitiesByIp(string ip)
+    public async Task<HashSet<uint>> GetCommunitiesByIpAsync(string ip, CancellationToken ct = default)
     {
         using var db = _dbFactory.CreateDbContext();
-        return db.Peers.AsNoTracking()
+        return await db.Peers.AsNoTracking()
             .Where(p => p.Ip == ip)
             .SelectMany(p => p.Communities)
             .Select(c => (uint)c.Community)
-            .ToHashSet();
+            .ToHashSetAsync(ct);
     }
 
-    public void SetCommunities(string peerId, HashSet<uint> communities)
+    public async Task SetCommunitiesAsync(string peerId, HashSet<uint> communities, CancellationToken ct = default)
     {
         using var db = _dbFactory.CreateDbContext();
         // #226: ExecuteDelete runs in its own implicit transaction and AddRange/SaveChanges in
         // another; without an explicit transaction a failure between them leaves the peer with an
         // EMPTY collection (delete committed, insert did not). Wrap both in one transaction so the
         // replace is atomic.
-        using var tx = db.Database.BeginTransaction();
-        db.Set<PeerCommunity>().Where(c => c.PeerId == peerId).ExecuteDelete();
+        using var tx = await db.Database.BeginTransactionAsync(ct);
+        await db.Set<PeerCommunity>().Where(c => c.PeerId == peerId).ExecuteDeleteAsync(ct);
         db.Set<PeerCommunity>().AddRange(
             communities.Select(c => new PeerCommunity { PeerId = peerId, Community = c }));
-        db.SaveChanges();
-        tx.Commit();
-    }
-
-    public void ClearCommunities(string peerId)
-    {
-        using var db = _dbFactory.CreateDbContext();
-        db.Set<PeerCommunity>().Where(c => c.PeerId == peerId).ExecuteDelete();
+        await db.SaveChangesAsync(ct);
+        await tx.CommitAsync(ct);
     }
 
     // AsNoTracking is a read-only-intent marker here — a no-op for this scalar projection (no entities are materialized to track).
-    public List<string> GetSubscriptions(string peerId)
+    public async Task<List<string>> GetSubscriptionsAsync(string peerId, CancellationToken ct = default)
     {
         using var db = _dbFactory.CreateDbContext();
-        return db.Set<PeerSubscription>().AsNoTracking()
+        return await db.Set<PeerSubscription>().AsNoTracking()
             .Where(s => s.PeerId == peerId)
             .Select(s => s.AsnListName)
-            .ToList();
+            .ToListAsync(ct);
     }
 
-    public void SetSubscriptions(string peerId, List<string> asnListNames)
+    public async Task SetSubscriptionsAsync(string peerId, List<string> asnListNames, CancellationToken ct = default)
     {
         using var db = _dbFactory.CreateDbContext();
-        // #226: wrap delete+insert in a transaction — see SetCommunities.
-        using var tx = db.Database.BeginTransaction();
-        db.Set<PeerSubscription>().Where(s => s.PeerId == peerId).ExecuteDelete();
+        // #226: wrap delete+insert in a transaction — see SetCommunitiesAsync.
+        using var tx = await db.Database.BeginTransactionAsync(ct);
+        await db.Set<PeerSubscription>().Where(s => s.PeerId == peerId).ExecuteDeleteAsync(ct);
         db.Set<PeerSubscription>().AddRange(
             asnListNames.Select(n => new PeerSubscription { PeerId = peerId, AsnListName = n }));
-        db.SaveChanges();
-        tx.Commit();
+        await db.SaveChangesAsync(ct);
+        await tx.CommitAsync(ct);
     }
 
     // AsNoTracking is a read-only-intent marker here — a no-op for this scalar projection (no entities are materialized to track).
-    public List<string> GetCustomPrefixes(string peerId)
+    public async Task<List<string>> GetCustomPrefixesAsync(string peerId, CancellationToken ct = default)
     {
         using var db = _dbFactory.CreateDbContext();
-        return db.Set<PeerCustomPrefix>().AsNoTracking()
+        return await db.Set<PeerCustomPrefix>().AsNoTracking()
             .Where(c => c.PeerId == peerId)
             .Select(c => c.Prefix + "/" + c.PrefixLength)
-            .ToList();
+            .ToListAsync(ct);
     }
 
-    public void SetCustomPrefixes(string peerId, List<(string Prefix, byte Length)> prefixes)
+    public async Task SetCustomPrefixesAsync(string peerId, List<(string Prefix, byte Length)> prefixes, CancellationToken ct = default)
     {
         using var db = _dbFactory.CreateDbContext();
-        // #226: wrap delete+insert in a transaction — see SetCommunities.
-        using var tx = db.Database.BeginTransaction();
-        db.Set<PeerCustomPrefix>().Where(c => c.PeerId == peerId).ExecuteDelete();
+        // #226: wrap delete+insert in a transaction — see SetCommunitiesAsync.
+        using var tx = await db.Database.BeginTransactionAsync(ct);
+        await db.Set<PeerCustomPrefix>().Where(c => c.PeerId == peerId).ExecuteDeleteAsync(ct);
         db.Set<PeerCustomPrefix>().AddRange(
             prefixes.Select(p => new PeerCustomPrefix { PeerId = peerId, Prefix = p.Prefix, PrefixLength = p.Length }));
-        db.SaveChanges();
-        tx.Commit();
+        await db.SaveChangesAsync(ct);
+        await tx.CommitAsync(ct);
     }
 
     // AsNoTracking is a read-only-intent marker here — a no-op for this scalar projection (no entities are materialized to track).
-    public List<uint> GetCustomAsns(string peerId)
+    public async Task<List<uint>> GetCustomAsnsAsync(string peerId, CancellationToken ct = default)
     {
         using var db = _dbFactory.CreateDbContext();
-        return db.Set<PeerCustomAsn>().AsNoTracking()
+        return await db.Set<PeerCustomAsn>().AsNoTracking()
             .Where(c => c.PeerId == peerId)
             .Select(c => c.Asn)
-            .ToList();
+            .ToListAsync(ct);
     }
 
-    public void SetCustomAsns(string peerId, List<uint> asns)
+    public async Task SetCustomAsnsAsync(string peerId, List<uint> asns, CancellationToken ct = default)
     {
         using var db = _dbFactory.CreateDbContext();
-        // #226: wrap delete+insert in a transaction — see SetCommunities.
-        using var tx = db.Database.BeginTransaction();
-        db.Set<PeerCustomAsn>().Where(c => c.PeerId == peerId).ExecuteDelete();
+        // #226: wrap delete+insert in a transaction — see SetCommunitiesAsync.
+        using var tx = await db.Database.BeginTransactionAsync(ct);
+        await db.Set<PeerCustomAsn>().Where(c => c.PeerId == peerId).ExecuteDeleteAsync(ct);
         db.Set<PeerCustomAsn>().AddRange(
             asns.Select(a => new PeerCustomAsn { PeerId = peerId, Asn = a }));
-        db.SaveChanges();
-        tx.Commit();
+        await db.SaveChangesAsync(ct);
+        await tx.CommitAsync(ct);
     }
 
     /// <summary>
     /// Lists all user-supplied URL-based prefix-list sources for a peer (#143). Sources are stored as
     /// URLs (not parsed); fetched at send time in SendAllRoutesAsync.
     /// </summary>
-    public List<PeerCustomSource> GetCustomSources(string peerId)
+    public async Task<List<PeerCustomSource>> GetCustomSourcesAsync(string peerId, CancellationToken ct = default)
     {
         using var db = _dbFactory.CreateDbContext();
-        return db.Set<PeerCustomSource>().AsNoTracking()
+        return await db.Set<PeerCustomSource>().AsNoTracking()
             .Where(c => c.PeerId == peerId)
-            .ToList();
+            .ToListAsync(ct);
     }
 
     /// <summary>Adds a URL-based prefix-list source to a peer. Returns the created entity (with Id).</summary>
-    public PeerCustomSource AddCustomSource(string peerId, string name, string url, string? community)
+    public async Task<PeerCustomSource> AddCustomSourceAsync(string peerId, string name, string url, string? community, CancellationToken ct = default)
     {
         using var db = _dbFactory.CreateDbContext();
         var source = new PeerCustomSource
@@ -546,27 +513,27 @@ public sealed class PeerStore : IPeerStore
             Community = community
         };
         db.Set<PeerCustomSource>().Add(source);
-        db.SaveChanges();
+        await db.SaveChangesAsync(ct);
         return source;
     }
 
     /// <summary>Removes a URL-based source by its Id, scoped to a peer. Returns true if found and removed.</summary>
-    public bool DeleteCustomSource(string peerId, string sourceId)
+    public async Task<bool> DeleteCustomSourceAsync(string peerId, string sourceId, CancellationToken ct = default)
     {
         using var db = _dbFactory.CreateDbContext();
-        var deleted = db.Set<PeerCustomSource>()
+        var deleted = await db.Set<PeerCustomSource>()
             .Where(c => c.Id == sourceId && c.PeerId == peerId)
-            .ExecuteDelete();
+            .ExecuteDeleteAsync(ct);
         return deleted > 0;
     }
 
     /// <summary>Toggles a source's active state, scoped to a peer. Returns true if found and updated.</summary>
-    public bool SetSourceActive(string peerId, string sourceId, bool active)
+    public async Task<bool> SetSourceActiveAsync(string peerId, string sourceId, bool active, CancellationToken ct = default)
     {
         using var db = _dbFactory.CreateDbContext();
-        var updated = db.Set<PeerCustomSource>()
+        var updated = await db.Set<PeerCustomSource>()
             .Where(c => c.Id == sourceId && c.PeerId == peerId)
-            .ExecuteUpdate(s => s.SetProperty(c => c.Active, active));
+            .ExecuteUpdateAsync(s => s.SetProperty(c => c.Active, active), ct);
         return updated > 0;
     }
 

--- a/BGPLite.Contracts/IPeerStore.cs
+++ b/BGPLite.Contracts/IPeerStore.cs
@@ -1,34 +1,18 @@
 namespace BGPLite.Contracts;
 
+/// <summary>
+/// The persistence surface the BGP session layer consumes (issues #262, #230). Every member is
+/// asynchronous — the store is invoked from session threads and the route-send path, and a sync
+/// EF call there blocks a thread-pool thread for the duration of any SQLite <c>busy_timeout</c>
+/// wait. The management API works with the concrete <c>PeerStore</c> (its surface is an API
+/// concern, not a session-layer contract) and stays out of this interface on purpose.
+/// </summary>
 public interface IPeerStore
 {
-    string CreatePeer(string ip, uint asn, string? description);
-    void UpsertPeer(string ip, uint asn);
-    void UpdateSessionStatus(string ip, uint asn, bool active);
-    void DeletePeer(string id);
-    PeerInfo? GetPeerByIp(string ip);
-    PeerInfo? GetPeer(string ip, uint asn);
-    PeerInfo? GetPeerById(string id);
-    List<string> GetSubscriptions(string peerId);
-    List<string> GetCustomPrefixes(string peerId);
-    List<uint> GetCustomAsns(string peerId);
-    HashSet<uint> GetCommunities(string peerId);
-    HashSet<uint> GetCommunities(string ip, uint asn);
-    void SetCommunities(string peerId, HashSet<uint> communities);
-    void ClearCommunities(string peerId);
-    void SetDescription(string id, string description);
-
-    /// <summary>
-    /// Loads a peer by its durable identity <c>(Ip, Asn)</c> together with the routing-relevant
-    /// child data (<see cref="PeerRoutingView.Subscriptions"/>, <see cref="PeerRoutingView.CustomPrefixes"/>,
-    /// <see cref="PeerRoutingView.CustomAsns"/>, <see cref="PeerRoutingView.UserSources"/>) in a SINGLE query,
-    /// and folds the "session active" status update (Status="active", LastSessionAt=now) into the SAME
-    /// DbContext — so the BGP send path does one read+write roundtrip instead of separate
-    /// <c>GetPeer</c>/<c>UpdateSessionStatus</c>/<c>GetSubscriptions</c>/<c>GetCustomPrefixes</c>/
-    /// <c>GetCustomAsns</c> calls (issue #84). Returns <c>null</c> when the peer is unknown (the caller
-    /// then auto-registers). The collection shapes match the standalone getters exactly (no behavior change).
-    /// </summary>
-    PeerRoutingView? LoadPeerRoutingView(string ip, uint asn);
+    Task<string> CreatePeerAsync(string ip, uint asn, string? description, CancellationToken ct = default);
+    Task UpsertPeerAsync(string ip, uint asn, CancellationToken ct = default);
+    Task UpdateSessionStatusAsync(string ip, uint asn, bool active, CancellationToken ct = default);
+    Task<PeerRoutingView?> LoadPeerRoutingViewAsync(string ip, uint asn, CancellationToken ct = default);
 }
 
 public class PeerInfo

--- a/BGPLite.Routing/AllowAllFilter.cs
+++ b/BGPLite.Routing/AllowAllFilter.cs
@@ -10,7 +10,8 @@ public sealed class AllowAllFilter : IRouteFilter
 
     public bool AcceptIncoming(Route route, PeerConfig peer) => true;
 
-    public IReadOnlySet<uint> ResolveOutgoingAllowSet(PeerConfig peer) => EmptyAllowSet;
+    public Task<IReadOnlySet<uint>> ResolveOutgoingAllowSetAsync(PeerConfig peer, CancellationToken ct = default)
+        => Task.FromResult(EmptyAllowSet);
 
     public bool AcceptOutgoing(Route route, PeerConfig peer, IReadOnlySet<uint> allowSet) => true;
 }

--- a/BGPLite.Routing/IRouteFilter.cs
+++ b/BGPLite.Routing/IRouteFilter.cs
@@ -11,13 +11,14 @@ public interface IRouteFilter
     /// allow-set, which may require a database roundtrip). The returned set is passed to
     /// <see cref="AcceptOutgoing"/> for every route in that send, so the resolution happens once
     /// per peer per refresh rather than once per advertised route. An empty set means "no
-    /// community restriction" (all routes pass).
+    /// community restriction" (all routes pass). Asynchronous since #262 — the DB read behind it
+    /// must not block a session thread.
     /// </summary>
-    IReadOnlySet<uint> ResolveOutgoingAllowSet(PeerConfig peer);
+    Task<IReadOnlySet<uint>> ResolveOutgoingAllowSetAsync(PeerConfig peer, CancellationToken ct = default);
 
     /// <summary>
     /// Per-route outgoing decision. <paramref name="allowSet"/> is the value returned by
-    /// <see cref="ResolveOutgoingAllowSet"/> for the current send and must not perform any
+    /// <see cref="ResolveOutgoingAllowSetAsync"/> for the current send and must not perform any
     /// per-route I/O.
     /// </summary>
     bool AcceptOutgoing(Route route, PeerConfig peer, IReadOnlySet<uint> allowSet);

--- a/BGPLite.Routing/PeerCommunityFilter.cs
+++ b/BGPLite.Routing/PeerCommunityFilter.cs
@@ -6,9 +6,9 @@ namespace BGPLite.Routing;
 public sealed class PeerCommunityFilter : IRouteFilter
 {
     private readonly uint _localAsn;
-    private readonly Func<string, uint?, HashSet<uint>> _getCommunities;
+    private readonly Func<string, uint?, CancellationToken, Task<HashSet<uint>>> _getCommunities;
 
-    public PeerCommunityFilter(uint localAsn, Func<string, uint?, HashSet<uint>> getCommunities)
+    public PeerCommunityFilter(uint localAsn, Func<string, uint?, CancellationToken, Task<HashSet<uint>>> getCommunities)
     {
         _localAsn = localAsn;
         _getCommunities = getCommunities;
@@ -19,9 +19,10 @@ public sealed class PeerCommunityFilter : IRouteFilter
     /// <summary>
     /// Resolves the peer's community allow-set once per send. This is the only place the
     /// (potentially database-backed) resolver runs on the advertise path — never per route.
+    /// Asynchronous since #262: the resolver's DB read ran synchronously on the session send path.
     /// </summary>
-    public IReadOnlySet<uint> ResolveOutgoingAllowSet(PeerConfig peer)
-        => _getCommunities(peer.Address, peer.RemoteAsn);
+    public async Task<IReadOnlySet<uint>> ResolveOutgoingAllowSetAsync(PeerConfig peer, CancellationToken ct = default)
+        => await _getCommunities(peer.Address, peer.RemoteAsn, ct);
 
     public bool AcceptOutgoing(Route route, PeerConfig peer, IReadOnlySet<uint> allowSet)
     {

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -30,7 +30,7 @@ public sealed class BgpSession : IDisposable
     private readonly BgpMetrics _metrics;
     private readonly ILogger<BgpSession> _logger;
     private readonly CancellationTokenSource _cts = new();
-    private readonly Action<string, uint>? _onPeerIdentified;
+    private readonly Func<string, uint, Task>? _onPeerIdentified;
     private readonly IPeerStore? _peerStore;
     // #265 item 1: set by BgpServer right after creation — "is this session still the registered
     // one?" A false answer at teardown-time means a replacement took the slot and owns the
@@ -253,7 +253,7 @@ public sealed class BgpSession : IDisposable
         IRouteFilter routeFilter,
         BgpMetrics metrics,
         ILogger<BgpSession> logger,
-        Action<string, uint>? onPeerIdentified = null,
+        Func<string, uint, Task>? onPeerIdentified = null,
         IPeerStore? peerStore = null,
         IPrefixAggregator? prefixAggregator = null,
         IRouteAssembler? routeAssembler = null,
@@ -342,7 +342,7 @@ public sealed class BgpSession : IDisposable
                     ? $"{c.Code}[{Convert.ToHexString(c.Data)}]"
                     : $"{c.Code}")));
 
-            ValidateOpen(remoteOpen);
+            await ValidateOpenAsync(remoteOpen);
 
             TransitionTo(BgpFsmState.OpenSent);
 
@@ -566,8 +566,9 @@ public sealed class BgpSession : IDisposable
                 var stillRegistered = _stillRegisteredProbe?.Invoke(this) ?? true;
                 if (!silent && stillRegistered)
                 {
-                    try { _peerStore?.UpdateSessionStatus(_peerConfig.Address, _remoteAsn, false); }
-                    catch (Exception ex) { _logger.LogWarning(ex, "Failed to persist session status for {Peer}", _peer); }
+                    if (_peerStore is not null)
+                        try { await _peerStore.UpdateSessionStatusAsync(_peerConfig.Address, _remoteAsn, false); }
+                        catch (Exception ex) { _logger.LogWarning(ex, "Failed to persist session status for {Peer}", _peer); }
 
                     // #366 review: a replacement can land between the probe and the write —
                     // re-probe and REPAIR. A false second probe means the registry swapped us out
@@ -579,8 +580,9 @@ public sealed class BgpSession : IDisposable
                     if (_stillRegisteredProbe?.Invoke(this) == false)
                     {
                         _logger.LogInformation("Replacement detected after status write for {Peer} — restoring active", _peer);
-                        try { _peerStore?.UpdateSessionStatus(_peerConfig.Address, _remoteAsn, true); }
-                        catch (Exception ex) { _logger.LogWarning(ex, "Failed to restore session status for {Peer}", _peer); }
+                        if (_peerStore is not null)
+                            try { await _peerStore.UpdateSessionStatusAsync(_peerConfig.Address, _remoteAsn, true); }
+                            catch (Exception ex) { _logger.LogWarning(ex, "Failed to restore session status for {Peer}", _peer); }
                     }
                 }
             }
@@ -1503,7 +1505,7 @@ public sealed class BgpSession : IDisposable
 
     #region Validation
 
-    private void ValidateOpen(BgpOpenMessage open)
+    private async Task ValidateOpenAsync(BgpOpenMessage open)
     {
         var localRouterId = BgpConstants.IPAddressToUint(_bgpConfig.GetRouterIdAddress());
         // #269: OPEN negotiation/validation lives in the protocol library (OpenNegotiator); the
@@ -1520,7 +1522,7 @@ public sealed class BgpSession : IDisposable
         // Announce/persist the peer only after the OPEN passes validation. Previously this fired
         // before the expected-ASN check, upserting a configured peer that declared a mismatched ASN
         // (BadPeerAs) just before the session was torn down.
-        _onPeerIdentified?.Invoke(_peerConfig.Address, _remoteAsn);
+        if (_onPeerIdentified is not null) await _onPeerIdentified(_peerConfig.Address, _remoteAsn);
 
         var peerGr = CapabilityHelper.GetGracefulRestart(open);
         _logger.LogInformation("Peer {Peer} Graceful Restart: {State}",

--- a/BGPLite.Server/BgpSessionFactory.cs
+++ b/BGPLite.Server/BgpSessionFactory.cs
@@ -63,8 +63,9 @@ public sealed class BgpSessionFactory : IBgpSessionFactory
         new(connection, peerConfig, _bgpConfig, _routeTable, _routeFilter, _metrics, _sessionLogger,
             // The peer row is upserted as soon as OPEN identifies the peer, so a peer that has never
             // been configured in the UI still shows up there. Previously a lambda hand-wired in
-            // Program.cs and threaded through BgpServer.
-            onPeerIdentified: _peerStore.UpsertPeer,
+            // Program.cs and threaded through BgpServer. Async since #262 — the upsert ran
+            // synchronously on the OPEN-handshake path.
+            onPeerIdentified: (ip, asn) => _peerStore.UpsertPeerAsync(ip, asn),
             peerStore: _peerStore,
             prefixAggregator: _prefixAggregator,
             routeAssembler: _routeAssembler,

--- a/BGPLite.Server/RouteAssembler.cs
+++ b/BGPLite.Server/RouteAssembler.cs
@@ -63,7 +63,7 @@ public sealed class RouteAssembler : IRouteAssembler
         var defaultComms = _communityResolver.Resolve(
             new CommunitySource(CommunitySourceKind.PrefixSource, _appConfig.DefaultPrefixSource));
 
-        var peer = _peerStore.LoadPeerRoutingView(peerIp, remoteAsn);
+        var peer = await _peerStore.LoadPeerRoutingViewAsync(peerIp, remoteAsn, ct);
         if (peer is not null)
         {
             var subscriptionIds = peer.Subscriptions;
@@ -90,7 +90,7 @@ public sealed class RouteAssembler : IRouteAssembler
                     _logger.LogError(ex, "Failed to fetch RU prefixes for {Peer}", peerLabel);
                 }
 
-                return FilterAndReturn(routes, filterPeerConfig);
+                return await FilterAndReturnAsync(routes, filterPeerConfig, ct);
             }
 
             _logger.LogInformation("Peer {Peer} subscriptions: [{Subs}]", peerLabel, string.Join(", ", subscriptionIds));
@@ -254,7 +254,7 @@ public sealed class RouteAssembler : IRouteAssembler
                 }
             }
 
-            return FilterAndReturn(routes, filterPeerConfig);
+            return await FilterAndReturnAsync(routes, filterPeerConfig, ct);
         }
         else
         {
@@ -265,12 +265,12 @@ public sealed class RouteAssembler : IRouteAssembler
             if (ct.IsCancellationRequested)
             {
                 _logger.LogInformation("Cancelled build for unknown peer {Ip} — not auto-registering", peerLabel);
-                return FilterAndReturn(routes, filterPeerConfig);
+                return await FilterAndReturnAsync(routes, filterPeerConfig, ct);
             }
 
             // Unknown peer — auto-register and send default RU list.
             _logger.LogInformation("Unknown peer {Ip}, auto-registering with RU defaults", peerLabel);
-            _peerStore.CreatePeer(peerIp, remoteAsn, null);
+            await _peerStore.CreatePeerAsync(peerIp, remoteAsn, null, ct);
 
             try
             {
@@ -286,15 +286,15 @@ public sealed class RouteAssembler : IRouteAssembler
                 _logger.LogError(ex, "Failed to fetch RU prefixes for {Peer}", peerLabel);
             }
 
-            return FilterAndReturn(routes, filterPeerConfig);
+            return await FilterAndReturnAsync(routes, filterPeerConfig, ct);
         }
     }
 
     /// <summary>Applies the per-peer outgoing community filter and returns the filtered list.</summary>
-    private List<Route> FilterAndReturn(List<Route> routes, PeerConfig filterPeerConfig)
+    private async Task<List<Route>> FilterAndReturnAsync(List<Route> routes, PeerConfig filterPeerConfig, CancellationToken ct)
     {
         // Resolve the community allow-set ONCE for the whole send — not once per route (#79).
-        var allowSet = _routeFilter.ResolveOutgoingAllowSet(filterPeerConfig);
+        var allowSet = await _routeFilter.ResolveOutgoingAllowSetAsync(filterPeerConfig, ct);
         return routes.Where(r => _routeFilter.AcceptOutgoing(r, filterPeerConfig, allowSet)).ToList();
     }
 

--- a/BGPLite.Server/SharedTableRouteAssembler.cs
+++ b/BGPLite.Server/SharedTableRouteAssembler.cs
@@ -32,7 +32,7 @@ public sealed class SharedTableRouteAssembler : IRouteAssembler
     }
 
     /// <inheritdoc />
-    public Task<List<Route>> BuildOutboundRoutesAsync(
+    public async Task<List<Route>> BuildOutboundRoutesAsync(
         string peerIp, uint remoteAsn, PeerConfig filterPeerConfig, string peerLabel, CancellationToken ct)
     {
         if (Interlocked.Exchange(ref _announced, 1) == 0)
@@ -48,7 +48,7 @@ public sealed class SharedTableRouteAssembler : IRouteAssembler
         // same table owned by its session (#289). Advertising those here would hand one peer's
         // injected routes to every other peer — a tenant-isolation failure, not just a wrong list.
         // The startup seed is written with no owner and is what this fallback is meant to serve.
-        var allowSet = _routeFilter.ResolveOutgoingAllowSet(filterPeerConfig);
+        var allowSet = await _routeFilter.ResolveOutgoingAllowSetAsync(filterPeerConfig, ct);
         var filtered = new List<Route>();
         foreach (var route in _routeTable.EnumerateUnowned())
         {
@@ -56,6 +56,6 @@ public sealed class SharedTableRouteAssembler : IRouteAssembler
                 filtered.Add(route);
         }
 
-        return Task.FromResult(filtered);
+        return filtered;
     }
 }

--- a/BGPLite.Tests/ApiHandlerBehaviorTests.cs
+++ b/BGPLite.Tests/ApiHandlerBehaviorTests.cs
@@ -81,7 +81,7 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
     public async Task ExportTxt_PlaintextBody_NotJsonQuoted()
     {
         var store = new PeerStore(new StaticOptionsFactory(new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(_connection).Options));
-        var id = store.SavePeerConfiguration("198.51.100.7", 65090, null, [], [("10.0.0.0", (byte)8)], []).Id;
+        var id = (await store.SavePeerConfigurationAsync("198.51.100.7", 65090, null, [], [("10.0.0.0", (byte)8)], [])).Id;
         _port = await StartAsync(new AppConfig { Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" } });
         _client = new HttpClient();
 

--- a/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
+++ b/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
@@ -505,22 +505,15 @@ public class BgpSessionRouteOwnershipTests
     private sealed class RecordingPeerStore : IPeerStore
     {
         public List<(string Ip, uint Asn, bool Active)> StatusWrites = [];
-        public string CreatePeer(string ip, uint asn, string? description) => "id";
-        public void UpsertPeer(string ip, uint asn) { }
-        public void UpdateSessionStatus(string ip, uint asn, bool active) => StatusWrites.Add((ip, asn, active));
-        public void DeletePeer(string id) { }
-        public PeerInfo? GetPeerByIp(string ip) => null;
-        public PeerInfo? GetPeer(string ip, uint asn) => null;
-        public PeerInfo? GetPeerById(string id) => null;
-        public List<string> GetSubscriptions(string peerId) => [];
-        public List<string> GetCustomPrefixes(string peerId) => [];
-        public List<uint> GetCustomAsns(string peerId) => [];
-        public HashSet<uint> GetCommunities(string peerId) => [];
-        public HashSet<uint> GetCommunities(string ip, uint asn) => [];
-        public void SetCommunities(string peerId, HashSet<uint> communities) { }
-        public void ClearCommunities(string peerId) { }
-        public void SetDescription(string id, string description) { }
-        public PeerRoutingView? LoadPeerRoutingView(string ip, uint asn) => new("id", [], [], [], []);
+        public Task<string> CreatePeerAsync(string ip, uint asn, string? description, CancellationToken ct = default) => Task.FromResult("id");
+        public Task UpsertPeerAsync(string ip, uint asn, CancellationToken ct = default) => Task.CompletedTask;
+        public Task UpdateSessionStatusAsync(string ip, uint asn, bool active, CancellationToken ct = default)
+        {
+            StatusWrites.Add((ip, asn, active));
+            return Task.CompletedTask;
+        }
+        public Task<PeerRoutingView?> LoadPeerRoutingViewAsync(string ip, uint asn, CancellationToken ct = default)
+            => Task.FromResult<PeerRoutingView?>(new("id", [], [], [], []));
     }
 
     private static async Task<(BgpSession Session, Task Run, RecordingPeerStore Store)> EstablishWithStoreAsync(
@@ -778,7 +771,7 @@ public class BgpSessionRouteOwnershipTests
     {
         private static readonly IReadOnlySet<uint> Empty = new HashSet<uint>();
         public bool AcceptIncoming(Route route, PeerConfig peer) => false;
-        public IReadOnlySet<uint> ResolveOutgoingAllowSet(PeerConfig peer) => Empty;
+        public Task<IReadOnlySet<uint>> ResolveOutgoingAllowSetAsync(PeerConfig peer, CancellationToken ct = default) => Task.FromResult(Empty);
         public bool AcceptOutgoing(Route route, PeerConfig peer, IReadOnlySet<uint> allowSet) => true;
     }
 }

--- a/BGPLite.Tests/BgpSessionShutdownTests.cs
+++ b/BGPLite.Tests/BgpSessionShutdownTests.cs
@@ -122,23 +122,11 @@ public class BgpSessionShutdownTests
     /// <summary>Every member throws; UpdateSessionStatus simulates the transient DB failure from #325.</summary>
     private sealed class ThrowingUpdateStatusStore : IPeerStore
     {
-        public string CreatePeer(string ip, uint asn, string? description) => throw new NotSupportedException();
-        public void UpsertPeer(string ip, uint asn) => throw new NotSupportedException();
-        public void UpdateSessionStatus(string ip, uint asn, bool active) =>
+        public Task<string> CreatePeerAsync(string ip, uint asn, string? description, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task UpsertPeerAsync(string ip, uint asn, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task UpdateSessionStatusAsync(string ip, uint asn, bool active, CancellationToken ct = default) =>
             throw new InvalidOperationException("simulated: database is locked");
-        public void DeletePeer(string id) => throw new NotSupportedException();
-        public PeerInfo? GetPeerByIp(string ip) => throw new NotSupportedException();
-        public PeerInfo? GetPeer(string ip, uint asn) => throw new NotSupportedException();
-        public PeerInfo? GetPeerById(string id) => throw new NotSupportedException();
-        public List<string> GetSubscriptions(string peerId) => throw new NotSupportedException();
-        public List<string> GetCustomPrefixes(string peerId) => throw new NotSupportedException();
-        public List<uint> GetCustomAsns(string peerId) => throw new NotSupportedException();
-        public HashSet<uint> GetCommunities(string peerId) => throw new NotSupportedException();
-        public HashSet<uint> GetCommunities(string ip, uint asn) => throw new NotSupportedException();
-        public void SetCommunities(string peerId, HashSet<uint> communities) => throw new NotSupportedException();
-        public void ClearCommunities(string peerId) => throw new NotSupportedException();
-        public void SetDescription(string id, string description) => throw new NotSupportedException();
-        public PeerRoutingView? LoadPeerRoutingView(string ip, uint asn) => throw new NotSupportedException();
+        public Task<PeerRoutingView?> LoadPeerRoutingViewAsync(string ip, uint asn, CancellationToken ct = default) => throw new NotSupportedException();
     }
 
     [Fact]

--- a/BGPLite.Tests/CompositionContractTests.cs
+++ b/BGPLite.Tests/CompositionContractTests.cs
@@ -246,23 +246,14 @@ public class CompositionContractTests
     {
         public (string Ip, uint Asn) Upserted { get; private set; }
 
-        public void UpsertPeer(string ip, uint asn) => Upserted = (ip, asn);
-        public void UpdateSessionStatus(string ip, uint asn, bool active) { }
-
-        public string CreatePeer(string ip, uint asn, string? description) => throw new NotSupportedException();
-        public void DeletePeer(string id) => throw new NotSupportedException();
-        public PeerInfo? GetPeerByIp(string ip) => throw new NotSupportedException();
-        public PeerInfo? GetPeer(string ip, uint asn) => throw new NotSupportedException();
-        public PeerInfo? GetPeerById(string id) => throw new NotSupportedException();
-        public List<string> GetSubscriptions(string peerId) => throw new NotSupportedException();
-        public List<string> GetCustomPrefixes(string peerId) => throw new NotSupportedException();
-        public List<uint> GetCustomAsns(string peerId) => throw new NotSupportedException();
-        public HashSet<uint> GetCommunities(string peerId) => throw new NotSupportedException();
-        public HashSet<uint> GetCommunities(string ip, uint asn) => throw new NotSupportedException();
-        public void SetCommunities(string peerId, HashSet<uint> communities) => throw new NotSupportedException();
-        public void ClearCommunities(string peerId) => throw new NotSupportedException();
-        public void SetDescription(string id, string description) => throw new NotSupportedException();
-        public PeerRoutingView? LoadPeerRoutingView(string ip, uint asn) => throw new NotSupportedException();
+        public Task UpsertPeerAsync(string ip, uint asn, CancellationToken ct = default)
+        {
+            Upserted = (ip, asn);
+            return Task.CompletedTask;
+        }
+        public Task UpdateSessionStatusAsync(string ip, uint asn, bool active, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<string> CreatePeerAsync(string ip, uint asn, string? description, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<PeerRoutingView?> LoadPeerRoutingViewAsync(string ip, uint asn, CancellationToken ct = default) => throw new NotSupportedException();
     }
 
     /// <summary>Drops every outbound route, so the filter's effect is unambiguous.</summary>
@@ -270,7 +261,7 @@ public class CompositionContractTests
     {
         private static readonly IReadOnlySet<uint> Empty = new HashSet<uint>();
         public bool AcceptIncoming(Route route, PeerConfig peer) => true;
-        public IReadOnlySet<uint> ResolveOutgoingAllowSet(PeerConfig peer) => Empty;
+        public Task<IReadOnlySet<uint>> ResolveOutgoingAllowSetAsync(PeerConfig peer, CancellationToken ct = default) => Task.FromResult(Empty);
         public bool AcceptOutgoing(Route route, PeerConfig peer, IReadOnlySet<uint> allowSet) => false;
     }
 

--- a/BGPLite.Tests/PeerCommunityFilterTests.cs
+++ b/BGPLite.Tests/PeerCommunityFilterTests.cs
@@ -19,145 +19,145 @@ public class PeerCommunityFilterTests
         Communities = communities
     };
 
-    private static PeerCommunityFilter NewFilter(Func<string, uint?, HashSet<uint>>? resolver = null) =>
-        new(LocalAsn, resolver ?? ((_, _) => new HashSet<uint>()));
+    private static PeerCommunityFilter NewFilter(Func<string, uint?, CancellationToken, Task<HashSet<uint>>>? resolver = null) =>
+        new(LocalAsn, resolver ?? ((_, _, _) => Task.FromResult(new HashSet<uint>())));
 
     // Exercises the resolve-once-per-send contract used by the advertise hot path: resolve the
     // peer's allow-set once, then make the per-route decision against the pre-resolved set.
-    private static bool Outgoing(PeerCommunityFilter filter, Route route, PeerConfig peer)
-        => filter.AcceptOutgoing(route, peer, filter.ResolveOutgoingAllowSet(peer));
+    private static async Task<bool> Outgoing(PeerCommunityFilter filter, Route route, PeerConfig peer)
+        => filter.AcceptOutgoing(route, peer, await filter.ResolveOutgoingAllowSetAsync(peer));
 
     [Theory]
     [InlineData(BgpConstants.Community.NoExport)]
     [InlineData(BgpConstants.Community.NoAdvertise)]
     [InlineData(BgpConstants.Community.NoExportSubconfed)]
-    public void WellKnownCommunity_BlocksOutgoing_OnEbgp(uint community)
+    public async Task WellKnownCommunity_BlocksOutgoing_OnEbgp(uint community)
     {
         var filter = NewFilter();
 
-        Assert.False(Outgoing(filter, RouteWith(community), EbgpPeer));
+        Assert.False(await Outgoing(filter, RouteWith(community), EbgpPeer));
     }
 
     [Fact]
-    public void SameIp_DifferentAsn_UsesPeerSpecificCommunities()
+    public async Task SameIp_DifferentAsn_UsesPeerSpecificCommunities()
     {
-        var filter = NewFilter((ip, asn) =>
+        var filter = NewFilter((ip, asn, _) =>
         {
-            if (ip != SharedIp || !asn.HasValue) return new HashSet<uint>();
-            return asn.Value switch
+            if (ip != SharedIp || !asn.HasValue) return Task.FromResult(new HashSet<uint>());
+            return Task.FromResult(asn.Value switch
             {
                 64512 => new HashSet<uint> { 0x0000FF01 },
                 64513 => new HashSet<uint> { 0x0000FF02 },
                 _ => new HashSet<uint>()
-            };
+            });
         });
 
         var peerA = new PeerConfig { Address = SharedIp, RemoteAsn = 64512 };
         var peerB = new PeerConfig { Address = SharedIp, RemoteAsn = 64513 };
 
-        Assert.True(Outgoing(filter, RouteWith(0x0000FF01), peerA));
-        Assert.False(Outgoing(filter, RouteWith(0x0000FF01), peerB));
-        Assert.True(Outgoing(filter, RouteWith(0x0000FF02), peerB));
-        Assert.False(Outgoing(filter, RouteWith(0x0000FF02), peerA));
+        Assert.True(await Outgoing(filter, RouteWith(0x0000FF01), peerA));
+        Assert.False(await Outgoing(filter, RouteWith(0x0000FF01), peerB));
+        Assert.True(await Outgoing(filter, RouteWith(0x0000FF02), peerB));
+        Assert.False(await Outgoing(filter, RouteWith(0x0000FF02), peerA));
     }
 
     [Fact]
-    public void NullRemoteAsn_FallsBackToIpOnlyCommunities()
+    public async Task NullRemoteAsn_FallsBackToIpOnlyCommunities()
     {
-        var filter = NewFilter((ip, asn) =>
+        var filter = NewFilter((ip, asn, _) => Task.FromResult(
             asn.HasValue
                 ? new HashSet<uint> { 0x0000FF01 }
-                : new HashSet<uint> { 0x0000FF03 });
+                : new HashSet<uint> { 0x0000FF03 }));
 
         var peerNullAsn = new PeerConfig { Address = SharedIp, RemoteAsn = null };
 
-        Assert.True(Outgoing(filter, RouteWith(0x0000FF03), peerNullAsn));
-        Assert.False(Outgoing(filter, RouteWith(0x0000FF01), peerNullAsn));
+        Assert.True(await Outgoing(filter, RouteWith(0x0000FF03), peerNullAsn));
+        Assert.False(await Outgoing(filter, RouteWith(0x0000FF01), peerNullAsn));
     }
 
     [Theory]
     [InlineData(BgpConstants.Community.NoExport)]
     [InlineData(BgpConstants.Community.NoAdvertise)]
     [InlineData(BgpConstants.Community.NoExportSubconfed)]
-    public void WellKnownCommunity_BlocksOutgoing_EvenWhenAllowed_OnEbgp(uint community)
+    public async Task WellKnownCommunity_BlocksOutgoing_EvenWhenAllowed_OnEbgp(uint community)
     {
         var allowed = new HashSet<uint> { community };
-        var filter = NewFilter((_, _) => allowed);
+        var filter = NewFilter((_, _, _) => Task.FromResult(allowed));
 
-        Assert.False(Outgoing(filter, RouteWith(community), EbgpPeer));
+        Assert.False(await Outgoing(filter, RouteWith(community), EbgpPeer));
     }
 
     [Theory]
     [InlineData(BgpConstants.Community.NoExport)]
     [InlineData(BgpConstants.Community.NoAdvertise)]
     [InlineData(BgpConstants.Community.NoExportSubconfed)]
-    public void WellKnownCommunity_BlocksOutgoing_EvenWhenMixedWithAllowed_OnEbgp(uint community)
+    public async Task WellKnownCommunity_BlocksOutgoing_EvenWhenMixedWithAllowed_OnEbgp(uint community)
     {
         var allowed = new HashSet<uint> { 0x0000FF01 };
-        var filter = NewFilter((_, _) => allowed);
+        var filter = NewFilter((_, _, _) => Task.FromResult(allowed));
 
-        Assert.False(Outgoing(filter, RouteWith(0x0000FF01, community), EbgpPeer));
+        Assert.False(await Outgoing(filter, RouteWith(0x0000FF01, community), EbgpPeer));
     }
 
     [Theory]
     [InlineData(BgpConstants.Community.NoExport)]
     [InlineData(BgpConstants.Community.NoExportSubconfed)]
-    public void ExportCommunities_AreAllowed_OnIbgp(uint community)
+    public async Task ExportCommunities_AreAllowed_OnIbgp(uint community)
     {
         var filter = NewFilter();
 
-        Assert.True(Outgoing(filter, RouteWith(community), IbgpPeer));
+        Assert.True(await Outgoing(filter, RouteWith(community), IbgpPeer));
     }
 
     [Fact]
-    public void NoAdvertise_BlocksOnIbgp()
+    public async Task NoAdvertise_BlocksOnIbgp()
     {
         var filter = NewFilter();
 
-        Assert.False(Outgoing(filter, RouteWith(BgpConstants.Community.NoAdvertise), IbgpPeer));
+        Assert.False(await Outgoing(filter, RouteWith(BgpConstants.Community.NoAdvertise), IbgpPeer));
     }
 
     [Fact]
-    public void ConfiguredCommunity_StillPasses_WhenNoWellKnownCommunity()
+    public async Task ConfiguredCommunity_StillPasses_WhenNoWellKnownCommunity()
     {
         var allowed = new HashSet<uint> { 0x0000FF01 };
-        var filter = NewFilter((_, _) => allowed);
+        var filter = NewFilter((_, _, _) => Task.FromResult(allowed));
 
-        Assert.True(Outgoing(filter, RouteWith(0x0000FF01), EbgpPeer));
+        Assert.True(await Outgoing(filter, RouteWith(0x0000FF01), EbgpPeer));
     }
 
     [Fact]
-    public void RouteWithoutCommunity_StillPasses_WhenNoFilterConfigured()
+    public async Task RouteWithoutCommunity_StillPasses_WhenNoFilterConfigured()
     {
         var filter = NewFilter();
 
-        Assert.True(Outgoing(filter, RouteWith(), EbgpPeer));
+        Assert.True(await Outgoing(filter, RouteWith(), EbgpPeer));
     }
 
     [Fact]
-    public void RouteWithDisallowedCommunity_IsRejected()
+    public async Task RouteWithDisallowedCommunity_IsRejected()
     {
         var allowed = new HashSet<uint> { 0x0000FF01 };
-        var filter = NewFilter((_, _) => allowed);
+        var filter = NewFilter((_, _, _) => Task.FromResult(allowed));
 
-        Assert.False(Outgoing(filter, RouteWith(0x0000FF02), EbgpPeer));
+        Assert.False(await Outgoing(filter, RouteWith(0x0000FF02), EbgpPeer));
     }
 
     [Fact]
-    public void Resolver_IsInvokedOncePerSend_NotPerRoute()
+    public async Task Resolver_IsInvokedOncePerSend_NotPerRoute()
     {
         // #79: the community allow-set (a database roundtrip in production) must be resolved
         // ONCE per send, then reused for every per-route AcceptOutgoing decision — not once per
         // advertised route (~20k queries per refresh before the fix).
         var invocations = 0;
-        var filter = NewFilter((_, _) =>
+        var filter = NewFilter((_, _, _) =>
         {
-            invocations++;
-            return new HashSet<uint> { 0x0000FF01 };
+            Interlocked.Increment(ref invocations);
+            return Task.FromResult(new HashSet<uint> { 0x0000FF01 });
         });
 
         // One resolution for the whole send.
-        var allowSet = filter.ResolveOutgoingAllowSet(EbgpPeer);
+        var allowSet = await filter.ResolveOutgoingAllowSetAsync(EbgpPeer);
         Assert.Equal(1, invocations);
 
         // Many per-route decisions against the pre-resolved set must NOT re-invoke the resolver.

--- a/BGPLite.Tests/PeerCustomSourceTests.cs
+++ b/BGPLite.Tests/PeerCustomSourceTests.cs
@@ -34,16 +34,16 @@ public class PeerCustomSourceTests
     }
 
     [Fact]
-    public void AddCustomSource_Adds_And_GetCustomSources_Returns_It()
+    public async Task AddCustomSource_Adds_And_GetCustomSources_Returns_It()
     {
         var (store, conn) = NewStore();
         using var _ = conn;
-        var peerId = store.CreatePeer(TestIp, 65001, null);
+        var peerId = await store.CreatePeerAsync(TestIp, 65001, null);
 
-        var source = store.AddCustomSource(peerId, "my-list", "https://example.com/list.txt", "65444:501");
+        var source = await store.AddCustomSourceAsync(peerId, "my-list", "https://example.com/list.txt", "65444:501");
 
         Assert.NotEmpty(source.Id);
-        var sources = store.GetCustomSources(peerId);
+        var sources = await store.GetCustomSourcesAsync(peerId);
         var fetched = Assert.Single(sources);
         Assert.Equal(source.Id, fetched.Id);
         Assert.Equal("my-list", fetched.Name);
@@ -52,155 +52,155 @@ public class PeerCustomSourceTests
     }
 
     [Fact]
-    public void AddCustomSource_SameName_SamePeer_OK()
+    public async Task AddCustomSource_SameName_SamePeer_OK()
     {
         // Name is just a label, not a unique key — duplicates are allowed (different Ids).
         var (store, conn) = NewStore();
         using var _ = conn;
-        var peerId = store.CreatePeer(TestIp, 65001, null);
+        var peerId = await store.CreatePeerAsync(TestIp, 65001, null);
 
-        var a = store.AddCustomSource(peerId, "my-list", "https://a.com/list.txt", null);
-        var b = store.AddCustomSource(peerId, "my-list", "https://b.com/other.txt", null);
+        var a = await store.AddCustomSourceAsync(peerId, "my-list", "https://a.com/list.txt", null);
+        var b = await store.AddCustomSourceAsync(peerId, "my-list", "https://b.com/other.txt", null);
 
         Assert.NotEqual(a.Id, b.Id);
-        Assert.Equal(2, store.GetCustomSources(peerId).Count);
+        Assert.Equal(2, (await store.GetCustomSourcesAsync(peerId)).Count);
     }
 
     [Fact]
-    public void DeleteCustomSource_BySourceId_Removes_Only_That_Source()
+    public async Task DeleteCustomSource_BySourceId_Removes_Only_That_Source()
     {
         var (store, conn) = NewStore();
         using var _ = conn;
-        var peerId = store.CreatePeer(TestIp, 65001, null);
+        var peerId = await store.CreatePeerAsync(TestIp, 65001, null);
 
-        var sourceA = store.AddCustomSource(peerId, "list-a", "https://a.com/list.txt", "65444:501");
-        store.AddCustomSource(peerId, "list-b", "https://b.com/list.txt", null);
+        var sourceA = await store.AddCustomSourceAsync(peerId, "list-a", "https://a.com/list.txt", "65444:501");
+        await store.AddCustomSourceAsync(peerId, "list-b", "https://b.com/list.txt", null);
 
-        var deleted = store.DeleteCustomSource(peerId, sourceA.Id);
+        var deleted = await store.DeleteCustomSourceAsync(peerId, sourceA.Id);
         Assert.True(deleted);
 
-        var remaining = store.GetCustomSources(peerId);
+        var remaining = await store.GetCustomSourcesAsync(peerId);
         var source = Assert.Single(remaining);
         Assert.Equal("list-b", source.Name);
     }
 
     [Fact]
-    public void DeleteCustomSource_NotFound_Returns_False()
+    public async Task DeleteCustomSource_NotFound_Returns_False()
     {
         var (store, conn) = NewStore();
         using var _ = conn;
-        var peerId = store.CreatePeer(TestIp, 65001, null);
+        var peerId = await store.CreatePeerAsync(TestIp, 65001, null);
 
-        Assert.False(store.DeleteCustomSource(peerId, "nonexistent-id"));
+        Assert.False(await store.DeleteCustomSourceAsync(peerId, "nonexistent-id"));
     }
 
     [Fact]
-    public void DeletePeer_Cascades_Sources()
+    public async Task DeletePeer_Cascades_Sources()
     {
         var (store, conn) = NewStore();
         using var _ = conn;
-        var peerId = store.CreatePeer(TestIp, 65001, null);
+        var peerId = await store.CreatePeerAsync(TestIp, 65001, null);
 
-        store.AddCustomSource(peerId, "list-a", "https://a.com/list.txt", null);
-        store.AddCustomSource(peerId, "list-b", "https://b.com/list.txt", null);
+        await store.AddCustomSourceAsync(peerId, "list-a", "https://a.com/list.txt", null);
+        await store.AddCustomSourceAsync(peerId, "list-b", "https://b.com/list.txt", null);
 
-        store.DeletePeer(peerId);
+        await store.DeletePeerAsync(peerId);
 
-        Assert.Empty(store.GetCustomSources(peerId));
+        Assert.Empty(await store.GetCustomSourcesAsync(peerId));
     }
 
     [Fact]
-    public void GetCustomSources_Empty_For_NewPeer()
+    public async Task GetCustomSources_Empty_For_NewPeer()
     {
         var (store, conn) = NewStore();
         using var _ = conn;
-        var peerId = store.CreatePeer(TestIp, 65001, null);
+        var peerId = await store.CreatePeerAsync(TestIp, 65001, null);
 
-        Assert.Empty(store.GetCustomSources(peerId));
+        Assert.Empty(await store.GetCustomSourcesAsync(peerId));
     }
 
     [Fact]
-    public void Community_Is_Optional_Null()
+    public async Task Community_Is_Optional_Null()
     {
         var (store, conn) = NewStore();
         using var _ = conn;
-        var peerId = store.CreatePeer(TestIp, 65001, null);
+        var peerId = await store.CreatePeerAsync(TestIp, 65001, null);
 
-        store.AddCustomSource(peerId, "no-comm", "https://example.com/list.txt", null);
+        await store.AddCustomSourceAsync(peerId, "no-comm", "https://example.com/list.txt", null);
 
-        var source = Assert.Single(store.GetCustomSources(peerId));
+        var source = Assert.Single(await store.GetCustomSourcesAsync(peerId));
         Assert.Null(source.Community);
     }
 
     [Fact]
-    public void NewSource_Is_Inactive_ByDefault()
+    public async Task NewSource_Is_Inactive_ByDefault()
     {
         var (store, conn) = NewStore();
         using var _ = conn;
-        var peerId = store.CreatePeer(TestIp, 65001, null);
+        var peerId = await store.CreatePeerAsync(TestIp, 65001, null);
 
-        var source = store.AddCustomSource(peerId, "paused", "https://example.com/list.txt", null);
+        var source = await store.AddCustomSourceAsync(peerId, "paused", "https://example.com/list.txt", null);
 
         Assert.False(source.Active, "new source must default to inactive (user explicitly activates)");
     }
 
     [Fact]
-    public void SetSourceActive_Toggles_State()
+    public async Task SetSourceActive_Toggles_State()
     {
         var (store, conn) = NewStore();
         using var _ = conn;
-        var peerId = store.CreatePeer(TestIp, 65001, null);
+        var peerId = await store.CreatePeerAsync(TestIp, 65001, null);
 
-        var source = store.AddCustomSource(peerId, "toggle", "https://example.com/list.txt", null);
+        var source = await store.AddCustomSourceAsync(peerId, "toggle", "https://example.com/list.txt", null);
         Assert.False(source.Active);
 
-        Assert.True(store.SetSourceActive(peerId, source.Id, true));
-        var fetched = Assert.Single(store.GetCustomSources(peerId));
+        Assert.True(await store.SetSourceActiveAsync(peerId, source.Id, true));
+        var fetched = Assert.Single(await store.GetCustomSourcesAsync(peerId));
         Assert.True(fetched.Active);
 
-        Assert.True(store.SetSourceActive(peerId, source.Id, false));
-        fetched = Assert.Single(store.GetCustomSources(peerId));
+        Assert.True(await store.SetSourceActiveAsync(peerId, source.Id, false));
+        fetched = Assert.Single(await store.GetCustomSourcesAsync(peerId));
         Assert.False(fetched.Active);
     }
 
     [Fact]
-    public void SetSourceActive_NotFound_Returns_False()
+    public async Task SetSourceActive_NotFound_Returns_False()
     {
         var (store, conn) = NewStore();
         using var _ = conn;
-        var peerId = store.CreatePeer(TestIp, 65001, null);
+        var peerId = await store.CreatePeerAsync(TestIp, 65001, null);
 
-        Assert.False(store.SetSourceActive(peerId, "nonexistent", true));
+        Assert.False(await store.SetSourceActiveAsync(peerId, "nonexistent", true));
     }
 
     [Fact]
-    public void DeleteCustomSource_CrossPeer_Returns_False()
+    public async Task DeleteCustomSource_CrossPeer_Returns_False()
     {
         var (store, conn) = NewStore();
         using var _ = conn;
-        var idA = store.CreatePeer(TestIp, 65001, null);
-        var idB = store.CreatePeer("203.0.113.11", 65002, null);
+        var idA = await store.CreatePeerAsync(TestIp, 65001, null);
+        var idB = await store.CreatePeerAsync("203.0.113.11", 65002, null);
 
-        var source = store.AddCustomSource(idA, "list-a", "https://a.com/list.txt", null);
+        var source = await store.AddCustomSourceAsync(idA, "list-a", "https://a.com/list.txt", null);
 
         // Peer B tries to delete Peer A's source — must fail (peer-scoped).
-        Assert.False(store.DeleteCustomSource(idB, source.Id));
-        Assert.Single(store.GetCustomSources(idA)); // source still exists for A
+        Assert.False(await store.DeleteCustomSourceAsync(idB, source.Id));
+        Assert.Single(await store.GetCustomSourcesAsync(idA)); // source still exists for A
     }
 
     [Fact]
-    public void SetSourceActive_CrossPeer_Returns_False()
+    public async Task SetSourceActive_CrossPeer_Returns_False()
     {
         var (store, conn) = NewStore();
         using var _ = conn;
-        var idA = store.CreatePeer(TestIp, 65001, null);
-        var idB = store.CreatePeer("203.0.113.11", 65002, null);
+        var idA = await store.CreatePeerAsync(TestIp, 65001, null);
+        var idB = await store.CreatePeerAsync("203.0.113.11", 65002, null);
 
-        var source = store.AddCustomSource(idA, "list-a", "https://a.com/list.txt", null);
+        var source = await store.AddCustomSourceAsync(idA, "list-a", "https://a.com/list.txt", null);
 
         // Peer B tries to toggle Peer A's source — must fail.
-        Assert.False(store.SetSourceActive(idB, source.Id, true));
-        var fetched = Assert.Single(store.GetCustomSources(idA));
+        Assert.False(await store.SetSourceActiveAsync(idB, source.Id, true));
+        var fetched = Assert.Single(await store.GetCustomSourcesAsync(idA));
         Assert.False(fetched.Active); // unchanged
     }
 }

--- a/BGPLite.Tests/PeerDeleteTeardownTests.cs
+++ b/BGPLite.Tests/PeerDeleteTeardownTests.cs
@@ -25,10 +25,10 @@ public sealed class PeerDeleteTeardownTests
     {
         using var connection = NewOpenConnection();
         var store = NewStore(connection);
-        var peerId = store.CreatePeer("203.0.113.7", 65002, null);
+        var peerId = await store.CreatePeerAsync("203.0.113.7", 65002, null);
         // At terminate time the row must still exist — that ordering is what keeps a dying
         // session's in-flight refresh away from the auto-register branch.
-        var manager = new RecordingSessionManager((_, _) => Assert.NotNull(store.GetDbPeerById(peerId)));
+        var manager = new RecordingSessionManager(async (_, _) => Assert.NotNull(await store.GetDbPeerByIdAsync(peerId)));
         using var api = NewApi(store, manager);
 
         var response = await api.HandleDeletePeer(peerId);
@@ -37,7 +37,7 @@ public sealed class PeerDeleteTeardownTests
         var terminated = Assert.Single(manager.Terminated);
         Assert.Equal("203.0.113.7", terminated.Ip);
         Assert.Equal(65002u, terminated.Asn);
-        Assert.Null(store.GetDbPeerById(peerId));
+        Assert.Null(await store.GetDbPeerByIdAsync(peerId));
     }
 
     [Fact]
@@ -117,11 +117,14 @@ public sealed class PeerDeleteTeardownTests
         using var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        var routes = await NewAssembler(store).BuildOutboundRoutesAsync(
-            "203.0.113.9", 65002, new PeerConfig { Address = "203.0.113.9" }, "203.0.113.9", cts.Token);
+        // #262: the async store surfaces an already-cancelled token as OCE from the load itself
+        // (previously the sync read ran through and the assembler returned an empty set). Either
+        // way the auto-register branch must not be reached — that is the #323 resurrection guard.
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            NewAssembler(store).BuildOutboundRoutesAsync(
+                "203.0.113.9", 65002, new PeerConfig { Address = "203.0.113.9" }, "203.0.113.9", cts.Token));
 
-        Assert.Empty(routes);
-        Assert.Empty(store.GetPeersByIp("203.0.113.9"));   // no resurrection of a deleted peer
+        Assert.Empty(await store.GetPeersByIpAsync("203.0.113.9"));   // no resurrection of a deleted peer
     }
 
     [Fact]
@@ -134,7 +137,7 @@ public sealed class PeerDeleteTeardownTests
             "203.0.113.9", 65002, new PeerConfig { Address = "203.0.113.9" }, "203.0.113.9", CancellationToken.None);
 
         // Control (D11 behavior): a live unknown peer is still auto-registered.
-        Assert.Single(store.GetPeersByIp("203.0.113.9"));
+        Assert.Single(await store.GetPeersByIpAsync("203.0.113.9"));
     }
 
     // ---- harness ----
@@ -217,7 +220,7 @@ public sealed class PeerDeleteTeardownTests
     }
 
     /// <summary>Records TerminatePeerAsync calls; the optional hook runs at call time (row-state assertions).</summary>
-    private sealed class RecordingSessionManager(Action<string, uint>? onTerminate = null) : ISessionManager
+    private sealed class RecordingSessionManager(Func<string, uint, Task>? onTerminate = null) : ISessionManager
     {
         public List<(string Ip, uint Asn)> Terminated { get; } = [];
 
@@ -226,11 +229,10 @@ public sealed class PeerDeleteTeardownTests
         public int GetAdvertisedPrefixCount(string peerIp, uint asn) => 0;
         public Task RefreshAllEstablishedAsync() => Task.CompletedTask;
 
-        public Task TerminatePeerAsync(string peerIp, uint asn, CancellationToken ct = default)
+        public async Task TerminatePeerAsync(string peerIp, uint asn, CancellationToken ct = default)
         {
             Terminated.Add((peerIp, asn));
-            onTerminate?.Invoke(peerIp, asn);
-            return Task.CompletedTask;
+            if (onTerminate is not null) await onTerminate(peerIp, asn);
         }
     }
 

--- a/BGPLite.Tests/PeerStoreAtomicityTests.cs
+++ b/BGPLite.Tests/PeerStoreAtomicityTests.cs
@@ -34,7 +34,7 @@ public class PeerStoreAtomicityTests
         public BgpDbContext CreateDbContext() => new(_options);
     }
 
-    private static string SeedPeer(PeerStore store) => store.CreatePeer(Ip, Asn, "test");
+    private static async Task<string> SeedPeer(PeerStore store) => await store.CreatePeerAsync(Ip, Asn, "test");
 
     // ---- #226: Set* atomicity ----
 
@@ -43,56 +43,56 @@ public class PeerStoreAtomicityTests
     /// delete+insert pair committed atomically, so there is never an empty-collection window.
     /// </summary>
     [Fact]
-    public void SetCommunities_Replaces_Atomiclly()
+    public async Task SetCommunities_Replaces_Atomiclly()
     {
         var (store, connection) = NewStore();
         using var conn = connection;
-        var peerId = SeedPeer(store);
+        var peerId = await SeedPeer(store);
 
-        store.SetCommunities(peerId, [0x65001000, 0x65002000]);
-        store.SetCommunities(peerId, [0x65003000]);
+        await store.SetCommunitiesAsync(peerId, [0x65001000, 0x65002000]);
+        await store.SetCommunitiesAsync(peerId, [0x65003000]);
 
-        var communities = store.GetCommunities(peerId).OrderBy(c => c).ToArray();
+        var communities = (await store.GetCommunitiesAsync(peerId)).OrderBy(c => c).ToArray();
         Assert.Equal([0x65003000u], communities);
     }
 
     [Fact]
-    public void SetSubscriptions_Replaces_Atomiclly()
+    public async Task SetSubscriptions_Replaces_Atomiclly()
     {
         var (store, connection) = NewStore();
         using var conn = connection;
-        var peerId = SeedPeer(store);
+        var peerId = await SeedPeer(store);
 
-        store.SetSubscriptions(peerId, ["list-a", "list-b"]);
-        store.SetSubscriptions(peerId, ["list-c"]);
+        await store.SetSubscriptionsAsync(peerId, ["list-a", "list-b"]);
+        await store.SetSubscriptionsAsync(peerId, ["list-c"]);
 
-        Assert.Equal(["list-c"], store.GetSubscriptions(peerId));
+        Assert.Equal(["list-c"], await store.GetSubscriptionsAsync(peerId));
     }
 
     [Fact]
-    public void SetCustomPrefixes_Replaces_Atomiclly()
+    public async Task SetCustomPrefixes_Replaces_Atomiclly()
     {
         var (store, connection) = NewStore();
         using var conn = connection;
-        var peerId = SeedPeer(store);
+        var peerId = await SeedPeer(store);
 
-        store.SetCustomPrefixes(peerId, [("10.0.0.0", (byte)24), ("10.1.0.0", (byte)24)]);
-        store.SetCustomPrefixes(peerId, [("192.168.0.0", (byte)16)]);
+        await store.SetCustomPrefixesAsync(peerId, [("10.0.0.0", (byte)24), ("10.1.0.0", (byte)24)]);
+        await store.SetCustomPrefixesAsync(peerId, [("192.168.0.0", (byte)16)]);
 
-        Assert.Equal(["192.168.0.0/16"], store.GetCustomPrefixes(peerId));
+        Assert.Equal(["192.168.0.0/16"], await store.GetCustomPrefixesAsync(peerId));
     }
 
     [Fact]
-    public void SetCustomAsns_Replaces_Atomiclly()
+    public async Task SetCustomAsns_Replaces_Atomiclly()
     {
         var (store, connection) = NewStore();
         using var conn = connection;
-        var peerId = SeedPeer(store);
+        var peerId = await SeedPeer(store);
 
-        store.SetCustomAsns(peerId, [64512, 64513]);
-        store.SetCustomAsns(peerId, [64514]);
+        await store.SetCustomAsnsAsync(peerId, [64512, 64513]);
+        await store.SetCustomAsnsAsync(peerId, [64514]);
 
-        Assert.Equal([64514u], store.GetCustomAsns(peerId));
+        Assert.Equal([64514u], await store.GetCustomAsnsAsync(peerId));
     }
 
     /// <summary>
@@ -101,18 +101,18 @@ public class PeerStoreAtomicityTests
     /// the transaction is dropped and an empty-collection window corrupts the state.
     /// </summary>
     [Fact]
-    public void SetCustomPrefixes_Empty_Then_Refill_Roundtrips()
+    public async Task SetCustomPrefixes_Empty_Then_Refill_Roundtrips()
     {
         var (store, connection) = NewStore();
         using var conn = connection;
-        var peerId = SeedPeer(store);
+        var peerId = await SeedPeer(store);
 
-        store.SetCustomPrefixes(peerId, [("10.0.0.0", (byte)8)]);
-        store.SetCustomPrefixes(peerId, []);
-        Assert.Empty(store.GetCustomPrefixes(peerId));
+        await store.SetCustomPrefixesAsync(peerId, [("10.0.0.0", (byte)8)]);
+        await store.SetCustomPrefixesAsync(peerId, []);
+        Assert.Empty(await store.GetCustomPrefixesAsync(peerId));
 
-        store.SetCustomPrefixes(peerId, [("172.16.0.0", (byte)12)]);
-        Assert.Equal(["172.16.0.0/12"], store.GetCustomPrefixes(peerId));
+        await store.SetCustomPrefixesAsync(peerId, [("172.16.0.0", (byte)12)]);
+        Assert.Equal(["172.16.0.0/12"], await store.GetCustomPrefixesAsync(peerId));
     }
 
     /// <summary>
@@ -123,12 +123,12 @@ public class PeerStoreAtomicityTests
     /// collection. Drives the regression directly: a fault mid-mutation must not corrupt prior state.
     /// </summary>
     [Fact]
-    public void SetCustomPrefixes_RollsBack_On_Insert_Failure()
+    public async Task SetCustomPrefixes_RollsBack_On_Insert_Failure()
     {
         var (store, connection) = NewStore();
         using var conn = connection;
-        var peerId = SeedPeer(store);
-        store.SetCustomPrefixes(peerId, [("10.0.0.0", (byte)24)]);
+        var peerId = await SeedPeer(store);
+        await store.SetCustomPrefixesAsync(peerId, [("10.0.0.0", (byte)24)]);
 
         // Reproduce the exact delete+insert shape of SetCustomPrefixes, then fault the insert side
         // with a SQLite UNIQUE violation. ExecuteSqlRaw bypasses the EF change tracker (which would
@@ -152,7 +152,7 @@ public class PeerStoreAtomicityTests
         }
 
         // The original prefix survives — the delete was rolled back together with the failed insert.
-        Assert.Equal(["10.0.0.0/24"], store.GetCustomPrefixes(peerId));
+        Assert.Equal(["10.0.0.0/24"], await store.GetCustomPrefixesAsync(peerId));
     }
 
     // ---- #227: atomic upsert ----
@@ -162,16 +162,16 @@ public class PeerStoreAtomicityTests
     /// upsert). Guards against the upsert accidentally keying on Ip only.
     /// </summary>
     [Fact]
-    public void CreatePeer_DistinctAsns_Coexist()
+    public async Task CreatePeer_DistinctAsns_Coexist()
     {
         var (store, connection) = NewStore();
         using var conn = connection;
 
-        var id1 = store.CreatePeer(Ip, 64512, "a");
-        var id2 = store.CreatePeer(Ip, 64513, "b");
+        var id1 = await store.CreatePeerAsync(Ip, 64512, "a");
+        var id2 = await store.CreatePeerAsync(Ip, 64513, "b");
 
         Assert.NotEqual(id1, id2);
-        Assert.Equal(2, store.GetPeersByIp(Ip).Count);
+        Assert.Equal(2, (await store.GetPeersByIpAsync(Ip)).Count);
     }
 
     /// <summary>
@@ -179,13 +179,13 @@ public class PeerStoreAtomicityTests
     /// a second call (update path). Called from the BGP connect path — must never throw.
     /// </summary>
     [Fact]
-    public void UpsertPeer_SetsActive_And_StampsLastSessionAt()
+    public async Task UpsertPeer_SetsActive_And_StampsLastSessionAt()
     {
         var (store, connection) = NewStore();
         using var conn = connection;
 
-        store.UpsertPeer(Ip, Asn);
-        var peer = store.GetPeer(Ip, Asn);
+        await store.UpsertPeerAsync(Ip, Asn);
+        var peer = await store.GetPeerAsync(Ip, Asn);
         Assert.NotNull(peer);
         Assert.Equal("active", peer!.Status);
         Assert.NotNull(peer.LastSessionAt);
@@ -198,8 +198,8 @@ public class PeerStoreAtomicityTests
         Thread.Sleep(15);
 
         // Second call (update path) — must refresh LastSessionAt, not throw.
-        store.UpsertPeer(Ip, Asn);
-        var peer2 = store.GetPeer(Ip, Asn);
+        await store.UpsertPeerAsync(Ip, Asn);
+        var peer2 = await store.GetPeerAsync(Ip, Asn);
         Assert.NotNull(peer2);
         Assert.Equal("active", peer2!.Status);
         Assert.NotNull(peer2.LastSessionAt);
@@ -213,22 +213,22 @@ public class PeerStoreAtomicityTests
     /// concurrently-deleted peer; now the UPDATE matches 0 rows silently).
     /// </summary>
     [Fact]
-    public void UpdateSessionStatus_FlipsStatus_And_Is_NoOp_For_Missing_Peer()
+    public async Task UpdateSessionStatus_FlipsStatus_And_Is_NoOp_For_Missing_Peer()
     {
         var (store, connection) = NewStore();
         using var conn = connection;
-        store.UpsertPeer(Ip, Asn);
+        await store.UpsertPeerAsync(Ip, Asn);
 
-        store.UpdateSessionStatus(Ip, Asn, active: false);
-        Assert.Equal("inactive", store.GetPeer(Ip, Asn)!.Status);
+        await store.UpdateSessionStatusAsync(Ip, Asn, active: false);
+        Assert.Equal("inactive", (await store.GetPeerAsync(Ip, Asn))!.Status);
 
-        store.UpdateSessionStatus(Ip, Asn, active: true);
-        var peer = store.GetPeer(Ip, Asn);
+        await store.UpdateSessionStatusAsync(Ip, Asn, active: true);
+        var peer = await store.GetPeerAsync(Ip, Asn);
         Assert.Equal("active", peer!.Status);
         Assert.NotNull(peer.LastSessionAt);
 
         // No-op for a peer that does not exist — must not throw.
-        store.UpdateSessionStatus("203.0.113.99", 99999, active: true);
+        await store.UpdateSessionStatusAsync("203.0.113.99", 99999, active: true);
     }
 
     // ---- #228: single-roundtrip GetPeerDetail equivalence ----
@@ -241,24 +241,24 @@ public class PeerStoreAtomicityTests
     /// GetCommunities calls returned. This is the contract BuildPeerDetail/HandleGetPeer now rely on.
     /// </summary>
     [Fact]
-    public void GetPeerDetail_Matches_Standalone_Getters()
+    public async Task GetPeerDetail_Matches_Standalone_Getters()
     {
         var (store, connection) = NewStore();
         using var conn = connection;
-        var peerId = store.CreatePeer(Ip, Asn, "test peer");
-        store.SetSubscriptions(peerId, ["list-a", "list-b"]);
-        store.SetCustomPrefixes(peerId, [("10.0.0.0", (byte)24), ("172.16.0.0", (byte)12)]);
-        store.SetCustomAsns(peerId, [64512u, 64513u]);
-        store.SetCommunities(peerId, [0x65001000u]);
+        var peerId = await store.CreatePeerAsync(Ip, Asn, "test peer");
+        await store.SetSubscriptionsAsync(peerId, ["list-a", "list-b"]);
+        await store.SetCustomPrefixesAsync(peerId, [("10.0.0.0", (byte)24), ("172.16.0.0", (byte)12)]);
+        await store.SetCustomAsnsAsync(peerId, [64512u, 64513u]);
+        await store.SetCommunitiesAsync(peerId, [0x65001000u]);
         // AddCustomSource creates sources inactive by default (Active=false); activate one explicitly
         // so the test exercises both Active states. GetPeerDetail carries ALL sources regardless of
         // Active — unlike PeerRoutingView which filters Active at the SQL level.
-        var activeSource = store.AddCustomSource(peerId, "src-active", "https://example.com/list.txt", "65000:100");
-        store.SetSourceActive(peerId, activeSource.Id, active: true);
+        var activeSource = await store.AddCustomSourceAsync(peerId, "src-active", "https://example.com/list.txt", "65000:100");
+        await store.SetSourceActiveAsync(peerId, activeSource.Id, active: true);
         // An inactive source must STILL appear in CustomSources (the API shows the toggle state).
-        store.AddCustomSource(peerId, "src-paused", "https://example.com/other.txt", null);
+        await store.AddCustomSourceAsync(peerId, "src-paused", "https://example.com/other.txt", null);
 
-        var detail = store.GetPeerDetail(peerId);
+        var detail = await store.GetPeerDetailAsync(peerId);
         Assert.NotNull(detail);
 
         // Scalar fields match the row.
@@ -268,16 +268,16 @@ public class PeerStoreAtomicityTests
         Assert.Equal("test peer", detail.Description);
 
         // Collection fields match the standalone getters exactly.
-        Assert.Equal(store.GetSubscriptions(peerId), detail.Subscriptions);
-        Assert.Equal(store.GetCustomPrefixes(peerId), detail.CustomPrefixes);
-        Assert.Equal(store.GetCustomAsns(peerId), detail.CustomAsns);
-        Assert.Equal(store.GetCommunities(peerId).Select(c => (long)c), detail.Communities);
+        Assert.Equal(await store.GetSubscriptionsAsync(peerId), detail.Subscriptions);
+        Assert.Equal(await store.GetCustomPrefixesAsync(peerId), detail.CustomPrefixes);
+        Assert.Equal(await store.GetCustomAsnsAsync(peerId), detail.CustomAsns);
+        Assert.Equal((await store.GetCommunitiesAsync(peerId)).Select(c => (long)c), detail.Communities);
 
         // CustomSources carries ALL fields (incl. Active) for ALL sources (incl. inactive) — matches
         // GetCustomSources exactly. Guards against a regression that filters inactive sources.
         // Compare as a set keyed by Name: the two load paths (EF projection vs GetCustomSources) do
         // not guarantee the same row order, so an index-based compare would be order-dependent.
-        var standalone = store.GetCustomSources(peerId).ToDictionary(s => s.Name);
+        var standalone = (await store.GetCustomSourcesAsync(peerId)).ToDictionary(s => s.Name);
         Assert.Equal(standalone.Count, detail.CustomSources.Count);
         Assert.Equal(2, detail.CustomSources.Count); // active + inactive both present
         Assert.Contains(detail.CustomSources, s => s.Name == "src-active" && s.Active);
@@ -297,10 +297,10 @@ public class PeerStoreAtomicityTests
     /// of HandleGetPeer / the null-fallback of BuildPeerDetail).
     /// </summary>
     [Fact]
-    public void GetPeerDetail_Returns_Null_For_Missing_Peer()
+    public async Task GetPeerDetail_Returns_Null_For_Missing_Peer()
     {
         var (store, connection) = NewStore();
         using var conn = connection;
-        Assert.Null(store.GetPeerDetail("does-not-exist"));
+        Assert.Null(await store.GetPeerDetailAsync("does-not-exist"));
     }
 }

--- a/BGPLite.Tests/PeerStoreConfigurationAtomicityTests.cs
+++ b/BGPLite.Tests/PeerStoreConfigurationAtomicityTests.cs
@@ -27,21 +27,21 @@ public class PeerStoreConfigurationAtomicityTests
     /// Deduplicated rather than rejected — a set of prefixes means the same thing either way.
     /// </summary>
     [Fact]
-    public void SavePeerConfiguration_DuplicatePrefixes_AreAcceptedIdempotently()
+    public async Task SavePeerConfiguration_DuplicatePrefixes_AreAcceptedIdempotently()
     {
         var (store, connection) = NewStore();
         using var _ = connection;
 
-        var id = store.SavePeerConfiguration(Ip, Asn, "dup prefixes",
+        var id = (await store.SavePeerConfigurationAsync(Ip, Asn, "dup prefixes",
             asnListNames: ["ru"],
             customPrefixes: [("10.0.0.0", 8), ("10.0.0.0", 8), ("192.0.2.0", 24)],
-            customAsns: [64512]).Id;
+            customAsns: [64512])).Id;
 
         // A set of prefixes: announcing 10.0.0.0/8 twice is the same as once, so the duplicate is
         // dropped rather than rejected.
-        Assert.Equal(["10.0.0.0/8", "192.0.2.0/24"], store.GetCustomPrefixes(id).Order().ToList());
-        Assert.Equal(["ru"], store.GetSubscriptions(id));
-        Assert.Equal([64512u], store.GetCustomAsns(id));
+        Assert.Equal(["10.0.0.0/8", "192.0.2.0/24"], (await store.GetCustomPrefixesAsync(id)).Order().ToList());
+        Assert.Equal(["ru"], await store.GetSubscriptionsAsync(id));
+        Assert.Equal([64512u], await store.GetCustomAsnsAsync(id));
     }
 
     /// <summary>
@@ -49,18 +49,18 @@ public class PeerStoreConfigurationAtomicityTests
     /// composite keys, so a pasted-twice list name or ASN threw exactly as a repeated CIDR did.
     /// </summary>
     [Fact]
-    public void SavePeerConfiguration_DuplicateListNamesAndAsns_AreAcceptedIdempotently()
+    public async Task SavePeerConfiguration_DuplicateListNamesAndAsns_AreAcceptedIdempotently()
     {
         var (store, connection) = NewStore();
         using var _ = connection;
 
-        var id = store.SavePeerConfiguration(Ip, Asn, "dup lists and asns",
+        var id = (await store.SavePeerConfigurationAsync(Ip, Asn, "dup lists and asns",
             asnListNames: ["ru", "ru", "cdn"],
             customPrefixes: [],
-            customAsns: [64512, 64512, 64513]).Id;
+            customAsns: [64512, 64512, 64513])).Id;
 
-        Assert.Equal(["cdn", "ru"], store.GetSubscriptions(id).Order().ToList());
-        Assert.Equal([64512u, 64513u], store.GetCustomAsns(id).Order().ToList());
+        Assert.Equal(["cdn", "ru"], (await store.GetSubscriptionsAsync(id)).Order().ToList());
+        Assert.Equal([64512u, 64513u], (await store.GetCustomAsnsAsync(id)).Order().ToList());
     }
 
     /// <summary>
@@ -68,19 +68,19 @@ public class PeerStoreConfigurationAtomicityTests
     /// asserts the peer is complete where it actually matters, not merely in the store.
     /// </summary>
     [Fact]
-    public void SavePeerConfiguration_AppliesEveryPartOrNothing()
+    public async Task SavePeerConfiguration_AppliesEveryPartOrNothing()
     {
         var (store, connection) = NewStore();
         using var _ = connection;
 
-        var id = store.SavePeerConfiguration(Ip, Asn, "full",
+        var id = (await store.SavePeerConfigurationAsync(Ip, Asn, "full",
             asnListNames: ["ru"],
             customPrefixes: [("10.0.0.0", 8)],
-            customAsns: [64512]).Id;
+            customAsns: [64512])).Id;
 
         // The failure #259 describes is a peer row committed with its child collections missing.
         // Assert the whole configuration is readable through the same view the send path uses.
-        var view = store.LoadPeerRoutingView(Ip, Asn);
+        var view = await store.LoadPeerRoutingViewAsync(Ip, Asn);
         Assert.NotNull(view);
         Assert.Equal(["ru"], view!.Subscriptions);
         Assert.Equal(["10.0.0.0/8"], view.CustomPrefixes);
@@ -95,13 +95,13 @@ public class PeerStoreConfigurationAtomicityTests
     /// composition into separate Set* calls.
     /// </summary>
     [Fact]
-    public void SavePeerConfiguration_RunsInASingleTransaction()
+    public async Task SavePeerConfiguration_RunsInASingleTransaction()
     {
         var (store, connection, transactions) = NewStoreCountingTransactions();
         using var _ = connection;
 
         transactions.Clear();
-        store.SavePeerConfiguration(Ip, Asn, "one transaction",
+        await store.SavePeerConfigurationAsync(Ip, Asn, "one transaction",
             asnListNames: ["ru", "cdn"],
             customPrefixes: [("10.0.0.0", 8), ("192.0.2.0", 24)],
             customAsns: [64512, 64513]);
@@ -113,15 +113,15 @@ public class PeerStoreConfigurationAtomicityTests
     /// The update path carries the same guarantee as the create path.
     /// </summary>
     [Fact]
-    public void UpdatePeerConfiguration_RunsInASingleTransaction()
+    public async Task UpdatePeerConfiguration_RunsInASingleTransaction()
     {
         var (store, connection, transactions) = NewStoreCountingTransactions();
         using var _ = connection;
-        var id = store.SavePeerConfiguration(Ip, Asn, "initial",
-            asnListNames: ["ru"], customPrefixes: [("10.0.0.0", 8)], customAsns: [64512]).Id;
+        var id = (await store.SavePeerConfigurationAsync(Ip, Asn, "initial",
+            asnListNames: ["ru"], customPrefixes: [("10.0.0.0", 8)], customAsns: [64512])).Id;
 
         transactions.Clear();
-        store.UpdatePeerConfiguration(id, "changed",
+        await store.UpdatePeerConfigurationAsync(id, "changed",
             asnListNames: ["cdn"],
             customPrefixes: [("192.0.2.0", 24)],
             customAsns: [64514]);
@@ -133,24 +133,24 @@ public class PeerStoreConfigurationAtomicityTests
     /// PATCH semantics: <c>null</c> means "leave this alone", while an empty list means "clear it".
     /// </summary>
     [Fact]
-    public void UpdatePeerConfiguration_NullsLeaveTheExistingValueAlone()
+    public async Task UpdatePeerConfiguration_NullsLeaveTheExistingValueAlone()
     {
         var (store, connection) = NewStore();
         using var _ = connection;
-        var id = store.SavePeerConfiguration(Ip, Asn, "initial",
-            asnListNames: ["ru"], customPrefixes: [("10.0.0.0", 8)], customAsns: [64512]).Id;
+        var id = (await store.SavePeerConfigurationAsync(Ip, Asn, "initial",
+            asnListNames: ["ru"], customPrefixes: [("10.0.0.0", 8)], customAsns: [64512])).Id;
 
         // Only the prefixes are supplied; the rest must survive untouched, matching the PATCH
         // semantics the management API exposes.
-        store.UpdatePeerConfiguration(id, description: null,
+        await store.UpdatePeerConfigurationAsync(id, description: null,
             asnListNames: null,
             customPrefixes: [("192.0.2.0", 24), ("192.0.2.0", 24)],
             customAsns: null);
 
-        Assert.Equal(["192.0.2.0/24"], store.GetCustomPrefixes(id));
-        Assert.Equal(["ru"], store.GetSubscriptions(id));
-        Assert.Equal([64512u], store.GetCustomAsns(id));
-        Assert.Equal("initial", store.GetDbPeerById(id)!.Description);
+        Assert.Equal(["192.0.2.0/24"], await store.GetCustomPrefixesAsync(id));
+        Assert.Equal(["ru"], await store.GetSubscriptionsAsync(id));
+        Assert.Equal([64512u], await store.GetCustomAsnsAsync(id));
+        Assert.Equal("initial", (await store.GetDbPeerByIdAsync(id))!.Description);
     }
 
     /// <summary>A store over an in-memory SQLite DB that records every transaction EF opens.</summary>

--- a/BGPLite.Tests/PeerStoreKeyingTests.cs
+++ b/BGPLite.Tests/PeerStoreKeyingTests.cs
@@ -40,18 +40,18 @@ public class PeerStoreKeyingTests
     }
 
     [Fact]
-    public void Distinct_Asns_From_Same_Ip_Create_Separate_Peer_Records()
+    public async Task Distinct_Asns_From_Same_Ip_Create_Separate_Peer_Records()
     {
         var (store, connection) = NewStore();
         using var conn = connection;
 
-        var idA = store.CreatePeer(SharedIp, 64512, "A");
-        var idB = store.CreatePeer(SharedIp, 64513, "B"); // same source IP, different AS
+        var idA = await store.CreatePeerAsync(SharedIp, 64512, "A");
+        var idB = await store.CreatePeerAsync(SharedIp, 64513, "B"); // same source IP, different AS
 
         Assert.NotEqual(idA, idB);
 
-        var a = store.GetPeer(SharedIp, 64512);
-        var b = store.GetPeer(SharedIp, 64513);
+        var a = await store.GetPeerAsync(SharedIp, 64512);
+        var b = await store.GetPeerAsync(SharedIp, 64513);
         Assert.NotNull(a);
         Assert.NotNull(b);
         Assert.Equal((uint?)64512, a!.Asn);
@@ -59,11 +59,11 @@ public class PeerStoreKeyingTests
         Assert.NotEqual(a.Id, b.Id);
 
         // Resolving by an AS that never connected must NOT return another peer's record.
-        Assert.Null(store.GetPeer(SharedIp, 64599));
+        Assert.Null(await store.GetPeerAsync(SharedIp, 64599));
     }
 
     [Fact]
-    public void Composite_Unique_Index_Rejects_Duplicate_IpAsn()
+    public async Task Composite_Unique_Index_Rejects_Duplicate_IpAsn()
     {
         var (_, connection) = NewStore();
         using var conn = connection;
@@ -86,20 +86,20 @@ public class PeerStoreKeyingTests
     }
 
     [Fact]
-    public void UpdateSessionStatus_Is_Scoped_To_IpAsn()
+    public async Task UpdateSessionStatus_Is_Scoped_To_IpAsn()
     {
         var (store, connection) = NewStore();
         using var conn = connection;
 
-        var idA = store.CreatePeer(SharedIp, 64512, "A");
-        var idB = store.CreatePeer(SharedIp, 64513, "B");
-        store.UpdateSessionStatus(SharedIp, 64512, active: true);
+        var idA = await store.CreatePeerAsync(SharedIp, 64512, "A");
+        var idB = await store.CreatePeerAsync(SharedIp, 64513, "B");
+        await store.UpdateSessionStatusAsync(SharedIp, 64512, active: true);
 
-        Assert.Equal("active", store.GetDbPeerById(idA)!.Status);
-        Assert.Equal("inactive", store.GetDbPeerById(idB)!.Status); // untouched — different AS
+        Assert.Equal("active", (await store.GetDbPeerByIdAsync(idA))!.Status);
+        Assert.Equal("inactive", (await store.GetDbPeerByIdAsync(idB))!.Status); // untouched — different AS
 
-        store.UpdateSessionStatus(SharedIp, 64513, active: true);
-        Assert.Equal("active", store.GetDbPeerById(idB)!.Status);
+        await store.UpdateSessionStatusAsync(SharedIp, 64513, active: true);
+        Assert.Equal("active", (await store.GetDbPeerByIdAsync(idB))!.Status);
     }
 
     /// <summary>
@@ -111,18 +111,18 @@ public class PeerStoreKeyingTests
     /// drop either the read or the folded write.
     /// </summary>
     [Fact]
-    public void LoadPeerRoutingView_Matches_Standalone_Calls_And_Folds_Status_Update()
+    public async Task LoadPeerRoutingView_Matches_Standalone_Calls_And_Folds_Status_Update()
     {
         var (store, connection) = NewStore();
         using var conn = connection;
 
-        var id = store.CreatePeer(SharedIp, 64512, "routed peer");
-        store.SetSubscriptions(id, ["ru", "microsoft"]);
-        store.SetCustomPrefixes(id, [("203.0.113.0", 24), ("198.51.100.0", 25)]);
-        store.SetCustomAsns(id, [65001, 65002]);
+        var id = await store.CreatePeerAsync(SharedIp, 64512, "routed peer");
+        await store.SetSubscriptionsAsync(id, ["ru", "microsoft"]);
+        await store.SetCustomPrefixesAsync(id, [("203.0.113.0", 24), ("198.51.100.0", 25)]);
+        await store.SetCustomAsnsAsync(id, [65001, 65002]);
 
         var before = DateTime.UtcNow;
-        var view = store.LoadPeerRoutingView(SharedIp, 64512);
+        var view = await store.LoadPeerRoutingViewAsync(SharedIp, 64512);
 
         Assert.NotNull(view);
         // Same peer row.
@@ -134,9 +134,9 @@ public class PeerStoreKeyingTests
         // Same ELEMENTS as the standalone getters. Order is unspecified (neither the getters nor
         // LoadPeerRoutingView impose ORDER BY; the BGP send path treats these as sets), so compare
         // sorted to avoid a flaky test while still pinning exact contents.
-        Assert.Equal(store.GetSubscriptions(id).Order().ToArray(), view.Subscriptions.Order().ToArray());
-        Assert.Equal(store.GetCustomPrefixes(id).Order().ToArray(), view.CustomPrefixes.Order().ToArray());
-        Assert.Equal(store.GetCustomAsns(id).Order().ToArray(), view.CustomAsns.Order().ToArray());
+        Assert.Equal((await store.GetSubscriptionsAsync(id)).Order().ToArray(), view.Subscriptions.Order().ToArray());
+        Assert.Equal((await store.GetCustomPrefixesAsync(id)).Order().ToArray(), view.CustomPrefixes.Order().ToArray());
+        Assert.Equal((await store.GetCustomAsnsAsync(id)).Order().ToArray(), view.CustomAsns.Order().ToArray());
         // Explicit contents (guards against a future shape regression even if getters change).
         Assert.Equal(new[] { "microsoft", "ru" }, view.Subscriptions.Order().ToArray());
         Assert.Equal(new[] { "198.51.100.0/25", "203.0.113.0/24" }, view.CustomPrefixes.Order().ToArray());
@@ -144,36 +144,36 @@ public class PeerStoreKeyingTests
 
         // The folded status write took effect: Status="active" and LastSessionAt stamped at/after
         // the call (was a separate UpdateSessionStatus call on its own DbContext before #84).
-        var peer = store.GetDbPeerById(id)!;
+        var peer = (await store.GetDbPeerByIdAsync(id))!;
         Assert.Equal("active", peer.Status);
         Assert.NotNull(peer.LastSessionAt);
         Assert.True(peer.LastSessionAt >= before);
     }
 
     [Fact]
-    public void LoadPeerRoutingView_Returns_Null_For_Unknown_Peer()
+    public async Task LoadPeerRoutingView_Returns_Null_For_Unknown_Peer()
     {
         var (store, connection) = NewStore();
         using var conn = connection;
 
         // No CreatePeer — the send path must see null so it auto-registers the unknown peer.
-        Assert.Null(store.LoadPeerRoutingView(SharedIp, 64599));
+        Assert.Null(await store.LoadPeerRoutingViewAsync(SharedIp, 64599));
     }
 
     [Fact]
-    public void LoadPeerRoutingView_UserSources_Only_Active_Loaded()
+    public async Task LoadPeerRoutingView_UserSources_Only_Active_Loaded()
     {
         // Issue #147: paused (Active=false) sources never leave the DB — only Active ones are
         // advertised. AddCustomSource defaults Active=false; SetSourceActive toggles.
         var (store, connection) = NewStore();
         using var conn = connection;
 
-        var id = store.CreatePeer(SharedIp, 64512, "sources peer");
-        var active = store.AddCustomSource(id, "on", "https://example.com/on.txt", null);
-        store.AddCustomSource(id, "off", "https://example.com/off.txt", "65000:9");
-        Assert.True(store.SetSourceActive(id, active.Id, true));
+        var id = await store.CreatePeerAsync(SharedIp, 64512, "sources peer");
+        var active = await store.AddCustomSourceAsync(id, "on", "https://example.com/on.txt", null);
+        await store.AddCustomSourceAsync(id, "off", "https://example.com/off.txt", "65000:9");
+        Assert.True(await store.SetSourceActiveAsync(id, active.Id, true));
 
-        var view = store.LoadPeerRoutingView(SharedIp, 64512);
+        var view = await store.LoadPeerRoutingViewAsync(SharedIp, 64512);
         Assert.NotNull(view);
         var src = Assert.Single(view!.UserSources);   // the inactive "off" source is excluded
         Assert.Equal("on", src.Name);
@@ -182,31 +182,31 @@ public class PeerStoreKeyingTests
     }
 
     [Fact]
-    public void LoadPeerRoutingView_UserSources_All_Inactive_Empty()
+    public async Task LoadPeerRoutingView_UserSources_All_Inactive_Empty()
     {
         var (store, connection) = NewStore();
         using var conn = connection;
 
-        var id = store.CreatePeer(SharedIp, 64512, "all-inactive");
-        store.AddCustomSource(id, "a", "https://example.com/a.txt", null);
-        store.AddCustomSource(id, "b", "https://example.com/b.txt", "65000:1");
+        var id = await store.CreatePeerAsync(SharedIp, 64512, "all-inactive");
+        await store.AddCustomSourceAsync(id, "a", "https://example.com/a.txt", null);
+        await store.AddCustomSourceAsync(id, "b", "https://example.com/b.txt", "65000:1");
 
-        var view = store.LoadPeerRoutingView(SharedIp, 64512);
+        var view = await store.LoadPeerRoutingViewAsync(SharedIp, 64512);
         Assert.NotNull(view);
         Assert.Empty(view!.UserSources);
     }
 
     [Fact]
-    public void CreatePeer_Is_Idempotent_On_IpAsn()
+    public async Task CreatePeer_Is_Idempotent_On_IpAsn()
     {
         var (store, connection) = NewStore();
         using var conn = connection;
 
-        var id1 = store.CreatePeer(SharedIp, 64512, "first");
-        var id2 = store.CreatePeer(SharedIp, 64512, "second"); // same (Ip, Asn) → update, not a new row
+        var id1 = await store.CreatePeerAsync(SharedIp, 64512, "first");
+        var id2 = await store.CreatePeerAsync(SharedIp, 64512, "second"); // same (Ip, Asn) → update, not a new row
 
         Assert.Equal(id1, id2);
-        Assert.Equal("second", store.GetDbPeerById(id1)!.Description);
+        Assert.Equal("second", (await store.GetDbPeerByIdAsync(id1))!.Description);
     }
 
     /// <summary>
@@ -217,7 +217,7 @@ public class PeerStoreKeyingTests
     /// a different AS can now coexist).
     /// </summary>
     [Fact]
-    public void Initialize_Migrates_Legacy_Unique_Index_And_Preserves_Data()
+    public async Task Initialize_Migrates_Legacy_Unique_Index_And_Preserves_Data()
     {
         using var connection = new SqliteConnection("DataSource=:memory:");
         connection.Open();
@@ -251,7 +251,7 @@ public class PeerStoreKeyingTests
 
         // The legacy Ip-only unique index is gone: a second peer with a DIFFERENT AS now coexists.
         var store = new PeerStore(new StaticOptionsFactory(options));
-        var idB = store.CreatePeer("203.0.113.10", 64513, "new peer behind same NAT");
+        var idB = await store.CreatePeerAsync("203.0.113.10", 64513, "new peer behind same NAT");
         Assert.NotEqual("peer-1", idB);
 
         using var check2 = new BgpDbContext(options);

--- a/BGPLite.Tests/PeerStoreSplitQueryTests.cs
+++ b/BGPLite.Tests/PeerStoreSplitQueryTests.cs
@@ -25,14 +25,14 @@ public class PeerStoreSplitQueryTests
     private const uint Asn = 64520;
 
     [Fact]
-    public void LoadPeerRoutingView_EmitsOneSelectPerCollection()
+    public async Task LoadPeerRoutingView_EmitsOneSelectPerCollection()
     {
         var (store, connection, selects) = NewStoreCountingSelects();
         using var _ = connection;
-        var id = SeedPeerWithChildren(store);
+        var id = await SeedPeerWithChildren(store);
 
         selects.Clear();
-        var view = store.LoadPeerRoutingView(Ip, Asn);
+        var view = await store.LoadPeerRoutingViewAsync(Ip, Asn);
 
         Assert.NotNull(view);
         // peer row + 4 collections; a single-query load would emit exactly 1 SELECT.
@@ -42,14 +42,14 @@ public class PeerStoreSplitQueryTests
     }
 
     [Fact]
-    public void GetPeerDetail_EmitsOneSelectPerCollection()
+    public async Task GetPeerDetail_EmitsOneSelectPerCollection()
     {
         var (store, connection, selects) = NewStoreCountingSelects();
         using var _ = connection;
-        var id = SeedPeerWithChildren(store);
+        var id = await SeedPeerWithChildren(store);
 
         selects.Clear();
-        var detail = store.GetPeerDetail(id);
+        var detail = await store.GetPeerDetailAsync(id);
 
         Assert.NotNull(detail);
         Assert.True(selects.Count > 1,
@@ -59,14 +59,14 @@ public class PeerStoreSplitQueryTests
 
     /// <summary>The split must not change what the reads return — the point is the SQL shape, not the data.</summary>
     [Fact]
-    public void SplitReadsReturnTheSameData()
+    public async Task SplitReadsReturnTheSameData()
     {
         var (store, connection, _) = NewStoreCountingSelects();
         using var __ = connection;
-        var id = SeedPeerWithChildren(store);
+        var id = await SeedPeerWithChildren(store);
 
-        var view = store.LoadPeerRoutingView(Ip, Asn);
-        var detail = store.GetPeerDetail(id);
+        var view = await store.LoadPeerRoutingViewAsync(Ip, Asn);
+        var detail = await store.GetPeerDetailAsync(id);
 
         Assert.NotNull(view);
         Assert.NotNull(detail);
@@ -100,15 +100,15 @@ public class PeerStoreSplitQueryTests
         return (new PeerStore(new StaticOptionsFactory(options)), connection, selects);
     }
 
-    private static string SeedPeerWithChildren(PeerStore store)
+    private static async Task<string> SeedPeerWithChildren(PeerStore store)
     {
-        var id = store.CreatePeer(Ip, Asn, "split-query test");
-        store.SetSubscriptions(id, ["list-a", "list-b"]);
-        store.SetCustomPrefixes(id, [("10.0.0.0", (byte)8), ("192.0.2.0", (byte)24)]);
-        store.SetCustomAsns(id, [64512u, 64513u]);
-        var active = store.AddCustomSource(id, "active-src", "https://example.invalid/a", null);
-        store.AddCustomSource(id, "paused-src", "https://example.invalid/b", null);
-        store.SetSourceActive(id, active.Id, true);
+        var id = await store.CreatePeerAsync(Ip, Asn, "split-query test");
+        await store.SetSubscriptionsAsync(id, ["list-a", "list-b"]);
+        await store.SetCustomPrefixesAsync(id, [("10.0.0.0", (byte)8), ("192.0.2.0", (byte)24)]);
+        await store.SetCustomAsnsAsync(id, [64512u, 64513u]);
+        var active = await store.AddCustomSourceAsync(id, "active-src", "https://example.invalid/a", null);
+        await store.AddCustomSourceAsync(id, "paused-src", "https://example.invalid/b", null);
+        await store.SetSourceActiveAsync(id, active.Id, true);
         return id;
     }
 

--- a/BGPLite.Tests/RefreshDebounceTests.cs
+++ b/BGPLite.Tests/RefreshDebounceTests.cs
@@ -24,29 +24,18 @@ public class RefreshDebounceTests
     {
         public volatile bool Armed;
         public int LoadCalls;
-        public readonly ManualResetEventSlim Release = new(false);
+        // #262: the contract is async now, so the gate awaits instead of parking a pool thread.
+        public readonly TaskCompletionSource Release = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public string CreatePeer(string ip, uint asn, string? description) => "peer";
-        public void UpsertPeer(string ip, uint asn) { }
-        public void UpdateSessionStatus(string ip, uint asn, bool active) { }
-        public void DeletePeer(string id) { }
-        public PeerInfo? GetPeerByIp(string ip) => null;
-        public PeerInfo? GetPeer(string ip, uint asn) => null;
-        public PeerInfo? GetPeerById(string id) => null;
-        public List<string> GetSubscriptions(string peerId) => [];
-        public List<string> GetCustomPrefixes(string peerId) => [];
-        public List<uint> GetCustomAsns(string peerId) => [];
-        public HashSet<uint> GetCommunities(string peerId) => [];
-        public HashSet<uint> GetCommunities(string ip, uint asn) => [];
-        public void SetCommunities(string peerId, HashSet<uint> communities) { }
-        public void ClearCommunities(string peerId) { }
-        public void SetDescription(string id, string description) { }
+        public Task<string> CreatePeerAsync(string ip, uint asn, string? description, CancellationToken ct = default) => Task.FromResult("peer");
+        public Task UpsertPeerAsync(string ip, uint asn, CancellationToken ct = default) => Task.CompletedTask;
+        public Task UpdateSessionStatusAsync(string ip, uint asn, bool active, CancellationToken ct = default) => Task.CompletedTask;
 
-        public PeerRoutingView? LoadPeerRoutingView(string ip, uint asn)
+        public async Task<PeerRoutingView?> LoadPeerRoutingViewAsync(string ip, uint asn, CancellationToken ct = default)
         {
             Interlocked.Increment(ref LoadCalls);
             if (Armed)
-                Release.Wait(); // block the refresh cycle mid-flight (sync contract)
+                await Release.Task; // hold the refresh cycle mid-flight
             return new PeerRoutingView("peer", [], [], [], []);
         }
     }
@@ -193,7 +182,7 @@ public class RefreshDebounceTests
             Assert.Equal(baseline + 1, Volatile.Read(ref store.LoadCalls)); // exactly ONE in-flight cycle
 
             store.Armed = false;
-            store.Release.Set();
+            store.Release.TrySetResult();
             await Task.WhenAll(tasks).WaitAsync(TimeSpan.FromSeconds(10));
 
             var total = Volatile.Read(ref store.LoadCalls) - baseline;
@@ -202,7 +191,7 @@ public class RefreshDebounceTests
         finally
         {
             store.Armed = false;
-            store.Release.Set(); // never leak a blocked pool thread on an assertion failure
+            store.Release.TrySetResult(); // never leak a blocked pool thread on an assertion failure
         }
     }
 

--- a/BGPLite.Tests/RouteAssemblerCancellationTests.cs
+++ b/BGPLite.Tests/RouteAssemblerCancellationTests.cs
@@ -77,22 +77,11 @@ public sealed class RouteAssemblerCancellationTests
     /// <summary>Resolves to an existing peer with no subscriptions — the unconfigured-peer branch.</summary>
     private sealed class UnconfiguredPeerStore : IPeerStore
     {
-        public string CreatePeer(string ip, uint asn, string? description) => "id";
-        public void UpsertPeer(string ip, uint asn) { }
-        public void UpdateSessionStatus(string ip, uint asn, bool active) { }
-        public void DeletePeer(string id) { }
-        public PeerInfo? GetPeerByIp(string ip) => null;
-        public PeerInfo? GetPeer(string ip, uint asn) => null;
-        public PeerInfo? GetPeerById(string id) => null;
-        public List<string> GetSubscriptions(string peerId) => [];
-        public List<string> GetCustomPrefixes(string peerId) => [];
-        public List<uint> GetCustomAsns(string peerId) => [];
-        public HashSet<uint> GetCommunities(string peerId) => [];
-        public HashSet<uint> GetCommunities(string ip, uint asn) => [];
-        public void SetCommunities(string peerId, HashSet<uint> communities) { }
-        public void ClearCommunities(string peerId) { }
-        public void SetDescription(string id, string description) { }
-        public PeerRoutingView? LoadPeerRoutingView(string ip, uint asn) => new("id", [], [], [], []);
+        public Task<string> CreatePeerAsync(string ip, uint asn, string? description, CancellationToken ct = default) => Task.FromResult("id");
+        public Task UpsertPeerAsync(string ip, uint asn, CancellationToken ct = default) => Task.CompletedTask;
+        public Task UpdateSessionStatusAsync(string ip, uint asn, bool active, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<PeerRoutingView?> LoadPeerRoutingViewAsync(string ip, uint asn, CancellationToken ct = default)
+            => Task.FromResult<PeerRoutingView?>(new("id", [], [], [], []));
     }
 
     private sealed class CapturingLogger : ILogger<RouteAssembler>

--- a/BGPLite.Tests/RouteAssemblerSuppressionTests.cs
+++ b/BGPLite.Tests/RouteAssemblerSuppressionTests.cs
@@ -146,22 +146,10 @@ public class RouteAssemblerSuppressionTests
     /// <summary>Resolves to a configured peer carrying one custom prefix + one custom ASN.</summary>
     private sealed class ConfiguredPeerStore(List<string> customPrefixes, List<uint> customAsns) : IPeerStore
     {
-        public string CreatePeer(string ip, uint asn, string? description) => "id";
-        public void UpsertPeer(string ip, uint asn) { }
-        public void UpdateSessionStatus(string ip, uint asn, bool active) { }
-        public void DeletePeer(string id) { }
-        public PeerInfo? GetPeerByIp(string ip) => null;
-        public PeerInfo? GetPeer(string ip, uint asn) => null;
-        public PeerInfo? GetPeerById(string id) => null;
-        public List<string> GetSubscriptions(string peerId) => [];
-        public List<string> GetCustomPrefixes(string peerId) => customPrefixes;
-        public List<uint> GetCustomAsns(string peerId) => customAsns;
-        public HashSet<uint> GetCommunities(string peerId) => [];
-        public HashSet<uint> GetCommunities(string ip, uint asn) => [];
-        public void SetCommunities(string peerId, HashSet<uint> communities) { }
-        public void ClearCommunities(string peerId) { }
-        public void SetDescription(string id, string description) { }
-        public PeerRoutingView? LoadPeerRoutingView(string ip, uint asn)
-            => new("id", [], customPrefixes, customAsns, []);
+        public Task<string> CreatePeerAsync(string ip, uint asn, string? description, CancellationToken ct = default) => Task.FromResult("id");
+        public Task UpsertPeerAsync(string ip, uint asn, CancellationToken ct = default) => Task.CompletedTask;
+        public Task UpdateSessionStatusAsync(string ip, uint asn, bool active, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<PeerRoutingView?> LoadPeerRoutingViewAsync(string ip, uint asn, CancellationToken ct = default)
+            => Task.FromResult<PeerRoutingView?>(new("id", [], customPrefixes, customAsns, []));
     }
 }

--- a/BGPLite.Tests/RouteRefreshHoldTimerTests.cs
+++ b/BGPLite.Tests/RouteRefreshHoldTimerTests.cs
@@ -23,33 +23,22 @@ public class RouteRefreshHoldTimerTests
     private sealed class GatedStore : IPeerStore
     {
         public volatile bool Armed;
-        public readonly ManualResetEventSlim Release = new(false);
+        // #262: the contract is async now, so the gate awaits instead of parking a pool thread.
+        public readonly TaskCompletionSource Release = new(TaskCreationOptions.RunContinuationsAsynchronously);
         /// <summary>Completes when a gated Load has actually ENTERED the block — the test waits
         /// for it before measuring liveness, so a delayed ROUTE_REFRESH cannot pass vacuously.</summary>
         public readonly TaskCompletionSource Entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public string CreatePeer(string ip, uint asn, string? description) => "peer";
-        public void UpsertPeer(string ip, uint asn) { }
-        public void UpdateSessionStatus(string ip, uint asn, bool active) { }
-        public void DeletePeer(string id) { }
-        public PeerInfo? GetPeerByIp(string ip) => null;
-        public PeerInfo? GetPeer(string ip, uint asn) => null;
-        public PeerInfo? GetPeerById(string id) => null;
-        public List<string> GetSubscriptions(string peerId) => [];
-        public List<string> GetCustomPrefixes(string peerId) => [];
-        public List<uint> GetCustomAsns(string peerId) => [];
-        public HashSet<uint> GetCommunities(string peerId) => [];
-        public HashSet<uint> GetCommunities(string ip, uint asn) => [];
-        public void SetCommunities(string peerId, HashSet<uint> communities) { }
-        public void ClearCommunities(string peerId) { }
-        public void SetDescription(string id, string description) { }
+        public Task<string> CreatePeerAsync(string ip, uint asn, string? description, CancellationToken ct = default) => Task.FromResult("peer");
+        public Task UpsertPeerAsync(string ip, uint asn, CancellationToken ct = default) => Task.CompletedTask;
+        public Task UpdateSessionStatusAsync(string ip, uint asn, bool active, CancellationToken ct = default) => Task.CompletedTask;
 
-        public PeerRoutingView? LoadPeerRoutingView(string ip, uint asn)
+        public async Task<PeerRoutingView?> LoadPeerRoutingViewAsync(string ip, uint asn, CancellationToken ct = default)
         {
             if (Armed)
             {
                 Entered.TrySetResult();
-                Release.Wait(); // the refresh hangs here, mid-flight
+                await Release.Task; // the refresh hangs here, mid-flight
             }
             return new PeerRoutingView("peer", [], [], [], []);
         }
@@ -213,7 +202,7 @@ public class RouteRefreshHoldTimerTests
 
         // Release the refresh and wind down cleanly.
         store.Armed = false;
-        store.Release.Set();
+        store.Release.TrySetResult();
         session.Dispose();
         await runTask.WaitAsync(TimeSpan.FromSeconds(10));
     }

--- a/BGPLite/Program.cs
+++ b/BGPLite/Program.cs
@@ -78,8 +78,9 @@ builder.Services.AddSingleton<PeerStore>();
 builder.Services.AddSingleton<IRouteFilter>(sp =>
 {
     var store = sp.GetRequiredService<PeerStore>();
-    return new PeerCommunityFilter(config.Bgp.Asn, (ip, asn) =>
-        asn.HasValue ? store.GetCommunities(ip, asn.Value) : store.GetCommunitiesByIp(ip));
+    // #262: the resolver is async — its DB read used to run synchronously on the session send path.
+    return new PeerCommunityFilter(config.Bgp.Asn, async (ip, asn, ct) =>
+        asn.HasValue ? await store.GetCommunitiesAsync(ip, asn.Value, ct) : await store.GetCommunitiesByIpAsync(ip, ct));
 });
 // Per-list community resolver: stamps a configured BGP community on prefixes by source
 // (AsnList / Country / PrefixSource). ConfigCommunityResolver reads static config; Phase 2 will


### PR DESCRIPTION
Closes #262
Refs #10 (P6 epic, "async PeerStore" item)

## Problem
The entire persistence contract was synchronous: all `IPeerStore` members, implemented with sync EF calls, invoked from async contexts — the BGP route-send path (`RouteAssembler`), session teardown/status writes (`BgpSession` `finally` blocks, the OPEN-handshake upsert via the factory delegate), the community filter's DB read on the advertise path (`Program.cs` lambda → `PeerCommunityFilter`), and every management-API handler. Under write contention each contending call pins a thread-pool thread for up to the 5 s `busy_timeout`, against the 64-slot in-flight cap. AGENTS.md called this out as the known exception, tracked here.

## Root Cause
The contract predates the async end-to-end send/read paths and was never moved; every month it survived made the caller-side migration larger (issue's own motivation).

## Fix (Expand–Contract, in one PR — there are no external consumers)
- **`IPeerStore` is now async-only** (`CreatePeerAsync`, `UpsertPeerAsync`, `UpdateSessionStatusAsync`, `LoadPeerRoutingViewAsync`, all with `CancellationToken ct = default`). The interface was simultaneously **narrowed to its actual consumers** (session layer: `RouteAssembler`, `BgpSession`, `BgpSessionFactory`) — 12 of the 16 members had zero interface-callers; the management API works with the concrete `PeerStore` (API concern, not a session-layer contract). Dead members (`GetPeerByIp`, `GetPeerById`, `ClearCommunities`, `SetDescription`, `GetAllPeers`) were removed outright; test-only members (`GetCommunitiesAsync(peerId)`, `GetCustomAsnsAsync`, `SetCommunitiesAsync`, `SetSubscriptionsAsync`, …) remain on the concrete class, off the interface.
- **`PeerStore`**: every member converted to EF async (`ToListAsync`/`FirstOrDefaultAsync`/`ExecuteDeleteAsync`/`ExecuteUpdateAsync`/`SaveChangesAsync`/`BeginTransactionAsync`/`ExecuteSqlInterpolatedAsync`/`ToHashSetAsync`; raw ADO upsert → `ExecuteReaderAsync`), all taking a `CancellationToken`.
- **Callers migrated**: `RouteAssembler` (hot path — `LoadPeerRoutingViewAsync` + `CreatePeerAsync`, `FilterAndReturnAsync`), `BgpSession` (both `finally` status writes + the awaited `onPeerIdentified` upsert — now `Func<…, Task>`), `BgpSessionFactory`, `SharedTableRouteAssembler`, `ManagementApi` (all handlers; sync handlers became `async Task<ApiResponse>`; `/api/me` multi-peer projection awaits `Task.WhenAll`), `Program.cs` filter lambda.
- **`IRouteFilter.ResolveOutgoingAllowSetAsync`**: the outgoing community filter's DB read no longer runs synchronously on the session send path (this was the #262 caller the issue's inventory missed).
- **Gated test stores** (`RefreshDebounceTests`, `RouteRefreshHoldTimerTests`) now gate with `TaskCompletionSource` awaits instead of `ManualResetEventSlim` — they no longer park a pool thread (which was, in fact, the pre-#253 hazard they model).
- AGENTS.md: the "known sync PeerStore exception" note is retired; new store members must be async.

## Honesty note (SQLite async semantics)
Microsoft.Data.Sqlite's ADO layer has no true async I/O — the async EF APIs on SQLite still complete on the calling thread, so busy_timeout waits do not magically stop blocking. What this PR buys is exactly what the issue asks for: the contract no longer forces sync-on-async, every caller awaits properly, cancellation propagates into the store calls, and a genuinely async provider can be adopted without touching callers again.

## Regression Test
Behavior-preserving migration — red/green does not apply. The affected suites keep pinning behavior: `PeerStore*` (in-memory SQLite, incl. SplitQuery SQL-shape assertions), `RefreshDebounceTests`/`RouteRefreshHoldTimerTests` (slow store vs keepalive liveness, now via async gates), `CompositionContractTests` (composition shape), `BgpSessionRouteOwnershipTests` (`RecordingPeerStore` status-write assertions), `PeerDeleteTeardownTests` (#323 resurrection guard — updated: an already-cancelled token now surfaces as OCE from the async load itself instead of an empty sync read; the no-auto-register invariant is asserted through the exception path, and OCE is verified as teardown-swallowed in `BgpSession`).

## Verification
- dotnet format / dotnet build BGPLite.sln (0 errors) / dotnet test BGPLite.sln: **894/894 passed**.
- Acceptance grep: no sync store member remains callable anywhere outside `PeerStore.cs` definitions (grep over the whole solution returns nothing).
- Latency acceptance ("establish/refresh latency under concurrent API writes does not degrade"): full suite + SplitQuery SQL-shape assertions give behavior parity; a dedicated concurrent-writes microbenchmark was not built (no existing harness) — flagged as a residual item, see report.

## RFC
none — no protocol surface.

## Behavior Change
None intended (async end-to-end; one observable nuance: an already-cancelled caller token aborts the routing-view load with OCE instead of returning through the empty-read path — same teardown outcome, no peer resurrection).

## Deviation from Issue Proposal
The issue proposed async twins for all 16 members; this PR instead **narrows the interface to the 4 members the session layer actually consumes through it** (the contract-phase "the interface is the thing being moved" taken to its logical end) and deletes dead surface. The issue's "should land together with or after #230" precondition was already satisfied.
