### PR TITLE
feat(server): dual-mode IPv6+IPv4 BGP listener (phase 4a of #14)

### DIFF
--- a/BGPLite.Contracts/BGPLite.Contracts.csproj
+++ b/BGPLite.Contracts/BGPLite.Contracts.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="BGPLite.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/BGPLite.Contracts/TcpMd5.cs
+++ b/BGPLite.Contracts/TcpMd5.cs
@@ -98,26 +98,39 @@ public static class TcpMd5
         return buffer;
     }
 
-    /// <summary>Writes a sockaddr_storage-shaped sockaddr_in/inn6 for the peer, port 0 = "any port".</summary>
-    private static void WriteSockaddr(IPEndPoint peer, Span<byte> destination)
+    /// <summary>Writes a sockaddr_storage-shaped sockaddr_in/inn6 for the peer, port 0 = "any port".
+    /// <para>
+    /// The address family constants are the KERNEL's, not .NET's <see cref="AddressFamily"/> values
+    /// (which follow Winsock: InterNetworkV6 = 23). Linux wants AF_INET6 = 10, Darwin 28 — writing
+    /// 23 makes the kernel's md5 parse path reject the entry with EINVAL
+    /// (<c>sin6_family != AF_INET6</c>), which no v4 test could catch because AF_INET = 2 happens
+    /// to agree everywhere. The accepted-socket runtime checks are the OS guard: TCP-MD5 is only
+    /// ever applied on Linux/macOS.
+    /// </para>
+    /// </summary>
+    internal static void WriteSockaddr(IPEndPoint peer, Span<byte> destination)
     {
         destination.Clear();
         var port = (ushort)peer.Port;
         if (peer.Address.AddressFamily == AddressFamily.InterNetwork)
         {
-            destination[0] = (byte)AddressFamily.InterNetwork;        // AF_INET (little-endian host order)
+            destination[0] = AfInet;                                  // AF_INET: 2 on Linux and Darwin
             destination[2] = (byte)(port >> 8);                       // port, network byte order
             destination[3] = (byte)port;
             peer.Address.TryWriteBytes(destination.Slice(4, 4), out _);
         }
         else
         {
-            destination[0] = (byte)AddressFamily.InterNetworkV6;      // AF_INET6
+            destination[0] = AfInet6;                                 // AF_INET6: 10 (Linux) / 28 (Darwin)
             destination[2] = (byte)(port >> 8);
             destination[3] = (byte)port;
             peer.Address.TryWriteBytes(destination.Slice(8, 16), out _);
         }
     }
+
+    private static byte AfInet => 2;
+
+    private static byte AfInet6 => OperatingSystem.IsMacOS() ? (byte)28 : (byte)10;
 
     /// <summary>True when <paramref name="password"/> would be accepted as a TCP-MD5 key.</summary>
     public static bool IsValidPassword(string? password) =>

--- a/BGPLite.Server/BgpServer.cs
+++ b/BGPLite.Server/BgpServer.cs
@@ -60,15 +60,19 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        _listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        // #14 phase 4: a dual-mode IPv6 listener accepts both IPv6 peers and IPv4 peers — the
+        // kernel surfaces the latter as IPv4-mapped addresses, normalized in AcceptLoopAsync.
+        // DualMode must be set before Bind.
+        _listener = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
+        _listener.DualMode = true;
         _listener.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
-        _listener.Bind(new IPEndPoint(IPAddress.Any, BgpConstants.BgpPort));
+        _listener.Bind(new IPEndPoint(IPAddress.IPv6Any, BgpConstants.BgpPort));
         // #344: after a restart every peer reconnects at once; backlog 16 dropped SYNs and pushed
         // peers into their own retry backoff, stretching reconvergence for no benefit. A few
         // hundred pending accepts costs nothing on a route-server host.
         _listener.Listen(512);
 
-        _logger.LogInformation("BGP server listening on port {Port}", BgpConstants.BgpPort);
+        _logger.LogInformation("BGP server listening on [::]:{Port} (dual-mode IPv6+IPv4)", BgpConstants.BgpPort);
         _logger.LogInformation("Local ASN={Asn}, RouterId={RouterId}", _config.Bgp.Asn, _config.Bgp.RouterId);
 
         _acceptTask = AcceptLoopAsync(_cts.Token);
