### PR TITLE
test: stabilize CompositionContract factory tests on slow runners

### DIFF
--- a/BGPLite.Tests/CompositionContractTests.cs
+++ b/BGPLite.Tests/CompositionContractTests.cs
@@ -148,6 +148,10 @@ public class CompositionContractTests
         var store = new RecordingPeerStore();
         var (session, run, conn) = await EstablishThroughFactoryAsync(assembler, store);
 
+        // IsEstablished flips BEFORE the establish dump finishes, so give the (async) build a
+        // moment to reach the assembler on a loaded CI runner instead of asserting immediately.
+        for (var i = 0; i < 250 && assembler.Asked == default; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(20));
         Assert.Equal(("127.0.0.1", 65002u), assembler.Asked);
         // The label is the peer's display form, which is what every assembler log line carries.
         Assert.Contains("127.0.0.1", assembler.Label);
@@ -166,6 +170,8 @@ public class CompositionContractTests
         var store = new RecordingPeerStore();
         var (session, run, conn) = await EstablishThroughFactoryAsync(new RecordingAssembler(), store);
 
+        for (var i = 0; i < 250 && store.Upserted == default; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(20));
         Assert.Equal(("127.0.0.1", 65002u), store.Upserted);
 
         await TeardownAsync(session, run, conn);


### PR DESCRIPTION
Follow-up to #399: `Factory_BuildsSessionsThatUseTheInjectedAssembler` / `...RegisterThePeerOnOpen` asserted `assembler.Asked` / `store.Upserted` immediately after `IsEstablished`, but the flag flips BEFORE the establish dump reaches the assembler — on a loaded CI runner the assert raced the async build (flaky failure on PR #398). Both tests now poll briefly (5 s) before asserting. Reproduced as CI-only; 15/15 + CI runs locally.