### PR TITLE
chore: integrate dev — IPv6 phases 1+2 (#14/#15)

### DIFF
--- a/BGPLite.Protocol/BgpCapabilityInfo.cs
+++ b/BGPLite.Protocol/BgpCapabilityInfo.cs
@@ -25,6 +25,14 @@ public sealed class BgpCapabilityInfo
         Data = [(byte)(BgpConstants.Afi.IPv4 >> 8), (byte)BgpConstants.Afi.IPv4, 0x00, BgpConstants.Safi.Unicast]
     };
 
+    /// <summary>MP-BGP IPv6/Unicast capability (RFC 4760 §8, code 1): AFI=2/SAFI=1 (#15 phase 2).
+    /// Signals that this speaker can receive IPv6 routes via MP_REACH_NLRI.</summary>
+    public static BgpCapabilityInfo MultiprotocolIpv6Unicast() => new()
+    {
+        Code = BgpConstants.Capability.Multiprotocol,
+        Data = [(byte)(BgpConstants.Afi.IPv6 >> 8), (byte)BgpConstants.Afi.IPv6, 0x00, BgpConstants.Safi.Unicast]
+    };
+
     /// <summary>
     /// Graceful Restart capability (RFC 4724, code 64) for IPv4/Unicast. Value layout:
     /// byte 0 = Restart Flags (bit 7 = R) | high 4 bits of Restart Time,

--- a/BGPLite.Protocol/BgpConstants.cs
+++ b/BGPLite.Protocol/BgpConstants.cs
@@ -127,6 +127,7 @@ public static class BgpConstants
     public static class Afi
     {
         public const ushort IPv4 = 1;
+        public const ushort IPv6 = 2; // RFC 1700 / IANA address family numbers (#15 phase 1)
     }
 
     public static class Safi
@@ -155,4 +156,59 @@ public static class BgpConstants
 
     public static IPAddress UintToIPAddress(uint address) =>
         new([(byte)(address >> 24), (byte)(address >> 16), (byte)(address >> 8), (byte)address]);
+
+    // ---- #15 phase 1: 16-byte-aware (de)serializers -------------------------------------------
+
+    /// <summary>
+    /// Non-truncating 128-bit form of an IP address: IPv4 in the low 32 bits (family carried
+    /// separately), IPv6 as the full big-endian 128 bits. Never truncates or maps silently.
+    /// </summary>
+    public static UInt128 ToUInt128(IPAddress address)
+    {
+        ArgumentNullException.ThrowIfNull(address);
+
+        var bytes = address.GetAddressBytes();
+        if (bytes.Length is not 4 and not 16)
+            throw new ArgumentException($"Unsupported address size: {bytes.Length} bytes.", nameof(address));
+
+        UInt128 value = 0;
+        var shift = bytes.Length == 4 ? 96 : 0; // IPv4 → low 32 bits
+        foreach (var b in bytes)
+        {
+            value = (value << 8) | b;
+            _ = shift;
+        }
+        return value;
+    }
+
+    /// <summary>Rebuilds an IP address from the 128-bit form produced by <see cref="ToUInt128"/>.
+    /// <paramref name="isIpv4"/> selects the family: only the low 32 bits are read (no truncation
+    /// of a genuine 128-bit value — that would be a caller bug, and it throws).</summary>
+    public static IPAddress FromUInt128(UInt128 value, bool isIpv4)
+    {
+        if (isIpv4)
+        {
+            if (value > uint.MaxValue)
+                throw new InvalidOperationException(
+                    $"Cannot convert a 128-bit value above uint.MaxValue to an IPv4 address (got 0x{value:X}).");
+            return UintToIPAddress((uint)value);
+        }
+
+        Span<byte> bytes = stackalloc byte[16];
+        for (var i = 0; i < 16; i++)
+            bytes[i] = (byte)(value >> (120 - i * 8));
+        return new IPAddress(bytes);
+    }
+
+    /// <summary>
+    /// Wrong-family guard for the IPv4-only consumers of a 128-bit value (#13/#15): throws
+    /// instead of silently truncating the high bits.
+    /// </summary>
+    public static uint ToUint32OrThrow(UInt128 value, string field)
+    {
+        if (value > uint.MaxValue)
+            throw new InvalidOperationException(
+                $"128-bit value does not fit in 32 bits — wrong address family for {field} (got 0x{value:X}).");
+        return (uint)value;
+    }
 }

--- a/BGPLite.Protocol/BgpMessageReader.cs
+++ b/BGPLite.Protocol/BgpMessageReader.cs
@@ -286,12 +286,18 @@ public static class BgpMessageReader
                 // (the attribute carries NLRI ⇒ treat-as-withdraw).
                 if (attr.TypeCode == MpReachCodec.MpReachNlriType)
                 {
-                    var reach = MpReachCodec.DecodeMpReachV6(attr.Data);
-                    mpReachV6 = reach;
+                    // RFC 4760: only one MP_REACH per UPDATE. A duplicate is a protocol error.
+                    if (mpReachV6 is not null)
+                        throw new BgpParseException("Duplicate MP_REACH_NLRI attribute",
+                            BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList);
+                    mpReachV6 = MpReachCodec.DecodeMpReachV6(attr.Data);
                     continue;
                 }
                 if (attr.TypeCode == MpReachCodec.MpUnreachNlriType)
                 {
+                    if (mpUnreachV6 is not null)
+                        throw new BgpParseException("Duplicate MP_UNREACH_NLRI attribute",
+                            BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList);
                     mpUnreachV6 = MpReachCodec.DecodeMpUnreachV6(attr.Data);
                     continue;
                 }

--- a/BGPLite.Protocol/BgpMessageReader.cs
+++ b/BGPLite.Protocol/BgpMessageReader.cs
@@ -265,6 +265,8 @@ public static class BgpMessageReader
                 BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList);
 
         var attributes = new List<PathAttribute>();
+        MpReachCodec.MpReachV6? mpReachV6 = null;
+        IReadOnlyList<IpPrefix>? mpUnreachV6 = null;
         if (attrsLen > 0)
         {
             var attrsEnd = offset + attrsLen;
@@ -274,8 +276,26 @@ public static class BgpMessageReader
                 // attribute TLV whose declared value crosses attrsEnd must be rejected instead
                 // of silently consuming NLRI bytes as attribute data (#245 review finding).
                 var (attr, consumed) = ParseAttribute(payload.Slice(offset, attrsEnd - offset));
-                attributes.Add(attr);
                 offset += consumed;
+
+                // #15 phase 2 (RFC 4760): MP_REACH_NLRI (14) / MP_UNREACH_NLRI (15) carry the
+                // IPv6 announcements/withdrawals — decode them into typed fields here and remove
+                // from the generic list so ParseRouteAttributes treats the UPDATE as v4-only.
+                // Malformed AFI=2 payloads throw BgpParseException (Update Message Error) — the
+                // whole UPDATE is discarded with the session kept (D17), matching RFC 7606 §2
+                // (the attribute carries NLRI ⇒ treat-as-withdraw).
+                if (attr.TypeCode == MpReachCodec.MpReachNlriType)
+                {
+                    var reach = MpReachCodec.DecodeMpReachV6(attr.Data);
+                    mpReachV6 = reach;
+                    continue;
+                }
+                if (attr.TypeCode == MpReachCodec.MpUnreachNlriType)
+                {
+                    mpUnreachV6 = MpReachCodec.DecodeMpUnreachV6(attr.Data);
+                    continue;
+                }
+                attributes.Add(attr);
             }
         }
 
@@ -291,7 +311,9 @@ public static class BgpMessageReader
         {
             WithdrawnRoutes = withdrawn,
             PathAttributes = attributes,
-            Nlri = nlri
+            Nlri = nlri,
+            MpReachV6 = mpReachV6,
+            MpUnreachV6 = mpUnreachV6
         };
     }
 

--- a/BGPLite.Protocol/BgpUpdateMessage.cs
+++ b/BGPLite.Protocol/BgpUpdateMessage.cs
@@ -6,4 +6,12 @@ public sealed class BgpUpdateMessage : BgpMessage
     public List<IpPrefix> WithdrawnRoutes { get; init; } = [];
     public List<PathAttribute> PathAttributes { get; init; } = [];
     public List<IpPrefix> Nlri { get; init; } = [];
+
+    /// <summary>Decoded MP_REACH_NLRI (RFC 4760, AFI=2/SAFI=1) IPv6 announcements — extracted from
+    /// the attribute list by the reader (#15 phase 2). Null when the UPDATE carries none.</summary>
+    public MpReachCodec.MpReachV6? MpReachV6 { get; init; }
+
+    /// <summary>Decoded MP_UNREACH_NLRI (RFC 4760, AFI=2/SAFI=1) IPv6 withdrawals. Null/empty when
+    /// the UPDATE carries none.</summary>
+    public IReadOnlyList<IpPrefix>? MpUnreachV6 { get; init; }
 }

--- a/BGPLite.Protocol/CapabilityHelper.cs
+++ b/BGPLite.Protocol/CapabilityHelper.cs
@@ -24,6 +24,21 @@ public static class CapabilityHelper
         return false;
     }
 
