### PR TITLE
fix: address the CodeRabbit findings on the integration review (3 fixes)

### DIFF
--- a/BGPLite.Providers/RipeStatPrefixCache.cs
+++ b/BGPLite.Providers/RipeStatPrefixCache.cs
@@ -44,12 +44,13 @@ public sealed class RipeStatPrefixCache
     // asn → gate serializing the cache-miss fetch path (prevents thundering herd on cold/expired
     // ASNs — #164).
     private readonly ConcurrentDictionary<uint, SemaphoreSlim> _locks = new();
-    // #267 item 3: ASNs with a fetch currently in flight. The capacity sweep must never evict an
-    // in-flight ASN's entry + gate: the fetcher holds that gate, and removing it let a later
-    // GetOrAdd create a second semaphore — two concurrent RIPEstat fetches for one ASN, breaking
-    // the #164 invariant. Marked before the gate is taken and unmarked after it is released, so
-    // "holding the gate" always implies "in-flight".
-    private readonly ConcurrentDictionary<uint, byte> _inflight = new();
+    // #267 item 3: ASNs with callers currently inside the fetch path. The capacity sweep must
+    // never evict an in-flight ASN's entry + gate: the fetcher holds that gate, and removing it
+    // let a later GetOrAdd create a second semaphore — two concurrent RIPEstat fetches for one
+    // ASN, breaking the #164 invariant. The value is an ACTIVE-CALLER COUNT (CodeRabbit on the
+    // integration review): a plain presence marker would be removed by the first caller's exit
+    // while a second caller is still inside/queued on the same gate.
+    private readonly ConcurrentDictionary<uint, int> _inflight = new();
 
     public RipeStatPrefixCache(
         RipeStatProvider ripe,
@@ -78,17 +79,20 @@ public sealed class RipeStatPrefixCache
         if (TryGetFresh(asn, out var fresh, out var freshIsNegative) && (serveNegativeEntries || !freshIsNegative))
             return fresh;
 
-        // #267 item 3: mark in-flight BEFORE the gate is taken (and unmark only after it is
-        // released) so the capacity sweep can never drop the gate this caller is about to wait on
-        // or holds — see the _inflight note.
-        _inflight.TryAdd(asn, 0);
+        // #267 item 3: register in-flight BEFORE the gate is taken (unregistered only after this
+        // caller's own turn is over) so the capacity sweep can never drop the gate this caller is
+        // about to wait on or holds — see the _inflight note. AddOrUpdate is atomic; the exit
+        // decrements and removes the key only while it still reads 0 (a concurrent re-enter wins
+        // the race: its increment lands between, and the conditional remove sees 1 and no-ops).
+        _inflight.AddOrUpdate(asn, 1, (_, count) => count + 1);
         try
         {
             return await FetchThroughGateAsync(asn, ct, serveNegativeEntries);
         }
         finally
         {
-            _inflight.TryRemove(asn, out _);
+            _inflight.AddOrUpdate(asn, 0, (_, count) => count - 1);
+            _inflight.TryRemove(new KeyValuePair<uint, int>(asn, 0));
         }
     }
 
@@ -199,10 +203,10 @@ public sealed class RipeStatPrefixCache
         foreach (var key in toEvict)
         {
             // #267 item 3: an in-flight ASN's entry is re-populated by its fetch — evicting both
-            // while the fetcher holds the gate made a later GetOrAdd mint a second semaphore and
-            // issue a duplicate concurrent fetch (#164). Skipping keeps the gate intact; losing a
-            // transient eviction slot is acceptable, never losing correctness.
-            if (_inflight.ContainsKey(key)) continue;
+            // while ANY of its callers holds/waits on the gate made a later GetOrAdd mint a second
+            // semaphore and issue a duplicate concurrent fetch (#164). Skipping keeps the gate
+            // intact; losing a transient eviction slot is acceptable, never losing correctness.
+            if (_inflight.TryGetValue(key, out var active) && active > 0) continue;
             if (_cache.TryRemove(key, out _))
                 _locks.TryRemove(key, out _);
         }

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -30,7 +30,7 @@ public sealed class BgpSession : IDisposable
     private readonly BgpMetrics _metrics;
     private readonly ILogger<BgpSession> _logger;
     private readonly CancellationTokenSource _cts = new();
