### PR TITLE
fix(server): process MP_REACH/MP_UNREACH-only UPDATEs (#407)

### DIFF
--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -917,8 +917,10 @@ public sealed class BgpSession : IDisposable
         foreach (var w in update.WithdrawnRoutes)
             WithdrawIfOwned(w, "Route withdrawn");
 
-        // Process announcements
-        if (update.Nlri.Count > 0)
+        // Process announcements. The gate must accept MP_REACH-only UPDATEs (#407): the normal
+        // wire shape for an IPv6 announcement (RFC 4760 §5) leaves the classic NLRI field EMPTY —
+        // gating on Nlri.Count alone silently dropped every such announcement.
+        if (update.Nlri.Count > 0 || update.MpReachV6 is not null)
         {
             // #270: the inbound attribute pipeline (per-attribute validation, mandatory set,
             // AS4_PATH reconstruction, aggregator consistency — subcodes 3/6/8/9/11) lives in the
@@ -1033,14 +1035,6 @@ public sealed class BgpSession : IDisposable
                 }
             }
 
-            // #15 phase 2 (RFC 4760 §7): MP_UNREACH_NLRI (AFI=2/SAFI=1) withdraws IPv6 routes
-            // this session installed — same ownership rule as the classic withdrawal path (#289).
-            if (update.MpUnreachV6 is { Count: > 0 } v6Withdrawn)
-            {
-                foreach (var prefix in v6Withdrawn)
-                    WithdrawIfOwned(prefix, "Route withdrawn (MP_UNREACH)");
-            }
-
             // MP_REACH_NLRI (AFI=2/SAFI=1) announcements: same install pipeline as the classic
             // IPv4 NLRI loop — AS-loop exclusion, filter, cap, ownership (#15 phase 2).
             if (update.MpReachV6 is { } mpReach)
@@ -1084,6 +1078,16 @@ public sealed class BgpSession : IDisposable
                     }
                 }
             }
+        }
+
+        // #15 phase 2 (RFC 4760 §7): MP_UNREACH_NLRI (AFI=2/SAFI=1) withdraws IPv6 routes this
+        // session installed — same ownership rule as the classic withdrawal path (#289). Runs
+        // OUTSIDE the announcement block (#407): an MP_UNREACH-only UPDATE (a peer withdrawing
+        // its IPv6 routes) has no classic NLRI and no MP_REACH, and must not depend on either.
+        if (update.MpUnreachV6 is { Count: > 0 } v6Withdrawn)
+        {
+            foreach (var prefix in v6Withdrawn)
+                WithdrawIfOwned(prefix, "Route withdrawn (MP_UNREACH)");
         }
 
         _metrics.SetRouteCount(_routeTable.Count);

--- a/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
+++ b/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
@@ -877,6 +877,80 @@ public class BgpSessionRouteOwnershipTests
         await TeardownAsync(session, run);
     }
 
