### PR TITLE
feat(protocol): MP-BGP IPv6/Unicast — phase 2 of #14/#15

### DIFF
--- a/BGPLite.Protocol/BgpCapabilityInfo.cs
+++ b/BGPLite.Protocol/BgpCapabilityInfo.cs
@@ -25,6 +25,14 @@ public sealed class BgpCapabilityInfo
         Data = [(byte)(BgpConstants.Afi.IPv4 >> 8), (byte)BgpConstants.Afi.IPv4, 0x00, BgpConstants.Safi.Unicast]
     };
 
+    /// <summary>MP-BGP IPv6/Unicast capability (RFC 4760 §8, code 1): AFI=2/SAFI=1 (#15 phase 2).
+    /// Signals that this speaker can receive IPv6 routes via MP_REACH_NLRI.</summary>
+    public static BgpCapabilityInfo MultiprotocolIpv6Unicast() => new()
+    {
+        Code = BgpConstants.Capability.Multiprotocol,
+        Data = [(byte)(BgpConstants.Afi.IPv6 >> 8), (byte)BgpConstants.Afi.IPv6, 0x00, BgpConstants.Safi.Unicast]
+    };
+
     /// <summary>
     /// Graceful Restart capability (RFC 4724, code 64) for IPv4/Unicast. Value layout:
     /// byte 0 = Restart Flags (bit 7 = R) | high 4 bits of Restart Time,

--- a/BGPLite.Protocol/BgpMessageReader.cs
+++ b/BGPLite.Protocol/BgpMessageReader.cs
@@ -265,6 +265,8 @@ public static class BgpMessageReader
                 BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList);
 
         var attributes = new List<PathAttribute>();
+        MpReachCodec.MpReachV6? mpReachV6 = null;
+        IReadOnlyList<IpPrefix>? mpUnreachV6 = null;
         if (attrsLen > 0)
         {
             var attrsEnd = offset + attrsLen;
@@ -274,8 +276,26 @@ public static class BgpMessageReader
                 // attribute TLV whose declared value crosses attrsEnd must be rejected instead
                 // of silently consuming NLRI bytes as attribute data (#245 review finding).
                 var (attr, consumed) = ParseAttribute(payload.Slice(offset, attrsEnd - offset));
-                attributes.Add(attr);
                 offset += consumed;
+
+                // #15 phase 2 (RFC 4760): MP_REACH_NLRI (14) / MP_UNREACH_NLRI (15) carry the
+                // IPv6 announcements/withdrawals — decode them into typed fields here and remove
+                // from the generic list so ParseRouteAttributes treats the UPDATE as v4-only.
+                // Malformed AFI=2 payloads throw BgpParseException (Update Message Error) — the
+                // whole UPDATE is discarded with the session kept (D17), matching RFC 7606 §2
+                // (the attribute carries NLRI ⇒ treat-as-withdraw).
+                if (attr.TypeCode == MpReachCodec.MpReachNlriType)
+                {
+                    var reach = MpReachCodec.DecodeMpReachV6(attr.Data);
+                    mpReachV6 = reach;
+                    continue;
+                }
+                if (attr.TypeCode == MpReachCodec.MpUnreachNlriType)
+                {
+                    mpUnreachV6 = MpReachCodec.DecodeMpUnreachV6(attr.Data);
+                    continue;
+                }
+                attributes.Add(attr);
             }
         }
 
@@ -291,7 +311,9 @@ public static class BgpMessageReader
         {
             WithdrawnRoutes = withdrawn,
             PathAttributes = attributes,
-            Nlri = nlri
+            Nlri = nlri,
+            MpReachV6 = mpReachV6,
+            MpUnreachV6 = mpUnreachV6
         };
     }
 

--- a/BGPLite.Protocol/BgpUpdateMessage.cs
+++ b/BGPLite.Protocol/BgpUpdateMessage.cs
@@ -6,4 +6,12 @@ public sealed class BgpUpdateMessage : BgpMessage
     public List<IpPrefix> WithdrawnRoutes { get; init; } = [];
     public List<PathAttribute> PathAttributes { get; init; } = [];
     public List<IpPrefix> Nlri { get; init; } = [];
