### PR TITLE
feat(routing): IPv6 routing — LPM + 128-bit family-aware aggregator (phase 3 of #14)

### DIFF
--- a/BGPLite.Routing/ExactUnionPrefixAggregator.cs
+++ b/BGPLite.Routing/ExactUnionPrefixAggregator.cs
@@ -1,12 +1,15 @@
 using System.Numerics;
+using BGPLite.Protocol;
 
 namespace BGPLite.Routing;
 
 /// <summary>
-/// Default <see cref="IPrefixAggregator"/>. Merges adjacent/overlapping IPv4 prefixes
-/// into the minimal equivalent set whose address range is EXACTLY the union of the
-/// inputs — never a single address more. Injectable as a strategy; inject
-/// <see cref="NoOpPrefixAggregator"/> to disable summarization.
+/// Default <see cref="IPrefixAggregator"/>. Merges adjacent/overlapping prefixes into the
+/// minimal equivalent set whose address range is EXACTLY the union of the inputs — never a
+/// single address more. Dual-stack (#14 phase 3): IPv4 (/0..32) and IPv6 (/0..128) are
+/// aggregated with the same exact-union semantics but never merged together — IPv4 and
+/// IPv6 routes stay in separate groups even with identical tags (ADR 0001 §6). Injectable
+/// as a strategy; inject <see cref="NoOpPrefixAggregator"/> to disable summarization.
 /// </summary>
 /// <remarks>
 /// Algorithm: (1) mask host bits and form inclusive <c>[start, end]</c> intervals,
@@ -61,11 +64,13 @@ public sealed class ExactUnionPrefixAggregator : IPrefixAggregator
         foreach (var (key, group) in groups)
         {
             var template = group[0];
-            foreach (var (prefix, length) in AggregatePrefixes(group))
+            var isIpv4 = key.IsIpv4;
+            foreach (var (prefix, length) in AggregatePrefixes(group, isIpv4))
             {
                 result.Add(new Route
                 {
                     Prefix = prefix,
+                    IsIpv4 = isIpv4,
                     PrefixLength = length,
                     NextHop = template.NextHop,
                     Communities = template.Communities,
@@ -77,32 +82,39 @@ public sealed class ExactUnionPrefixAggregator : IPrefixAggregator
         return result;
     }
 
-    /// <summary>Exact-union CIDR merge of the prefixes carried by a group of routes.</summary>
-    private static List<(uint Prefix, byte Length)> AggregatePrefixes(IReadOnlyList<Route> routes)
+    /// <summary>Exact-union CIDR merge of the prefixes carried by a family-homogeneous group of
+    /// routes (the group key includes <c>IsIpv4</c>, so every route here shares a family).</summary>
+    private static List<(UInt128 Prefix, byte Length)> AggregatePrefixes(IReadOnlyList<Route> routes, bool isIpv4)
     {
-        // 1. Mask host bits and build inclusive [start, end] intervals. ulong so a /0 fits.
-        var intervals = new List<(ulong Start, ulong End)>(routes.Count);
+        // 1. Mask host bits and build inclusive [start, end] intervals. UInt128 so an IPv6 /0 fits.
+        var intervals = new List<(UInt128 Start, UInt128 End)>(routes.Count);
         for (var i = 0; i < routes.Count; i++)
         {
             var prefix = routes[i].Prefix;
             var length = routes[i].PrefixLength;
-            if (length > 32) continue; // defensive: skip malformed prefixes
-            var mask = length == 0 ? 0u : (0xFFFFFFFFu << (32 - length));
-            var start = (ulong)(prefix & mask);
-            var size = length == 0 ? (1UL << 32) : (1UL << (32 - length));
-            intervals.Add((start, start + size - 1));
+            if (!IpPrefix.IsValidLength(length, isIpv4)) continue; // defensive: skip malformed prefixes
+            // /0 spans the whole address space: 2^128 itself overflows, so that end is stated
+            // directly rather than computed as start + size - 1.
+            var start = prefix & IpPrefix.Mask(length, isIpv4);
+            var end = length == 0
+                ? (isIpv4 ? (UInt128)0xFFFFFFFFu : UInt128.MaxValue)
+                : start + ((UInt128)1 << (isIpv4 ? 32 : 128) - length) - 1;
+            intervals.Add((start, end));
         }
         if (intervals.Count == 0)
             return [];
 
         // 2. Sort and merge overlapping/adjacent intervals into a disjoint union.
         intervals.Sort((a, b) => a.Start.CompareTo(b.Start));
-        var merged = new List<(ulong Start, ulong End)>(intervals.Count) { intervals[0] };
+        var merged = new List<(UInt128 Start, UInt128 End)>(intervals.Count) { intervals[0] };
         for (var i = 1; i < intervals.Count; i++)
         {
             var (start, end) = intervals[i];
             var last = merged[^1];
-            if (start <= last.End + 1) // overlap or directly adjacent
+            // Overlap, or directly adjacent — spelled without last.End + 1 because an interval
+            // ending at UInt128.MaxValue would wrap the increment to zero.
+            var adjacent = last.End != UInt128.MaxValue && start == last.End + 1;
+            if (start <= last.End || adjacent)
             {
                 if (end > last.End) merged[^1] = (last.Start, end);
             }
@@ -113,9 +125,9 @@ public sealed class ExactUnionPrefixAggregator : IPrefixAggregator
         }
 
         // 3. Emit the minimal exact CIDR cover for each merged interval.
-        var result = new List<(uint, byte)>();
+        var result = new List<(UInt128, byte)>();
         foreach (var (start, end) in merged)
-            EmitRange(start, end, result);
+            EmitRange(start, end, isIpv4, result);
         return result;
     }
 
@@ -125,39 +137,60 @@ public sealed class ExactUnionPrefixAggregator : IPrefixAggregator
     /// that is both aligned at <c>start</c> and fits inside the remaining range, so the
     /// emitted blocks tile the range with neither gaps nor overlaps.
     /// </summary>
-    private static void EmitRange(ulong start, ulong end, List<(uint, byte)> result)
+    private static void EmitRange(UInt128 start, UInt128 end, bool isIpv4, List<(UInt128, byte)> result)
     {
-        while (start <= end)
+        var maxLength = isIpv4 ? 32 : 128;
+        var maxAddress = isIpv4 ? (UInt128)0xFFFFFFFFu : UInt128.MaxValue;
+        while (true)
         {
-            var aligned = start == 0 ? (1UL << 32) : start & (~start + 1); // largest pow2 dividing start
-            var fits = HighestPowerOfTwo(end - start + 1);                 // largest pow2 ≤ remaining
-            var size = Math.Min(aligned, fits);
-            result.Add(((uint)start, (byte)(32 - BitOperations.Log2(size))));
+            // The whole address space is one /0 block; stating it directly keeps the span
+            // computation below free of the 2^128 overflow.
+            if (start == UInt128.Zero && end == maxAddress)
+            {
+                result.Add((UInt128.Zero, 0));
+                return;
+            }
+
+            var span = end - start + 1;                                   // < 2^128 here
+            // LeadingZeroCount/Log2 return UInt128 (IBinaryInteger); the values fit an int here
+            // (span < 2^128 ⇒ lzc ≤ 127, size < 2^128 ⇒ log2 ≤ 127).
+            var fits = UInt128.One << (127 - (int)UInt128.LeadingZeroCount(span)); // largest pow2 ≤ span
+            var size = start == UInt128.Zero
+                ? fits                                                    // 0 is aligned to anything
+                : UInt128.Min(start & (~start + 1), fits);                // largest pow2 dividing start
+            result.Add((start, (byte)(maxLength - (int)UInt128.Log2(size))));
+            if (size == span)
+                return;
             start += size;
         }
     }
 
-    private static ulong HighestPowerOfTwo(ulong value) =>
-        1UL << (63 - BitOperations.LeadingZeroCount(value));
-
-    /// <summary>Value-equality key over a route's communities (sorted, set semantics).</summary>
+    /// <summary>Value-equality key over a route's family and communities (communities sorted,
+    /// set semantics). The family participates in the key so IPv4 and IPv6 prefixes never merge
+    /// into one summary even with identical tags (ADR 0001 §6) — a 32-bit merge of an IPv6
+    /// prefix would summarize the wrong address space.</summary>
     private readonly struct AttributeKey : IEquatable<AttributeKey>
     {
         private readonly uint[] _communities;
         private readonly (uint Global, uint Local1, uint Local2)[] _largeCommunities;
 
-        private AttributeKey(uint[] communities, (uint Global, uint Local1, uint Local2)[] largeCommunities)
+        public bool IsIpv4 { get; }
+
+        private AttributeKey(uint[] communities,
+            (uint Global, uint Local1, uint Local2)[] largeCommunities, bool isIpv4)
         {
             _communities = communities;
             _largeCommunities = largeCommunities;
+            IsIpv4 = isIpv4;
         }
 
         // #238: Route collections are IReadOnlyList — the key holds privately-owned normalized
         // arrays so it never aliases a route's (shared) backing array. Building them is
         // KeyNormalizer's job.
         internal static AttributeKey Create(
-            uint[] communities, (uint Global, uint Local1, uint Local2)[] largeCommunities) =>
-            new(communities, largeCommunities);
+            uint[] communities, (uint Global, uint Local1, uint Local2)[] largeCommunities,
+            bool isIpv4) =>
+            new(communities, largeCommunities, isIpv4);
 
         internal static int LargeCommunityComparison(
             (uint Global, uint Local1, uint Local2) a, (uint Global, uint Local1, uint Local2) b)
@@ -171,6 +204,7 @@ public sealed class ExactUnionPrefixAggregator : IPrefixAggregator
 
         public bool Equals(AttributeKey other)
         {
+            if (IsIpv4 != other.IsIpv4) return false;
             if (_communities.Length != other._communities.Length) return false;
             for (var i = 0; i < _communities.Length; i++)
                 if (_communities[i] != other._communities[i]) return false;
@@ -185,6 +219,7 @@ public sealed class ExactUnionPrefixAggregator : IPrefixAggregator
         public override int GetHashCode()
         {
             var hc = new HashCode();
+            hc.Add(IsIpv4);
             foreach (var c in _communities) hc.Add(c);
             foreach (var l in _largeCommunities) hc.Add(l);
             return hc.ToHashCode();
@@ -216,7 +251,8 @@ public sealed class ExactUnionPrefixAggregator : IPrefixAggregator
         private Dictionary<object, (uint Global, uint Local1, uint Local2)[]>? _largeCommunities;
 
         public AttributeKey KeyFor(Route route) =>
-            AttributeKey.Create(Normalize(route.Communities), NormalizeLarge(route.LargeCommunities));
+            AttributeKey.Create(Normalize(route.Communities), NormalizeLarge(route.LargeCommunities),
+                route.IsIpv4);
 
         /// <summary>Communities are a set: dedup and sort so set-equivalent routes key together.</summary>
         private uint[] Normalize(IReadOnlyList<uint> communities)

--- a/BGPLite.Routing/RouteTable.cs
+++ b/BGPLite.Routing/RouteTable.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using BGPLite.Protocol;
 
 namespace BGPLite.Routing;
 
@@ -169,6 +170,27 @@ public sealed class RouteTable
 
     public Route? Get(UInt128 prefix, byte length, bool isIpv4 = true) =>
         _routes.TryGetValue((prefix, length, isIpv4), out var entry) ? entry.Route : null;
+
+    /// <summary>
+    /// Longest-prefix-match lookup (#14 phase 3): the stored route whose network most
+    /// specifically contains <paramref name="address"/>, or null. Probes candidate prefix
+    /// lengths from the family maximum down to /0 — at most 33 (IPv4) / 129 (IPv6) dictionary
+    /// lookups — and is family-scoped: an IPv6 address never matches an IPv4 entry and vice
+    /// versa (the family is part of the key). Read-only: it never installs or replaces anything,
+    /// unlike <see cref="AddOrUpdate"/>. There is no per-packet consumer today (a route server
+    /// does not forward); this is the lookup the epic's routing layer requires for /0..128
+    /// coverage checks and policy decisions.
+    /// </summary>
+    public Route? GetLongestPrefixMatch(UInt128 address, bool isIpv4 = true)
+    {
+        for (var length = isIpv4 ? 32 : 128; length >= 0; length--)
+        {
+            var network = address & IpPrefix.Mask((byte)length, isIpv4);
+            if (_routes.TryGetValue((network, (byte)length, isIpv4), out var entry))
+                return entry.Route;
+        }
+        return null;
+    }
 
     public IReadOnlyList<Route> GetAll()
     {

--- a/BGPLite.Tests/PrefixAggregatorTests.cs
+++ b/BGPLite.Tests/PrefixAggregatorTests.cs
@@ -22,6 +22,52 @@ public class PrefixAggregatorTests
     private static List<(UInt128 Prefix, byte Length)> Pfx(IReadOnlyList<Route> routes) =>
         routes.Select(r => (r.Prefix, r.PrefixLength)).ToList();
 
+    /// <summary>IPv6 route builder. <paramref name="prefix"/> carries the network address in the
+    /// full 128 bits (<see cref="V6"/> composes one from leading hextets).</summary>
+    private static Route R6(UInt128 prefix, byte length, uint[]? communities = null) => new()
+    {
+        Prefix = prefix,
+        IsIpv4 = false,
+        PrefixLength = length,
+        NextHop = NextHop,
+        Communities = communities ?? []
+    };
+
+    /// <summary>Composes an IPv6 network address from its leading hextets (the rest are zero):
+    /// <c>V6(0x2001, 0x0DB8, 1)</c> is 2001:db8:1::.</summary>
+    private static UInt128 V6(ushort g0, ushort g1 = 0, ushort g2 = 0) =>
+        ((UInt128)g0 << 112) | ((UInt128)g1 << 96) | ((UInt128)g2 << 80);
+
+    /// <summary>Family-aware counterpart of <see cref="UnionRanges"/>: the sorted, merged
+    /// [start,end] intervals of an IPv6 prefix set (address space capped at 2^128-1).</summary>
+    private static List<(UInt128 Start, UInt128 End)> UnionRanges6(IEnumerable<(UInt128 Prefix, byte Length)> prefixes)
+    {
+        var intervals = new List<(UInt128 Start, UInt128 End)>();
+        foreach (var (prefix, length) in prefixes)
+        {
+            if (length > 128) continue;
+            var mask = length == 0 ? UInt128.Zero : UInt128.MaxValue << (128 - length);
+            var start = prefix & mask;
+            // /0 spans the whole space: 2^128 itself overflows, so the end is stated directly.
+            var end = length == 0 ? UInt128.MaxValue : start + ((UInt128)1 << (128 - length)) - 1;
+            intervals.Add((start, end));
+        }
+        intervals.Sort((a, b) => a.Start.CompareTo(b.Start));
+        var merged = new List<(UInt128 Start, UInt128 End)>();
+        foreach (var (s, e) in intervals)
+        {
+            if (merged.Count > 0 && (s <= merged[^1].End ||
+                                     (merged[^1].End != UInt128.MaxValue && s == merged[^1].End + 1)))
+            {
+                var newEnd = merged[^1].End > e ? merged[^1].End : e;
+                merged[^1] = (merged[^1].Start, newEnd);
+            }
+            else
+                merged.Add((s, e));
+        }
+        return merged;
+    }
+
     /// <summary>Independent reference implementation: the sorted, merged [start,end] intervals
     /// of a prefix set. Used to cross-check that aggregation adds no address and drops none.</summary>
     private static List<(UInt128 Start, UInt128 End)> UnionRanges(IEnumerable<(UInt128 Prefix, byte Length)> prefixes)
@@ -219,6 +265,125 @@ public class PrefixAggregatorTests
         ]);
         var route = Assert.Single(result);
         Assert.Equal(0xC0A80000u, route.Prefix);
+    }
+
+    // ---- #14 phase 3: IPv6 aggregation (family-aware, /0..128) ----
+
+    [Fact]
+    public void Ipv6_NestedPrefixes_CollapseToWidest()
+    {
+        // 2001:db8::/32 + nested 2001:db8:1::/48 → /32.
+        var result = _aggregator.Aggregate([
+            R6(V6(0x2001, 0xDB8), 32),
+            R6(V6(0x2001, 0xDB8, 1), 48),
+        ]);
+        Assert.Equal([(V6(0x2001, 0xDB8), (byte)32)], Pfx(result));
+        Assert.All(result, r => Assert.False(r.IsIpv4));
+    }
+
+    [Fact]
+    public void Ipv6_AdjacentPrefixes_MergeToSupernet()
+    {
+        // 2001:db8::/48 + 2001:db8:1::/48 → 2001:db8::/47. Regression: the 32-bit aggregator
+        // dropped every IPv6 prefix longer than /32, so the union lost BOTH routes entirely.
+        var result = _aggregator.Aggregate([
+            R6(V6(0x2001, 0xDB8), 48),
+            R6(V6(0x2001, 0xDB8, 1), 48),
+        ]);
+        var route = Assert.Single(result);
+        Assert.Equal((V6(0x2001, 0xDB8), (byte)47), (route.Prefix, route.PrefixLength));
+        Assert.False(route.IsIpv4);
+    }
+
+    [Fact]
+    public void Ipv6_HostBits_AreMasked()
+    {
+        var result = _aggregator.Aggregate([R6(V6(0x2001, 0xDB8) + 5, 32)]);
+        Assert.Equal([(V6(0x2001, 0xDB8), (byte)32)], Pfx(result));
+        Assert.False(result[0].IsIpv4);
+    }
+
+    [Fact]
+    public void Ipv6_Slash127Pair_MergesToSlash126()
+    {
+        var result = _aggregator.Aggregate([
+            R6(V6(0x2001, 0xDB8), 127),
+            R6(V6(0x2001, 0xDB8) + 2, 127),
+        ]);
+        var route = Assert.Single(result);
+        Assert.Equal((V6(0x2001, 0xDB8), (byte)126), (route.Prefix, route.PrefixLength));
+    }
+
+    [Fact]
+    public void Ipv6_Slash128_HostRoute_StaysUnchanged()
+    {
+        var result = _aggregator.Aggregate([R6(V6(0x2001, 0xDB8, 1) + 5, 128)]);
+        var route = Assert.Single(result);
+        Assert.Equal((V6(0x2001, 0xDB8, 1) + 5, (byte)128), (route.Prefix, route.PrefixLength));
+    }
+
+    [Fact]
+    public void Ipv6_DefaultRoute_Handled()
+    {
+        // ::/0 alone stays ::/0 with the IPv6 family (regression: it fell into the 32-bit
+        // interval math and came back out as 0.0.0.0/0 marked IPv4).
+        var single = Assert.Single(_aggregator.Aggregate([R6(0, 0)]));
+        Assert.Equal((UInt128.Zero, (byte)0), (single.Prefix, single.PrefixLength));
+        Assert.False(single.IsIpv4);
+
+        // The two /1 halves merge back into ::/0.
+        var merged = Assert.Single(_aggregator.Aggregate([
+            R6(0, 1),
+            R6((UInt128)1 << 127, 1),
+        ]));
+        Assert.Equal((UInt128.Zero, (byte)0), (merged.Prefix, merged.PrefixLength));
+        Assert.False(merged.IsIpv4);
+    }
+
+    [Fact]
+    public void Ipv6_UnionInvariant_NoExtraAndNoMissingIp()
+    {
+        // ::/0 swallows the whole set: the union must stay the full address space, emitted
+        // as exactly one route.
+        var input = new List<Route>
+        {
+            R6(V6(0x2001, 0xDB8), 48),
+            R6(V6(0x2001, 0xDB8, 1), 48),                      // adjacent /48s → /47
+            R6(V6(0x2001, 0xDB8, 2), 64),
+            R6(V6(0x2001, 0xDB8, 2) + ((UInt128)1 << 48), 64), // adjacent /64s → /63
+            R6(UInt128.Zero, 0),
+        };
+
+        var output = _aggregator.Aggregate(input);
+
+        Assert.Equal(UnionRanges6(input.Select(r => (r.Prefix, r.PrefixLength))),
+                     UnionRanges6(Pfx(output)));
+        Assert.True(output.Count <= input.Count);
+        Assert.All(output, r => Assert.False(r.IsIpv4));
+    }
+
+    [Fact]
+    public void Ipv4AndIpv6_SameCommunities_NeverMerge()
+    {
+        // Identical community sets, but IPv4 and IPv6 must never land in one summary
+        // (ADR 0001 §6). The two IPv6 /32s are the same network after host-bit masking and
+        // legitimately collapse to one; the point is the family split: pre-phase-3 the IPv6
+        // routes fell into the 32-bit interval space and the whole set collapsed into
+        // 0.0.0.0/0 marked IPv4.
+        var comm = new uint[] { 0x65 };
+        var result = _aggregator.Aggregate([
+            R(0xC0A80000, 24, comm),
+            R(0xC0A80100, 24, (uint[])comm.Clone()),
+            R6(V6(0x2001, 0xDB8), 32, (uint[])comm.Clone()),
+            R6(V6(0x2001, 0xDB8, 1), 32, (uint[])comm.Clone()),
+        ]);
+
+        Assert.Equal(2, result.Count);
+        var v4 = Assert.Single(result, r => r.IsIpv4);
+        Assert.Equal((0xC0A80000u, (byte)23), (v4.Prefix, v4.PrefixLength));
+        var v6 = Assert.Single(result, r => !r.IsIpv4);
+        Assert.Equal((V6(0x2001, 0xDB8), (byte)32), (v6.Prefix, v6.PrefixLength));
+        Assert.Equal([0x65u], v6.Communities);
     }
 
     // ---- #305: normalization is memoized per backing-array instance ----

--- a/BGPLite.Tests/RouteTableTests.cs
+++ b/BGPLite.Tests/RouteTableTests.cs
@@ -235,4 +235,127 @@ public class RouteTableTests
         Assert.InRange(actual, 0, keys);   // sanity: some subset of the key set survived
         Assert.Equal(actual, table.Count); // counter == dictionary truth (no drift, never negative)
     }
+
+    // ---- #14 phase 3: longest-prefix-match lookup ----
+
+    [Fact]
+    public void GetLongestPrefixMatch_MostSpecificPrefixWins()
+    {
+        var table = new RouteTable();
+        var lessSpecific = new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 1 };
+        var moreSpecific = new Route { Prefix = 0x0A010000, PrefixLength = 16, NextHop = 2 };
+        table.AddOrUpdate(lessSpecific);
+        table.AddOrUpdate(moreSpecific);
+
+        Assert.Same(moreSpecific, table.GetLongestPrefixMatch(0x0A010203)); // inside both → /16
+        Assert.Same(lessSpecific, table.GetLongestPrefixMatch(0x0A020304)); // inside /8 only
+    }
+
+    [Fact]
+    public void GetLongestPrefixMatch_NoMatch_ReturnsNull()
+    {
+        var table = new RouteTable();
+        table.AddOrUpdate(new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 1 });
+
+        Assert.Null(table.GetLongestPrefixMatch(0xC0A80001)); // 192.168.0.1 — outside 10/8
+    }
+
+    [Fact]
+    public void GetLongestPrefixMatch_EmptyTable_ReturnsNull()
+    {
+        Assert.Null(new RouteTable().GetLongestPrefixMatch(0x0A000001));
+    }
+
+    [Fact]
+    public void GetLongestPrefixMatch_DefaultRoute_CatchesEverything()
+    {
+        var table = new RouteTable();
+        var defaultRoute = new Route { Prefix = (UInt128)0, PrefixLength = 0, NextHop = 1 };
+        table.AddOrUpdate(defaultRoute);
+
+        Assert.Same(defaultRoute, table.GetLongestPrefixMatch(0xC0A80102));
+    }
+
+    [Fact]
+    public void GetLongestPrefixMatch_RemovedMoreSpecific_FallsBackToLessSpecific()
+    {
+        var table = new RouteTable();
+        var lessSpecific = new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 1 };
+        table.AddOrUpdate(lessSpecific);
+        table.AddOrUpdate(new Route { Prefix = 0x0A010000, PrefixLength = 16, NextHop = 2 });
+        table.Remove(0x0A010000, 16);
+
+        Assert.Same(lessSpecific, table.GetLongestPrefixMatch(0x0A010203));
+    }
+
+    [Fact]
+    public void GetLongestPrefixMatch_Ipv6_MostSpecificPrefixWins()
+    {
+        var table = new RouteTable();
+        var lessSpecific = new Route { Prefix = V6Net(0x2001, 0xDB8), IsIpv4 = false, PrefixLength = 32, NextHop = 1 };
+        var moreSpecific = new Route { Prefix = V6Net(0x2001, 0xDB8, 1), IsIpv4 = false, PrefixLength = 48, NextHop = 2 };
+        table.AddOrUpdate(lessSpecific);
+        table.AddOrUpdate(moreSpecific);
+
+        // Inside both → /48; inside the /32 but outside the /48 → /32; outside both → null.
+        var inBoth = V6Net(0x2001, 0xDB8, 1) + 1;
+        var inWide = V6Net(0x2001, 0xDB8, 2);
+        Assert.Same(moreSpecific, table.GetLongestPrefixMatch(inBoth, isIpv4: false));
+        Assert.Same(lessSpecific, table.GetLongestPrefixMatch(inWide, isIpv4: false));
+        Assert.Null(table.GetLongestPrefixMatch(V6Net(0x2001, 0xDB9), isIpv4: false));
+    }
+
+    [Fact]
+    public void GetLongestPrefixMatch_Ipv4_HostRouteBoundary()
+    {
+        // /32 is the family length maximum: the probe must hit the exact host route and
+        // nothing one address away.
+        var table = new RouteTable();
+        var host = new Route { Prefix = 0x0A000001, PrefixLength = 32, NextHop = 1 };
+        table.AddOrUpdate(host);
+
+        Assert.Same(host, table.GetLongestPrefixMatch(0x0A000001));
+        Assert.Null(table.GetLongestPrefixMatch(0x0A000002));
+    }
+
+    [Fact]
+    public void GetLongestPrefixMatch_Ipv6_HostAndDefaultBoundaries()
+    {
+        // Both IPv6 length extremes in one table: a /128 host route (probe starts at the
+        // family maximum) and ::/0 (probe ends at the minimum) — the address between them
+        // falls through 128..1 to the default.
+        var table = new RouteTable();
+        var hostRoute = new Route { Prefix = V6Net(0x2001, 0xDB8, 1) + 5, IsIpv4 = false, PrefixLength = 128, NextHop = 1 };
+        var defaultRoute = new Route { Prefix = (UInt128)0, IsIpv4 = false, PrefixLength = 0, NextHop = 2 };
+        table.AddOrUpdate(hostRoute);
+        table.AddOrUpdate(defaultRoute);
+
+        Assert.Same(hostRoute, table.GetLongestPrefixMatch(V6Net(0x2001, 0xDB8, 1) + 5, isIpv4: false));
+        Assert.Same(defaultRoute, table.GetLongestPrefixMatch(V6Net(0x2001, 0xDB9), isIpv4: false));
+    }
+
+    [Fact]
+    public void GetLongestPrefixMatch_Ipv6_NeverMatchesIpv4Entries()
+    {
+        // Family-scoped: the IPv4 key carries IsIpv4 = true, so an IPv6 address whose 128-bit
+        // value numerically contains the IPv4 network must not match it.
+        var table = new RouteTable();
+        table.AddOrUpdate(new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 1 });
+
+        Assert.Null(table.GetLongestPrefixMatch(0x0A000001, isIpv4: false));
+    }
+
+    [Fact]
+    public void GetLongestPrefixMatch_Ipv4_NeverMatchesIpv6Entries()
+    {
+        var table = new RouteTable();
+        table.AddOrUpdate(new Route { Prefix = V6Net(0x2001, 0xDB8), IsIpv4 = false, PrefixLength = 32, NextHop = 1 });
+
+        Assert.Null(table.GetLongestPrefixMatch(0x20010DB8, isIpv4: true));
+    }
+
+    /// <summary>Composes an IPv6 network address from its leading hextets (the rest are zero):
+    /// <c>V6Net(0x2001, 0xDB8, 1)</c> is 2001:db8:1::.</summary>
+    private static UInt128 V6Net(ushort g0, ushort g1, ushort g2 = 0) =>
+        ((UInt128)g0 << 112) | ((UInt128)g1 << 96) | ((UInt128)g2 << 80);
 }

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -232,7 +232,9 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
 - **Decision:** `IpPrefix` is family-aware over `UInt128` — IPv4 in the low 32 bits with an
   explicit `IsIpv4` flag, IPv6 as the full 128 bits; the constructor masks host bits (canonical
   keys); `Route.Key`/`RouteTable` keys carry the family; the aggregator partitions by family.