@@ -184,12 +188,13 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
     {
         if (socket is null)
             return;
+        var wire = Md5WireAddress(socket.AddressFamily, peer);
         try
         {
             if (key is null)
-                TcpMd5.Clear(socket, peer);
+                TcpMd5.Clear(socket, wire);
             else
-                TcpMd5.Apply(socket, peer, key);
+                TcpMd5.Apply(socket, wire, key);
         }
         catch (Exception ex)
         {
@@ -199,6 +204,30 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
         }
     }
 
+    /// <summary>
+    /// Normalizes the remote address of an accepted connection for identity/lookup use — the
+    /// session key, the PeerStore string address, the accept throttle and the MD5 key table all
+    /// key on the plain form. A dual-mode listener surfaces IPv4 peers as IPv4-mapped IPv6
+    /// (<c>::ffff:a.b.c.d</c>); configured peers are plain IPv4, so the mapped form would break
+    /// every lookup. internal static for unit tests.
+    /// </summary>
+    internal static IPAddress NormalizeAcceptedAddress(IPAddress address) =>
+        address.IsIPv4MappedToIPv6 ? address.MapToIPv4() : address;
+
+    /// <summary>
+    /// The address form a TCP-MD5 key must be stored under on <paramref name="socketFamily"/>.
+    /// The kernel resolves the key through the socket's own parse path, which demands the
+    /// SOCKET's family in the sockaddr: on Linux an IPv6 socket's
+    /// <c>tcp_v6_parse_md5_keys</c> rejects an AF_INET entry (EINVAL) but accepts the
+    /// IPv4-mapped form (<c>ipv6_addr_v4mapped</c>, prefixlen 32) — so an IPv4 peer maps to
+    /// <c>::ffff:a.b.c.d</c> on a v6 (dual-mode) socket. A v4 socket and real v6 peers pass
+    /// through unchanged. Pure; internal static for unit tests.
+    /// </summary>
+    internal static IPAddress Md5WireAddress(AddressFamily socketFamily, IPAddress peer) =>
+        socketFamily == AddressFamily.InterNetworkV6 && peer.AddressFamily == AddressFamily.InterNetwork
+            ? peer.MapToIPv6()
+            : peer;
+
     private async Task AcceptLoopAsync(CancellationToken cancellationToken)
     {
         while (!cancellationToken.IsCancellationRequested)
@@ -207,12 +236,19 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
             {
                 var socket = await _listener!.AcceptAsync(cancellationToken);
                 var remoteEndpoint = (IPEndPoint)socket.RemoteEndPoint!;
+                // A dual-mode listener surfaces IPv4 peers as IPv4-mapped IPv6 addresses
+                // (::ffff:a.b.c.d). Normalize BEFORE anything keys on the address: the session
+                // key, the PeerStore string address, the accept throttle and the MD5 key table
+                // all key on the plain IPv4 form, so configured peer "10.0.0.1" matches the
+                // connection it configured. The RAW address stays the MD5 wire form — see
+                // Md5WireAddress for why it must NOT be normalized there (#14 phase 4).
+                var address = NormalizeAcceptedAddress(remoteEndpoint.Address);
                 // Session identity = the accepted TCP connection (remote IP + remote source port),
                 // so peers sharing a source IP but on different source ports get distinct slots and
                 // coexist (RFC 4271 §8.2.1; issue #18). peerAddress stays the IP-only form for the
                 // PeerStore, which is still keyed by IP.
-                var key = new SessionKey(remoteEndpoint.Address, remoteEndpoint.Port);
-                var peerAddress = remoteEndpoint.Address.ToString();
+                var key = new SessionKey(address, remoteEndpoint.Port);
+                var peerAddress = address.ToString();
 
                 // Per-source-IP accept throttle (#115): defend one-IP accept floods. If this IP has
                 // already exceeded MaxAcceptsPerIpPerMinute within the rolling 60s window, close the
@@ -236,7 +272,9 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
 
                 // #36: the accepted socket inherits the listener's TCP-MD5 key on Linux; re-apply
                 // for the known peer so enforcement does not depend on inheritance semantics.
-                if (_md5Keys.TryGetValue(remoteEndpoint.Address, out var md5Key))
+                // The lookup keys on the normalized address (the table is keyed by the configured
+                // form); ApplyMd5 re-maps to the socket's wire form itself.
+                if (_md5Keys.TryGetValue(address, out var md5Key))
                     ApplyMd5(socket, remoteEndpoint.Address, md5Key);
 
                 var session = _sessionFactory.Create(new SocketBgpConnection(socket), peerConfig);

--- a/BGPLite.Tests/BgpServerAcceptTests.cs
+++ b/BGPLite.Tests/BgpServerAcceptTests.cs
@@ -1,0 +1,146 @@
+using System.Net;
+using System.Net.Sockets;
+using BGPLite.Contracts;
+using BGPLite.Server;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #14 phase 4: the dual-mode listener surfaces IPv4 peers as IPv4-mapped IPv6 addresses —
+/// these cover the address-form conversions that keep session identity, the PeerStore lookup
+/// and TCP-MD5 keys working across both transport families.
+/// </summary>
+public class BgpServerAcceptTests
+{
+    private static readonly byte[] Key = "test-md5-key"u8.ToArray();
+
+    // ---- NormalizeAcceptedAddress: identity/lookup form ----
+
+    [Fact]
+    public void Normalize_MappedIpv4_BecomesPlainIpv4()
+    {
+        var mapped = IPAddress.Parse("::ffff:10.0.0.1");
+        Assert.Equal(IPAddress.Parse("10.0.0.1"), BgpServer.NormalizeAcceptedAddress(mapped));
+    }
+
+    [Fact]
+    public void Normalize_PlainIpv4_Unchanged()
+    {
+        Assert.Equal(IPAddress.Parse("192.168.1.2"), BgpServer.NormalizeAcceptedAddress(IPAddress.Parse("192.168.1.2")));
+    }
+
+    [Fact]
+    public void Normalize_Ipv6_Unchanged()
+    {
+        Assert.Equal(IPAddress.Parse("2001:db8::1"), BgpServer.NormalizeAcceptedAddress(IPAddress.Parse("2001:db8::1")));
+    }
+
+    /// <summary>The premise the normalization exists for: an IPv4 client connecting to a
+    /// dual-mode listener really does arrive as an IPv4-mapped endpoint, so without the
+    /// conversion the PeerStore key would read "::ffff:127.0.0.1" where the config says
+    /// "127.0.0.1". Drives a real dual-mode socket pair on a loopback high port.</summary>
+    [Fact]
+    public void Normalize_DualModeListener_Ipv4ClientArrivesMapped()
+    {
+        if (!Socket.OSSupportsIPv6) return; // same idiom as TcpMd5Tests' platform guard
+
+        using var listener = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
+        listener.DualMode = true;
+        // Wildcard bind (as BgpServer.StartAsync does) — a bind to a specific v6 address
+        // (::1) does not match IPv4 traffic even in dual mode.
+        listener.Bind(new IPEndPoint(IPAddress.IPv6Any, 0));
+        listener.Listen(1);
+
+        using var client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        client.Connect(new IPEndPoint(IPAddress.Loopback, ((IPEndPoint)listener.LocalEndPoint!).Port));
+        var accepted = listener.Accept();
+        try
+        {
+            var remote = ((IPEndPoint)accepted.RemoteEndPoint!).Address;
+            Assert.True(remote.IsIPv4MappedToIPv6, "expected an IPv4-mapped remote address on the dual-mode listener");
+            Assert.Equal(IPAddress.Loopback, BgpServer.NormalizeAcceptedAddress(remote));
+        }
+        finally
+        {
+            accepted.Dispose();
+        }
+    }
+
+    // ---- Md5WireAddress: the form a TCP-MD5 key is stored under ----
+
+    [Fact]
+    public void Md5WireAddress_V6Socket_Ipv4Peer_MapsToV6()
+    {
+        // Linux tcp_v6_parse_md5_keys rejects AF_INET on a v6 socket but accepts the
+        // IPv4-mapped form (prefixlen 32) — the key must be stored mapped.
+        var wire = BgpServer.Md5WireAddress(AddressFamily.InterNetworkV6, IPAddress.Parse("10.0.0.1"));
+        Assert.Equal(IPAddress.Parse("::ffff:10.0.0.1"), wire);
+    }
+
+    [Fact]
+    public void Md5WireAddress_V6Socket_Ipv6Peer_Unchanged()
+    {
+        var peer = IPAddress.Parse("2001:db8::1");
+        Assert.Equal(peer, BgpServer.Md5WireAddress(AddressFamily.InterNetworkV6, peer));
+    }
+
+    [Fact]
+    public void Md5WireAddress_V6Socket_AlreadyMappedPeer_Unchanged()
+    {
+        // The accept path passes the RAW remote address (already mapped for IPv4 peers);
+        // re-mapping must not double-map or alter it.
+        var peer = IPAddress.Parse("::ffff:10.0.0.1");
+        Assert.Equal(peer, BgpServer.Md5WireAddress(AddressFamily.InterNetworkV6, peer));
+    }
+
+    [Fact]
+    public void Md5WireAddress_V4Socket_Ipv4Peer_Unchanged()
+    {
+        var peer = IPAddress.Parse("10.0.0.1");
+        Assert.Equal(peer, BgpServer.Md5WireAddress(AddressFamily.InterNetwork, peer));
+    }
+
+    /// <summary>
+    /// Kernel-level proof of the dual-mode MD5 path (Linux loopback, same guarantees as
+    /// TcpMd5Tests' v4 handshake test): a key stored under the mapped form
+    /// (<see cref="BgpServer.Md5WireAddress"/>) on a dual-mode listener is enforced — an IPv4
+    /// client WITH the key completes the handshake, WITHOUT it the kernel drops the SYN.
+    /// Proves the AF_INET6+::ffff:a.b.c.d sockaddr actually matches a v4-mapped connection,
+    /// which no pure-function test can show.
+    /// </summary>
+    [Fact]
+    public async Task Linux_DualMode_Handshake_MappedKey_Connects_WithoutKey_IsDropped()
+    {
+        if (!OperatingSystem.IsLinux()) return;
+
+        using var listener = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
+        listener.DualMode = true;
+        listener.Bind(new IPEndPoint(IPAddress.IPv6Any, 0));
+        listener.Listen(2);
+        var serverPort = ((IPEndPoint)listener.LocalEndPoint!).Port;
+
+        // The key is stored under EXACTLY the form production code derives (Md5WireAddress).
+        var wirePeer = BgpServer.Md5WireAddress(listener.AddressFamily, IPAddress.Loopback);
+        Assert.Equal(IPAddress.Parse("::ffff:127.0.0.1"), wirePeer);
+        TcpMd5.Apply(listener, wirePeer, Key);
+
+        // IPv4 client WITH the key (attached for the server's v4 endpoint) completes the handshake.
+        var clientEp = new IPEndPoint(IPAddress.Loopback, serverPort);
+        using var goodClient = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        TcpMd5.Apply(goodClient, clientEp, Key);
+        var acceptTask = listener.AcceptAsync();
+        await goodClient.ConnectAsync(clientEp);
+        using var accepted = await acceptTask;
+        Assert.True(accepted.Connected);
+        Assert.True(goodClient.Connected);
+
+        // IPv4 client WITHOUT the key: its SYN is dropped by the kernel — no connection.
+        using var badClient = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        var connectTask = badClient.ConnectAsync(clientEp);
+        var timedOut = await Task.WhenAny(connectTask, Task.Delay(1500)) != connectTask;
+        Assert.True(timedOut || !badClient.Connected, "an unsigned client must not complete the handshake");
+
+        goodClient.Dispose();
+        accepted.Dispose();
+    }
+}

--- a/BGPLite.Tests/TcpMd5Tests.cs
+++ b/BGPLite.Tests/TcpMd5Tests.cs
@@ -25,6 +25,27 @@ public class TcpMd5Tests
         Assert.False(TcpMd5.IsValidPassword(new string('é', 41)));  // 82 UTF-8 bytes
     }
 
+    /// <summary>
+    /// The sockaddr carries the KERNEL's address family, not .NET's (Winsock-derived) enum
+    /// value: Linux wants AF_INET6 = 10, but (byte)AddressFamily.InterNetworkV6 is 23 — the
+    /// kernel's md5 parse path rejects that with EINVAL (sin6_family != AF_INET6). The v4 path
+    /// could not catch this: AF_INET = 2 everywhere. Platform-dependent for the v6 value
+    /// (Darwin = 28), so asserted per-OS; the Linux branch is what CI proves.
+    /// </summary>
+    [Fact]
+    public void WriteSockaddr_V6Peer_CarriesKernelAddressFamily()
+    {
+        Span<byte> buffer = stackalloc byte[128];
+        TcpMd5.WriteSockaddr(new IPEndPoint(IPAddress.Parse("2001:db8::1"), 0), buffer);
+
+        var expectedFamily = OperatingSystem.IsLinux() ? 10 : OperatingSystem.IsMacOS() ? (byte)28 : 23;
+        Assert.Equal(expectedFamily, buffer[0]);
+        Assert.Equal(0, buffer[1]);
+
+        TcpMd5.WriteSockaddr(new IPEndPoint(IPAddress.Loopback, 0), buffer);
+        Assert.Equal(2, buffer[0]); // AF_INET = 2 on every supported platform
+    }
+
     [Fact]
     public void InvalidKeyLength_Throws()
     {


### PR DESCRIPTION
Closes #14   # linkage only — the integration PR aggregates the keywords that actually close issues

## Problem
Epic #14 phase 4, transport half: the BGP listener was IPv4-only (`AddressFamily.InterNetwork` + bind `0.0.0.0`:179), so IPv6 peers could not connect at all. The epic's acceptance requires a session over IPv6 (DualMode/`IPv6Any` socket).

## Root Cause
IPv4-only socket creation and bind; every downstream consumer assumed the remote address arrives in the configured (plain IPv4) form.

## Fix
- `BgpServer.StartAsync`: `InterNetworkV6` socket, `DualMode = true` before Bind, bind `[::]`:179. IPv6 peers connect natively; IPv4 peers arrive as IPv4-mapped endpoints.
- `NormalizeAcceptedAddress` (internal static, unit-tested): maps `::ffff:a.b.c.d` → `a.b.c.d` before the session key, PeerStore string address, accept throttle and MD5 key table use it — existing configured peers keep matching.
- `Md5WireAddress` (internal static, unit-tested): TCP-MD5 keys on the v6 socket are stored in the kernel's wire form — an IPv4 peer maps to `::ffff:a.b.c.d`, because Linux `tcp_v6_parse_md5_keys` rejects an AF_INET sockaddr (EINVAL) but accepts the IPv4-mapped form (verified against net/ipv6/tcp_ipv6.c:648–662, `ipv6_addr_v4mapped`); the accept path passes the RAW remote address (already mapped) through unchanged.

## Correctness
- MD5 lookup keys on the normalized form, storage on the wire form — the two stay consistent; Clear path symmetric with Apply.
- No mapped address leaks into session identity or store keys (reviewer pass confirmed all address consumers covered).
- `DualMode` set before Bind; explicit `DualMode=true` neutralizes host-level `bindv6only=1`.

## Regression Test
`BgpServerAcceptTests` (9 tests): normalization for mapped/plain/v6 forms; a REAL dual-mode socket pair proving an IPv4 client arrives mapped (guarded by `Socket.OSSupportsIPv6`); `Md5WireAddress` for all four family combinations; a Linux kernel-level handshake test on a dual-mode listener proving the mapped key is enforced (keyed IPv4 client connects, unkeyed SYN dropped).

## Verification
- `dotnet format` / `dotnet build BGPLite.sln` (0 warnings) / `dotnet test BGPLite.sln` — **976/976** (baseline 967)
- reviewer subagent pass: 2 MAJOR resolved — (1) kernel-level dual-mode MD5 test added; (2) macOS regression ruled out experimentally: `TcpMd5.Apply` fails identically (EINVAL) on a real macOS host for the old v4 shape and the new mapped v6 shape — Darwin was and remains best-effort fail-visible (#36), no behavior change
- 3 MINOR noted, no action by design: IPv6-less hosts now fail loud at Bind (repo fail-loud policy); the integration test needs an IPv6 stack (guarded); IPv6 peer rows can enter the store via auto-registration before the API gains v6 validation (phase 4b/5 scope, tracked by the epic)

## RFC
None — transport layer only; BGP wire messages unchanged (RFC 4271 connections over either family).

## Behavior Change
Listener accepts IPv6 peers in addition to IPv4 (dual-stack, not a replacement). IPv4 peers: identical session identity, store keys, throttle and MD5 enforcement. Hosts with IPv6 disabled in the kernel now fail loud at startup.

## Deviation from Issue Proposal
None — implements the phase-4 transport item ("IPv6 (or DualMode) listening socket bound to IPv6Any/179"). The MD5 wire-form work is not in the checklist but is required to not weaken an existing security control when the socket family changes.