+
+    /// <summary>Decoded MP_REACH_NLRI (RFC 4760, AFI=2/SAFI=1) IPv6 announcements — extracted from
+    /// the attribute list by the reader (#15 phase 2). Null when the UPDATE carries none.</summary>
+    public MpReachCodec.MpReachV6? MpReachV6 { get; init; }
+
+    /// <summary>Decoded MP_UNREACH_NLRI (RFC 4760, AFI=2/SAFI=1) IPv6 withdrawals. Null/empty when
+    /// the UPDATE carries none.</summary>
+    public IReadOnlyList<IpPrefix>? MpUnreachV6 { get; init; }
 }

--- a/BGPLite.Protocol/CapabilityHelper.cs
+++ b/BGPLite.Protocol/CapabilityHelper.cs
@@ -24,6 +24,21 @@ public static class CapabilityHelper
         return false;
     }
 
+    /// <summary>Detects the MP-BGP IPv6/Unicast capability (AFI=2/SAFI=1) in the peer's OPEN
+    /// (#15 phase 2): the peer can send IPv6 routes via MP_REACH_NLRI.</summary>
+    public static bool SupportsMultiprotocolIpv6Unicast(BgpOpenMessage open)
+    {
+        foreach (var cap in open.Capabilities)
+        {
+            if (cap.Code == BgpConstants.Capability.Multiprotocol &&
+                cap.Data.Length >= 4 &&
+                BinaryPrimitives.ReadUInt16BigEndian(cap.Data) == BgpConstants.Afi.IPv6 &&
+                cap.Data[3] == BgpConstants.Safi.Unicast)
+                return true;
+        }
+        return false;
+    }
+
     public static bool SupportsMultiprotocolIpv4Unicast(BgpOpenMessage open)
     {
         foreach (var cap in open.Capabilities)

--- a/BGPLite.Protocol/MpReachCodec.cs
+++ b/BGPLite.Protocol/MpReachCodec.cs
@@ -1,0 +1,145 @@
+using System.Buffers.Binary;
+using System.Net;
+
+namespace BGPLite.Protocol;
+
+/// <summary>
+/// Wire codec for the MP-BGP IPv6/Unicast attributes (RFC 4760, #15 phase 2):
+/// <list type="bullet">
+/// <item><c>MP_REACH_NLRI</c> (type 14): AFI(2) + SAFI(1) + NH-Len(1) + Next Hop + Reserved(1) + NLRI.</item>
+/// <item><c>MP_UNREACH_NLRI</c> (type 15): AFI(2) + SAFI(1) + Withdrawn NLRI.</item>
+/// </list>
+/// All functions operate on the attribute VALUE (after the 2-3 byte TLV header). Malformed input
+/// throws <see cref="BgpParseException"/> with Update Message Error so the caller's treat-as-withdraw
+/// path (RFC 7606 §2 — the attribute carries NLRI) handles it: the UPDATE is discarded, the session
+/// stays up (D17). The 32-byte next-hop form of RFC 2545 §3 (global + link-local) is decoded — the
+/// global address (first 16 bytes) is used; a next-hop length other than 16/32 is a parse error.
+/// </summary>
+public static class MpReachCodec
+{
+    public const ushort AfiIpv6 = (ushort)BgpConstants.Afi.IPv6;
+    public const byte SafiUnicast = BgpConstants.Safi.Unicast;
+    public const byte MpReachNlriType = 14;
+    public const byte MpUnreachNlriType = 15;
+
+    public readonly record struct MpReachV6(UInt128 NextHop, IReadOnlyList<IpPrefix> Prefixes);
+
+    /// <summary>Builds the MP_REACH_NLRI (type 14) attribute VALUE for IPv6/Unicast:
+    /// a 16-byte global next hop plus the NLRI prefix list.</summary>
+    public static byte[] EncodeMpReachV6(UInt128 nextHop, IReadOnlyList<IpPrefix> prefixes)
+    {
+        ArgumentNullException.ThrowIfNull(prefixes);
+
+        // size = AFI(2) + SAFI(1) + NH-Len(1) + NH(16) + Reserved(1) + Σ NLRI
+        var nlriSize = 0;
+        foreach (var p in prefixes)
+            nlriSize += 1 + (p.Length + 7) / 8;
+
+        var buffer = new byte[21 + nlriSize];
+        buffer[0] = (byte)(AfiIpv6 >> 8);
+        buffer[1] = (byte)AfiIpv6;
+        buffer[2] = SafiUnicast;
+        buffer[3] = 16;                                   // next-hop length: global only
+        for (var i = 0; i < 16; i++)
+            buffer[4 + i] = (byte)(nextHop >> (120 - i * 8));
+        // buffer[20] = reserved 0x00
+        var offset = 21;
+        foreach (var p in prefixes)
+            offset += PrefixCodec.Encode(p, buffer.AsSpan(offset));
+        return buffer;
+    }
+
+    /// <summary>Decodes an MP_REACH_NLRI (type 14) VALUE for IPv6/Unicast. The next hop is the
+    /// first 16 bytes; the RFC 2545 32-byte form (global + link-local) is accepted and the
+    /// link-local half is skipped — the link-local address is only meaningful on a shared
+    /// interface, which this session is not required to have.</summary>
+    public static MpReachV6 DecodeMpReachV6(ReadOnlySpan<byte> value)
+    {
+        // AFI(2) + SAFI(1) + NH-Len(1) + Reserved(1) = 5 bytes of fixed header, plus at least
+        // 16 bytes of next hop.
+        if (value.Length < 21)
+            throw new BgpParseException(
+                $"Truncated MP_REACH_NLRI: have {value.Length} bytes, need at least 21",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
+
+        var afi = BinaryPrimitives.ReadUInt16BigEndian(value);
+        var safi = value[2];
+        if (afi != AfiIpv6 || safi != SafiUnicast)
+            throw new BgpParseException(
+                $"MP_REACH_NLRI for unsupported address family: AFI={afi}, SAFI={safi} (expected 2/1)",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
+
+        var nhLength = value[3];
+        if (nhLength is not 16 and not 32)
+            throw new BgpParseException(
+                $"Invalid MP_REACH_NLRI next-hop length: {nhLength} (must be 16 or 32 per RFC 2545)",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
+        if (value.Length < 4 + nhLength + 1)
+            throw new BgpParseException(
+                $"Truncated MP_REACH_NLRI next hop: need {nhLength} bytes at offset 4",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
+
+        UInt128 nextHop = 0;
+        for (var i = 0; i < 16; i++)
+            nextHop = (nextHop << 8) | value[4 + i];
+
+        // value[4+nhLength] is the Reserved byte — MUST be 0 per RFC 4760 §4, but tolerated on
+        // receive (some implementations send garbage there; it carries no information).
+        var nlriOffset = 4 + nhLength + 1;
+        var prefixes = new List<IpPrefix>();
+        while (nlriOffset < value.Length)
+        {
+            var (prefix, consumed) = PrefixCodec.Decode6(value[nlriOffset..]);
+            prefixes.Add(prefix);
+            nlriOffset += consumed;
+        }
+
+        return new MpReachV6(nextHop, prefixes);
+    }
+
+    /// <summary>Builds the MP_UNREACH_NLRI (type 15) attribute VALUE for IPv6/Unicast:
+    /// AFI(2) + SAFI(1) + the withdrawn NLRI prefix list.</summary>
+    public static byte[] EncodeMpUnreachV6(IReadOnlyList<IpPrefix> prefixes)
+    {
+        ArgumentNullException.ThrowIfNull(prefixes);
+
+        var nlriSize = 0;
+        foreach (var p in prefixes)
+            nlriSize += 1 + (p.Length + 7) / 8;
+
+        var buffer = new byte[3 + nlriSize];
+        buffer[0] = (byte)(AfiIpv6 >> 8);
+        buffer[1] = (byte)AfiIpv6;
+        buffer[2] = SafiUnicast;
+        var offset = 3;
+        foreach (var p in prefixes)
+            offset += PrefixCodec.Encode(p, buffer.AsSpan(offset));
+        return buffer;
+    }
+
+    /// <summary>Decodes an MP_UNREACH_NLRI (type 15) VALUE for IPv6/Unicast.</summary>
+    public static IReadOnlyList<IpPrefix> DecodeMpUnreachV6(ReadOnlySpan<byte> value)
+    {
+        if (value.Length < 3)
+            throw new BgpParseException(
+                $"Truncated MP_UNREACH_NLRI: have {value.Length} bytes, need at least 3",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
+
+        var afi = BinaryPrimitives.ReadUInt16BigEndian(value);
+        var safi = value[2];
+        if (afi != AfiIpv6 || safi != SafiUnicast)
+            throw new BgpParseException(
+                $"MP_UNREACH_NLRI for unsupported address family: AFI={afi}, SAFI={safi} (expected 2/1)",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
+
+        var prefixes = new List<IpPrefix>();
+        var offset = 3;
+        while (offset < value.Length)
+        {
+            var (prefix, consumed) = PrefixCodec.Decode6(value[offset..]);
+            prefixes.Add(prefix);
+            offset += consumed;
+        }
+        return prefixes;
+    }
+}

--- a/BGPLite.Protocol/UpdateCodec.cs
+++ b/BGPLite.Protocol/UpdateCodec.cs
@@ -121,13 +121,15 @@ public static class UpdateCodec
     /// Validates that a route announcement carried the mandatory well-known attributes
     /// (ORIGIN, AS_PATH, NEXT_HOP). Throws <see cref="BgpNotificationException"/> on a missing attribute.
     /// </summary>
-    public static void ValidateMandatoryAttributes(bool originSeen, bool asPathSeen, bool nextHopSeen)
+    public static void ValidateMandatoryAttributes(bool originSeen, bool asPathSeen, bool nextHopSeen, bool mpReachV6Present = false)
     {
         if (!originSeen)
             throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MissingWellKnownAttribute, "Missing mandatory ORIGIN attribute");
         if (!asPathSeen)
             throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MissingWellKnownAttribute, "Missing mandatory AS_PATH attribute");
-        if (!nextHopSeen)
+        // RFC 4760 §5: an UPDATE whose routes ride in MP_REACH_NLRI carries the next hop inside
+        // the attribute — the classic NEXT_HOP requirement applies only to the IPv4 NLRI field.
+        if (!nextHopSeen && !mpReachV6Present)
             throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MissingWellKnownAttribute, "Missing mandatory NEXT_HOP attribute");
     }
 
@@ -208,7 +210,7 @@ public static class UpdateCodec
     /// caller can apply treat-as-withdraw (RFC 7606) — the exact pipeline previously inlined in
     /// BgpSession.HandleUpdateAsync, moved verbatim (#270).
     /// </summary>
-    public static RouteAttributes ParseRouteAttributes(BgpUpdateMessage update, bool fourByteAsnSession, uint? localRouterId = null)
+    public static RouteAttributes ParseRouteAttributes(BgpUpdateMessage update, bool fourByteAsnSession, uint? localRouterId = null, bool mpReachV6Present = false)
     {
         try
         {
@@ -319,7 +321,7 @@ public static class UpdateCodec
                 }
             }
 
-            ValidateMandatoryAttributes(originSeen, asPathSeen, nextHopSeen);
+            ValidateMandatoryAttributes(originSeen, asPathSeen, nextHopSeen, mpReachV6Present);
             // RFC 4271 §6.3/§6.8: a semantically incorrect NEXT_HOP MUST be rejected with subcode 8
             // (Invalid NEXT_HOP Attribute) — "a valid unicast host address", never multicast, never
             // the receiving speaker's own address. Routed through the caller's treat-as-withdraw

--- a/BGPLite.Routing/Route.cs
+++ b/BGPLite.Routing/Route.cs
@@ -10,11 +10,12 @@ public sealed class Route
 {
     // #15 phase 1: 128-bit prefix — IPv4 in the low 32 bits with IsIpv4 = true (the implicit
     // uint → UInt128 conversion in object initializers lands exactly there), IPv6 in the full
-    // 128 bits with IsIpv4 = false. NextHop stays IPv4 (uint) until the MP_REACH phase.
+    // 128 bits with IsIpv4 = false. #15 phase 2: NextHop is likewise 128-bit (IPv4 low bits);
+    // for MP_REACH routes it carries the peer's IPv6 next hop.
     public required UInt128 Prefix { get; init; }
     public bool IsIpv4 { get; init; } = true;
     public required byte PrefixLength { get; init; }
-    public required uint NextHop { get; init; }
+    public required UInt128 NextHop { get; init; }
     public IReadOnlyList<uint> AsPath { get; init; } = [];
     public IReadOnlyList<uint> Communities { get; init; } = [];
     /// <summary>BGP Large Communities (RFC 8092): triplets of (Global : Local1 : Local2).</summary>

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -31,6 +31,8 @@ public sealed class BgpSession : IDisposable
     private readonly ILogger<BgpSession> _logger;
     private readonly CancellationTokenSource _cts = new();
     private readonly Func<string, uint, CancellationToken, Task>? _onPeerIdentified;
+    // #15 phase 2: the peer advertised MP-BGP IPv6/Unicast.
+    private bool _peerMpIpv6Unicast;
     // #391: the EFFECTIVE per-peer prefix ceiling — the peer row's MaxPrefix override when the
     // peer is configured, else the global Bgp.MaxPrefixesPerPeer. Resolved once per
     // establish/refresh cycle in SendAllRoutesAsync (never per UPDATE); read on the UPDATE path
@@ -927,7 +929,8 @@ public sealed class BgpSession : IDisposable
             {
                 // #292 item 1: local router-id for the §6.8 self-address check on NEXT_HOP.
                 attrs = UpdateCodec.ParseRouteAttributes(update, _remoteFourByteAsn,
-                    BgpConstants.IPAddressToUint(_bgpConfig.GetRouterIdAddress()));
+                    BgpConstants.IPAddressToUint(_bgpConfig.GetRouterIdAddress()),
+                    mpReachV6Present: update.MpReachV6 is not null);
             }
             catch (BgpNotificationException ex) when (ex.ErrorCode == BgpConstants.Error.UpdateMessageError)
             {
@@ -948,6 +951,9 @@ public sealed class BgpSession : IDisposable
                 // what this peer installed, not whatever is at that prefix.
                 foreach (var nlri in update.Nlri)
                     WithdrawIfOwned(nlri, "Route withdrawn (treat-as-withdraw)");
+                if (update.MpReachV6 is { } failedReach)
+                    foreach (var p in failedReach.Prefixes)
+                        WithdrawIfOwned(p, "Route withdrawn (treat-as-withdraw, MP_REACH)");
                 _metrics.SetRouteCount(_routeTable.Count);
                 throw;
             }
@@ -1026,6 +1032,58 @@ public sealed class BgpSession : IDisposable
                         _logger.LogDebug("Route added: {Prefix} via {NextHop}", nlri, BgpConstants.UintToIPAddress(attrs.NextHop));
                 }
             }
+
+            // #15 phase 2 (RFC 4760 §7): MP_UNREACH_NLRI (AFI=2/SAFI=1) withdraws IPv6 routes
+            // this session installed — same ownership rule as the classic withdrawal path (#289).
+            if (update.MpUnreachV6 is { Count: > 0 } v6Withdrawn)
+            {
+                foreach (var prefix in v6Withdrawn)
+                    WithdrawIfOwned(prefix, "Route withdrawn (MP_UNREACH)");
+            }
+
+            // MP_REACH_NLRI (AFI=2/SAFI=1) announcements: same install pipeline as the classic
+            // IPv4 NLRI loop — AS-loop exclusion, filter, cap, ownership (#15 phase 2).
+            if (update.MpReachV6 is { } mpReach)
+            {
+                foreach (var nlri in mpReach.Prefixes)
+                {
+                    var route = new Route
+                    {
+                        Prefix = nlri.Address,
+                        IsIpv4 = false,
+                        PrefixLength = nlri.Length,
+                        NextHop = mpReach.NextHop,
+                        AsPath = attrs.AsPath,
+                        Communities = attrs.Communities,
+                        LargeCommunities = attrs.LargeCommunities
+                    };
+
+                    if (attrs.AsPath.AsSpan().Contains(_bgpConfig.Asn))
+                    {
+                        if (_logger.IsEnabled(LogLevel.Debug))
+                            _logger.LogDebug("Excluded looping route {Prefix} from {Peer}: local AS {Asn} in AS_PATH",
+                                nlri, _peer, _bgpConfig.Asn);
+                        continue;
+                    }
+
+                    if (_routeFilter.AcceptIncoming(route, filterPeerConfig))
+                    {
+                        var cap = Volatile.Read(ref _effectiveMaxPrefix);
+                        if (cap > 0 && !_installedPrefixes.ContainsKey(nlri) && _installedPrefixes.Count >= cap)
+                            throw new BgpNotificationException(
+                                BgpConstants.Error.Cease, BgpConstants.SubError.CeaseMaxPrefixes,
+                                $"Peer {_peer} exceeded the per-peer prefix limit ({cap}); session reset per RFC 4486");
+                        _installedPrefixes.TryAdd(nlri, 0);
+                        _routeTable.AddOrUpdate(route, owner: this);
+
+                        if (cap > 0 && !_maxPrefixesWarned && _installedPrefixes.Count >= MaxPrefixWarningThreshold(cap))
+                        {
+                            _maxPrefixesWarned = true;
+                            _logger.LogWarning("Peer {Peer} at {Count}/{Cap} of the per-peer prefix limit", _peer, _installedPrefixes.Count, cap);
+                        }
+                    }
+                }
+            }
         }
 
         _metrics.SetRouteCount(_routeTable.Count);
@@ -1063,7 +1121,7 @@ public sealed class BgpSession : IDisposable
     {
         // Inbound v4 withdrawals: the NLRI address lives in the low 32 bits of the 128-bit form
         // (IsIpv4 = true matches the install key from the UPDATE path).
-        if (!_routeTable.RemoveOwnedBy(prefix.Address, prefix.Length, isIpv4: true, owner: this))
+        if (!_routeTable.RemoveOwnedBy(prefix.Address, prefix.Length, prefix.IsIpv4, owner: this))
         {
             if (_logger.IsEnabled(LogLevel.Debug))
                 _logger.LogDebug("Ignoring withdrawal of {Prefix} from {Peer}: not owned by this session", prefix, _peer);
@@ -1415,6 +1473,10 @@ public sealed class BgpSession : IDisposable
         if (remoteOpen.Capabilities.Any(c => c.Code == BgpConstants.Capability.RouteRefresh))
             capabilities.Add(BgpCapabilityInfo.RouteRefresh());
 
+        // #15 phase 2: advertise MP IPv6/Unicast only when the peer also supports it.
+        if (CapabilityHelper.SupportsMultiprotocolIpv6Unicast(remoteOpen))
+            capabilities.Add(BgpCapabilityInfo.MultiprotocolIpv6Unicast());
+
         // #318: the Graceful Restart capability is deliberately NOT advertised. RFC 4724 §4.2 obliges
         // a speaker engaging GR procedures to retain and stale-mark a restarting peer's routes;
         // BGPLite implements none of that receiving half, so advertising the <AFI, SAFI, F> tuple
@@ -1556,6 +1618,9 @@ public sealed class BgpSession : IDisposable
         // CodeRabbit (integration review): propagate the session token into the upsert so a
         // locked SQLite cannot out-wait shutdown/replacement before cancellation is observed.
         if (_onPeerIdentified is not null) await _onPeerIdentified(_peerConfig.Address, _remoteAsn, ct);
+
+        // #15 phase 2: the peer can send IPv6 routes via MP_REACH_NLRI (AFI=2/SAFI=1).
+        _peerMpIpv6Unicast = CapabilityHelper.SupportsMultiprotocolIpv6Unicast(open);
 
         var peerGr = CapabilityHelper.GetGracefulRestart(open);
         _logger.LogInformation("Peer {Peer} Graceful Restart: {State}",

--- a/BGPLite.Tests/MpReachCodecTests.cs
+++ b/BGPLite.Tests/MpReachCodecTests.cs
@@ -1,0 +1,162 @@
+using System.Net;
+using System.Net.Sockets;
+using BGPLite.Protocol;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #15 phase 2: MP_REACH_NLRI / MP_UNREACH_NLRI (RFC 4760) wire codec for IPv6/Unicast —
+/// attribute VALUE encode/decode roundtrips at boundary lengths, the RFC 2545 32-byte next-hop
+/// form, and malformed-input handling (truncated header/body, unsupported AFI/SAFI, bad
+/// next-hop length).
+/// </summary>
+public class MpReachCodecTests
+{
+    private static readonly byte[] Nh16 = new byte[16];
+    private static IpPrefix V6(byte length) => new(BgpConstants.ToUInt128(IPAddress.Parse("2001:db8::")), length, isIpv4: false);
+
+    [Fact]
+    public void Encode_ExactByteLayout()
+    {
+        var prefixes = new List<IpPrefix> { new(ToV6("20010db8000000000000000000000001"), 128, isIpv4: false) };
+        var data = MpReachCodec.EncodeMpReachV6(ToV6("20010db8ffff00000000000000000001"), prefixes);
+
+        // AFI=2 / SAFI=1 / NH-Len=16 / next-hop / reserved / length=128 / 16 bytes of 2001:0db8::1
+        Assert.Equal(
+        [
+            0x00, 0x02,             // AFI = 2
+            0x01,                   // SAFI = 1
+            16,                     // next-hop length
+            0x20, 0x01, 0x0d, 0xb8, 0xff, 0xff, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,   // next hop
+            0x00,                   // reserved
+            128,                    // NLRI: /128
+            0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,   // 2001:db8::1
+        ], data);
+    }
+
+    [Fact]
+    public void Roundtrip_MultiplePrefixes()
+    {
+        var prefixes = new List<IpPrefix>
+        {
+            V6(0),    // ::/0
+            V6(32),   // 2001:db8::/32
+            V6(64),   // 2001:db8::/64 (host bits masked)
+            new(ToV6("20010db8000000000000000000000001"), 128, isIpv4: false),
+        };
+        var nextHop = ToV6("fe800000000000000000000000000001");
+
+        var encoded = MpReachCodec.EncodeMpReachV6(nextHop, prefixes);
+        var decoded = MpReachCodec.DecodeMpReachV6(encoded);
+
+        Assert.Equal(nextHop, decoded.NextHop);
+        Assert.Equal(prefixes.Count, decoded.Prefixes.Count);
+        for (var i = 0; i < prefixes.Count; i++)
+            Assert.Equal(prefixes[i], decoded.Prefixes[i]);
+    }
+
+    [Fact]
+    public void Decode_AcceptsRfc2545_32ByteNextHop()
+    {
+        // RFC 2545 §3: global (16 bytes) + link-local (16 bytes) = 32-byte next-hop form.
+        // header: AFI(2) + SAFI(1) + NH-Len(1) + NH(32) + Reserved(1) = 37, then /64 NLRI (9) = 46.
+        var value = new byte[46];
+        value[0] = 0; value[1] = 2; value[2] = 1; value[3] = 32;
+        for (var i = 0; i < 16; i++) value[4 + i] = 0x20;         // global
+        for (var i = 0; i < 16; i++) value[20 + i] = 0xFE;        // link-local
+        value[36] = 0;                                             // reserved
+        value[37] = 64;                                            // /64 prefix
+        for (var i = 0; i < 8; i++) value[38 + i] = 0x20;         // 2001:...
+
+        var decoded = MpReachCodec.DecodeMpReachV6(value);
+
+        // The GLOBAL address (first 16 bytes of 0x20) is used; link-local (0xFE) skipped.
+        Assert.Equal((UInt128)0x20, decoded.NextHop >> 120);   // top byte = global's first byte
+        Assert.Single(decoded.Prefixes);
+    }
+
+    [Fact]
+    public void Decode_BadNextHopLength_Throws()
+    {
+        var value = new byte[21];
+        value[0] = 0; value[1] = 2; value[2] = 1; value[3] = 8; // NH len 8 — invalid
+
+        Assert.Throws<BgpParseException>(() => MpReachCodec.DecodeMpReachV6(value));
+    }
+
+    [Fact]
+    public void Decode_WrongAfi_Throws()
+    {
+        var value = new byte[21];
+        value[0] = 0; value[1] = 1; value[2] = 1; value[3] = 16; // AFI=1 — IPv4, not supported here
+
+        Assert.Throws<BgpParseException>(() => MpReachCodec.DecodeMpReachV6(value));
+    }
+
+    [Fact]
+    public void Decode_Truncated_Throws()
+    {
+        Assert.Throws<BgpParseException>(() => MpReachCodec.DecodeMpReachV6(new byte[10]));
+    }
+
+    [Fact]
+    public void EncodeUnreach_DecodeUnreach_Roundtrip()
+    {
+        var prefixes = new List<IpPrefix> { V6(48), V6(128) };
+        var encoded = MpReachCodec.EncodeMpUnreachV6(prefixes);
+
+        // AFI=2 / SAFI=1 header
+        Assert.Equal(0x00, encoded[0]);
+        Assert.Equal(0x02, encoded[1]);
+        Assert.Equal(0x01, encoded[2]);
+
+        var decoded = MpReachCodec.DecodeMpUnreachV6(encoded);
+        Assert.Equal(2, decoded.Count);
+        Assert.Equal(prefixes[0], decoded[0]);
+        Assert.Equal(prefixes[1], decoded[1]);
+    }
+
+    [Fact]
+    public void DecodeUnreach_Truncated_Throws()
+    {
+        Assert.Throws<BgpParseException>(() => MpReachCodec.DecodeMpUnreachV6(new byte[2]));
+    }
+
+    [Fact]
+    public void ReaderExtracts_MpReachV6()
+    {
+        var attr = new PathAttribute { Flags = 0x80, TypeCode = 14, Data = MpReachCodec.EncodeMpReachV6(0x2001, [V6(128)]) };
+        var update = new BgpUpdateMessage
+        {
+            WithdrawnRoutes = [],
+            PathAttributes = [AttributeHelper.WriteOrigin(0), AttributeHelper.WriteAsPath([65002], fourByteAsn: true), attr],
+            Nlri = []
+        };
+        var buf = new byte[512];
+        var n = BgpMessageWriter.WriteMessage(update, buf);
+        var read = (BgpUpdateMessage)BgpMessageReader.ReadMessage(buf.AsSpan(0, n));
+        Assert.NotNull(read.MpReachV6);
+        Assert.True(read.MpReachV6 is { } reach && reach.Prefixes.Count == 1);
+    }
+
+    [Fact]
+    public void Encode_NonCanonicalPrefix_Masked()
+    {
+        var prefix = new IpPrefix(ToV6("20010db8012345670000000000000001"), 48, isIpv4: false);
+
+        var encoded = MpReachCodec.EncodeMpReachV6(0, [prefix]);
+        var decoded = MpReachCodec.DecodeMpReachV6(encoded);
+
+        // The host bits below /48 were masked by the IpPrefix constructor.
+        Assert.Equal(new IpPrefix(ToV6("20010db8012300000000000000000000"), 48, isIpv4: false), decoded.Prefixes[0]);
+    }
+
+    private static UInt128 ToV6(string hex)
+    {
+        UInt128 value = 0;
+        foreach (var c in hex) value = (value << 4) | (UInt128)Uri.FromHex(c);
+        return value;
+    }
+}


### PR DESCRIPTION
Refs #15 (phase 2)
Refs #14 (epic), #13 (wrong-family), RFC 4760, RFC 2545

## Feature
Phase 2 of the IPv6 epic: **MP-BGP IPv6/Unicast** — MP_REACH_NLRI (attr 14) and MP_UNREACH_NLRI (attr 15) encode/decode, IPv6/Unicast capability advertisement and detection, and the session receive path for IPv6 routes.

## Implementation
- **`MpReachCodec`** (new): wire codec for MP_REACH/MP_UNREACH attribute values — AFI(2) + SAFI(1) header, next-hop (16-byte global or 32-byte global+link-local per RFC 2545), Reserved byte, NLRI prefix list. Malformed input throws `BgpParseException` (Update Message Error) → treat-as-withdraw (RFC 7606 §2, attribute carries NLRI).
- **`BgpCapabilityInfo.MultiprotocolIpv6Unicast()`**: capability factory (code 1, AFI=2/SAFI=1).
- **`CapabilityHelper.SupportsMultiprotocolIpv6Unicast`**: detects the peer's AFI=2/SAFI=1 capability.
- **`BgpSession`**: advertises MP IPv6 in OPEN when the peer supports it (same pattern as Route Refresh); processes MP_REACH announcements (AS-loop exclusion, filter, per-peer cap) and MP_UNREACH withdrawals with the same ownership semantics as IPv4 (#289); treats malformed MP_REACH in the treat-as-withdraw path (RFC 7606 §2); `WithdrawIfOwned` passes through `prefix.IsIpv4`.
- **`BgpUpdateMessage`**: carries typed `MpReachV6`/`MpUnreachV6` fields extracted by the reader.
- **`UpdateCodec.ParseRouteAttributes`**: waives the classic NEXT_HOP requirement when MP_REACH is present (RFC 4760 §5).
- **`Route.NextHop`** widened to `UInt128` (IPv4 low bits — implicit conversion keeps call sites).

## Out of scope
- IPv6 route origination (no IPv6 sources until Phase 4); MP_REACH in the send path (codec-level encoding unit-tested for Phase 4 integration).
- RFC 2545 link-local next hop is decoded but not used (route server context).

## Tests
`MpReachCodecTests` (9): exact byte layout, multi-prefix roundtrips /0../128, RFC 2545 32-byte NH, bad NH length, wrong AFI, truncated MP_REACH/MP_UNREACH, non-canonical prefix masking. Plus all existing IPv4 tests green.

## Verification
dotnet format / dotnet build BGPLite.sln (0 errors) / dotnet test BGPLite.sln: **949/949** (baseline 939).

## RFC
RFC 4760 (MP-BGP), RFC 2545 (BGP + IPv6 next-hop), RFC 5492 (capability advertisement).

## Behavior Change
None for IPv4-only deployments (no MP attrs in UPDATEs). Peers that advertise MP IPv6 can now send IPv6 routes to BGPLite, which installs them with ownership tracking and per-peer cap enforcement.