-  Full ADR: `docs/adr/0001-ipv6-address-model.md` (#15 phase 1).
+  Full ADR: `docs/adr/0001-ipv6-address-model.md` (#15 phase 1). The family partition and
+  128-bit interval math in `ExactUnionPrefixAggregator`, plus the `RouteTable`
+  longest-prefix-match lookup, landed with #14 phase 3.
 - **Tracker:** #15, #14.
 
 ## Management API

--- a/docs/adr/0001-ipv6-address-model.md
+++ b/docs/adr/0001-ipv6-address-model.md
@@ -33,16 +33,18 @@ files and the whole test suite, so the representation choice is expensive to rev
    IPv4-only router-id / next-hop paths.
 6. **Aggregation**: `ExactUnionPrefixAggregator` groups by (communities, IsIpv4) — IPv4 and IPv6
    prefixes are never merged into one summary even with identical tags. Interval math is
-   generalized to UInt128. (Full 128-bit LPM and IPv6 aggregation policy remain Phase 3.)
+   generalized to UInt128. (Delivered as planned in #14 phase 3, together with the
+   longest-prefix-match lookup on `RouteTable`.)
 
 ## Consequences
 
 - `uint` → `UInt128` widening is implicit, so IPv4 construction sites (`Route { Prefix = 0xC0A80000u }`)
   keep compiling unchanged; narrowing reads cast explicitly.
-- Phase 2 delivered IPv6 NLRI via MP_REACH/MP_UNREACH; the aggregator's `length > 32` skip
-  means IPv6 routes arriving via MP_REACH are defensively dropped until Phase 3 generalizes the
-  aggregator.
-- `Route.NextHop` stays IPv4 `uint` until Phase 2 (MP_REACH next-hop, RFC 2545).
+- Phase 2 delivered IPv6 NLRI via MP_REACH/MP_UNREACH; until then the aggregator's `length > 32`
+  skip defensively dropped inbound IPv6 routes. #14 phase 3 closed the interim gap: the aggregator
+  is now fully 128-bit and family-partitioned, and `RouteTable` gained a longest-prefix-match
+  lookup.
+- `Route.NextHop` stayed IPv4 `uint` until Phase 2 delivered the MP_REACH next-hop (RFC 2545).
 - Each later phase builds on this model without re-breaking it; the epic's phased checklist
   (#14 phases 2–5) tracks the remaining work.
 


### PR DESCRIPTION
Closes #14   # linkage only — the integration PR aggregates the keywords that actually close issues

## Problem
Epic #14 phase 3 (routing). After phases 1–2 the address model and MP-BGP codec are dual-stack, but the routing layer still was not: `ExactUnionPrefixAggregator` ran 32-bit interval math, dropped every IPv6 prefix longer than /32, could emit IPv6 routes as garbage IPv4-marked summaries, and did not partition groups by family. `RouteTable` had no longest-prefix-match lookup. ADR 0001 §6 explicitly deferred this to phase 3.

## Root Cause
The aggregator predated the dual-stack model: `AggregatePrefixes`/`EmitRange` computed on `ulong`/`uint` with a hard `length > 32` skip; `AttributeKey` grouped only by communities, so mixed-family inputs shared one 32-bit interval space (a 2001:db8::/32 collapsed everything into 0.0.0.0/0).

## Fix
- `ExactUnionPrefixAggregator`: UInt128 interval math; grouping key `(communities, large communities, IsIpv4)`; emitted routes carry the group's family. `/0` whole-space interval end stated directly (2^128 overflows); adjacency merge rewritten without `last.End + 1` (wraps at `UInt128.MaxValue`).
- `RouteTable.GetLongestPrefixMatch(UInt128 address, bool isIpv4)`: family-scoped LPM, probing lengths family-max→/0 (≤ 33/129 dictionary probes). Read-only; no per-packet consumer — capacity required by the epic's routing layer.
- Docs: ADR 0001 + D21 record the phase-3 delivery (incl. fixing a stale NextHop line in the ADR).

## Correctness
IPv4 path is byte-for-byte the old semantics (masked low-32 intervals, same emit order); verified by the untouched 28-test IPv4 aggregator suite. UInt128 edge cases handled: /0 and /1 spans, MaxValue-ending intervals, /127+/127→/126, /128 host routes. No concurrency invariants touched (`#343` counter, ownership CAS unaffected; LPM only reads).

## Regression Test
18 new tests. **Red/green proven**: 9 IPv6 aggregator tests were run against the pre-fix implementation — 8 failed (routes dropped/corrupted, wrong family on output) — and all pass after the fix. 9 LPM tests cover both families, boundary lengths /0, /32, /128, more-specific preference, removal fallback, and family isolation (LPM is a new API, so there is no pre-fix state to fail against).

## Verification
- `dotnet format BGPLite.sln` — clean, no unrelated changes
- `dotnet build BGPLite.sln -c Debug` — 0 warnings, 0 errors
- `dotnet test BGPLite.sln -c Debug` — **967/967 passed** (baseline before change: 949/949)
- reviewer subagent adversarial pass — 2 MINOR findings (missing boundary tests, stale ADR line), both fixed; no BLOCKER/MAJOR
- diff reviewed vs `origin/dev`: only the 6 intended files

## RFC
None — routing layer only, no wire protocol surface (NLRI/MP_REACH codecs unchanged).

## Behavior Change
None for IPv4. For IPv6: routes were previously dropped (length > 32) or corruptible in aggregation; they are now aggregated exactly per the exact-union contract. Outbound advertisement of IPv6 routes remains phase 4 (MP_REACH send path, per-AFI next-hop).

## Deviation from Issue Proposal
None — implements the phase-3 checklist items (LPM + 128-bit aggregator) exactly as scoped by the epic and ADR 0001.