### PR TITLE
fix(config): fail loud on peer 0.0.0.0/missing RemoteAsn + negative tunables (#390)

### DIFF
--- a/BGPLite.Configuration/AppConfig.cs
+++ b/BGPLite.Configuration/AppConfig.cs
@@ -129,13 +129,25 @@ public sealed class AppConfig
         for (var i = 0; i < Peers.Count; i++)
         {
             var peer = Peers[i];
+            // #390: an omitted Address used to default to "0.0.0.0" and slip through — require a
+            // real unicast address and reject the all-zeros placeholder explicitly.
+            if (string.IsNullOrWhiteSpace(peer.Address))
+                throw new InvalidOperationException(
+                    $"Invalid configuration: Peers[{i}].Address is required — a configured peer must know where it connects from.");
             if (!IPAddress.TryParse(peer.Address, out var address)
-                || address.AddressFamily != AddressFamily.InterNetwork)
+                || address.AddressFamily != AddressFamily.InterNetwork
+                || IPAddress.Any.Equals(address))
             {
                 throw new InvalidOperationException(
-                    $"Invalid configuration: Peers[{i}].Address must be a valid IPv4 address " +
+                    $"Invalid configuration: Peers[{i}].Address must be a valid IPv4 address other than 0.0.0.0 " +
                     $"(got '{peer.Address}').");
             }
+            // #390: a configured peer without a remote ASN can never match an OPEN — fail loud
+            // instead of silently relying on auto-registration.
+            if (peer.RemoteAsn is null)
+                throw new InvalidOperationException(
+                    $"Invalid configuration: Peers[{i}].RemoteAsn is required for a configured peer " +
+                    "(omit the Peers entry entirely to rely on auto-registration).");
         }
 
         // #327: prefix-source errors used to surface only at load time, where LoadAllAsync absorbs
@@ -217,6 +229,34 @@ public sealed class AppConfig
                 throw new InvalidOperationException(
                     $"Invalid configuration: RipeStat.AsnLists[{i}] is empty — each item must be a mapping (Name, Asns, ...).");
             ValidateCommunity(list.Community, $"RipeStat.AsnLists[{i}] ('{list.Name}'): Community");
+        }
+
+        // #390: resilience/auto-refresh tunables were taken verbatim — a negative silently
+        // disabled retries or (worse) scheduled a zero-second timer storm. Fail loud.
+        if (RipeStat is { } ripe)
+        {
+            if (ripe.TimeoutSeconds < 0)
+                throw new InvalidOperationException(
+                    $"Invalid configuration: RipeStat.TimeoutSeconds must be >= 0 seconds (got {ripe.TimeoutSeconds}).");
+            if (ripe.RetryAttempts < 0)
+                throw new InvalidOperationException(
+                    $"Invalid configuration: RipeStat.RetryAttempts must be >= 0 (got {ripe.RetryAttempts}).");
+            if (ripe.RetryDelaySeconds < 0)
+                throw new InvalidOperationException(
+                    $"Invalid configuration: RipeStat.RetryDelaySeconds must be >= 0 seconds (got {ripe.RetryDelaySeconds}).");
+        }
+
+        if (AutoRefresh is { } auto)
+        {
+            if (auto.IntervalSeconds < 1)
+                throw new InvalidOperationException(
+                    $"Invalid configuration: AutoRefresh.IntervalSeconds must be a positive number of seconds (got {auto.IntervalSeconds}).");
+            if (auto.NoEtagIntervalSeconds < 1)
+                throw new InvalidOperationException(
+                    $"Invalid configuration: AutoRefresh.NoEtagIntervalSeconds must be a positive number of seconds (got {auto.NoEtagIntervalSeconds}).");
+            if (auto.MaxJitterMs < 0)
+                throw new InvalidOperationException(
+                    $"Invalid configuration: AutoRefresh.MaxJitterMs must be >= 0 ms (got {auto.MaxJitterMs}).");
         }
     }
 

--- a/BGPLite.Configuration/ConfigLoader.cs
+++ b/BGPLite.Configuration/ConfigLoader.cs
@@ -22,10 +22,4 @@ public static class ConfigLoader
         // hot-reload path logs it and keeps the previous config, as with any other bad edit.
         Deserializer.Deserialize<AppConfig>(yaml)
             ?? throw new InvalidOperationException("The configuration is empty — nothing to load.");
-
-    private static readonly ISerializer Serializer = new SerializerBuilder()
-        .Build();
-
-    public static string Save(AppConfig config) =>
-        Serializer.Serialize(config);
 }

--- a/BGPLite.Configuration/PeerConfig.cs
+++ b/BGPLite.Configuration/PeerConfig.cs
@@ -5,8 +5,10 @@ namespace BGPLite.Configuration;
 
 public sealed class PeerConfig
 {
+    // #390: empty default (was "0.0.0.0") — an omitted Address trips the fail-loud validation
+    // instead of silently configuring a peer at the invalid all-zeros address.
     [YamlMember(Alias = "Address")]
-    public string Address { get; init; } = "0.0.0.0";
+    public string Address { get; init; } = "";
 
     [YamlMember(Alias = "RemoteAsn")]
     public uint? RemoteAsn { get; init; }

--- a/BGPLite.Tests/ConfigValidationTests.cs
+++ b/BGPLite.Tests/ConfigValidationTests.cs
@@ -20,6 +20,36 @@ public class ConfigValidationTests
             MaxPrefixesPerPeer = maxPrefixesPerPeer
         };
 