-    private readonly Func<string, uint, Task>? _onPeerIdentified;
+    private readonly Func<string, uint, CancellationToken, Task>? _onPeerIdentified;
     private readonly IPeerStore? _peerStore;
     // #265 item 1: set by BgpServer right after creation — "is this session still the registered
     // one?" A false answer at teardown-time means a replacement took the slot and owns the
@@ -253,7 +253,7 @@ public sealed class BgpSession : IDisposable
         IRouteFilter routeFilter,
         BgpMetrics metrics,
         ILogger<BgpSession> logger,
-        Func<string, uint, Task>? onPeerIdentified = null,
+        Func<string, uint, CancellationToken, Task>? onPeerIdentified = null,
         IPeerStore? peerStore = null,
         IPrefixAggregator? prefixAggregator = null,
         IRouteAssembler? routeAssembler = null,
@@ -342,7 +342,7 @@ public sealed class BgpSession : IDisposable
                     ? $"{c.Code}[{Convert.ToHexString(c.Data)}]"
                     : $"{c.Code}")));
 
-            await ValidateOpenAsync(remoteOpen);
+            await ValidateOpenAsync(remoteOpen, linkedCts.Token);
 
             TransitionTo(BgpFsmState.OpenSent);
 
@@ -1505,7 +1505,7 @@ public sealed class BgpSession : IDisposable
 
     #region Validation
 