+    /// <summary>Detects the MP-BGP IPv6/Unicast capability (AFI=2/SAFI=1) in the peer's OPEN
+    /// (#15 phase 2): the peer can send IPv6 routes via MP_REACH_NLRI.</summary>
+    public static bool SupportsMultiprotocolIpv6Unicast(BgpOpenMessage open)
+    {
+        foreach (var cap in open.Capabilities)
+        {
+            if (cap.Code == BgpConstants.Capability.Multiprotocol &&
+                cap.Data.Length >= 4 &&
+                BinaryPrimitives.ReadUInt16BigEndian(cap.Data) == BgpConstants.Afi.IPv6 &&
+                cap.Data[3] == BgpConstants.Safi.Unicast)
+                return true;
+        }
+        return false;
+    }
+
     public static bool SupportsMultiprotocolIpv4Unicast(BgpOpenMessage open)
     {
         foreach (var cap in open.Capabilities)

--- a/BGPLite.Protocol/IpPrefix.cs
+++ b/BGPLite.Protocol/IpPrefix.cs
@@ -1,6 +1,80 @@
+using System.Net;
+using System.Net.Sockets;
+
 namespace BGPLite.Protocol;
 
-public readonly record struct IpPrefix(uint Address, byte Length)
+/// <summary>
+/// A family-aware IP prefix: IPv4 lives in the LOW 32 bits with <see cref="IsIpv4"/> set
+/// (e.g. 10.0.0.0/8 → <c>0x0A000000</c>); IPv6 uses the full <see cref="UInt128"/>. The
+/// constructor is canonicalizing — host bits are masked off, so an <see cref="IpPrefix"/>
+/// value is always a valid network address and is safe to use as a routing key (dual-stack:
+/// the IPv4 low-bits form cannot collide with a full-128 IPv6 form that carries
+/// <see cref="IsIpv4"/> = false).
+/// <para>
+/// Length domain: 0..32 for IPv4, 0..128 for IPv6. <c>ToString</c> renders IPv4 dotted-quad
+/// and IPv6 in RFC 5952 compressed form.
+/// </para>
+/// </summary>
+public readonly record struct IpPrefix : IComparable<IpPrefix>
 {
-    public override string ToString() => $"{BgpConstants.UintToIPAddress(Address)}/{Length}";
+    public UInt128 Address { get; }
+    public byte Length { get; }
+    public bool IsIpv4 { get; }
+
+    /// <summary>IPv4 prefix: <paramref name="ipv4Address"/> occupies the low 32 bits.</summary>
+    public IpPrefix(uint ipv4Address, byte length)
+        : this(ipv4Address, length, isIpv4: true)
+    {
+    }
+
+    /// <summary>Family-aware prefix. IPv4 values occupy the low 32 bits; IPv6 the full 128.
+    /// Host bits are masked to the network address.</summary>
+    public IpPrefix(UInt128 address, byte length, bool isIpv4)
+    {
+        if (isIpv4 && length > 32)
+            throw new ArgumentOutOfRangeException(nameof(length), length, "IPv4 prefix length must be in 0..32.");
+        if (length > 128)
+            throw new ArgumentOutOfRangeException(nameof(length), length, "Prefix length must be in 0..128.");
+
+        Address = isIpv4 ? address & Ipv4Mask(length) : address & V6Mask(length);
+        Length = length;
+        IsIpv4 = isIpv4;
+    }
+
+    public IpPrefix(IPAddress address, byte length)
+        : this(BgpConstants.ToUInt128(address), length, isIpv4: address.AddressFamily == AddressFamily.InterNetwork)
+    {
+    }
+
+    public static bool IsValidLength(byte length, bool isIpv4) => isIpv4 ? length <= 32 : length <= 128;
+
+    /// <summary>Network mask for the family, aligned to the value's bit layout.</summary>
+    public static UInt128 Mask(byte length, bool isIpv4) =>
+        isIpv4 ? Ipv4Mask(length) : V6Mask(length);
+
+    private static UInt128 Ipv4Mask(byte length) =>
+        length == 0 ? UInt128.Zero : (UInt128)(0xFFFFFFFFu << (32 - length));
+
+    private static UInt128 V6Mask(byte length) =>
+        length == 0 ? UInt128.Zero : UInt128.MaxValue << (128 - length);
+
+    public int CompareTo(IpPrefix other)
+    {
+        var byFamily = IsIpv4.CompareTo(other.IsIpv4);
+        if (byFamily != 0) return byFamily;
+        var byAddress = Address.CompareTo(other.Address);
+        if (byAddress != 0) return byAddress;
+        return Length.CompareTo(other.Length);
+    }
+
+    public override string ToString()
+    {
+        if (IsIpv4)
+            return $"{BgpConstants.UintToIPAddress((uint)Address)}/{Length}";
+
+        Span<byte> bytes = stackalloc byte[16];
+        for (var i = 0; i < 16; i++)
+            bytes[i] = (byte)(Address >> (120 - i * 8));
+        return $"{new IPAddress(bytes)}/{Length}";
+    }
 }

--- a/BGPLite.Protocol/MpReachCodec.cs
+++ b/BGPLite.Protocol/MpReachCodec.cs
@@ -1,0 +1,145 @@
+using System.Buffers.Binary;
+using System.Net;
+
+namespace BGPLite.Protocol;
+
+/// <summary>
+/// Wire codec for the MP-BGP IPv6/Unicast attributes (RFC 4760, #15 phase 2):
+/// <list type="bullet">
+/// <item><c>MP_REACH_NLRI</c> (type 14): AFI(2) + SAFI(1) + NH-Len(1) + Next Hop + Reserved(1) + NLRI.</item>
+/// <item><c>MP_UNREACH_NLRI</c> (type 15): AFI(2) + SAFI(1) + Withdrawn NLRI.</item>
+/// </list>
+/// All functions operate on the attribute VALUE (after the 2-3 byte TLV header). Malformed input
+/// throws <see cref="BgpParseException"/> with Update Message Error so the caller's treat-as-withdraw
+/// path (RFC 7606 §2 — the attribute carries NLRI) handles it: the UPDATE is discarded, the session
+/// stays up (D17). The 32-byte next-hop form of RFC 2545 §3 (global + link-local) is decoded — the
+/// global address (first 16 bytes) is used; a next-hop length other than 16/32 is a parse error.
+/// </summary>
+public static class MpReachCodec
+{
+    public const ushort AfiIpv6 = (ushort)BgpConstants.Afi.IPv6;
+    public const byte SafiUnicast = BgpConstants.Safi.Unicast;
+    public const byte MpReachNlriType = 14;
+    public const byte MpUnreachNlriType = 15;
+
+    public readonly record struct MpReachV6(UInt128 NextHop, IReadOnlyList<IpPrefix> Prefixes);
+
+    /// <summary>Builds the MP_REACH_NLRI (type 14) attribute VALUE for IPv6/Unicast:
+    /// a 16-byte global next hop plus the NLRI prefix list.</summary>
+    public static byte[] EncodeMpReachV6(UInt128 nextHop, IReadOnlyList<IpPrefix> prefixes)
+    {
+        ArgumentNullException.ThrowIfNull(prefixes);
+
+        // size = AFI(2) + SAFI(1) + NH-Len(1) + NH(16) + Reserved(1) + Σ NLRI
+        var nlriSize = 0;
+        foreach (var p in prefixes)
+            nlriSize += 1 + (p.Length + 7) / 8;
+
+        var buffer = new byte[21 + nlriSize];
+        buffer[0] = (byte)(AfiIpv6 >> 8);
+        buffer[1] = (byte)AfiIpv6;
+        buffer[2] = SafiUnicast;
+        buffer[3] = 16;                                   // next-hop length: global only
+        for (var i = 0; i < 16; i++)
+            buffer[4 + i] = (byte)(nextHop >> (120 - i * 8));
+        // buffer[20] = reserved 0x00
+        var offset = 21;
+        foreach (var p in prefixes)
+            offset += PrefixCodec.Encode(p, buffer.AsSpan(offset));
+        return buffer;
+    }
+
+    /// <summary>Decodes an MP_REACH_NLRI (type 14) VALUE for IPv6/Unicast. The next hop is the
+    /// first 16 bytes; the RFC 2545 32-byte form (global + link-local) is accepted and the
+    /// link-local half is skipped — the link-local address is only meaningful on a shared
+    /// interface, which this session is not required to have.</summary>
+    public static MpReachV6 DecodeMpReachV6(ReadOnlySpan<byte> value)
+    {
+        // AFI(2) + SAFI(1) + NH-Len(1) + Reserved(1) = 5 bytes of fixed header, plus at least
+        // 16 bytes of next hop.
+        if (value.Length < 21)
+            throw new BgpParseException(
+                $"Truncated MP_REACH_NLRI: have {value.Length} bytes, need at least 21",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
+
+        var afi = BinaryPrimitives.ReadUInt16BigEndian(value);
+        var safi = value[2];
+        if (afi != AfiIpv6 || safi != SafiUnicast)
+            throw new BgpParseException(
+                $"MP_REACH_NLRI for unsupported address family: AFI={afi}, SAFI={safi} (expected 2/1)",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
+
+        var nhLength = value[3];
+        if (nhLength is not 16 and not 32)
+            throw new BgpParseException(
+                $"Invalid MP_REACH_NLRI next-hop length: {nhLength} (must be 16 or 32 per RFC 2545)",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
+        if (value.Length < 4 + nhLength + 1)
+            throw new BgpParseException(
+                $"Truncated MP_REACH_NLRI next hop: need {nhLength} bytes at offset 4",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
+
+        UInt128 nextHop = 0;
+        for (var i = 0; i < 16; i++)
+            nextHop = (nextHop << 8) | value[4 + i];
+
+        // value[4+nhLength] is the Reserved byte — MUST be 0 per RFC 4760 §4, but tolerated on
+        // receive (some implementations send garbage there; it carries no information).
+        var nlriOffset = 4 + nhLength + 1;
+        var prefixes = new List<IpPrefix>();
+        while (nlriOffset < value.Length)
+        {
+            var (prefix, consumed) = PrefixCodec.Decode6(value[nlriOffset..]);
+            prefixes.Add(prefix);
+            nlriOffset += consumed;
+        }
+
+        return new MpReachV6(nextHop, prefixes);
+    }
+
+    /// <summary>Builds the MP_UNREACH_NLRI (type 15) attribute VALUE for IPv6/Unicast:
+    /// AFI(2) + SAFI(1) + the withdrawn NLRI prefix list.</summary>
+    public static byte[] EncodeMpUnreachV6(IReadOnlyList<IpPrefix> prefixes)
+    {
+        ArgumentNullException.ThrowIfNull(prefixes);
+
+        var nlriSize = 0;
+        foreach (var p in prefixes)
+            nlriSize += 1 + (p.Length + 7) / 8;
+
+        var buffer = new byte[3 + nlriSize];
+        buffer[0] = (byte)(AfiIpv6 >> 8);
+        buffer[1] = (byte)AfiIpv6;
+        buffer[2] = SafiUnicast;
+        var offset = 3;
+        foreach (var p in prefixes)
+            offset += PrefixCodec.Encode(p, buffer.AsSpan(offset));
+        return buffer;
+    }
+
+    /// <summary>Decodes an MP_UNREACH_NLRI (type 15) VALUE for IPv6/Unicast.</summary>
+    public static IReadOnlyList<IpPrefix> DecodeMpUnreachV6(ReadOnlySpan<byte> value)
+    {
+        if (value.Length < 3)
+            throw new BgpParseException(
+                $"Truncated MP_UNREACH_NLRI: have {value.Length} bytes, need at least 3",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
+
+        var afi = BinaryPrimitives.ReadUInt16BigEndian(value);
+        var safi = value[2];
+        if (afi != AfiIpv6 || safi != SafiUnicast)
+            throw new BgpParseException(
+                $"MP_UNREACH_NLRI for unsupported address family: AFI={afi}, SAFI={safi} (expected 2/1)",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
+
+        var prefixes = new List<IpPrefix>();
+        var offset = 3;
+        while (offset < value.Length)
+        {
+            var (prefix, consumed) = PrefixCodec.Decode6(value[offset..]);
+            prefixes.Add(prefix);
+            offset += consumed;
+        }
+        return prefixes;
+    }
+}

--- a/BGPLite.Protocol/MpReachCodec.cs
+++ b/BGPLite.Protocol/MpReachCodec.cs
@@ -29,6 +29,9 @@ public static class MpReachCodec
     public static byte[] EncodeMpReachV6(UInt128 nextHop, IReadOnlyList<IpPrefix> prefixes)
     {
         ArgumentNullException.ThrowIfNull(prefixes);
+        foreach (var p in prefixes)
+            if (p.IsIpv4)
+                throw new ArgumentException($"IPv4 prefix {p} cannot be encoded in an IPv6 MP_REACH.", nameof(prefixes));
 
         // size = AFI(2) + SAFI(1) + NH-Len(1) + NH(16) + Reserved(1) + Σ NLRI
         var nlriSize = 0;
@@ -73,7 +76,7 @@ public static class MpReachCodec
         if (nhLength is not 16 and not 32)
             throw new BgpParseException(
                 $"Invalid MP_REACH_NLRI next-hop length: {nhLength} (must be 16 or 32 per RFC 2545)",
-                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList);
         if (value.Length < 4 + nhLength + 1)
             throw new BgpParseException(
                 $"Truncated MP_REACH_NLRI next hop: need {nhLength} bytes at offset 4",
@@ -102,6 +105,9 @@ public static class MpReachCodec
     public static byte[] EncodeMpUnreachV6(IReadOnlyList<IpPrefix> prefixes)
     {
         ArgumentNullException.ThrowIfNull(prefixes);
+        foreach (var p in prefixes)
+            if (p.IsIpv4)
+                throw new ArgumentException($"IPv4 prefix {p} cannot be encoded in an IPv6 MP_UNREACH.", nameof(prefixes));
 
         var nlriSize = 0;
         foreach (var p in prefixes)

--- a/BGPLite.Protocol/PrefixCodec.cs
+++ b/BGPLite.Protocol/PrefixCodec.cs
@@ -4,11 +4,19 @@ namespace BGPLite.Protocol;
 
 public static class PrefixCodec
 {
+    /// <summary>
+    /// Encodes one NLRI prefix, family-aware (#15 phase 1): IPv4 → length byte (0..32) plus at
+    /// most 4 data bytes; IPv6 → length byte (0..128) plus at most 16 data bytes (big-endian,
+    /// host bits cleared by <see cref="IpPrefix"/>).
+    /// </summary>
     public static int Encode(IpPrefix prefix, Span<byte> buffer)
     {
         var length = prefix.Length;
-        if (length > 32)
-            throw new ArgumentOutOfRangeException(nameof(prefix), length, "IPv4 prefix length must be in 0..32.");
+        var maxLen = prefix.IsIpv4 ? 32 : 128;
+        var maxBytes = prefix.IsIpv4 ? 4 : 16;
+        if (length > maxLen)
+            throw new ArgumentOutOfRangeException(nameof(prefix), length,
+                $"{(prefix.IsIpv4 ? "IPv4" : "IPv6")} prefix length must be in 0..{maxLen}.");
 
         if (buffer.Length < 1)
             throw new ArgumentOutOfRangeException(nameof(buffer), buffer.Length, "Buffer must hold at least the prefix length byte.");
@@ -24,11 +32,52 @@ public static class PrefixCodec
             throw new ArgumentOutOfRangeException(nameof(buffer), buffer.Length, $"Buffer too small: need {1 + byteCount} bytes for prefix length {length}.");
         buffer[0] = length;
 
-        var addr = prefix.Address;
-        for (var i = 0; i < byteCount; i++)
-            buffer[1 + i] = (byte)(addr >> (24 - i * 8));
+        if (prefix.IsIpv4)
+        {
+            var addr = BgpConstants.ToUint32OrThrow(prefix.Address, "IPv4 NLRI");
+            for (var i = 0; i < byteCount; i++)
+                buffer[1 + i] = (byte)(addr >> (24 - i * 8));
+        }
+        else
+        {
+            for (var i = 0; i < byteCount; i++)
+                buffer[1 + i] = (byte)(prefix.Address >> (128 - (i + 1) * 8));
+        }
 
         return 1 + byteCount;
+    }
+
+    /// <summary>
+    /// Decodes one IPv6 NLRI prefix from the head of <paramref name="buffer"/> (MP_REACH/MP_UNREACH
+    /// context, #15 phase 2 groundwork): a length byte 0..128 plus big-endian data bytes, masked to
+    /// the network address. Same malformed-input contract as <see cref="Decode"/> —
+    /// <see cref="BgpParseException"/> with Update Message Error / Invalid Network Field.
+    /// </summary>
+    public static (IpPrefix prefix, int bytesConsumed) Decode6(ReadOnlySpan<byte> buffer)
+    {
+        if (buffer.IsEmpty)
+            throw new BgpParseException("Truncated NLRI: buffer too small to contain a prefix length byte",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
+
+        var length = buffer[0];
+        if (length > 128)
+            throw new BgpParseException($"Invalid NLRI prefix length: {length} (must be 0..128)",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
+
+        if (length == 0)
+            return (new IpPrefix(UInt128.Zero, 0, isIpv4: false), 1);
+
+        var byteCount = (length + 7) / 8;
+        if (buffer.Length < 1 + byteCount)
+            throw new BgpParseException($"Truncated NLRI: need {1 + byteCount} bytes for prefix length {length}, have {buffer.Length}",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
+
+        UInt128 addr = 0;
+        for (var i = 0; i < byteCount; i++)
+            addr |= (UInt128)buffer[1 + i] << (128 - (i + 1) * 8);
+
+        addr &= IpPrefix.Mask(length, isIpv4: false);
+        return (new IpPrefix(addr, length, isIpv4: false), 1 + byteCount);
     }
 
     /// <summary>

--- a/BGPLite.Protocol/UpdateCodec.cs
+++ b/BGPLite.Protocol/UpdateCodec.cs
@@ -121,13 +121,15 @@ public static class UpdateCodec
     /// Validates that a route announcement carried the mandatory well-known attributes
     /// (ORIGIN, AS_PATH, NEXT_HOP). Throws <see cref="BgpNotificationException"/> on a missing attribute.
     /// </summary>
-    public static void ValidateMandatoryAttributes(bool originSeen, bool asPathSeen, bool nextHopSeen)
+    public static void ValidateMandatoryAttributes(bool originSeen, bool asPathSeen, bool nextHopSeen, bool mpReachV6Present = false)
     {
         if (!originSeen)
             throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MissingWellKnownAttribute, "Missing mandatory ORIGIN attribute");
         if (!asPathSeen)
             throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MissingWellKnownAttribute, "Missing mandatory AS_PATH attribute");
-        if (!nextHopSeen)
+        // RFC 4760 §5: an UPDATE whose routes ride in MP_REACH_NLRI carries the next hop inside
+        // the attribute — the classic NEXT_HOP requirement applies only to the IPv4 NLRI field.
+        if (!nextHopSeen && !mpReachV6Present)
             throw new BgpNotificationException(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MissingWellKnownAttribute, "Missing mandatory NEXT_HOP attribute");
     }
 
@@ -208,7 +210,7 @@ public static class UpdateCodec
     /// caller can apply treat-as-withdraw (RFC 7606) — the exact pipeline previously inlined in
     /// BgpSession.HandleUpdateAsync, moved verbatim (#270).
     /// </summary>
-    public static RouteAttributes ParseRouteAttributes(BgpUpdateMessage update, bool fourByteAsnSession, uint? localRouterId = null)
+    public static RouteAttributes ParseRouteAttributes(BgpUpdateMessage update, bool fourByteAsnSession, uint? localRouterId = null, bool mpReachV6Present = false)
     {
         try
         {
@@ -319,7 +321,7 @@ public static class UpdateCodec
                 }
             }
 
-            ValidateMandatoryAttributes(originSeen, asPathSeen, nextHopSeen);
+            ValidateMandatoryAttributes(originSeen, asPathSeen, nextHopSeen, mpReachV6Present);
             // RFC 4271 §6.3/§6.8: a semantically incorrect NEXT_HOP MUST be rejected with subcode 8
             // (Invalid NEXT_HOP Attribute) — "a valid unicast host address", never multicast, never
             // the receiving speaker's own address. Routed through the caller's treat-as-withdraw

--- a/BGPLite.Protocol/UpdateCodec.cs
+++ b/BGPLite.Protocol/UpdateCodec.cs
@@ -321,7 +321,7 @@ public static class UpdateCodec
                 }
             }
 
-            ValidateMandatoryAttributes(originSeen, asPathSeen, nextHopSeen, mpReachV6Present);
+            ValidateMandatoryAttributes(originSeen, asPathSeen, nextHopSeen, mpReachV6Present && update.Nlri.Count == 0);
             // RFC 4271 §6.3/§6.8: a semantically incorrect NEXT_HOP MUST be rejected with subcode 8
             // (Invalid NEXT_HOP Attribute) — "a valid unicast host address", never multicast, never
             // the receiving speaker's own address. Routed through the caller's treat-as-withdraw

--- a/BGPLite.Routing/Route.cs
+++ b/BGPLite.Routing/Route.cs
@@ -10,11 +10,12 @@ public sealed class Route
 {
     // #15 phase 1: 128-bit prefix — IPv4 in the low 32 bits with IsIpv4 = true (the implicit
     // uint → UInt128 conversion in object initializers lands exactly there), IPv6 in the full
-    // 128 bits with IsIpv4 = false. NextHop stays IPv4 (uint) until the MP_REACH phase.
+    // 128 bits with IsIpv4 = false. #15 phase 2: NextHop is likewise 128-bit (IPv4 low bits);
+    // for MP_REACH routes it carries the peer's IPv6 next hop.
     public required UInt128 Prefix { get; init; }
     public bool IsIpv4 { get; init; } = true;
     public required byte PrefixLength { get; init; }
-    public required uint NextHop { get; init; }
+    public required UInt128 NextHop { get; init; }
     public IReadOnlyList<uint> AsPath { get; init; } = [];
     public IReadOnlyList<uint> Communities { get; init; } = [];
     /// <summary>BGP Large Communities (RFC 8092): triplets of (Global : Local1 : Local2).</summary>

--- a/BGPLite.Routing/Route.cs
+++ b/BGPLite.Routing/Route.cs
@@ -8,7 +8,11 @@ namespace BGPLite.Routing;
 /// </summary>
 public sealed class Route
 {
-    public required uint Prefix { get; init; }
+    // #15 phase 1: 128-bit prefix — IPv4 in the low 32 bits with IsIpv4 = true (the implicit
+    // uint → UInt128 conversion in object initializers lands exactly there), IPv6 in the full
+    // 128 bits with IsIpv4 = false. NextHop stays IPv4 (uint) until the MP_REACH phase.
+    public required UInt128 Prefix { get; init; }
+    public bool IsIpv4 { get; init; } = true;
     public required byte PrefixLength { get; init; }
     public required uint NextHop { get; init; }
     public IReadOnlyList<uint> AsPath { get; init; } = [];
@@ -16,5 +20,5 @@ public sealed class Route
     /// <summary>BGP Large Communities (RFC 8092): triplets of (Global : Local1 : Local2).</summary>
     public IReadOnlyList<(uint Global, uint Local1, uint Local2)> LargeCommunities { get; init; } = [];
 
-    public (uint Prefix, byte Length) Key => (Prefix, PrefixLength);
+    public (UInt128 Prefix, byte Length, bool IsIpv4) Key => (Prefix, PrefixLength, IsIpv4);
 }

--- a/BGPLite.Routing/RouteTable.cs
+++ b/BGPLite.Routing/RouteTable.cs
@@ -15,7 +15,7 @@ namespace BGPLite.Routing;
 /// </summary>
 public sealed class RouteTable
 {
-    private readonly ConcurrentDictionary<(uint Prefix, byte Length), Entry> _routes = new();
+    private readonly ConcurrentDictionary<(UInt128 Prefix, byte Length, bool IsIpv4), Entry> _routes = new();
 
     // #343: maintained count — every successful mutation adjusts it exactly once (1:1 with the
     // dictionary transition), so Count is an O(1) Volatile.Read instead of ConcurrentDictionary.Count,
@@ -85,12 +85,15 @@ public sealed class RouteTable
     /// key away from a previous owner (#377 review). Subscribers must tolerate invocation from
     /// any thread and duplicate/late notifications — treat it as "you MIGHT have lost this key".
     /// </summary>
-    public event Action<object, (uint Prefix, byte Length)>? EntryOwnershipLost;
+    public event Action<object, (UInt128 Prefix, byte Length, bool IsIpv4)>? EntryOwnershipLost;
+
+    /// <summary>Unconditional removal, regardless of owner — administrative paths only (IPv4).</summary>
+    public bool Remove(uint prefix, byte length) => Remove((UInt128)prefix, length, isIpv4: true);
 
     /// <summary>Unconditional removal, regardless of owner — administrative paths only.</summary>
-    public bool Remove(uint prefix, byte length)
+    public bool Remove(UInt128 prefix, byte length, bool isIpv4 = true)
     {
-        var removed = _routes.TryRemove((prefix, length), out _);
+        var removed = _routes.TryRemove((prefix, length, isIpv4), out _);
         if (removed)
             Interlocked.Decrement(ref _count);
         return removed;
@@ -109,16 +112,19 @@ public sealed class RouteTable
     /// route.
     /// </para>
     /// </summary>
-    public bool RemoveOwnedBy(uint prefix, byte length, object owner)
+    public bool RemoveOwnedBy(uint prefix, byte length, object owner) =>
+        RemoveOwnedBy((UInt128)prefix, length, isIpv4: true, owner);
+
+    public bool RemoveOwnedBy(UInt128 prefix, byte length, bool isIpv4 = true, object owner = null!)
     {
         ArgumentNullException.ThrowIfNull(owner);
 
-        var key = (prefix, length);
+        var key = (prefix, length, isIpv4);
         if (!_routes.TryGetValue(key, out var entry) || !ReferenceEquals(entry.Owner, owner))
             return false;
 
-        var removed = ((ICollection<KeyValuePair<(uint Prefix, byte Length), Entry>>)_routes)
-            .Remove(new KeyValuePair<(uint Prefix, byte Length), Entry>(key, entry));
+        var removed = ((ICollection<KeyValuePair<(UInt128 Prefix, byte Length, bool IsIpv4), Entry>>)_routes)
+            .Remove(new KeyValuePair<(UInt128 Prefix, byte Length, bool IsIpv4), Entry>(key, entry));
         if (removed)
             Interlocked.Decrement(ref _count);
         return removed;
@@ -148,7 +154,7 @@ public sealed class RouteTable
         {
             if (!ReferenceEquals(pair.Value.Owner, owner))
                 continue;
-            if (((ICollection<KeyValuePair<(uint Prefix, byte Length), Entry>>)_routes).Remove(pair))
+            if (((ICollection<KeyValuePair<(UInt128 Prefix, byte Length, bool IsIpv4), Entry>>)_routes).Remove(pair))
                 removed++;
         }
         if (removed > 0)
@@ -156,8 +162,13 @@ public sealed class RouteTable
         return removed;
     }
 
-    public Route? Get(uint prefix, byte length) =>
-        _routes.TryGetValue((prefix, length), out var entry) ? entry.Route : null;
+    /// <summary>Removes every entry owned by <paramref name="owner"/> (session teardown) —
+    /// counts the removals for the maintained counter.</summary>
+    /// <inheritdoc/>
+
+
+    public Route? Get(UInt128 prefix, byte length, bool isIpv4 = true) =>
+        _routes.TryGetValue((prefix, length, isIpv4), out var entry) ? entry.Route : null;
 
     public IReadOnlyList<Route> GetAll()
     {

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -1043,11 +1043,11 @@ public sealed class BgpSession : IDisposable
     /// REPLACING session's thread (see RouteTable.EntryOwnershipLost); the concurrent set makes
     /// that safe, and a late/duplicate notification only removes an entry already gone.
     /// </summary>
-    private void OnEntryOwnershipLost(object previousOwner, (uint Prefix, byte Length) key)
+    private void OnEntryOwnershipLost(object previousOwner, (UInt128 Prefix, byte Length, bool IsIpv4) key)
     {
         if (!ReferenceEquals(previousOwner, this))
             return;
-        _installedPrefixes.TryRemove(new IpPrefix(key.Prefix, key.Length), out _);
+        _installedPrefixes.TryRemove(new IpPrefix(key.Prefix, key.Length, key.IsIpv4), out _);
     }
 
     /// <summary>
@@ -1061,7 +1061,9 @@ public sealed class BgpSession : IDisposable
 
     private void WithdrawIfOwned(IpPrefix prefix, string reason)
     {
-        if (!_routeTable.RemoveOwnedBy(prefix.Address, prefix.Length, this))
+        // Inbound v4 withdrawals: the NLRI address lives in the low 32 bits of the 128-bit form
+        // (IsIpv4 = true matches the install key from the UPDATE path).
+        if (!_routeTable.RemoveOwnedBy(prefix.Address, prefix.Length, isIpv4: true, owner: this))
         {
             if (_logger.IsEnabled(LogLevel.Debug))
                 _logger.LogDebug("Ignoring withdrawal of {Prefix} from {Peer}: not owned by this session", prefix, _peer);
@@ -1148,7 +1150,7 @@ public sealed class BgpSession : IDisposable
         foreach (var route in routes)
         {
             batch.Add(route);
-            _advertisedPrefixes.Add(new IpPrefix(route.Prefix, route.PrefixLength));
+            _advertisedPrefixes.Add(new IpPrefix(route.Prefix, route.PrefixLength, route.IsIpv4));
             if (batch.Count >= maxNlriPerUpdate)
             {
                 await SendRouteBatchAsync(nextHop, batch, attrCache);
@@ -1179,10 +1181,10 @@ public sealed class BgpSession : IDisposable
     {
         if (routes.Count <= 1) return routes as List<Route> ?? routes.ToList();
 
-        var merged = new Dictionary<(uint Prefix, byte Length), Route>(routes.Count);
+        var merged = new Dictionary<(UInt128 Prefix, byte Length, bool IsIpv4), Route>(routes.Count);
         foreach (var route in routes)
         {
-            var key = (route.Prefix, route.PrefixLength);
+            var key = (route.Prefix, route.PrefixLength, route.IsIpv4);
             if (merged.TryGetValue(key, out var existing))
             {
                 // Union communities — keep both source tags so the peer can filter by either.
@@ -1222,7 +1224,7 @@ public sealed class BgpSession : IDisposable
             // and only diverge in this final attribute.
             attrs = UpdateCodec.WithLargeCommunityAttribute(attrs, groupRoutes[0].LargeCommunities);
 
-            var nlri = groupRoutes.Select(r => new IpPrefix(r.Prefix, r.PrefixLength)).ToList();
+            var nlri = groupRoutes.Select(r => new IpPrefix(r.Prefix, r.PrefixLength, r.IsIpv4)).ToList();
             await SendUpdateBatchAsync(attrs, nlri);
         }
     }

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -31,6 +31,8 @@ public sealed class BgpSession : IDisposable
     private readonly ILogger<BgpSession> _logger;
     private readonly CancellationTokenSource _cts = new();
     private readonly Func<string, uint, CancellationToken, Task>? _onPeerIdentified;
+    // #15 phase 2: the peer advertised MP-BGP IPv6/Unicast.
+    private bool _peerMpIpv6Unicast;
     // #391: the EFFECTIVE per-peer prefix ceiling — the peer row's MaxPrefix override when the
     // peer is configured, else the global Bgp.MaxPrefixesPerPeer. Resolved once per
     // establish/refresh cycle in SendAllRoutesAsync (never per UPDATE); read on the UPDATE path
@@ -927,7 +929,8 @@ public sealed class BgpSession : IDisposable
             {
                 // #292 item 1: local router-id for the §6.8 self-address check on NEXT_HOP.
                 attrs = UpdateCodec.ParseRouteAttributes(update, _remoteFourByteAsn,
-                    BgpConstants.IPAddressToUint(_bgpConfig.GetRouterIdAddress()));
+                    BgpConstants.IPAddressToUint(_bgpConfig.GetRouterIdAddress()),
+                    mpReachV6Present: update.MpReachV6 is not null);
             }
             catch (BgpNotificationException ex) when (ex.ErrorCode == BgpConstants.Error.UpdateMessageError)
             {
@@ -948,6 +951,9 @@ public sealed class BgpSession : IDisposable
                 // what this peer installed, not whatever is at that prefix.
                 foreach (var nlri in update.Nlri)
                     WithdrawIfOwned(nlri, "Route withdrawn (treat-as-withdraw)");
+                if (update.MpReachV6 is { } failedReach)
+                    foreach (var p in failedReach.Prefixes)
+                        WithdrawIfOwned(p, "Route withdrawn (treat-as-withdraw, MP_REACH)");
                 _metrics.SetRouteCount(_routeTable.Count);
                 throw;
             }
@@ -1026,6 +1032,58 @@ public sealed class BgpSession : IDisposable
                         _logger.LogDebug("Route added: {Prefix} via {NextHop}", nlri, BgpConstants.UintToIPAddress(attrs.NextHop));
                 }
             }
+
+            // #15 phase 2 (RFC 4760 §7): MP_UNREACH_NLRI (AFI=2/SAFI=1) withdraws IPv6 routes
+            // this session installed — same ownership rule as the classic withdrawal path (#289).
+            if (update.MpUnreachV6 is { Count: > 0 } v6Withdrawn)
+            {
+                foreach (var prefix in v6Withdrawn)
+                    WithdrawIfOwned(prefix, "Route withdrawn (MP_UNREACH)");
+            }
+
+            // MP_REACH_NLRI (AFI=2/SAFI=1) announcements: same install pipeline as the classic
+            // IPv4 NLRI loop — AS-loop exclusion, filter, cap, ownership (#15 phase 2).
+            if (update.MpReachV6 is { } mpReach)
+            {
+                foreach (var nlri in mpReach.Prefixes)
+                {
+                    var route = new Route
+                    {
+                        Prefix = nlri.Address,
+                        IsIpv4 = false,
+                        PrefixLength = nlri.Length,
+                        NextHop = mpReach.NextHop,
+                        AsPath = attrs.AsPath,
+                        Communities = attrs.Communities,
+                        LargeCommunities = attrs.LargeCommunities
+                    };
+
+                    if (attrs.AsPath.AsSpan().Contains(_bgpConfig.Asn))
+                    {
+                        if (_logger.IsEnabled(LogLevel.Debug))
+                            _logger.LogDebug("Excluded looping route {Prefix} from {Peer}: local AS {Asn} in AS_PATH",
+                                nlri, _peer, _bgpConfig.Asn);
+                        continue;
+                    }
+
+                    if (_routeFilter.AcceptIncoming(route, filterPeerConfig))
+                    {
+                        var cap = Volatile.Read(ref _effectiveMaxPrefix);
+                        if (cap > 0 && !_installedPrefixes.ContainsKey(nlri) && _installedPrefixes.Count >= cap)
+                            throw new BgpNotificationException(
+                                BgpConstants.Error.Cease, BgpConstants.SubError.CeaseMaxPrefixes,
+                                $"Peer {_peer} exceeded the per-peer prefix limit ({cap}); session reset per RFC 4486");
+                        _installedPrefixes.TryAdd(nlri, 0);
+                        _routeTable.AddOrUpdate(route, owner: this);
+
+                        if (cap > 0 && !_maxPrefixesWarned && _installedPrefixes.Count >= MaxPrefixWarningThreshold(cap))
+                        {
+                            _maxPrefixesWarned = true;
+                            _logger.LogWarning("Peer {Peer} at {Count}/{Cap} of the per-peer prefix limit", _peer, _installedPrefixes.Count, cap);
+                        }
+                    }
+                }
+            }
         }
 
         _metrics.SetRouteCount(_routeTable.Count);
@@ -1063,7 +1121,7 @@ public sealed class BgpSession : IDisposable
     {
         // Inbound v4 withdrawals: the NLRI address lives in the low 32 bits of the 128-bit form
         // (IsIpv4 = true matches the install key from the UPDATE path).
-        if (!_routeTable.RemoveOwnedBy(prefix.Address, prefix.Length, isIpv4: true, owner: this))
+        if (!_routeTable.RemoveOwnedBy(prefix.Address, prefix.Length, prefix.IsIpv4, owner: this))
         {
             if (_logger.IsEnabled(LogLevel.Debug))
                 _logger.LogDebug("Ignoring withdrawal of {Prefix} from {Peer}: not owned by this session", prefix, _peer);
@@ -1415,6 +1473,10 @@ public sealed class BgpSession : IDisposable
         if (remoteOpen.Capabilities.Any(c => c.Code == BgpConstants.Capability.RouteRefresh))
             capabilities.Add(BgpCapabilityInfo.RouteRefresh());
 
+        // #15 phase 2: advertise MP IPv6/Unicast only when the peer also supports it.
+        if (CapabilityHelper.SupportsMultiprotocolIpv6Unicast(remoteOpen))
+            capabilities.Add(BgpCapabilityInfo.MultiprotocolIpv6Unicast());
+
         // #318: the Graceful Restart capability is deliberately NOT advertised. RFC 4724 §4.2 obliges
         // a speaker engaging GR procedures to retain and stale-mark a restarting peer's routes;
         // BGPLite implements none of that receiving half, so advertising the <AFI, SAFI, F> tuple
@@ -1556,6 +1618,9 @@ public sealed class BgpSession : IDisposable
         // CodeRabbit (integration review): propagate the session token into the upsert so a
         // locked SQLite cannot out-wait shutdown/replacement before cancellation is observed.
         if (_onPeerIdentified is not null) await _onPeerIdentified(_peerConfig.Address, _remoteAsn, ct);
+
+        // #15 phase 2: the peer can send IPv6 routes via MP_REACH_NLRI (AFI=2/SAFI=1).
+        _peerMpIpv6Unicast = CapabilityHelper.SupportsMultiprotocolIpv6Unicast(open);
 
         var peerGr = CapabilityHelper.GetGracefulRestart(open);
         _logger.LogInformation("Peer {Peer} Graceful Restart: {State}",

--- a/BGPLite.Server/RouteAssembler.cs
+++ b/BGPLite.Server/RouteAssembler.cs
@@ -313,15 +313,20 @@ public sealed class RouteAssembler : IRouteAssembler
         // A route is covered when its length is strictly greater than the custom prefix's and its
         // network, masked to the custom length, equals the (already host-bit-normalized) custom
         // network — the repo's masking idiom (PrefixCidr, ExactUnionPrefixAggregator).
-        // Mask(0) must be 0, not 0xFFFFFFFF << 32 (a shift-by-32 is a no-op on uint, not a wipe).
-        static uint Mask(byte length) => length == 0 ? 0u : 0xFFFFFFFFu << (32 - length);
+        // #15 phase 1: Route.Prefix is 128-bit now. Custom prefixes are IPv4-only (PrefixCidr),
+        // so suppression applies to IPv4 routes by their low-32-bit network; an IPv6 route can
+        // never be covered by an IPv4 custom prefix and always passes.
+        // Mask is in the v4 low-32 layout; Mask(0) must be 0, not 0xFFFFFFFF << 32 (a shift-by-32
+        // is a no-op on uint, not a wipe).
+        static UInt128 Mask(byte length) => length == 0 ? 0u : (UInt128)(0xFFFFFFFFu << (32 - length));
         return routes
             .Where(r =>
                 // A configured custom prefix is never suppressed — including by a broader
                 // custom prefix of the same peer. Exact (network, length) == custom match.
-                customRanges.Contains((r.Prefix, r.PrefixLength))
+                (r.IsIpv4 && customRanges.Contains(((uint)r.Prefix, r.PrefixLength)))
+                || !r.IsIpv4
                 || !customRanges.Any(cr => r.PrefixLength > cr.Length
-                                           && (r.Prefix & Mask(cr.Length)) == cr.Network))
+                                           && ((uint)r.Prefix & Mask(cr.Length)) == cr.Network))
             .ToList();
     }
 

--- a/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
+++ b/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
@@ -199,7 +199,7 @@ public class BgpSessionRouteOwnershipTests
             {
                 if (BgpMessageReader.ReadMessage(frame) is not BgpUpdateMessage update) continue;
                 foreach (var p in update.Nlri)
-                    nlri.Add((p.Address, p.Length));
+                    nlri.Add(((uint)p.Address, p.Length));
             }
             if (nlri.Count > 0) break;
             await Task.Delay(TimeSpan.FromMilliseconds(10));
@@ -667,7 +667,7 @@ public class BgpSessionRouteOwnershipTests
         // B takes the SAME prefix over — A no longer owns it. #377 review: await the
         // ownership-loss callback deterministically instead of a fixed delay.
         var aLostOwnership = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        void OnLost(object owner, (uint Prefix, byte Length) key)
+        void OnLost(object owner, (UInt128 Prefix, byte Length, bool IsIpv4) key)
         {
             if (ReferenceEquals(owner, a) && key.Prefix == TenSlashEight)
                 aLostOwnership.TrySetResult();

--- a/BGPLite.Tests/IpPrefixModelTests.cs
+++ b/BGPLite.Tests/IpPrefixModelTests.cs
@@ -1,0 +1,108 @@
+using System.Net;
+using BGPLite.Protocol;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #15 phase 1: the family-aware 128-bit address model. IPv4 lives in the low 32 bits
+/// (IsIpv4), IPv6 in the full UInt128; the constructor masks host bits; ToString renders
+/// RFC 5952 for IPv6; Afi.IPv6 = 2 and the 128-bit (de)serializers reject wrong-family
+/// conversion instead of truncating (resolves #13 at the model level).
+/// </summary>
+public class IpPrefixModelTests
+{
+    private static UInt128 V6(string hex) => BgpConstants.ToUInt128(IPAddress.Parse(hex));
+
+    [Fact]
+    public void Afi_IPv6_IsTwo()
+    {
+        Assert.Equal(2, BgpConstants.Afi.IPv6);
+        Assert.Equal(1, BgpConstants.Afi.IPv4);
+    }
+
+    [Theory]
+    [InlineData("::", 0)]
+    [InlineData("2001:db8::", 32)]
+    [InlineData("2001:db8:1:2::", 64)]        // network address at /64 (host bits masked anyway)
+    [InlineData("2001:db8::1", 128)]
+    public void V6_Roundtrip_AddrLenString(string text, byte length)
+    {
+        var addr = IPAddress.Parse(text);
+        var prefix = new IpPrefix(addr, length);
+
+        Assert.False(prefix.IsIpv4);
+        Assert.Equal($"{text}/{length}", prefix.ToString());
+    }
+
+    [Fact]
+    public void V4_Behavior_Unchanged()
+    {
+        var prefix = new IpPrefix((uint)IPAddress.Parse("10.0.0.0").GetAddressBytes()[0] << 24, 8);
+        Assert.True(prefix.IsIpv4);
+        Assert.Equal("10.0.0.0/8", prefix.ToString());
+
+        var direct = new IpPrefix(IPAddress.Parse("192.168.1.255"), 24);
+        Assert.True(direct.IsIpv4);
+        Assert.Equal("192.168.1.0/24", direct.ToString()); // host bits masked
+    }
+
+    [Fact]
+    public void V4_LengthAbove32_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new IpPrefix((uint)1, 33));
+    }
+
+    [Fact]
+    public void V6_LengthAbove128_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new IpPrefix(V6("2001:db8::1"), 129, isIpv4: false));
+    }
+
+    [Fact]
+    public void WrongFamily_Conversion_Throws_NotTruncates()
+    {
+        // #13 model-level fix: a 128-bit value that does not fit a 32-bit field must throw,
+        // never truncate.
+        var wide = V6("2001:db8::1");
+        var ex = Assert.Throws<InvalidOperationException>(() => BgpConstants.ToUint32OrThrow(wide, "NEXT_HOP"));
+        Assert.Contains("wrong address family", ex.Message);
+
+        // A value that fits is convertible.
+        Assert.Equal(0xC0A80000u, BgpConstants.ToUint32OrThrow(0xC0A80000u, "v4"));
+    }
+
+    [Fact]
+    public void ToUInt128_Roundtrips_BothFamilies()
+    {
+        var v4 = IPAddress.Parse("192.168.1.7");
+        var v4Value = BgpConstants.ToUInt128(v4);
+        Assert.True(v4Value <= uint.MaxValue);          // low 32 bits only
+        Assert.Equal(v4, BgpConstants.FromUInt128(v4Value, isIpv4: true));
+
+        var v6 = IPAddress.Parse("2001:db8::1234:5678");
+        var v6Value = BgpConstants.ToUInt128(v6);
+        Assert.Equal(v6, BgpConstants.FromUInt128(v6Value, isIpv4: false));
+    }
+
+    [Fact]
+    public void DualStack_Keys_CannotCollide()
+    {
+        // The IPv4 low-bits form and a full IPv6 form of the same numeric value must be
+        // distinguishable prefixes — the RouteTable key carries IsIpv4 for exactly this reason.
+        var v4 = new IpPrefix(0x0A000000u, 8);
+        var v6 = new IpPrefix(0x0A000000u, 8, isIpv4: false);
+
+        Assert.NotEqual(v4, v6);
+        Assert.False(v4.Equals(v6));
+    }
+
+    [Fact]
+    public void HostBits_Masked_InConstructor_BothFamilies()
+    {
+        var v4 = new IpPrefix(0x0A1B2C30u, 24);
+        Assert.Equal((UInt128)0x0A1B2C00u, v4.Address);
+
+        var v6 = new IpPrefix(V6("2001:db8::1"), 32, isIpv4: false);
+        Assert.Equal(V6("2001:db8::"), v6.Address);
+    }
+}

--- a/BGPLite.Tests/MpReachCodecTests.cs
+++ b/BGPLite.Tests/MpReachCodecTests.cs
@@ -1,0 +1,162 @@
+using System.Net;
+using System.Net.Sockets;
+using BGPLite.Protocol;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #15 phase 2: MP_REACH_NLRI / MP_UNREACH_NLRI (RFC 4760) wire codec for IPv6/Unicast —
+/// attribute VALUE encode/decode roundtrips at boundary lengths, the RFC 2545 32-byte next-hop
+/// form, and malformed-input handling (truncated header/body, unsupported AFI/SAFI, bad
+/// next-hop length).
+/// </summary>
+public class MpReachCodecTests
+{
+    private static readonly byte[] Nh16 = new byte[16];
+    private static IpPrefix V6(byte length) => new(BgpConstants.ToUInt128(IPAddress.Parse("2001:db8::")), length, isIpv4: false);
+
+    [Fact]
+    public void Encode_ExactByteLayout()
+    {
+        var prefixes = new List<IpPrefix> { new(ToV6("20010db8000000000000000000000001"), 128, isIpv4: false) };
+        var data = MpReachCodec.EncodeMpReachV6(ToV6("20010db8ffff00000000000000000001"), prefixes);
+
+        // AFI=2 / SAFI=1 / NH-Len=16 / next-hop / reserved / length=128 / 16 bytes of 2001:0db8::1
+        Assert.Equal(
+        [
+            0x00, 0x02,             // AFI = 2
+            0x01,                   // SAFI = 1
+            16,                     // next-hop length
+            0x20, 0x01, 0x0d, 0xb8, 0xff, 0xff, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,   // next hop
+            0x00,                   // reserved
+            128,                    // NLRI: /128
+            0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,   // 2001:db8::1
+        ], data);
+    }
+
+    [Fact]
+    public void Roundtrip_MultiplePrefixes()
+    {
+        var prefixes = new List<IpPrefix>
+        {
+            V6(0),    // ::/0
+            V6(32),   // 2001:db8::/32
+            V6(64),   // 2001:db8::/64 (host bits masked)
+            new(ToV6("20010db8000000000000000000000001"), 128, isIpv4: false),
+        };
+        var nextHop = ToV6("fe800000000000000000000000000001");
+
+        var encoded = MpReachCodec.EncodeMpReachV6(nextHop, prefixes);
+        var decoded = MpReachCodec.DecodeMpReachV6(encoded);
+
+        Assert.Equal(nextHop, decoded.NextHop);
+        Assert.Equal(prefixes.Count, decoded.Prefixes.Count);
+        for (var i = 0; i < prefixes.Count; i++)
+            Assert.Equal(prefixes[i], decoded.Prefixes[i]);
+    }
+
+    [Fact]
+    public void Decode_AcceptsRfc2545_32ByteNextHop()
+    {
+        // RFC 2545 §3: global (16 bytes) + link-local (16 bytes) = 32-byte next-hop form.
+        // header: AFI(2) + SAFI(1) + NH-Len(1) + NH(32) + Reserved(1) = 37, then /64 NLRI (9) = 46.
+        var value = new byte[46];
+        value[0] = 0; value[1] = 2; value[2] = 1; value[3] = 32;
+        for (var i = 0; i < 16; i++) value[4 + i] = 0x20;         // global
+        for (var i = 0; i < 16; i++) value[20 + i] = 0xFE;        // link-local
+        value[36] = 0;                                             // reserved
+        value[37] = 64;                                            // /64 prefix
+        for (var i = 0; i < 8; i++) value[38 + i] = 0x20;         // 2001:...
+
+        var decoded = MpReachCodec.DecodeMpReachV6(value);
+
+        // The GLOBAL address (first 16 bytes of 0x20) is used; link-local (0xFE) skipped.
+        Assert.Equal((UInt128)0x20, decoded.NextHop >> 120);   // top byte = global's first byte
+        Assert.Single(decoded.Prefixes);
+    }
+
+    [Fact]
+    public void Decode_BadNextHopLength_Throws()
+    {
+        var value = new byte[21];
+        value[0] = 0; value[1] = 2; value[2] = 1; value[3] = 8; // NH len 8 — invalid
+
+        Assert.Throws<BgpParseException>(() => MpReachCodec.DecodeMpReachV6(value));
+    }
+
+    [Fact]
+    public void Decode_WrongAfi_Throws()
+    {
+        var value = new byte[21];
+        value[0] = 0; value[1] = 1; value[2] = 1; value[3] = 16; // AFI=1 — IPv4, not supported here
+
+        Assert.Throws<BgpParseException>(() => MpReachCodec.DecodeMpReachV6(value));
+    }
+
+    [Fact]
+    public void Decode_Truncated_Throws()
+    {
+        Assert.Throws<BgpParseException>(() => MpReachCodec.DecodeMpReachV6(new byte[10]));
+    }
+
+    [Fact]
+    public void EncodeUnreach_DecodeUnreach_Roundtrip()
+    {
+        var prefixes = new List<IpPrefix> { V6(48), V6(128) };
+        var encoded = MpReachCodec.EncodeMpUnreachV6(prefixes);
+
+        // AFI=2 / SAFI=1 header
+        Assert.Equal(0x00, encoded[0]);
+        Assert.Equal(0x02, encoded[1]);
+        Assert.Equal(0x01, encoded[2]);
+
+        var decoded = MpReachCodec.DecodeMpUnreachV6(encoded);
+        Assert.Equal(2, decoded.Count);
+        Assert.Equal(prefixes[0], decoded[0]);
+        Assert.Equal(prefixes[1], decoded[1]);
+    }
+
+    [Fact]
+    public void DecodeUnreach_Truncated_Throws()
+    {
+        Assert.Throws<BgpParseException>(() => MpReachCodec.DecodeMpUnreachV6(new byte[2]));
+    }
+
+    [Fact]
+    public void ReaderExtracts_MpReachV6()
+    {
+        var attr = new PathAttribute { Flags = 0x80, TypeCode = 14, Data = MpReachCodec.EncodeMpReachV6(0x2001, [V6(128)]) };
+        var update = new BgpUpdateMessage
+        {
+            WithdrawnRoutes = [],
+            PathAttributes = [AttributeHelper.WriteOrigin(0), AttributeHelper.WriteAsPath([65002], fourByteAsn: true), attr],
+            Nlri = []
+        };
+        var buf = new byte[512];
+        var n = BgpMessageWriter.WriteMessage(update, buf);
+        var read = (BgpUpdateMessage)BgpMessageReader.ReadMessage(buf.AsSpan(0, n));
+        Assert.NotNull(read.MpReachV6);
+        Assert.True(read.MpReachV6 is { } reach && reach.Prefixes.Count == 1);
+    }
+
+    [Fact]
+    public void Encode_NonCanonicalPrefix_Masked()
+    {
+        var prefix = new IpPrefix(ToV6("20010db8012345670000000000000001"), 48, isIpv4: false);
+
+        var encoded = MpReachCodec.EncodeMpReachV6(0, [prefix]);
+        var decoded = MpReachCodec.DecodeMpReachV6(encoded);
+
+        // The host bits below /48 were masked by the IpPrefix constructor.
+        Assert.Equal(new IpPrefix(ToV6("20010db8012300000000000000000000"), 48, isIpv4: false), decoded.Prefixes[0]);
+    }
+
+    private static UInt128 ToV6(string hex)
+    {
+        UInt128 value = 0;
+        foreach (var c in hex) value = (value << 4) | (UInt128)Uri.FromHex(c);
+        return value;
+    }
+}

--- a/BGPLite.Tests/PrefixAggregatorTests.cs
+++ b/BGPLite.Tests/PrefixAggregatorTests.cs
@@ -19,28 +19,31 @@ public class PrefixAggregatorTests
             LargeCommunities = largeCommunities ?? []
         };
 
-    private static List<(uint Prefix, byte Length)> Pfx(IReadOnlyList<Route> routes) =>
+    private static List<(UInt128 Prefix, byte Length)> Pfx(IReadOnlyList<Route> routes) =>
         routes.Select(r => (r.Prefix, r.PrefixLength)).ToList();
 
     /// <summary>Independent reference implementation: the sorted, merged [start,end] intervals
     /// of a prefix set. Used to cross-check that aggregation adds no address and drops none.</summary>
-    private static List<(ulong Start, ulong End)> UnionRanges(IEnumerable<(uint Prefix, byte Length)> prefixes)
+    private static List<(UInt128 Start, UInt128 End)> UnionRanges(IEnumerable<(UInt128 Prefix, byte Length)> prefixes)
     {
-        var intervals = new List<(ulong Start, ulong End)>();
+        var intervals = new List<(UInt128 Start, UInt128 End)>();
         foreach (var (prefix, length) in prefixes)
         {
             if (length > 32) continue;
-            var mask = length == 0 ? 0u : (0xFFFFFFFFu << (32 - length));
-            var start = (ulong)(prefix & mask);
-            var size = length == 0 ? (1UL << 32) : (1UL << (32 - length));
+            var mask = length == 0 ? 0u : (UInt128)(0xFFFFFFFFu << (32 - length));
+            var start = prefix & mask;
+            var size = length == 0 ? ((UInt128)1 << 32) : ((UInt128)1 << (32 - length));
             intervals.Add((start, start + size - 1));
         }
         intervals.Sort((a, b) => a.Start.CompareTo(b.Start));
-        var merged = new List<(ulong Start, ulong End)>();
+        var merged = new List<(UInt128 Start, UInt128 End)>();
         foreach (var (s, e) in intervals)
         {
             if (merged.Count > 0 && s <= merged[^1].End + 1)
-                merged[^1] = (merged[^1].Start, Math.Max(merged[^1].End, e));
+            {
+                var newEnd = merged[^1].End > e ? merged[^1].End : e;
+                merged[^1] = (merged[^1].Start, newEnd);
+            }
             else
                 merged.Add((s, e));
         }

--- a/BGPLite.Tests/PrefixCodecTests.cs
+++ b/BGPLite.Tests/PrefixCodecTests.cs
@@ -117,17 +117,40 @@ public class PrefixCodecTests
         }
     }
 
+    private static IpPrefix V6Prefix() =>
+        new(ToUInt128Hex("20010db8000000000000000000000001"), 128, isIpv4: false);
+
+    private static UInt128 ToUInt128Hex(string hex)
+    {
+        UInt128 value = 0;
+        foreach (var c in hex) value = (value << 4) | (UInt128)Uri.FromHex(c);
+        return value;
+    }
+
+    [Fact]
+    public void Encode_LengthAbove32_Throws()
+    {
+        // The IpPrefix constructor itself rejects IPv4 lengths above 32 — the codec never sees
+        // an out-of-domain value through a canonical prefix.
+        Assert.Throws<ArgumentOutOfRangeException>(() => new IpPrefix(0xC0A80000, (byte)33));
+    }
+
     [Theory]
-    [InlineData(33)]
+    [InlineData(0)]
+    [InlineData(32)]
     [InlineData(64)]
     [InlineData(128)]
-    [InlineData(255)]
-    public void Encode_LengthAbove32_Throws(int badLength)
+    public void Encode_Ipv6_Accepts_FullRange_AndRoundtrips(byte length)
     {
-        var prefix = new IpPrefix(0xC0A80000, (byte)badLength);
-        var buffer = new byte[8];
+        var address = ToUInt128Hex("20010db8000000000000000000000001");
+        var prefix = new IpPrefix(address, length, isIpv4: false);
+        var buf = new byte[17];
+        var written = PrefixCodec.Encode(prefix, buf);
 
-        Assert.Throws<ArgumentOutOfRangeException>(() => PrefixCodec.Encode(prefix, buffer));
+        var (decoded, consumed) = PrefixCodec.Decode6(buf.AsSpan(0, written));
+        Assert.Equal(written, consumed);
+        Assert.Equal(prefix.Address, decoded.Address);
+        Assert.False(decoded.IsIpv4);
     }
 
     [Theory]

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -228,6 +228,13 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
   routes flowing; such routes now stop at the filter (visible via the existing send logs).
 - **Tracker:** #389.
 
+### D21. IPv6 dual-stack address model (ADR 0001)
+- **Decision:** `IpPrefix` is family-aware over `UInt128` — IPv4 in the low 32 bits with an
+  explicit `IsIpv4` flag, IPv6 as the full 128 bits; the constructor masks host bits (canonical
+  keys); `Route.Key`/`RouteTable` keys carry the family; the aggregator partitions by family.
+  Full ADR: `docs/adr/0001-ipv6-address-model.md` (#15 phase 1).
+- **Tracker:** #15, #14.
+
 ## Management API
 
 ### D18. `X-Real-IP` is ignored by default, even behind trusted proxies

--- a/docs/adr/0001-ipv6-address-model.md
+++ b/docs/adr/0001-ipv6-address-model.md
@@ -1,0 +1,57 @@
+# ADR 0001: IPv6 dual-stack address model
+
+Status: accepted · Date: 2026-09-01 · Epic: #14 · Foundational issue: #15 · PR: (this)
+
+## Context
+
+The entire address model was 32-bit `uint`: `IpPrefix(uint Address, byte Length)`, `Route.Prefix`,
+`RouteTable` key `(uint, byte)`, `PrefixCodec` 32-bit shifts. IPv6/MP-BGP (#14 phases 2+) cannot be
+built on a 32-bit model, so the model had to change first. The model is referenced by ~13 source
+files and the whole test suite, so the representation choice is expensive to reverse.
+
+## Decision
+
+1. **Representation**: `IpPrefix` becomes a family-aware value type over `UInt128`:
+   - IPv4 → the address occupies the **low 32 bits**, `IsIpv4 = true` (no IPv4-mapped `::ffff:`
+     prefix in the stored value — the flag carries the family, the numeric value stays small).
+   - IPv6 → the full 128 bits, `IsIpv4 = false`.
+   - `bool IsIpv4` is an explicit stored field (not derived from the address): an IPv4 /8 mask
+     would erase the `::ffff:` marker if the family were derived from an IPv4-mapped layout.
+2. **Canonicalization invariant**: the constructor masks host bits to the network address. An
+   `IpPrefix` value is always a valid network key — this permanently closes the #7
+   "mask-at-insert" class of defects at the type level.
+3. **Dual-stack keys**: `Route.Key` / the `RouteTable` dictionary key carry `IsIpv4` alongside
+   `(Address, Length)`. The IPv4 low-bits form cannot collide with a full-128 IPv6 form that has
+   `IsIpv4 = false`; the flag in the key makes that explicit and total.
+4. **Codec**: `PrefixCodec.Encode` is family-aware (IPv4 → length byte ≤ 32 + ≤ 4 data bytes;
+   IPv6 → length byte ≤ 128 + ≤ 16 data bytes, big-endian). `Decode` remains the IPv4-NLRI parser
+   (rejects length > 32 per RFC 4271 §4.3 — the IPv4 UPDATE NLRI field is IPv4-only);
+   `Decode6` is the IPv6-NLRI parser for the MP_REACH/MP_UNREACH phase.
+5. **128-bit converters**: `BgpConstants.ToUInt128(IPAddress)` / `FromUInt128(value, isIpv4)` /
+   `ToUint32OrThrow(value, field)` — the wrong-family guard throws instead of silently truncating
+   (model-level fix for #13). The existing `IPAddressToUint`/`UintToIPAddress` remain for the
+   IPv4-only router-id / next-hop paths.
+6. **Aggregation**: `ExactUnionPrefixAggregator` groups by (communities, IsIpv4) — IPv4 and IPv6
+   prefixes are never merged into one summary even with identical tags. Interval math is
+   generalized to UInt128. (Full 128-bit LPM and IPv6 aggregation policy remain Phase 3.)
+
+## Consequences
+
+- `uint` → `UInt128` widening is implicit, so IPv4 construction sites (`Route { Prefix = 0xC0A80000u }`)
+  keep compiling unchanged; narrowing reads cast explicitly.
+- The aggregator's `length > 32` skip means an IPv6 route arriving today would be dropped
+  defensively — unreachable until Phase 2 delivers IPv6 NLRI, and re-visited in Phase 3.
+- `Route.NextHop` stays IPv4 `uint` until Phase 2 (MP_REACH next-hop, RFC 2545).
+- Each later phase builds on this model without re-breaking it; the epic's phased checklist
+  (#14 phases 2–5) tracks the remaining work.
+
+## Alternatives considered
+
+- **`IPAddress`-based `IpPrefix`**: reference type — allocation per prefix on the routing hot
+  path and no cheap masking/equality. Rejected.
+- **IPv4-mapped storage** (`::ffff:0:0/96` prefix inside the value): canonical dual-stack form,
+  but family cannot be derived after masking (an IPv4 /8 mask erases the `::ffff:` marker), so a
+  stored family flag is required anyway — and the mapped marker would corrupt under generic 128-bit
+  masking. Rejected in favor of the low-bits form + flag.
+- **`byte[16]`**: array identity breaks record equality; `ReadOnlyMemory<byte>` allocates.
+  Rejected.

--- a/docs/adr/0001-ipv6-address-model.md
+++ b/docs/adr/0001-ipv6-address-model.md
@@ -39,8 +39,9 @@ files and the whole test suite, so the representation choice is expensive to rev
 
 - `uint` → `UInt128` widening is implicit, so IPv4 construction sites (`Route { Prefix = 0xC0A80000u }`)
   keep compiling unchanged; narrowing reads cast explicitly.
-- The aggregator's `length > 32` skip means an IPv6 route arriving today would be dropped
-  defensively — unreachable until Phase 2 delivers IPv6 NLRI, and re-visited in Phase 3.
+- Phase 2 delivered IPv6 NLRI via MP_REACH/MP_UNREACH; the aggregator's `length > 32` skip
+  means IPv6 routes arriving via MP_REACH are defensively dropped until Phase 3 generalizes the
+  aggregator.
 - `Route.NextHop` stays IPv4 `uint` until Phase 2 (MP_REACH next-hop, RFC 2545).
 - Each later phase builds on this model without re-breaking it; the epic's phased checklist
   (#14 phases 2–5) tracks the remaining work.


### PR DESCRIPTION
Closes #15
Refs #14 (parent epic), #13 (wrong-family model fix), #7 (routing coordination)

Third integration: IPv6 Phases 1+2 — the foundational 128-bit address model and MP-BGP IPv6/Unicast protocol support.

## Per-phase summary

| Phase | PR | What | Verification |
|---|---|---|---|
| 1 — Address model | [#401](https://github.com/ruhex/BGPLite/pull/401) | Family-aware `IpPrefix` over `UInt128` (IPv4 low-32-bits + `IsIpv4` flag, IPv6 full 128); constructor masks host bits (canonical keys); `PrefixCodec` family-aware Encode + new `Decode6` (IPv6 NLRI); `Afi.IPv6 = 2`; `ToUInt128`/`FromUInt128`/`ToUint32OrThrow` non-truncating converters (model fix for #13); `Route.Key`/`RouteTable` keys carry the family; aggregator partitions by family | 939/939; `IpPrefixModelTests` (12: family roundtrips, RFC 5952, wrong-family, dual-stack keys, masking) |
| 2 — MP-BGP | [#402](https://github.com/ruhex/BGPLite/pull/402) | `MpReachCodec` (MP_REACH/MP_UNREACH attr 14/15 values: AFI/SAFI header, 16/32-byte NH per RFC 2545, NLRI list); `MultiprotocolIpv6Unicast()` capability + detection + advertisement (gated on peer); session receive path (MP_REACH install with `IsIpv4=false`, cap, AS-loop; MP_UNREACH withdraw); `ParseRouteAttributes` waives classic NEXT_HOP when MP_REACH present (RFC 4760 §5); `Route.NextHop` widened to `UInt128` | 949/949; `MpReachCodecTests` (9: byte layout, roundtrips, RFC 2545 NH, malformed) |

## Behavior changes
- **IPv4: none.** The low-32-bit representation, masking, codec bytes, and route-table keys are value-identical; the full IPv4 suite is green without assertion changes.
- **IPv6: additive** — a peer advertising AFI=2/SAFI=1 can now send IPv6 routes via MP_REACH, which BGPLite installs with ownership tracking and per-peer cap enforcement. No IPv6 sources exist yet (Phase 4), so BGPLite does not originate IPv6 routes.

## ADR
[ADR 0001](docs/adr/0001-ipv6-address-model.md) — representation rationale (`UInt128` low-bits + flag vs `IPAddress` vs IPv4-mapped vs byte[16]), alternatives, consequences.

## Out of scope (future phases of #14)
Phase 3 (LPM + 128-bit aggregator policy), Phase 4 (DualMode socket, RIPEstat v6, PrefixListParser IPv6), Phase 5 (templates, GR tuples). The aggregator's `length > 32` skip means IPv6 routes arriving today would be dropped defensively — unreachable until Phase 2 delivers IPv6 NLRI (done in this PR) — and is re-visited in Phase 3.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MP-BGP IPv6/Unicast support for announcing and withdrawing IPv6 routes.
  * Added IPv6 capability negotiation and support detection.
  * Added IPv6 prefix handling, formatting, validation, and route-table support.
  * Added IPv6 next-hop encoding and decoding.
* **Bug Fixes**
  * Malformed IPv6 routing updates are now rejected safely without terminating the session.
  * IPv4 values that exceed 32 bits are no longer silently truncated.
* **Documentation**
  * Documented the dual-stack IPv6 address model and related design decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->