+    // ---- #407: MP_REACH/MP_UNREACH-only UPDATEs (RFC 4760 §5/§7) ----
+
+    /// <summary>2001:db8:ffff::/48 — the announced IPv6 prefix, full 128-bit form.</summary>
+    private static readonly UInt128 V6TestPrefix =
+        ((UInt128)0x2001 << 112) | ((UInt128)0x0DB8 << 96) | ((UInt128)0xFFFF << 80);
+
+    /// <summary>2001:db8::2 — the MP_REACH next hop.</summary>
+    private static readonly UInt128 V6TestNextHop =
+        ((UInt128)0x2001 << 112) | ((UInt128)0x0DB8 << 96) | 2;
+
+    /// <summary>
+    /// ORIGIN + AS_PATH + MP_REACH_NLRI carrying 2001:db8:ffff::/48, NO classic NLRI — the
+    /// normal wire shape for an IPv6 announcement (RFC 4760 §5: the next hop rides in the
+    /// attribute, the classic NLRI field stays empty).
+    /// </summary>
+    private static byte[] MpReachOnlyAnnounceFrame()
+    {
+        var value = MpReachCodec.EncodeMpReachV6(
+            V6TestNextHop, [new IpPrefix(V6TestPrefix, 48, isIpv4: false)]);
+        var attrs = new List<byte>
+        {
+            0x40, 0x01, 0x01, 0x00,                                 // ORIGIN igp
+            0x40, 0x02, 0x06, 0x02, 0x01, 0x00, 0x00, 0x00, 0x64,   // AS_PATH seq [100]
+            0x80, MpReachCodec.MpReachNlriType, (byte)value.Length, // MP_REACH: optional, non-transitive
+        };
+        attrs.AddRange(value);
+        var payload = new List<byte> { 0x00, 0x00, 0x00, (byte)attrs.Count };  // no withdrawn, no classic NLRI
+        payload.AddRange(attrs);
+        return Frame(BgpMessageType.Update, [.. payload]);
+    }
+
+    /// <summary>MP_UNREACH_NLRI-only UPDATE withdrawing 2001:db8:ffff::/48 (RFC 4760 §7).</summary>
+    private static byte[] MpUnreachOnlyWithdrawFrame()
+    {
+        var value = MpReachCodec.EncodeMpUnreachV6([new IpPrefix(V6TestPrefix, 48, isIpv4: false)]);
+        var attrs = new List<byte> { 0x80, MpReachCodec.MpUnreachNlriType, (byte)value.Length };
+        attrs.AddRange(value);
+        var payload = new List<byte> { 0x00, 0x00, 0x00, (byte)attrs.Count };  // no withdrawn, no classic NLRI
+        payload.AddRange(attrs);
+        return Frame(BgpMessageType.Update, [.. payload]);
+    }
+
+    [Fact]
+    public async Task MpReachOnly_Announcement_InstallsTheIpv6Route()
+    {
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        conn.EnqueueFrame(MpReachOnlyAnnounceFrame());
+        await SettleAsync(conn, () => routeTable.Count == 1);
+
+        var route = routeTable.Get(V6TestPrefix, 48, isIpv4: false);
+        Assert.NotNull(route);
+        Assert.Equal(V6TestNextHop, route.NextHop);
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task MpUnreachOnly_Withdrawal_RemovesTheIpv6Route()
+    {
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        conn.EnqueueFrame(MpReachOnlyAnnounceFrame());
+        await SettleAsync(conn, () => routeTable.Count == 1);
+
+        conn.EnqueueFrame(MpUnreachOnlyWithdrawFrame());
+        await SettleAsync(conn, () => routeTable.Count == 0);
+        Assert.Null(routeTable.Get(V6TestPrefix, 48, isIpv4: false));
+
+        await TeardownAsync(session, run);
+    }
+
     private sealed class RejectAllIncomingFilter : IRouteFilter
     {
         private static readonly IReadOnlySet<uint> Empty = new HashSet<uint>();


### PR DESCRIPTION
Closes #407

## Problem
A real BIRD2 peer (docker compose integration stand) announced 2001:db8:ffff::/48 via MP_REACH_NLRI over a negotiated MP-IPv6 session — the route never appeared in the server's route table. Symmetrically, MP_UNREACH-only withdrawals were lost: a peer removing its IPv6 routes left them installed on BGPLite.

## Root Cause
`HandleUpdateAsync` gated the entire announcement pipeline on the classic IPv4 NLRI field:
```csharp
if (update.Nlri.Count > 0) { ...MP_REACH install... ...MP_UNREACH withdraw... }
```
An MP_REACH-only UPDATE — the NORMAL wire shape per RFC 4760 §5 (classic NLRI empty, next hop inside the attribute) — has `Nlri.Count == 0` and skipped the whole block. MP_UNREACH-only withdrawals were gated identically.

## Fix
- Announcement block gate: `Nlri.Count > 0 || MpReachV6 != null`.
- MP_UNREACH handling moved outside the gate entirely: a withdrawal carries no announcements, needs no attribute validation, and must not depend on NLRI/MP_REACH presence.

## Correctness
Order preserved: classic withdrawals → announcements (v4 NLRI, then MP_REACH) → MP_UNREACH withdrawals (RFC 4271 §6.3 processing order; withdrawn-first is why the MP_UNREACH branch sits after the announce block). Mandatory-attribute validation unchanged for announcing UPDATEs (RFC 4760 §5 relaxation for MP_REACH-only already in place from #15 phase 2).

## Regression Test
Two session-level tests (`BgpSessionRouteOwnershipTests`) drive hand-built wire frames through the REAL read loop: MP_REACH-only announce must install the IPv6 route; MP_UNREACH-only withdraw must remove it. **Red/green proven**: both failed against the pre-fix code; both pass after. (Unit-level codec tests from phase 2 could not see this — the gate lives in the session layer.)

## Verification
- `dotnet format` / `dotnet build BGPLite.sln` (0 warnings) / `dotnet test BGPLite.sln` — **979/979** (baseline 977)
- Integration stand (follow-up PR): BIRD2 announced 2001:db8:ffff::/48 — confirmed missing before this fix via server debug logs, expected green after

## RFC
RFC 4760 §5 (MP_REACH_NLRI — next hop in attribute, used with empty classic NLRI), §7 (MP_UNREACH_NLRI withdrawals), RFC 4271 §6.3 (UPDATE processing).

## Behavior Change
IPv6 routes announced via MP_REACH-only UPDATEs are now installed (previously silently dropped); MP_UNREACH-only withdrawals now remove routes (previously ignored). IPv4 behavior unchanged.

## Deviation from Issue Proposal
None — implements the fix shape proposed in #407.