### PR TITLE
fix(routing): community-less routes are denied under an active per-peer allowlist (#389)

### DIFF
--- a/BGPLite.Routing/PeerCommunityFilter.cs
+++ b/BGPLite.Routing/PeerCommunityFilter.cs
@@ -34,8 +34,11 @@ public sealed class PeerCommunityFilter : IRouteFilter
         if (allowSet.Count == 0)
             return true; // no filter = all routes
 
+        // #389: with an ACTIVE allowlist, a community-less route is an untagged stranger — the
+        // operator's allowlist is the peer's consent to receive specific tags, and an untagged
+        // route carries no such consent. Default-deny; documented as D20.
         if (route.Communities.Count == 0)
-            return true; // routes without community always pass
+            return false;
 
         foreach (var c in route.Communities)
         {

--- a/BGPLite.Tests/PeerCommunityFilterTests.cs
+++ b/BGPLite.Tests/PeerCommunityFilterTests.cs
@@ -129,9 +129,22 @@ public class PeerCommunityFilterTests
     [Fact]
     public async Task RouteWithoutCommunity_StillPasses_WhenNoFilterConfigured()
     {
+        // No allowlist = no filter: everything passes, tagged or not (D20 fast path).
         var filter = NewFilter();
 
         Assert.True(await Outgoing(filter, RouteWith(), EbgpPeer));
+    }
+
+    [Fact]
+    public async Task RouteWithoutCommunity_IsRejected_WhenAllowlistActive()
+    {
+        // #389 (D20): a community-less route carries no consent tag — under an ACTIVE allowlist
+        // it is denied, not unconditionally admitted. RED pre-fix: it passed the filter.
+        var allowed = new HashSet<uint> { 0x0000FF01 };
+        var filter = NewFilter((_, _, _) => Task.FromResult(allowed));
+
+        Assert.False(await Outgoing(filter, RouteWith(), EbgpPeer));
+        Assert.False(await Outgoing(filter, RouteWith(), IbgpPeer));
     }
 
     [Fact]

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -214,6 +214,20 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
   deterministic filter, so `_advertisedPrefixes` stays consistent for withdrawals.
 - **Tracker:** #220.
 
+### D20. Community-less routes are denied under an active per-peer allowlist
+- **Decision:** when a peer has an active outgoing community allowlist (`PeerCommunities` set), a
+  route with NO COMMUNITY attribute is rejected; only tagged routes whose tag is in the allowlist
+  pass. The no-allowlist fast path (everything passes) is unchanged.
+- **Context:** the allowlist is the peer's consent to receive specific tags (#79); a community-less
+  route carries no such consent, and the previous default-allow let untagged routes bypass an
+  operator's filter entirely (PeerCommunityFilter.cs, #7 audit). Chosen over documenting
+  default-allow after review (#389) — strictness matches the filter's purpose; in BGPLite every
+  source path stamps communities via `ConfigCommunityResolver`, so community-less routes are
+  exceptional (a failed/absent resolver override), not a legitimate class.
+- **Consequence:** behavior change for deployments that used an allowlist AND relied on untagged
+  routes flowing; such routes now stop at the filter (visible via the existing send logs).
+- **Tracker:** #389.
+
 ## Management API
 
 ### D18. `X-Real-IP` is ignored by default, even behind trusted proxies


### PR DESCRIPTION
Closes #389

## Problem
`PeerCommunityFilter.AcceptOutgoing` admitted ANY route with no COMMUNITY attribute even when the peer had an **active** outgoing community allowlist — an untagged route carried no consent tag yet bypassed the operator's filter entirely. Unchanged since the initial commit; no design-decision cover existed (flagged by the #7 routing-correctness audit).

## Decision
User-approved in #389: **Option A — default-deny**. The allowlist is the peer's consent to receive specific tags; a community-less route carries no such consent and is denied. In BGPLite every source path stamps communities via `ConfigCommunityResolver`, so community-less routes are exceptional (a failed/absent resolver override) — exactly the class an allowlist should stop.

## Fix
`AcceptOutgoing`: the unconditional community-less early-return becomes a deny under an active allowlist. The `allowSet.Count == 0` fast path (no filter configured → everything passes) is unchanged, as are the well-known-community (NoExport/NoAdvertise) rules. Documented as **D20** in docs/DESIGN_DECISIONS.md.

## Regression Test
`RouteWithoutCommunity_IsRejected_WhenAllowlistActive` — eBGP and iBGP peers, active allowlist, community-less route → denied. **RED pre-fix proven** (with the fix temporarily reverted the test fails: the route passed). `RouteWithoutCommunity_StillPasses_WhenNoFilterConfigured` stays green (fast path untouched). Full filter suite 19/19.

## Verification
- dotnet format / dotnet build BGPLite.sln (0 errors) / dotnet test BGPLite.sln: **903/903 passed** (baseline 902).

## RFC
none — operator filtering policy (communities semantics per RFC 1997 unchanged on the wire).

## Behavior Change
**Yes, intentional**: deployments using an outgoing community allowlist AND relying on untagged routes flowing will now see those routes filtered. No-allowlist deployments are unaffected. Documented in D20.
