### PR TITLE
feat(server): per-peer MaxPrefix override (#391)

### DIFF
--- a/BGPLite.Api/Entities/Peer.cs
+++ b/BGPLite.Api/Entities/Peer.cs
@@ -10,6 +10,10 @@ public class Peer
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime? LastSessionAt { get; set; }
 
+    /// <summary>Per-peer prefix ceiling (#391). NULL = inherit the global
+    /// <c>Bgp.MaxPrefixesPerPeer</c>; explicit 0 = unlimited for this peer.</summary>
+    public int? MaxPrefix { get; set; }
+
     public List<PeerCommunity> Communities { get; set; } = [];
     public List<PeerSubscription> Subscriptions { get; set; } = [];
     public List<PeerCustomPrefix> CustomPrefixes { get; set; } = [];

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -787,6 +787,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
             description = peer.Description,
             status = peer.Status,
             createdAt = peer.CreatedAt,
+            maxPrefix = peer.MaxPrefix,
             lastSessionAt = peer.LastSessionAt,
             lists = peer.Subscriptions,
             customPrefixes = peer.CustomPrefixes,
@@ -842,6 +843,11 @@ public sealed class ManagementApi : IHostedService, IDisposable
             SanitizeForLog(string.Join(",", asnLists)), SanitizeForLog(string.Join(",", data.CustomPrefixes ?? [])),
             SanitizeForLog(string.Join(",", data.CustomAsns ?? [])));
 
+        // #391: the per-peer prefix ceiling — an optional override of Bgp.MaxPrefixesPerPeer;
+        // 0 means "unlimited for this peer". Reject negatives at the boundary.
+        if (data.MaxPrefix is < 0)
+            return ApiResponse.Error("Invalid MaxPrefix: must be 0 (unlimited) or a positive prefix count.", 400);
+
         if (data.CustomPrefixes is not null)
         {
             foreach (var cidr in data.CustomPrefixes)
@@ -861,7 +867,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // #267 item 6: the upsert returns (Id, Status, CreatedAt) from its RETURNING clause — no
         // follow-up GetDbPeerById roundtrip for fields the caller already knows.
         var saved = await _store.SavePeerConfigurationAsync(
-            normalizedIp, data.Asn, data.Description, asnLists, customPrefixes, data.CustomAsns ?? []);
+            normalizedIp, data.Asn, data.Description, asnLists, customPrefixes, data.CustomAsns ?? [], data.MaxPrefix);
 
         _logger.LogInformation("Created peer {Ip} AS{Asn} ({Id}): {Subs} lists, {Prefixes} custom prefixes, {Asns} custom AS",
             normalizedIp, data.Asn, saved.Id, asnLists.Count, customPrefixes.Count, data.CustomAsns?.Count ?? 0);
@@ -876,6 +882,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
             description = data.Description,
             status = saved.Status,
             createdAt = saved.CreatedAt,
+            maxPrefix = saved.MaxPrefix,
             lists = asnLists,
             customPrefixes = data.CustomPrefixes ?? [],
             customAsns = data.CustomAsns ?? []
@@ -897,6 +904,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
             description = peer.Description,
             status = peer.Status,
             createdAt = peer.CreatedAt,
+            maxPrefix = peer.MaxPrefix,
             lastSessionAt = peer.LastSessionAt,
             lists = peer.Subscriptions,
             customPrefixes = peer.CustomPrefixes,
@@ -964,7 +972,12 @@ public sealed class ManagementApi : IHostedService, IDisposable
                     "See /api/asn-lists for the configured names.", 400);
         }
 
-        await _store.UpdatePeerConfigurationAsync(peerId, data.Description, data.Lists, parsedPrefixes, data.CustomAsns);
+        // #391: PATCH semantics — MaxPrefix omitted means "leave it alone"; an explicit value
+        // (including 0 = unlimited for this peer) is set. Reject negatives at the boundary.
+        if (data.MaxPrefix is < 0)
+            return ApiResponse.Error("Invalid MaxPrefix: must be 0 (unlimited) or a positive prefix count.", 400);
+
+        await _store.UpdatePeerConfigurationAsync(peerId, data.Description, data.Lists, parsedPrefixes, data.CustomAsns, data.MaxPrefix);
 
         _logger.LogInformation("Updated peer {Id}", SanitizeForLog(peerId));
 
@@ -1703,8 +1716,8 @@ public sealed class ManagementApi : IHostedService, IDisposable
         _listener?.Close();
     }
 
-    private record CreatePeerRequest(string Ip, uint Asn, string? Description, [property: JsonPropertyName("lists")] List<string>? AsnLists, List<string>? CustomPrefixes, List<uint>? CustomAsns);
-    private record UpdatePeerRequest(string? Description, [property: JsonPropertyName("lists")] List<string>? Lists, List<string>? CustomPrefixes, List<uint>? CustomAsns);
+    private record CreatePeerRequest(string Ip, uint Asn, string? Description, [property: JsonPropertyName("lists")] List<string>? AsnLists, List<string>? CustomPrefixes, List<uint>? CustomAsns, int? MaxPrefix);
+    private record UpdatePeerRequest(string? Description, [property: JsonPropertyName("lists")] List<string>? Lists, List<string>? CustomPrefixes, List<uint>? CustomAsns, int? MaxPrefix);
     private record AddSourceRequest(string Name, string Url, string? Community);
     private record PatchSourceRequest([property: JsonPropertyName("active")] bool? Active);
 