+    // --- #390: resilience/auto-refresh tunables fail loud --------------------------------------
+
+    [Theory]
+    [InlineData("TimeoutSeconds", -1)]
+    [InlineData("RetryAttempts", -1)]
+    [InlineData("RetryDelaySeconds", -5)]
+    public void Validate_RejectsNegativeRipeStatTunables(string field, int value)
+    {
+        var ripe = new RipeStatConfig();
+        typeof(RipeStatConfig).GetProperty(field)!.SetValue(ripe, value);
+        var config = new AppConfig { Bgp = Bgp(), RipeStat = ripe };
+
+        var ex = Assert.Throws<InvalidOperationException>(() => config.Validate());
+        Assert.Contains($"RipeStat.{field}", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("IntervalSeconds", 0)]
+    [InlineData("NoEtagIntervalSeconds", 0)]
+    [InlineData("MaxJitterMs", -1)]
+    public void Validate_RejectsBadAutoRefreshTunables(string field, int value)
+    {
+        var auto = new AutoRefreshConfig();
+        typeof(AutoRefreshConfig).GetProperty(field)!.SetValue(auto, value);
+        var config = new AppConfig { Bgp = Bgp(), AutoRefresh = auto };
+
+        var ex = Assert.Throws<InvalidOperationException>(() => config.Validate());
+        Assert.Contains($"AutoRefresh.{field}", ex.Message);
+    }
+
     private static AppConfig Config(BgpConfig? bgp = null, int apiPort = 5001, List<PeerConfig>? peers = null,
         List<PrefixSourceConfig>? sources = null, string? defaultSource = null)
         => new()
@@ -397,6 +427,7 @@ public class ConfigValidationTests
     }
 
     [Theory]
+    [InlineData("0.0.0.0")]   // #390: the all-zeros placeholder is never a valid peer address
     [InlineData("not-an-ip")]
     [InlineData("::1")]
     public void Validate_RejectsBadPeerAddress(string address)
@@ -405,6 +436,27 @@ public class ConfigValidationTests
 
         var ex = Assert.Throws<InvalidOperationException>(() => config.Validate());
         Assert.Contains("Peers[0].Address", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_RequiresPeerAddress()
+    {
+        // #390: PeerConfig.Address now defaults to "" so an omitted Address trips validation
+        // instead of silently configuring the all-zeros placeholder.
+        var config = Config(peers: [new PeerConfig { RemoteAsn = 65002 }]);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => config.Validate());
+        Assert.Contains("Peers[0].Address is required", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_RequiresPeerRemoteAsn()
+    {
+        // #390: a configured peer without a remote ASN can never match an OPEN — fail loud.
+        var config = Config(peers: [new PeerConfig { Address = "10.0.0.2" }]);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => config.Validate());
+        Assert.Contains("Peers[0].RemoteAsn is required", ex.Message);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #390
Refs #8

## Problem
Three residual config-validation items from the #8 audit (~75% done): a configured peer at `0.0.0.0` (or with an omitted Address — the default was literally `"0.0.0.0"`) slipped through; `Peers[i].RemoteAsn` was never required; `RipeStat`/`AutoRefresh` integer tunables were taken verbatim (negatives silently disabled retries or risked a zero-second timer storm); `ConfigLoader.Save` had zero callers.

## Fix
- `Peers[i].Address`: empty → "Address is required"; `0.0.0.0` explicitly rejected (was a valid-IPv4 pass); unparseable/non-IPv4 messages unchanged.
- `Peers[i].RemoteAsn`: required — a configured peer without an ASN can never match an OPEN; omitting the whole Peers entry still relies on auto-registration.
- `PeerConfig.Address` default `"0.0.0.0"` → `""` (omission trips validation instead of silently configuring the placeholder).
- `RipeStat.TimeoutSeconds/RetryAttempts/RetryDelaySeconds ≥ 0`; `AutoRefresh.IntervalSeconds/NoEtagIntervalSeconds ≥ 1`, `MaxJitterMs ≥ 0` — clear `InvalidOperationException` messages per field.
- `ConfigLoader.Save` **deleted** (zero callers: state lives in SQLite; YAML is a read-only input) — the #8 atomic-Save item closes as obsolete rather than implemented.

## Tests
ConfigValidationTests (+9): peer all-zeros / missing Address / missing RemoteAsn, negative RipeStat and AutoRefresh tunables (Theory per field). Suite: **918/918** (baseline 909).

## Verification
dotnet format / dotnet build BGPLite.sln (0 errors) / dotnet test BGPLite.sln.

## RFC
none — configuration surface only.

## Behavior Change
Intentional fail-loud: previously-accepted invalid YAML (peer at 0.0.0.0, peer without RemoteAsn, negative tunables) now aborts startup / keeps the previous config on hot reload, per the #8 contract.