-    private async Task ValidateOpenAsync(BgpOpenMessage open)
+    private async Task ValidateOpenAsync(BgpOpenMessage open, CancellationToken ct)
     {
         var localRouterId = BgpConstants.IPAddressToUint(_bgpConfig.GetRouterIdAddress());
         // #269: OPEN negotiation/validation lives in the protocol library (OpenNegotiator); the
@@ -1522,7 +1522,9 @@ public sealed class BgpSession : IDisposable
         // Announce/persist the peer only after the OPEN passes validation. Previously this fired
         // before the expected-ASN check, upserting a configured peer that declared a mismatched ASN
         // (BadPeerAs) just before the session was torn down.
-        if (_onPeerIdentified is not null) await _onPeerIdentified(_peerConfig.Address, _remoteAsn);
+        // CodeRabbit (integration review): propagate the session token into the upsert so a
+        // locked SQLite cannot out-wait shutdown/replacement before cancellation is observed.
+        if (_onPeerIdentified is not null) await _onPeerIdentified(_peerConfig.Address, _remoteAsn, ct);
 
         var peerGr = CapabilityHelper.GetGracefulRestart(open);
         _logger.LogInformation("Peer {Peer} Graceful Restart: {State}",

--- a/BGPLite.Server/BgpSessionFactory.cs
+++ b/BGPLite.Server/BgpSessionFactory.cs
@@ -65,7 +65,7 @@ public sealed class BgpSessionFactory : IBgpSessionFactory
             // been configured in the UI still shows up there. Previously a lambda hand-wired in
             // Program.cs and threaded through BgpServer. Async since #262 — the upsert ran
             // synchronously on the OPEN-handshake path.
-            onPeerIdentified: (ip, asn) => _peerStore.UpsertPeerAsync(ip, asn),
+            onPeerIdentified: (ip, asn, ct) => _peerStore.UpsertPeerAsync(ip, asn, ct),
             peerStore: _peerStore,
             prefixAggregator: _prefixAggregator,
             routeAssembler: _routeAssembler,

--- a/BGPLite.Server/RouteAssembler.cs
+++ b/BGPLite.Server/RouteAssembler.cs
@@ -300,10 +300,11 @@ public sealed class RouteAssembler : IRouteAssembler
 
     /// <summary>
     /// #220 "suppress more-specifics": a custom prefix is an explicit operator override, so any
-    /// route covered by one is dropped from the outbound list, regardless of its source or
-    /// community set. Coverage is strictly-more-specific — an exact custom==source duplicate stays
-    /// in the list and gets its communities unioned by <c>BgpSession.MergeDuplicatePrefixes</c>
-    /// (#209), which is the desired exact-match behavior. Runs on the flat per-peer list BEFORE the
+    /// SOURCE route covered by one is dropped from the outbound list, regardless of its source or
+    /// community set. Two things survive: an exact custom==source duplicate (its communities get
+    /// unioned by <c>BgpSession.MergeDuplicatePrefixes</c>, #209) and every CONFIGURED CUSTOM
+    /// prefix itself — nested customs (e.g. /8 + a deliberate /16) must not suppress each other
+    /// (CodeRabbit on the integration review). Runs on the flat per-peer list BEFORE the
     /// per-community-set aggregator sees it. Extracted as a pure function for unit tests.
     /// </summary>
     internal static List<Route> SuppressCoveredByCustomPrefixes(
@@ -315,8 +316,12 @@ public sealed class RouteAssembler : IRouteAssembler
         // Mask(0) must be 0, not 0xFFFFFFFF << 32 (a shift-by-32 is a no-op on uint, not a wipe).
         static uint Mask(byte length) => length == 0 ? 0u : 0xFFFFFFFFu << (32 - length);
         return routes
-            .Where(r => !customRanges.Any(cr => r.PrefixLength > cr.Length
-                                                && (r.Prefix & Mask(cr.Length)) == cr.Network))
+            .Where(r =>
+                // A configured custom prefix is never suppressed — including by a broader
+                // custom prefix of the same peer. Exact (network, length) == custom match.
+                customRanges.Contains((r.Prefix, r.PrefixLength))
+                || !customRanges.Any(cr => r.PrefixLength > cr.Length
+                                           && (r.Prefix & Mask(cr.Length)) == cr.Network))
             .ToList();
     }
 

--- a/BGPLite.Tests/PrefixServiceTests.cs
+++ b/BGPLite.Tests/PrefixServiceTests.cs
@@ -446,6 +446,73 @@ public class PrefixServiceTests
         Assert.Single(result);
     }
 
+    /// <summary>
+    /// CodeRabbit (integration review of #267): the in-flight marker was a presence flag removed
+    /// by the FIRST caller's exit while a second caller was still queued on the same gate — the
+    /// sweep then dropped the held gate and a third caller minted a second semaphore (duplicate
+    /// fetch). The marker is an active-caller COUNT now; this pins that with a queued second
+    /// caller the gate survives both the first caller's exit and an intervening sweep.
+    /// </summary>
+    [Fact]
+    public async Task Eviction_KeepsGate_While_QueuedCaller_IsStillFetching()
+    {
+        var handler = new BlockingPerAsnHandler();
+        var clock = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        var cache = new RipeStatPrefixCache(
+            new RipeStatProvider(new StubFactory(handler), NullLogger<RipeStatProvider>.Instance,
+                new RipeStatConfig { RetryAttempts = 0, RetryDelaySeconds = 0 }),
+            cacheTtl: TimeSpan.FromHours(1),
+            maxCacheEntries: 1,
+            timeProvider: clock);
+
+        // 1. Populate ASN 1 (fresh entry, fills the cap of 1).
+        await cache.GetPrefixesAsync(1);
+        Assert.Equal(1, handler.CallsFor(1));
+
+        // 2. Expire the entry; start caller A — blocked inside its fetch, holding the gate.
+        clock.Advance(TimeSpan.FromHours(2));
+        handler.Block(1);
+        using var cancelA = new CancellationTokenSource();
+        var callerA = cache.GetPrefixesAsync(1, cancelA.Token);
+        await handler.WaitStarted(1);
+
+        // 3. Caller B queues on the same gate.
+        var callerB = cache.GetPrefixesAsync(1);
+
+        // 4. Cancel A mid-fetch: it unwinds WITHOUT inserting (OCE rethrow) and unregisters —
+        // yet B is still inside the path, so the gate must stay protected.
+        cancelA.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => callerA);
+
+        // 5. B acquires the now-free gate and blocks in its own fetch. Wire calls for ASN 1 so
+        // far: populate + A + B = 3.
+        var untilBFetches = Task.Run(async () =>
+        {
+            while (handler.CallsFor(1) < 3) await Task.Delay(10);
+        });
+        await untilBFetches.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // 6. ASN 2's insert sweeps; ASN 1's (expired) entry + B's HELD gate are the sweep target.
+        await cache.GetPrefixesAsync(2);
+        // Checkpoint: the sweep itself must not have minted a second fetch for ASN 1.
+        Assert.Equal(3, handler.CallsFor(1));
+
+        // 7. A third caller joins: it must share B's gate, not mint a second one.
+        var callerC = cache.GetPrefixesAsync(1);
+
+        handler.Unblock(1);
+        var resultB = await callerB;
+        var resultC = await callerC;
+
+        // Caller C must have been served by B's fetch (fresh re-check), not fetched again:
+        // wire calls stay at populate + A + B = 3.
+        // RED pre-fix (presence marker): A's exit removed the marker while B held the gate, the
+        // sweep evicted it mid-fetch, and C minted a second semaphore → Calls == 4.
+        Assert.Equal(3, handler.CallsFor(1));
+        Assert.Single(resultB);
+        Assert.Single(resultC);
+    }
+
     /// <summary>Like <see cref="PerAsnHandler"/> but able to block a specific ASN's response until
     /// released — models a slow RIPEstat fetch holding the per-ASN gate (#267 item 3).</summary>
     private sealed class BlockingPerAsnHandler : HttpMessageHandler