--- a/BGPLite.Api/Migrations/20260901102233_AddPeerMaxPrefix.Designer.cs
+++ b/BGPLite.Api/Migrations/20260901102233_AddPeerMaxPrefix.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BGPLite.Api;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BGPLite.Api.Migrations
 {
     [DbContext(typeof(BgpDbContext))]
-    partial class BgpDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260901102233_AddPeerMaxPrefix")]
+    partial class AddPeerMaxPrefix
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.11");

--- a/BGPLite.Api/Migrations/20260901102233_AddPeerMaxPrefix.cs
+++ b/BGPLite.Api/Migrations/20260901102233_AddPeerMaxPrefix.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BGPLite.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPeerMaxPrefix : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "MaxPrefix",
+                table: "Peers",
+                type: "INTEGER",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MaxPrefix",
+                table: "Peers");
+        }
+    }
+}

--- a/BGPLite.Api/PeerDetailDto.cs
+++ b/BGPLite.Api/PeerDetailDto.cs
@@ -24,4 +24,5 @@ public sealed record PeerDetailDto(
     List<string> CustomPrefixes,
     List<uint> CustomAsns,
     List<PeerSourceView> CustomSources,
-    List<long> Communities);
+    List<long> Communities,
+    int? MaxPrefix = null);

--- a/BGPLite.Api/PeerStore.cs
+++ b/BGPLite.Api/PeerStore.cs
@@ -8,7 +8,7 @@ namespace BGPLite.Api;
 /// <summary>The persisted state of a peer row right after an upsert (#267 item 6): everything the
 /// POST /api/peers response needs, returned from the upsert's RETURNING clause instead of a
 /// follow-up read.</summary>
-public sealed record SavedPeer(string Id, string Status, DateTime CreatedAt);
+public sealed record SavedPeer(string Id, string Status, DateTime CreatedAt, int? MaxPrefix = null);
 
 public sealed class PeerStore : IPeerStore
 {
@@ -32,7 +32,7 @@ public sealed class PeerStore : IPeerStore
     /// an enclosing transaction (#259) instead of always committing on its own. Behaviour is
     /// unchanged from the #227 implementation this was extracted from.
     /// </summary>
-    private static async Task<SavedPeer> UpsertPeerRowAsync(BgpDbContext db, string ip, uint asn, string? description, CancellationToken ct)
+    private static async Task<SavedPeer> UpsertPeerRowAsync(BgpDbContext db, string ip, uint asn, string? description, CancellationToken ct, int? maxPrefix = null)
     {
         // #227: atomic SQLite upsert eliminates the read-then-write race on the composite unique
         // index UX_Peers_Ip_Asn. Two concurrent CreatePeer calls for the same (Ip, Asn) previously
@@ -62,22 +62,24 @@ public sealed class PeerStore : IPeerStore
             }
             using var cmd = connection.CreateCommand();
             cmd.CommandText =
-                "INSERT INTO Peers (Id, Ip, Asn, Description, Status, CreatedAt, LastSessionAt) " +
-                "VALUES (@id, @ip, @asn, @desc, 'inactive', @now, NULL) " +
-                "ON CONFLICT(Ip, Asn) DO UPDATE SET Description = excluded.Description " +
-                "RETURNING Id, Status, CreatedAt";
+                "INSERT INTO Peers (Id, Ip, Asn, Description, Status, CreatedAt, LastSessionAt, MaxPrefix) " +
+                "VALUES (@id, @ip, @asn, @desc, 'inactive', @now, NULL, @maxprefix) " +
+                "ON CONFLICT(Ip, Asn) DO UPDATE SET Description = excluded.Description, MaxPrefix = excluded.MaxPrefix " +
+                "RETURNING Id, Status, CreatedAt, MaxPrefix";
             AddParam(cmd, "@id", id);
             AddParam(cmd, "@ip", ip);
             AddParam(cmd, "@asn", (long)asn);
             AddParam(cmd, "@desc", (object?)description ?? DBNull.Value);
             AddParam(cmd, "@now", now);
+            AddParam(cmd, "@maxprefix", (object?)maxPrefix ?? DBNull.Value);
             using var reader = await cmd.ExecuteReaderAsync(ct);
             await reader.ReadAsync(ct);
             return new SavedPeer(
                 reader.GetString(0),
                 reader.GetString(1),
                 // CreatedAt is written in the "O" (round-trip) format above.
-                DateTime.Parse(reader.GetString(2), CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind));
+                DateTime.Parse(reader.GetString(2), CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind),
+                reader.IsDBNull(3) ? null : reader.GetInt32(3));
         }
         finally
         {
@@ -167,6 +169,20 @@ public sealed class PeerStore : IPeerStore
     }
 
     /// <summary>
