### PR TITLE
fix: address the CodeRabbit findings on the IPv6 integration review (#403)

### DIFF
--- a/BGPLite.Protocol/BgpMessageReader.cs
+++ b/BGPLite.Protocol/BgpMessageReader.cs
@@ -286,12 +286,18 @@ public static class BgpMessageReader
                 // (the attribute carries NLRI ⇒ treat-as-withdraw).
                 if (attr.TypeCode == MpReachCodec.MpReachNlriType)
                 {
-                    var reach = MpReachCodec.DecodeMpReachV6(attr.Data);
-                    mpReachV6 = reach;
+                    // RFC 4760: only one MP_REACH per UPDATE. A duplicate is a protocol error.
+                    if (mpReachV6 is not null)
+                        throw new BgpParseException("Duplicate MP_REACH_NLRI attribute",
+                            BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList);
+                    mpReachV6 = MpReachCodec.DecodeMpReachV6(attr.Data);
                     continue;
                 }
                 if (attr.TypeCode == MpReachCodec.MpUnreachNlriType)
                 {
+                    if (mpUnreachV6 is not null)
+                        throw new BgpParseException("Duplicate MP_UNREACH_NLRI attribute",
+                            BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList);
                     mpUnreachV6 = MpReachCodec.DecodeMpUnreachV6(attr.Data);
                     continue;
                 }

--- a/BGPLite.Protocol/MpReachCodec.cs
+++ b/BGPLite.Protocol/MpReachCodec.cs
@@ -29,6 +29,9 @@ public static class MpReachCodec
     public static byte[] EncodeMpReachV6(UInt128 nextHop, IReadOnlyList<IpPrefix> prefixes)
     {
         ArgumentNullException.ThrowIfNull(prefixes);
+        foreach (var p in prefixes)
+            if (p.IsIpv4)
+                throw new ArgumentException($"IPv4 prefix {p} cannot be encoded in an IPv6 MP_REACH.", nameof(prefixes));
 
         // size = AFI(2) + SAFI(1) + NH-Len(1) + NH(16) + Reserved(1) + Σ NLRI
         var nlriSize = 0;
@@ -73,7 +76,7 @@ public static class MpReachCodec
         if (nhLength is not 16 and not 32)
             throw new BgpParseException(
                 $"Invalid MP_REACH_NLRI next-hop length: {nhLength} (must be 16 or 32 per RFC 2545)",
-                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList);
         if (value.Length < 4 + nhLength + 1)
             throw new BgpParseException(
                 $"Truncated MP_REACH_NLRI next hop: need {nhLength} bytes at offset 4",
@@ -102,6 +105,9 @@ public static class MpReachCodec
     public static byte[] EncodeMpUnreachV6(IReadOnlyList<IpPrefix> prefixes)
     {
         ArgumentNullException.ThrowIfNull(prefixes);
+        foreach (var p in prefixes)
+            if (p.IsIpv4)
+                throw new ArgumentException($"IPv4 prefix {p} cannot be encoded in an IPv6 MP_UNREACH.", nameof(prefixes));
 
         var nlriSize = 0;
         foreach (var p in prefixes)

--- a/BGPLite.Protocol/UpdateCodec.cs
+++ b/BGPLite.Protocol/UpdateCodec.cs
@@ -321,7 +321,7 @@ public static class UpdateCodec
                 }
             }
 
-            ValidateMandatoryAttributes(originSeen, asPathSeen, nextHopSeen, mpReachV6Present);
+            ValidateMandatoryAttributes(originSeen, asPathSeen, nextHopSeen, mpReachV6Present && update.Nlri.Count == 0);
             // RFC 4271 §6.3/§6.8: a semantically incorrect NEXT_HOP MUST be rejected with subcode 8
             // (Invalid NEXT_HOP Attribute) — "a valid unicast host address", never multicast, never
             // the receiving speaker's own address. Routed through the caller's treat-as-withdraw

--- a/docs/adr/0001-ipv6-address-model.md
+++ b/docs/adr/0001-ipv6-address-model.md
@@ -39,8 +39,9 @@ files and the whole test suite, so the representation choice is expensive to rev
 
 - `uint` → `UInt128` widening is implicit, so IPv4 construction sites (`Route { Prefix = 0xC0A80000u }`)
   keep compiling unchanged; narrowing reads cast explicitly.
-- The aggregator's `length > 32` skip means an IPv6 route arriving today would be dropped
-  defensively — unreachable until Phase 2 delivers IPv6 NLRI, and re-visited in Phase 3.
+- Phase 2 delivered IPv6 NLRI via MP_REACH/MP_UNREACH; the aggregator's `length > 32` skip
+  means IPv6 routes arriving via MP_REACH are defensively dropped until Phase 3 generalizes the
+  aggregator.
 - `Route.NextHop` stays IPv4 `uint` until Phase 2 (MP_REACH next-hop, RFC 2545).
 - Each later phase builds on this model without re-breaking it; the epic's phased checklist
   (#14 phases 2–5) tracks the remaining work.


### PR DESCRIPTION
Follow-up fixing 5 actionable CodeRabbit findings on integration PR #403:

1. **Duplicate MP_REACH/MP_UNREACH rejected** (Major): two type-14 attrs in one UPDATE silently overwrote each other; now throws BgpParseException.
2. **IPv4 prefixes rejected in IPv6 MP encoders** (Major): EncodeMpReachV6/EncodeMpUnreachV6 now throw ArgumentException when handed an IPv4 prefix.
3. **MP_REACH next-hop length error** uses MalformedAttributeList instead of InvalidNetworkField (attribute framing, not NLRI field error).
4. **NEXT_HOP required with classic IPv4 NLRI** even when MP_REACH is present (v4 routes still need the classic next hop; only MP_REACH-only updates waive it).
5. **ADR 0001** status updated: Phase 2 delivered IPv6 NLRI.

Outside-diff finding on BgpSession.cs:921 (gate must include MpReachV6) — already addressed in this branch's base (#402 code).

949/949 tests.