@@ -481,7 +548,7 @@ public class PrefixServiceTests
                 gate = _blocks.TryGetValue(asn, out var t) ? t.Task : null;
             }
             if (gate is not null)
-                await gate;
+                await gate.WaitAsync(ct);
 
             var hi = (int)((asn >> 8) & 0xFF);
             var lo = (int)(asn & 0xFF);

--- a/BGPLite.Tests/RouteAssemblerSuppressionTests.cs
+++ b/BGPLite.Tests/RouteAssemblerSuppressionTests.cs
@@ -88,6 +88,24 @@ public class RouteAssemblerSuppressionTests
     }
 
     [Fact]
+    public void NestedCustomPrefixes_DoNotSuppressEachOther()
+    {
+        // CodeRabbit (integration review): both are CONFIGURED custom prefixes — the operator's
+        // deliberate /16 must survive its own broader /8. Only source routes are suppressed.
+        var customs = new List<(uint, byte)> { (Net("10.0.0.0"), 8), (Net("10.1.0.0"), 16) };
+        var routes = new List<Route>
+        {
+            R("10.0.0.0", 8), R("10.1.0.0", 16),          // the two configured customs
+            R("10.2.0.0", 16), R("10.1.1.0", 24)          // source routes covered by them
+        };
+
+        var result = RouteAssembler.SuppressCoveredByCustomPrefixes(routes, customs);
+
+        Assert.Equal([(Net("10.0.0.0"), (byte)8), (Net("10.1.0.0"), (byte)16)],
+            result.Select(r => (r.Prefix, r.PrefixLength)));
+    }
+
+    [Fact]
     public void ZeroLengthCustom_Covers_Everything()
     {
         var customs = new List<(uint, byte)> { (Net("0.0.0.0"), 0) };
@@ -107,7 +125,7 @@ public class RouteAssemblerSuppressionTests
         // (arriving here through the custom-ASN path) sit inside it.
         var config = new AppConfig { Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" } };
         var assembler = new RouteAssembler(
-            new StubPrefixService(),
+            new StubPrefixService(("91.108.4.0", 22), ("91.108.8.0", 22)),
             new ConfiguredPeerStore(["91.108.0.0/16"], [64512]),
             new ConfigCommunityResolver(config, config.Bgp),
             AllowAllFilter.Instance,
@@ -122,17 +140,37 @@ public class RouteAssemblerSuppressionTests
         Assert.Equal([(Net("91.108.0.0"), (byte)16)], routes.Select(r => ((uint)r.Prefix, (byte)r.PrefixLength)));
     }
 
-    /// <summary>Serves two YouTube-like /22s for the custom ASN; nothing else.</summary>
-    private sealed class StubPrefixService : IPrefixService
+    [Fact]
+    public async Task BuildOutboundRoutes_NestedCustomPrefixes_BothAdvertised_SourceSuppressed()
+    {
+        var config = new AppConfig { Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" } };
+        var assembler = new RouteAssembler(
+            new StubPrefixService(("10.2.3.0", 24)),
+            new ConfiguredPeerStore(["10.0.0.0/8", "10.1.0.0/16"], [64512]),
+            new ConfigCommunityResolver(config, config.Bgp),
+            AllowAllFilter.Instance,
+            config,
+            config.Bgp,
+            NullLogger<RouteAssembler>.Instance);
+
+        var routes = await assembler.BuildOutboundRoutesAsync(
+            "203.0.113.9", 65002, new PeerConfig { Address = "203.0.113.9" }, "203.0.113.9",
+            CancellationToken.None);
+
+        // The /24 (from the custom-ASN fetch) is suppressed as a source route; BOTH configured
+        // customs — including the nested /16 — are advertised.
+        Assert.Equal(
+            [(Net("10.0.0.0"), (byte)8), (Net("10.1.0.0"), (byte)16)],
+            routes.Select(r => ((uint)r.Prefix, (byte)r.PrefixLength)));
+    }
+
+    /// <summary>Serves the configured prefixes for the custom-ASN fetch; nothing else.</summary>
+    private sealed class StubPrefixService(params (string Ip, byte Length)[] prefixes) : IPrefixService
     {
         public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
             => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
         public Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
-            => Task.FromResult(new List<(uint, byte, uint)>
-            {
-                (Net("91.108.4.0"), 22, 64512),
-                (Net("91.108.8.0"), 22, 64512)
-            });
+            => Task.FromResult(prefixes.Select(p => (Net(p.Ip), p.Length, 64512u)).ToList());
         public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
         public Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
             => Task.FromResult(new List<(uint, byte, uint)>());

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Protocol:
 
 - BGP-4 messages: OPEN / UPDATE / KEEPALIVE / NOTIFICATION; route refresh (RFC 2918, capability-gated, rate-limited)
 - 4-octet ASN (RFC 6793): AS_TRANS, AS4_PATH/AS4_AGGREGATOR tunneling for 2-octet-only peers
-- Capability negotiation (RFC 5492), Graceful Restart advertisement (RFC 4724)
+- Capability negotiation (RFC 5492); Graceful Restart (RFC 4724): not advertised, receiving-side retention not implemented (D6/#318)
 - Communities (RFC 1997) and Large Communities (RFC 8092): per-peer tagging and outgoing filters
 - UPDATE batching (≤100 NLRI) and exact-union CIDR aggregation
 
@@ -177,7 +177,7 @@ A section-by-section audit lives in [`docs/RFC_COMPLIANCE.md`](docs/RFC_COMPLIAN
 | [4893](https://www.rfc-editor.org/rfc/rfc4893) / [6793](https://www.rfc-editor.org/rfc/rfc6793) | 4-byte ASN, AS4_PATH | implemented |
 | [5492](https://www.rfc-editor.org/rfc/rfc5492) | Capabilities | implemented |
 | [1997](https://www.rfc-editor.org/rfc/rfc1997) | Communities | implemented |
-| [4724](https://www.rfc-editor.org/rfc/rfc4724) | Graceful Restart | advertised; receiving-side retention open (#318) |
+| [4724](https://www.rfc-editor.org/rfc/rfc4724) | Graceful Restart | not advertised; receiving-side retention open (#318, D6) |
 | [2918](https://www.rfc-editor.org/rfc/rfc2918) | Route Refresh | implemented |
 | [2385](https://www.rfc-editor.org/rfc/rfc2385) | TCP-MD5 auth | open (#36) |
 | [4760](https://www.rfc-editor.org/rfc/rfc4760) / [2545](https://www.rfc-editor.org/rfc/rfc2545) | MP-BGP / IPv6 | roadmap (#14/#15) |

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -165,10 +165,10 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
 - **Decision:** `ISessionManager.TerminatePeerAsync` (management-API peer deletion) sends a Cease
   (Administrative Reset) to the peer's established sessions even when Graceful Restart is enabled —
   unlike `StopAsync`, which silent-closes under GR.
-- **Context:** GR retention exists so peers keep our routes across a restart we will return from
-  (RFC 4724 §4). Deleting a peer is a permanent removal, not a restart — retention would leave stale
-  routes at the peer until its restart timer expired, so the NOTIFICATION termination (which bypasses
-  GR and makes the peer flush) is the correct signal (#323).
+- **Context:** the sending-side GR conveniences (End-of-RIB, the GR-aware silent close in
+  `StopAsync`) signal "this is a restart, retain" — but deletion is a permanent removal, not a
+  restart, so the NOTIFICATION termination is the correct signal there regardless (and since D6 the
+  capability is not advertised, so no peer retains our routes across ANY of our disconnects) (#323).
 - **Consequence:** deletion is not a revocation: nothing stops the peer from reconnecting, and D11
   auto-registration serves it again on the next OPEN (a deny-list is a separate product decision).
   Pre-OPEN connections (remote ASN not yet known) are not matched by the (ip, asn) termination and


### PR DESCRIPTION
Follow-up PR: fixes the three actionable CodeRabbit findings from the integration review (#387), each independently verified against the code before adoption. Plus the outside-diff doc finding (stale GR claims in README/D16).

1. **RipeStatPrefixCache refcount** (found on #267 code): the in-flight marker was a presence flag removed by the first caller's exit while a second caller was still queued on the same gate — an intervening sweep then dropped the held gate and a third caller minted a second semaphore (duplicate concurrent RIPEstat fetch, #164). Now an active-caller COUNT (atomic `AddOrUpdate` + value-conditional `TryRemove`). Regression `Eviction_KeepsGate_While_QueuedCaller_IsStillFetching`: **RED pre-fix = 4 wire calls, GREEN = 3**.

2. **#220 suppression vs nested custom prefixes** (real bug): a configured custom prefix nested under a broader custom prefix of the same peer (e.g. deliberate `10.1.0.0/16` under `10.0.0.0/8`) was suppressed by its own sibling. Exact (network, length) matches against the custom ranges are now always preserved; source routes still suppressed. Regression: pure case + end-to-end (`BothAdvertised_SourceSuppressed`).

3. **Cancellation propagation** (found on #262 code): the `onPeerIdentified` upsert now carries the session's linked token through `ValidateOpenAsync`, so a locked SQLite cannot out-wait shutdown/replacement before cancellation is observed.

Docs: README's stale "Graceful Restart advertisement" claims aligned with D6 (outside-diff finding); D16 rationale rewritten to not cite retention we do not provide.

Verification: dotnet format / build 0 errors / **897/897** tests.