+    /// Resolves the peer's per-peer prefix ceiling (#391): the row's <c>MaxPrefix</c> override or
+    /// <c>null</c> when the peer is unknown / has no override. A light single-column read — the
+    /// session calls it once per establish/refresh cycle, never per UPDATE.
+    /// </summary>
+    public async Task<int?> GetPeerMaxPrefixAsync(string ip, uint asn, CancellationToken ct = default)
+    {
+        using var db = _dbFactory.CreateDbContext();
+        return await db.Peers.AsNoTracking()
+            .Where(p => p.Ip == ip && p.Asn == asn)
+            .Select(p => p.MaxPrefix)
+            .FirstOrDefaultAsync(ct);
+    }
+
+    /// <summary>
     /// Single-roundtrip replacement for the <c>GetPeer</c> + <c>UpdateSessionStatus</c> +
     /// <c>GetSubscriptions</c> + <c>GetCustomPrefixes</c> + <c>GetCustomAsns</c> sequence the BGP
     /// send path used to issue as FIVE separate <c>DbContext</c>s (issue #84). Loads the peer by
@@ -224,7 +240,8 @@ public sealed class PeerStore : IPeerStore
             // already excluded paused rows at the SQL level.
             peer.CustomSources
                 .Select(c => new CustomSourceView(c.Name, c.Url, c.Community))
-                .ToList());
+                .ToList(),
+            peer.MaxPrefix);
     }
 
     /// <summary>
@@ -272,7 +289,9 @@ public sealed class PeerStore : IPeerStore
                     .Select(c => new PeerSourceView(c.Id, c.Name, c.Url, c.Community, c.Active))
                     .ToList(),
                 // Communities stored as long (PeerCommunity.Community); the API formats to "ASN:VAL".
-                p.Communities.Select(c => c.Community).ToList()))
+                p.Communities.Select(c => c.Community).ToList(),
+                // #391: the per-peer prefix ceiling (NULL = inherit Bgp.MaxPrefixesPerPeer).
+                p.MaxPrefix))
             .AsSplitQuery()
             .FirstOrDefaultAsync(ct);
         await read.CommitAsync(ct);
@@ -301,12 +320,12 @@ public sealed class PeerStore : IPeerStore
         string ip, uint asn, string? description,
         IReadOnlyList<string> asnListNames,
         IReadOnlyList<(string Prefix, byte Length)> customPrefixes,
-        IReadOnlyList<uint> customAsns, CancellationToken ct = default)
+        IReadOnlyList<uint> customAsns, int? maxPrefix = null, CancellationToken ct = default)
     {
         using var db = _dbFactory.CreateDbContext();
         using var tx = await db.Database.BeginTransactionAsync(ct);
 
-        var saved = await UpsertPeerRowAsync(db, ip, asn, description, ct);
+        var saved = await UpsertPeerRowAsync(db, ip, asn, description, ct, maxPrefix);
         await ReplaceSubscriptionsAsync(db, saved.Id, asnListNames, ct);
         await ReplaceCustomPrefixesAsync(db, saved.Id, customPrefixes, ct);
         await ReplaceCustomAsnsAsync(db, saved.Id, customAsns, ct);
@@ -325,7 +344,7 @@ public sealed class PeerStore : IPeerStore
         string peerId, string? description,
         IReadOnlyList<string>? asnListNames,
         IReadOnlyList<(string Prefix, byte Length)>? customPrefixes,
-        IReadOnlyList<uint>? customAsns, CancellationToken ct = default)
+        IReadOnlyList<uint>? customAsns, int? maxPrefix = null, CancellationToken ct = default)
     {
         using var db = _dbFactory.CreateDbContext();
         using var tx = await db.Database.BeginTransactionAsync(ct);
@@ -334,6 +353,13 @@ public sealed class PeerStore : IPeerStore
         {
             await db.Peers.Where(p => p.Id == peerId)
                 .ExecuteUpdateAsync(s => s.SetProperty(p => p.Description, description), ct);
+        }
+        // #391: maxPrefix follows the PATCH pattern — null means "leave it alone"; an explicit
+        // value (including 0 = unlimited for this peer) is set. The create path always sets it.
+        if (maxPrefix is not null)
+        {
+            await db.Peers.Where(p => p.Id == peerId)
+                .ExecuteUpdateAsync(s => s.SetProperty(p => p.MaxPrefix, maxPrefix), ct);
         }
         if (asnListNames is not null) await ReplaceSubscriptionsAsync(db, peerId, asnListNames, ct);
         if (customPrefixes is not null) await ReplaceCustomPrefixesAsync(db, peerId, customPrefixes, ct);

--- a/BGPLite.Contracts/IPeerStore.cs
+++ b/BGPLite.Contracts/IPeerStore.cs
@@ -13,6 +13,14 @@ public interface IPeerStore
     Task UpsertPeerAsync(string ip, uint asn, CancellationToken ct = default);
     Task UpdateSessionStatusAsync(string ip, uint asn, bool active, CancellationToken ct = default);
     Task<PeerRoutingView?> LoadPeerRoutingViewAsync(string ip, uint asn, CancellationToken ct = default);
+
+    /// <summary>
+    /// Resolves the peer's effective per-peer prefix ceiling (#391): the row's <c>MaxPrefix</c>
+    /// override, or <c>null</c> when the peer is unknown / has no override (the caller then uses
+    /// the global <c>Bgp.MaxPrefixesPerPeer</c>). Read once per establish/refresh cycle by the
+    /// session — never per UPDATE.
+    /// </summary>
+    Task<int?> GetPeerMaxPrefixAsync(string ip, uint asn, CancellationToken ct = default);
 }
 
 public class PeerInfo
@@ -45,4 +53,5 @@ public sealed record PeerRoutingView(
     List<string> Subscriptions,
     List<string> CustomPrefixes,
     List<uint> CustomAsns,
-    List<CustomSourceView> UserSources);
+    List<CustomSourceView> UserSources,
+    int? MaxPrefix = null);

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -31,6 +31,11 @@ public sealed class BgpSession : IDisposable
     private readonly ILogger<BgpSession> _logger;
     private readonly CancellationTokenSource _cts = new();
     private readonly Func<string, uint, CancellationToken, Task>? _onPeerIdentified;
+    // #391: the EFFECTIVE per-peer prefix ceiling — the peer row's MaxPrefix override when the
+    // peer is configured, else the global Bgp.MaxPrefixesPerPeer. Resolved once per
+    // establish/refresh cycle in SendAllRoutesAsync (never per UPDATE); read on the UPDATE path
+    // via Volatile.Read. Int semantics: 0 = unlimited, > 0 = the cap.
+    private int _effectiveMaxPrefix;
     private readonly IPeerStore? _peerStore;
     // #265 item 1: set by BgpServer right after creation — "is this session still the registered
     // one?" A false answer at teardown-time means a replacement took the slot and owns the
@@ -264,6 +269,7 @@ public sealed class BgpSession : IDisposable
         _peerConfig = peerConfig;
         _peer = peerConfig.ToString();
         _bgpConfig = bgpConfig;
+        _effectiveMaxPrefix = bgpConfig.MaxPrefixesPerPeer;
         _routeTable = routeTable;
         _routeFilter = routeFilter;
         _metrics = metrics;
@@ -991,7 +997,7 @@ public sealed class BgpSession : IDisposable
                     // loop's treat-as-withdraw filter does not swallow it — it unwinds to RunAsync's
                     // BgpNotificationException handler, which sends the NOTIFICATION and tears the
                     // session down (owned routes are flushed by the finally, RFC 4271 §8.2.2).
-                    var cap = _bgpConfig.MaxPrefixesPerPeer;
+                    var cap = Volatile.Read(ref _effectiveMaxPrefix);
                     if (cap > 0 && !_installedPrefixes.ContainsKey(nlri) && _installedPrefixes.Count >= cap)
                         throw new BgpNotificationException(
                             BgpConstants.Error.Cease, BgpConstants.SubError.CeaseMaxPrefixes,
@@ -1078,6 +1084,16 @@ public sealed class BgpSession : IDisposable
     /// </summary>
     private async Task SendAllRoutesAsync()
     {
+        // #391: refresh the effective per-peer prefix ceiling once per cycle — the peer row's
+        // MaxPrefix override when the peer is configured (operator edits apply on the next
+        // refresh), else the global default. Unknown peers (auto-register path) read null here
+        // and keep the global cap until their row exists.
+        if (_peerStore is not null)
+        {
+            var overrideCap = await _peerStore.GetPeerMaxPrefixAsync(_peerConfig.Address, _remoteAsn, _cts.Token);
+            Volatile.Write(ref _effectiveMaxPrefix, overrideCap ?? _bgpConfig.MaxPrefixesPerPeer);
+        }
+
         var nextHop = BgpConstants.IPAddressToUint(_bgpConfig.GetRouterIdAddress());
         var routes = await _routeAssembler.BuildOutboundRoutesAsync(
             _peerConfig.Address, _remoteAsn, GetFilterPeerConfig(), _peer, _cts.Token);

--- a/BGPLite.Tests/ApiHandlerBehaviorTests.cs
+++ b/BGPLite.Tests/ApiHandlerBehaviorTests.cs
@@ -152,6 +152,51 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
         Assert.Equal(HttpStatusCode.RequestEntityTooLarge, tooLarge.StatusCode);
     }
 
+    [Fact]
+    public async Task MaxPrefix_CreateValidate_DetailRoundtrip()
+    {
+        var config = new AppConfig { Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" } };
+        _port = await StartAsync(config);
+        _client = new HttpClient();
+
+        // Negative MaxPrefix is rejected at the boundary.
+        using (var bad = await _client.PostAsync($"http://127.0.0.1:{_port}/api/peers",
+            new StringContent("""{"ip":"198.51.100.8","asn":65011,"maxPrefix":-1}""", Encoding.UTF8, "application/json")))
+            Assert.Equal(HttpStatusCode.BadRequest, bad.StatusCode);
+
+        // Create with an override → the response echoes MaxPrefix and carries the durable id.
+        string peerId;
+        using (var ok = await _client.PostAsync($"http://127.0.0.1:{_port}/api/peers",
+            new StringContent("""{"ip":"198.51.100.8","asn":65011,"maxPrefix":5000}""", Encoding.UTF8, "application/json")))
+        {
+            Assert.Equal(HttpStatusCode.OK, ok.StatusCode);
+            using var doc = JsonDocument.Parse(await ok.Content.ReadAsStringAsync());
+            peerId = doc.RootElement.GetProperty("id").GetString()!;
+            Assert.Equal(5000, doc.RootElement.GetProperty("maxPrefix").GetInt32());
+        }
+
+        // Sanity: the created peer must be readable by id immediately.
+        using (var sanity = await _client.GetAsync($"http://127.0.0.1:{_port}/api/peers/{peerId}"))
+            Assert.True(sanity.IsSuccessStatusCode, $"sanity get: {(int)sanity.StatusCode}");
+
+        // PUT /api/peers/{id} — MaxPrefix PATCH-style: omitted leaves it; explicit 0 sets
+        // unlimited-for-peer. (The update route is PUT; field semantics are partial.)
+        using (var put = new HttpRequestMessage(HttpMethod.Put, $"http://127.0.0.1:{_port}/api/peers/{peerId}")
+        {
+            Content = new StringContent("""{"maxPrefix":0}""", Encoding.UTF8, "application/json")
+        })
+        using (var response = await _client.SendAsync(put))
+            Assert.True(response.IsSuccessStatusCode,
+                $"put: {(int)response.StatusCode} {await response.Content.ReadAsStringAsync()} peerId='{peerId}'");
+
+        using (var detail = await _client.GetAsync($"http://127.0.0.1:{_port}/api/peers/{peerId}"))
+        {
+            var json = await detail.Content.ReadAsStringAsync();
+            Assert.True(detail.IsSuccessStatusCode, $"detail: {(int)detail.StatusCode} {json} peerId={peerId}");
+            Assert.Contains("\"maxPrefix\":0", json);
+        }
+    }
+
     private static int FreeTcpPort()
     {
         using var socket = new System.Net.Sockets.Socket(System.Net.Sockets.AddressFamily.InterNetwork, System.Net.Sockets.SocketType.Stream, System.Net.Sockets.ProtocolType.Tcp);

--- a/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
+++ b/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
@@ -505,6 +505,9 @@ public class BgpSessionRouteOwnershipTests
     private sealed class RecordingPeerStore : IPeerStore
     {
         public List<(string Ip, uint Asn, bool Active)> StatusWrites = [];
+        /// <summary>#391: the per-peer MaxPrefix override returned by GetPeerMaxPrefixAsync
+        /// (null = no row / no override — the session falls back to the global cap).</summary>
+        public int? MaxPrefixOverride;
         public Task<string> CreatePeerAsync(string ip, uint asn, string? description, CancellationToken ct = default) => Task.FromResult("id");
         public Task UpsertPeerAsync(string ip, uint asn, CancellationToken ct = default) => Task.CompletedTask;
         public Task UpdateSessionStatusAsync(string ip, uint asn, bool active, CancellationToken ct = default)
@@ -512,6 +515,8 @@ public class BgpSessionRouteOwnershipTests
             StatusWrites.Add((ip, asn, active));
             return Task.CompletedTask;
         }
+        public Task<int?> GetPeerMaxPrefixAsync(string ip, uint asn, CancellationToken ct = default)
+            => Task.FromResult(MaxPrefixOverride);
         public Task<PeerRoutingView?> LoadPeerRoutingViewAsync(string ip, uint asn, CancellationToken ct = default)
             => Task.FromResult<PeerRoutingView?>(new("id", [], [], [], []));
     }
@@ -736,6 +741,104 @@ public class BgpSessionRouteOwnershipTests
         Assert.NotNull(notif);
         Assert.Equal(BgpConstants.SubError.CeaseMaxPrefixes, notif.SubErrorCode);
         Assert.Equal(0, routeTable.Count);                  // owned routes flushed by the finally
+    }
+
+    /// <summary>#391: waits for the route table to reach the expected size. Generous timeout:
+    /// a cold-JIT first run can take longer than SettleAsync's 2 s window to get from
+    /// Established through the establish dump to a started read loop.</summary>
+    private static async Task WaitForRouteCountAsync(RouteTable routeTable, int expected)
+    {
+        while (routeTable.Count < expected)
+            await Task.Delay(TimeSpan.FromMilliseconds(20));
+    }
+
+    /// <summary>#391: establishes a session whose peer store returns a per-peer MaxPrefix
+    /// override on top of a global cap. Exercises the effective-cap resolution in
+    /// SendAllRoutesAsync (override ?? global) on the establish path.</summary>
+    private static async Task<(BgpSession Session, Task Run, ScriptedConnection Conn, RouteTable Table, RecordingPeerStore Store)>
+        EstablishWithMaxPrefixOverrideAsync(int globalCap, int? overrideCap)
+    {
+        var routeTable = new RouteTable();
+        var conn = new ScriptedConnection();
+        var config = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0, MaxPrefixesPerPeer = globalCap };
+        var store = new RecordingPeerStore { MaxPrefixOverride = overrideCap };
+        var session = new BgpSession(
+            conn, new PeerConfig { Address = "127.0.0.1" }, config, routeTable,
+            AllowAllFilter.Instance, new BgpMetrics(), NullLogger<BgpSession>.Instance,
+            peerStore: store);
+        var run = session.RunAsync();
+        conn.EnqueueMessage(new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = 0,
+            RouterId = 0x0A000002,
+            Capabilities = [BgpCapabilityInfo.FourOctetAsn(65002)],
+        });
+        conn.EnqueueMessage(BgpKeepaliveMessage.Instance);
+        for (var i = 0; i < 200 && !session.IsEstablished; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        Assert.True(session.IsEstablished, "session must reach Established");
+        return (session, run, conn, routeTable, store);
+    }
+
+    [Fact]
+    public async Task PerPeerMaxPrefixOverride_Wins_OverLooserGlobalCap()
+    {
+        // Global cap 10, peer override 1: the SECOND distinct prefix trips Cease/MaxPrefixes.
+        // RED pre-fix: the effective cap was always the global one, so both prefixes were accepted.
+        var (session, run, conn, routeTable, _) = await EstablishWithMaxPrefixOverrideAsync(globalCap: 10, overrideCap: 1);
+
+        conn.EnqueueFrame(AnnounceFrame(8, 0x0A));
+        await WaitForRouteCountAsync(routeTable, 1);
+        Assert.True(session.IsEstablished);
+
+        conn.EnqueueFrame(AnnounceFrame(24, 0xC0, 0x00, 0x02)); // 2nd distinct prefix — over the override
+        var completed = await Task.WhenAny(run, Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.Same(run, completed);
+        var notif = conn.Sent
+            .Select(b => BgpMessageReader.ReadMessage(b.AsSpan()))
+            .OfType<BgpNotificationMessage>()
+            .SingleOrDefault(n => n.ErrorCode == BgpConstants.Error.Cease);
+        Assert.NotNull(notif);
+        Assert.Equal(BgpConstants.SubError.CeaseMaxPrefixes, notif.SubErrorCode);
+    }
+
+    [Fact]
+    public async Task PerPeerMaxPrefixOverride_Zero_IsUnlimited_ForThisPeer()
+    {
+        // Global cap 2, peer override 0 ("unlimited for this peer"): three prefixes all install.
+        // RED pre-fix: the global cap was applied, so the third prefix tore the session down.
+        var routeTable = new RouteTable();
+        var (session, run, conn, _, _) = await EstablishWithMaxPrefixOverrideAsync(globalCap: 2, overrideCap: 0);
+
+        for (var i = 0; i < 3; i++)
+            conn.EnqueueFrame(AnnounceFrame(24, 0xC0, 0x00, (byte)(10 + i)));
+        await SettleAsync(conn);
+
+        Assert.True(session.IsEstablished, $"override 0 = unlimited; count={routeTable.Count}; run={run.Status}; exc={run.Exception?.GetBaseException().GetType().Name}:{run.Exception?.GetBaseException().Message}");
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task PerPeerMaxPrefixOverride_Absent_FallsBackToGlobalCap()
+    {
+        // No override (null): the global cap applies — this pins the ?? fallback itself.
+        var (session, run, conn, routeTable, _) = await EstablishWithMaxPrefixOverrideAsync(globalCap: 1, overrideCap: null);
+
+        conn.EnqueueFrame(AnnounceFrame(8, 0x0A));
+        await WaitForRouteCountAsync(routeTable, 1);
+        Assert.True(session.IsEstablished);
+
+        conn.EnqueueFrame(AnnounceFrame(24, 0xC0, 0x00, 0x02)); // 2nd distinct prefix — over the global cap
+        var completed = await Task.WhenAny(run, Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.Same(run, completed);
+        var notif = conn.Sent
+            .Select(b => BgpMessageReader.ReadMessage(b.AsSpan()))
+            .OfType<BgpNotificationMessage>()
+            .SingleOrDefault(n => n.ErrorCode == BgpConstants.Error.Cease);
+        Assert.NotNull(notif);
+        Assert.Equal(BgpConstants.SubError.CeaseMaxPrefixes, notif.SubErrorCode);
     }
 
     [Fact]

--- a/BGPLite.Tests/BgpSessionShutdownTests.cs
+++ b/BGPLite.Tests/BgpSessionShutdownTests.cs
@@ -126,6 +126,7 @@ public class BgpSessionShutdownTests
         public Task UpsertPeerAsync(string ip, uint asn, CancellationToken ct = default) => throw new NotSupportedException();
         public Task UpdateSessionStatusAsync(string ip, uint asn, bool active, CancellationToken ct = default) =>
             throw new InvalidOperationException("simulated: database is locked");
+        public Task<int?> GetPeerMaxPrefixAsync(string ip, uint asn, CancellationToken ct = default) => Task.FromResult<int?>(null);
         public Task<PeerRoutingView?> LoadPeerRoutingViewAsync(string ip, uint asn, CancellationToken ct = default) => throw new NotSupportedException();
     }
 

--- a/BGPLite.Tests/CompositionContractTests.cs
+++ b/BGPLite.Tests/CompositionContractTests.cs
@@ -252,6 +252,7 @@ public class CompositionContractTests
             return Task.CompletedTask;
         }
         public Task UpdateSessionStatusAsync(string ip, uint asn, bool active, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<int?> GetPeerMaxPrefixAsync(string ip, uint asn, CancellationToken ct = default) => Task.FromResult<int?>(null);
         public Task<string> CreatePeerAsync(string ip, uint asn, string? description, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<PeerRoutingView?> LoadPeerRoutingViewAsync(string ip, uint asn, CancellationToken ct = default) => throw new NotSupportedException();
     }

--- a/BGPLite.Tests/PeerStoreConfigurationAtomicityTests.cs
+++ b/BGPLite.Tests/PeerStoreConfigurationAtomicityTests.cs
@@ -153,6 +153,40 @@ public class PeerStoreConfigurationAtomicityTests
         Assert.Equal("initial", (await store.GetDbPeerByIdAsync(id))!.Description);
     }
 
+    /// <summary>
+    /// #391: the per-peer MaxPrefix override persists through the create/update paths: create
+    /// writes it (NULL when omitted = inherit the global cap), update follows PATCH semantics
+    /// (null = leave alone, explicit value including 0 = set), and the light session read
+    /// (<c>GetPeerMaxPrefixAsync</c>) sees the effective value.
+    /// </summary>
+    [Fact]
+    public async Task MaxPrefix_CreateUpdate_Roundtrip()
+    {
+        var (store, connection) = NewStore();
+        using var _ = connection;
+
+        // Create without MaxPrefix → NULL (inherit global).
+        var id = (await store.SavePeerConfigurationAsync(Ip, Asn, "no override",
+            asnListNames: ["ru"], customPrefixes: [], customAsns: [])).MaxPrefix;
+        Assert.Null(id);
+        Assert.Null(await store.GetPeerMaxPrefixAsync(Ip, Asn));
+
+        // Create WITH an override.
+        var saved = await store.SavePeerConfigurationAsync("203.0.113.31", Asn, "with override",
+            asnListNames: ["ru"], customPrefixes: [], customAsns: [], maxPrefix: 5000);
+        Assert.Equal(5000, saved.MaxPrefix);
+        Assert.Equal(5000, await store.GetPeerMaxPrefixAsync("203.0.113.31", Asn));
+
+        // PATCH: null leaves it alone; explicit 0 sets "unlimited for this peer".
+        await store.UpdatePeerConfigurationAsync(saved.Id, description: null,
+            asnListNames: null, customPrefixes: null, customAsns: null, maxPrefix: null);
+        Assert.Equal(5000, await store.GetPeerMaxPrefixAsync("203.0.113.31", Asn));
+
+        await store.UpdatePeerConfigurationAsync(saved.Id, description: null,
+            asnListNames: null, customPrefixes: null, customAsns: null, maxPrefix: 0);
+        Assert.Equal(0, await store.GetPeerMaxPrefixAsync("203.0.113.31", Asn));
+    }
+
     /// <summary>A store over an in-memory SQLite DB that records every transaction EF opens.</summary>
     private static (PeerStore Store, SqliteConnection Connection, List<string> Transactions) NewStoreCountingTransactions()
     {

--- a/BGPLite.Tests/PeerStoreKeyingTests.cs
+++ b/BGPLite.Tests/PeerStoreKeyingTests.cs
@@ -330,7 +330,7 @@ public class PeerStoreKeyingTests
         using var check = new BgpDbContext(options);
         var applied = check.Database.SqlQueryRaw<string>(
             "SELECT \"MigrationId\" AS \"Value\" FROM __EFMigrationsHistory ORDER BY \"MigrationId\"").ToList();
-        Assert.Equal(["20260826182256_Init", "20260826182324_LegacyEnsureCreated"], applied);
+        Assert.Equal(["20260826182256_Init", "20260826182324_LegacyEnsureCreated", "20260901102233_AddPeerMaxPrefix"], applied);
         // The full schema is in place (spot-check a table from each era).
         Assert.NotNull(check.Peers);
     }

--- a/BGPLite.Tests/RefreshDebounceTests.cs
+++ b/BGPLite.Tests/RefreshDebounceTests.cs
@@ -30,6 +30,7 @@ public class RefreshDebounceTests
         public Task<string> CreatePeerAsync(string ip, uint asn, string? description, CancellationToken ct = default) => Task.FromResult("peer");
         public Task UpsertPeerAsync(string ip, uint asn, CancellationToken ct = default) => Task.CompletedTask;
         public Task UpdateSessionStatusAsync(string ip, uint asn, bool active, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<int?> GetPeerMaxPrefixAsync(string ip, uint asn, CancellationToken ct = default) => Task.FromResult<int?>(null);
 
         public async Task<PeerRoutingView?> LoadPeerRoutingViewAsync(string ip, uint asn, CancellationToken ct = default)
         {

--- a/BGPLite.Tests/RouteAssemblerCancellationTests.cs
+++ b/BGPLite.Tests/RouteAssemblerCancellationTests.cs
@@ -80,6 +80,7 @@ public sealed class RouteAssemblerCancellationTests
         public Task<string> CreatePeerAsync(string ip, uint asn, string? description, CancellationToken ct = default) => Task.FromResult("id");
         public Task UpsertPeerAsync(string ip, uint asn, CancellationToken ct = default) => Task.CompletedTask;
         public Task UpdateSessionStatusAsync(string ip, uint asn, bool active, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<int?> GetPeerMaxPrefixAsync(string ip, uint asn, CancellationToken ct = default) => Task.FromResult<int?>(null);
         public Task<PeerRoutingView?> LoadPeerRoutingViewAsync(string ip, uint asn, CancellationToken ct = default)
             => Task.FromResult<PeerRoutingView?>(new("id", [], [], [], []));
     }

--- a/BGPLite.Tests/RouteAssemblerSuppressionTests.cs
+++ b/BGPLite.Tests/RouteAssemblerSuppressionTests.cs
@@ -187,6 +187,7 @@ public class RouteAssemblerSuppressionTests
         public Task<string> CreatePeerAsync(string ip, uint asn, string? description, CancellationToken ct = default) => Task.FromResult("id");
         public Task UpsertPeerAsync(string ip, uint asn, CancellationToken ct = default) => Task.CompletedTask;
         public Task UpdateSessionStatusAsync(string ip, uint asn, bool active, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<int?> GetPeerMaxPrefixAsync(string ip, uint asn, CancellationToken ct = default) => Task.FromResult<int?>(null);
         public Task<PeerRoutingView?> LoadPeerRoutingViewAsync(string ip, uint asn, CancellationToken ct = default)
             => Task.FromResult<PeerRoutingView?>(new("id", [], customPrefixes, customAsns, []));
     }

--- a/BGPLite.Tests/RouteRefreshHoldTimerTests.cs
+++ b/BGPLite.Tests/RouteRefreshHoldTimerTests.cs
@@ -32,6 +32,7 @@ public class RouteRefreshHoldTimerTests
         public Task<string> CreatePeerAsync(string ip, uint asn, string? description, CancellationToken ct = default) => Task.FromResult("peer");
         public Task UpsertPeerAsync(string ip, uint asn, CancellationToken ct = default) => Task.CompletedTask;
         public Task UpdateSessionStatusAsync(string ip, uint asn, bool active, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<int?> GetPeerMaxPrefixAsync(string ip, uint asn, CancellationToken ct = default) => Task.FromResult<int?>(null);
 
         public async Task<PeerRoutingView?> LoadPeerRoutingViewAsync(string ip, uint asn, CancellationToken ct = default)
         {


### PR DESCRIPTION
Closes #391
Refs #10 (MaxPrefix item), #304 (global cap)

## Problem
`Bgp.MaxPrefixesPerPeer` (#304) applies one ceiling to every peer. A route server needs per-peer headroom: a heavy transit peer may warrant a larger cap, a stub peer a smaller one — without touching the global default for everyone.

## Scope correction (vs the issue text)
The issue (from the #10 audit) proposed `PeerConfig.MaxPrefix` — but the YAML `Peers` list never reaches sessions: the accept loop builds `PeerConfig { Address, Port }` from the remote endpoint (BgpServer.cs:183), and production peer config lives in **SQLite**, reaching sessions via `PeerRoutingView`. So the override is implemented in the SQLite peer config + API, which is where peers are actually managed. Design recorded in the issue comment.

## Fix
- **Schema**: `Peers.MaxPrefix (int?, NULL)` — EF migration `AddPeerMaxPrefix`. NULL = inherit the global cap; explicit **0 = unlimited for this peer**.
- **Contract**: `IPeerStore.GetPeerMaxPrefixAsync(ip, asn, ct)` — a light single-column read (session-layer concern, consistent with the #262 contract shape).
- **Session**: `SendAllRoutesAsync` resolves the effective cap once per establish/refresh cycle (`override ?? global`) into a volatile field; `HandleUpdateAsync` enforces against it. The Cease/MaxPrefixes path, RFC 4486 subcode 1, and the 75% one-shot warning are unchanged. Operator edits apply on the next refresh cycle (`RefreshPeerAsync` fires on save).
- **CRUD/API**: `PeerRoutingView`/`PeerDetailDto` carry `MaxPrefix`; `POST`/`PUT /api/peers` accept it (negative → 400; omitted on update = leave alone, PATCH-style field semantics on the PUT route); create/update/detail responses echo it.

## Tests
- Session (scripted connection + fake store): **override wins over a looser global cap** (2nd prefix → Cease subcode 1); **override 0 = unlimited** for this peer (3 prefixes install under a global cap of 2); **absent override falls back** to the global cap.
- Store (in-memory SQLite): create writes NULL/explicit override; `GetPeerMaxPrefixAsync` sees it; update PATCH semantics (null leaves, 0 sets).
- API end-to-end (real listener): negative `maxPrefix` → 400; create echoes `maxPrefix` and the id; PUT with 0 → detail shows `"maxPrefix":0`.
- `PeerStoreKeyingTests.Initialize_FreshDatabase_AppliesMigrations_And_IsIdempotent` — migration list expectation updated.

## Verification
- dotnet format / dotnet build BGPLite.sln (0 errors) / dotnet test BGPLite.sln: **902/902 passed** (baseline 897).

## RFC
RFC 4271 §6.7 / RFC 4486 §2 (Cease subcode 1 — already enforced by #304; unchanged).

## Behavior Change
None by default (NULL override inherits the global cap); operators gain a per-peer override via the API/YAML-free peer config.

## Deviation from Issue Proposal
`PeerConfig.MaxPrefix` replaced by the SQLite peer-config field — the YAML Peers list is not a live session input (see Scope correction).
