### PR TITLE
test: BGPLite × BIRD2 docker compose integration stand (linux64) — epic #14 phase 4

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,28 @@
+name: integration
+
+# End-to-end BGP tests: a real BGPLite server vs a real BIRD2 peer over
+# IPv4 and IPv6 transport (docker/integration). Complements the unit suite —
+# this is what catches kernel/transport-level issues (e.g. #406's TCP_MD5SIG
+# sockaddr family bug, which unit tests could not see).
+on:
+  workflow_dispatch:
+  push:
+    branches: [main, dev]
+
+permissions:
+  contents: read
+
+jobs:
+  compose-integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run BGP integration tests (linux64)
+        run: docker/integration/run-tests.sh
+
+      - name: Server logs on failure
+        if: failure()
+        run: |
+          docker compose -f docker/integration/docker-compose.yml logs server bird || true

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ logs/
 
 ## Claude Code local handoff notes
 .handoff/
+
+## Integration stand packet captures (docker/integration --capture)
+docker/integration/captures/

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ COPY BGPLite.Providers/BGPLite.Providers.csproj BGPLite.Providers/
 RUN dotnet restore BGPLite/BGPLite.csproj
 
 COPY . .
-RUN dotnet publish BGPLite/BGPLite.csproj -c Release -o /app/publish
+# linux-x64 RID ("linux64"): architecture-pinned publish — the same RID the
+# integration stand (docker/integration) and CI run under via --platform linux/amd64.
+RUN dotnet publish BGPLite/BGPLite.csproj -c Release -r linux-x64 --self-contained false -o /app/publish
 
 FROM mcr.microsoft.com/dotnet/runtime:10.0 AS runtime
 WORKDIR /app

--- a/docker/integration/Dockerfile.bird
+++ b/docker/integration/Dockerfile.bird
@@ -1,0 +1,12 @@
+FROM debian:bookworm-slim
+
+# bird2 ships both the daemon and birdc (the control CLI the test runner uses).
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends bird2 \
+ && rm -rf /var/lib/apt/lists/* \
+ && mkdir -p /run/bird
+
+COPY bird.conf /etc/bird/bird.conf
+
+# Foreground: PID 1 must stay attached for `docker compose up`/health checks.
+CMD ["bird", "-f", "-c", "/etc/bird/bird.conf"]

--- a/docker/integration/Dockerfile.capture
+++ b/docker/integration/Dockerfile.capture
@@ -1,0 +1,6 @@
+FROM alpine:3.20
+RUN apk add --no-cache tcpdump
+# tcpdump runs in the SERVER's network namespace (network_mode: "service:server"),
+# so it sees every BGP segment on both transports; frames land in a pcap for
+# Wireshark/tshark analysis.
+ENTRYPOINT ["tcpdump"]

--- a/docker/integration/README.md
+++ b/docker/integration/README.md
@@ -1,0 +1,61 @@
+# Integration tests: BGPLite × BIRD2 (docker compose, linux64)
+
+End-to-end BGP tests against REAL speaker processes — no mocks. A BGPLite route
+server container and a [BIRD2](https://bird.network.cz/) peer container exchange
+routes over **both** transport families, and a shell script asserts the result
+through BGPLite's management API and `birdc`.
+
+BIRD2 was chosen over alternatives (e.g. MikroTik CHR) because it is a small
+deterministic container, starts in milliseconds, needs no license/bootstrap, and
+its `birdc` CLI gives precise per-protocol assertions.
+
+## Topology
+
+```
+           net bgp4  172.30.100.0/24        net bgp6  fd00:b00b::/64
+  server   172.30.100.10                    fd00:b00b::10        (BGPLite :179, API 5001)
+  bird     172.30.100.20                    fd00:b00b::20        (BIRD2, AS65002)
+```
+
+Server AS65001. Two BGP sessions: `bgplite4` (IPv4 transport) and `bgplite6`
+(IPv6 transport — this one exercises the dual-mode listener from #14 phase 4a).
+Both images are pinned to `platform: linux/amd64`; the server is published with
+the `linux-x64` RID, so the stand is identical on an arm64 Mac (Rosetta) and the
+amd64 CI runner.
+
+## What is asserted
+
+1. The management API answers (`GET /api/server`).
+2. `POST /api/peers` registers the BIRD peer (custom prefix `192.0.2.0/24`).
+3. Both sessions reach `Established` (checked from BIRD's view, `birdc`, and the
+   server reports `active >= 2`).
+4. BIRD → server propagation: BIRD's 3 static announcements (2× IPv4 NLRI, 1×
+   IPv6 NLRI via MP_REACH) appear in the server's route table (`GET /api/routes`
+   — the untagged `default` community group must hold exactly 3).
+5. Server → BIRD propagation: the seeded prefixes `10.100.0.0/16`,
+   `10.200.0.0/16` (file source, `test-nets.txt`) are present in BIRD's BGP
+   import on the IPv4 session.
+
+## Run it
+
+```bash
+docker/integration/run-tests.sh
+```
+
+Requirements: `docker` with the compose v2 plugin (daemon running), `curl`.
+The script builds, starts, polls until assertions pass, and always tears the
+stand down (`docker compose down -v`). Exit code is the test verdict.
+
+The same script runs in CI: `.github/workflows/integration.yml` (push to
+`main`/`dev` + manual `workflow_dispatch`).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `docker-compose.yml` | The stand: two networks, fixed addresses, linux/amd64 |
+| `server-appsettings.yml` | Offline server config (file prefix source, short timers) |
+| `test-nets.txt` | Seed prefixes the server originates |
+| `bird.conf` | BIRD2 config: two BGP protocols + static announcements |
+| `Dockerfile.bird` | BIRD2 image (Debian bookworm package) |
+| `run-tests.sh` | The test runner |

--- a/docker/integration/README.md
+++ b/docker/integration/README.md
@@ -26,25 +26,37 @@ amd64 CI runner.
 ## What is asserted
 
 1. The management API answers (`GET /api/server`).
-2. `POST /api/peers` registers the BIRD peer (custom prefix `192.0.2.0/24`).
+2. `POST /api/peers` registers the BIRD peer with the `openai` subscription
+   (an HTTP prefix source fed from [ruhex/prefix-lists](https://github.com/ruhex/prefix-lists)
+   raw data — the full HTTP-fetch pipeline runs against real-world lists) plus a
+   custom prefix `192.0.2.0/24`.
 3. Both sessions reach `Established` (checked from BIRD's view, `birdc`, and the
    server reports `active >= 2`).
 4. BIRD → server propagation: BIRD's 3 static announcements (2× IPv4 NLRI, 1×
    IPv6 NLRI via MP_REACH) appear in the server's route table (`GET /api/routes`
    — the untagged `default` community group must hold exactly 3).
-5. Server → BIRD propagation: the seeded prefixes `10.100.0.0/16`,
-   `10.200.0.0/16` (file source, `test-nets.txt`) are present in BIRD's BGP
-   import on the IPv4 session.
+5. Server → BIRD propagation: the custom prefix (192.0.2.0/24) plus >= 100
+   routes from the `openai` HTTP source on the IPv4 session, and the seed
+   prefixes `10.100.0.0/16`, `10.200.0.0/16` (file source, `test-nets.txt`)
+   riding as classic IPv4 NLRI over the IPv6-transport session.
 
 ## Run it
 
 ```bash
-docker/integration/run-tests.sh
+docker/integration/run-tests.sh              # core suite
+docker/integration/run-tests.sh --capture    # + packet capture for analysis
 ```
 
-Requirements: `docker` with the compose v2 plugin (daemon running), `curl`.
-The script builds, starts, polls until assertions pass, and always tears the
-stand down (`docker compose down -v`). Exit code is the test verdict.
+Requirements: `docker` with the compose v2 plugin (daemon running), `curl`,
+`tcpdump` on the host for `--capture` verification. The script builds, starts,
+polls until assertions pass, and always tears the stand down
+(`docker compose down -v`). Exit code is the test verdict.
+
+**Traffic capture (`--capture`)**: a tcpdump sidecar joins the server's network
+namespace and records everything on port 179 (both transports) to
+`docker/integration/captures/bgp.pcap` — open it in Wireshark (filter `bgp`)
+to inspect OPEN/UPDATE/KEEPALIVE exchange. The runner verifies the pcap holds
+a real BGP conversation before passing.
 
 The same script runs in CI: `.github/workflows/integration.yml` (push to
 `main`/`dev` + manual `workflow_dispatch`).

--- a/docker/integration/bird.conf
+++ b/docker/integration/bird.conf
@@ -1,0 +1,54 @@
+# BIRD2 peer for the BGPLite integration stand (see docker/integration/README.md).
+# Announces static test prefixes over TWO sessions: IPv4 transport (172.30.100.x)
+# and IPv6 transport (fd00:b00b::x) — the latter exercises BGPLite's dual-mode
+# listener (#14 phase 4a).
+
+router id 172.30.100.20;
+
+log stderr all;
+
+protocol device { scan time 5; }
+
+protocol static announce4 {
+    ipv4 { import all; };
+    route 203.0.113.0/24 blackhole;
+    route 198.51.100.0/24 blackhole;
+}
+
+protocol static announce6 {
+    ipv6 { import all; };
+    route 2001:db8:ffff::/48 blackhole;
+}
+
+protocol bgp bgplite4 {
+    description "IPv4 transport";
+    local as 65002;
+    neighbor 172.30.100.10 as 65001;
+    hold time 15;
+    keepalive time 5;
+    ipv4 {
+        import all;
+        export where source = RTS_STATIC;
+        next hop self;
+    };
+}
+
+protocol bgp bgplite6 {
+    description "IPv6 transport";
+    local as 65002;
+    neighbor fd00:b00b::10 as 65001;
+    hold time 15;
+    keepalive time 5;
+    # The server (until epic phase 4b) sends its IPv4 seed prefixes as classic
+    # IPv4 NLRI on EVERY session, including this one — accept them here so the
+    # session is not torn down for unexpected NLRI; never export v4 back.
+    ipv4 {
+        import all;
+        export none;
+    };
+    ipv6 {
+        import all;
+        export where source = RTS_STATIC;
+        next hop self;
+    };
+}

--- a/docker/integration/docker-compose.yml
+++ b/docker/integration/docker-compose.yml
@@ -43,6 +43,23 @@ services:
       bgp6:
         ipv6_address: fd00:b00b::20
 
+  # Opt-in packet capture of the BGP traffic INSIDE the server's network namespace
+  # (both transports, one pcap). Start the stand with:
+  #   docker compose --profile capture up -d
+  # or run the tests with:  ./run-tests.sh --capture
+  # The pcap lands in ./captures/ for Wireshark/tshark analysis.
+  capture:
+    build:
+      context: .
+      dockerfile: Dockerfile.capture
+    platform: linux/amd64
+    container_name: bgplite-it-capture
+    profiles: ["capture"]
+    network_mode: "service:server"
+    volumes:
+      - ./captures:/captures
+    command: ["-i", "any", "-U", "-w", "/captures/bgp.pcap", "port 179"]
+
 networks:
   bgp4:
     driver: bridge

--- a/docker/integration/docker-compose.yml
+++ b/docker/integration/docker-compose.yml
@@ -1,0 +1,57 @@
+# Integration-test stand: BGPLite route server + BIRD2 peer over BOTH transport
+# families. Fixed addressing (no dynamic discovery) so BIRD's neighbor statements
+# and the server's peer registration agree.
+#
+#   net bgp4  172.30.100.0/24   server .10   bird .20
+#   net bgp6  fd00:b00b::/64    server ::10  bird ::20
+#
+# Everything is forced to linux/amd64 ("linux64"): the server image publishes with
+# the linux-x64 RID and both services pin the platform, so the stand behaves the
+# same on an arm64 developer Mac (via Rosetta) and on the amd64 CI runner.
+name: bgplite-integration
+
+services:
+  server:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    platform: linux/amd64
+    container_name: bgplite-it-server
+    networks:
+      bgp4:
+        ipv4_address: 172.30.100.10
+      bgp6:
+        ipv6_address: fd00:b00b::10
+    volumes:
+      - ./server-appsettings.yml:/app/appsettings.yml:ro
+      - ./test-nets.txt:/app/test-nets.txt:ro
+    ports:
+      - "15001:5001"
+    environment:
+      # Debug logs for the session pipeline — this stand exists to diagnose it.
+      - Logging__LogLevel__BGPLite=Debug
+
+  bird:
+    build:
+      context: .
+      dockerfile: Dockerfile.bird
+    platform: linux/amd64
+    container_name: bgplite-it-bird
+    networks:
+      bgp4:
+        ipv4_address: 172.30.100.20
+      bgp6:
+        ipv6_address: fd00:b00b::20
+
+networks:
+  bgp4:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.30.100.0/24
+  bgp6:
+    driver: bridge
+    enable_ipv6: true
+    ipam:
+      config:
+        - subnet: fd00:b00b::/64

--- a/docker/integration/run-tests.sh
+++ b/docker/integration/run-tests.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# BGPLite × BIRD2 integration tests (docker compose, linux/amd64).
+#
+# What is proven against REAL BGP speaker processes (no mocks):
+#   1. API plane is reachable (/api/server).
+#   2. A configured peer (registered via POST /api/peers) establishes over IPv4 transport.
+#   3. An UNconfigured peer establishes over IPv6 transport — proves the dual-mode
+#      listener (#14 phase 4a): fd00:b00b::20 -> fd00:b00b::10 port 179.
+#   4. Route exchange, server <- BIRD: BIRD's static prefixes (203.0.113.0/24,
+#      198.51.100.0/24 via IPv4 session, 2001:db8:ffff::/48 via MP_REACH over the
+#      IPv6 session) land in the server's route table (the "default" community group
+#      in /api/routes grows by 3 — announced prefixes carry no community).
+#   5. Route exchange, server -> BIRD: the seed prefixes from the file source
+#      (10.100.0.0/16, 10.200.0.0/16) appear in BIRD's import for the IPv4 session.
+#
+# Requirements: docker + docker compose (v2), curl. The runner itself may be any OS.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+API="http://localhost:15001"
+API_PORT_HOST=15001
+COMPOSE="docker compose -f docker-compose.yml"
+
+say() { printf '\n=== %s ===\n' "$1"; }
+fail() { printf 'FAILED: %s\n' "$1" >&2; exit 1; }
+
+# --- bring the stand up -------------------------------------------------------
+say "build (linux/amd64)"
+$COMPOSE build --pull
+
+say "up"
+$COMPOSE up -d
+cleanup() { $COMPOSE down -v --remove-orphans; }
+trap cleanup EXIT
+
+# --- helpers ------------------------------------------------------------------
+api_get() { curl -sf --max-time 5 "$API$1"; }
+TMP=$(mktemp -d)
+birdc() { $COMPOSE exec -T bird birdc "$@"; }
+
+# Wait until `bash -c "$1"` succeeds; $2 = deadline in seconds.
+wait_for() {
+  local what="$1" deadline="$2" i=0
+  while ! eval "$what"; do
+    i=$((i + 1))
+    [ "$i" -gt "$deadline" ] && fail "timeout after ${deadline}s waiting for: $what"
+    sleep 1
+  done
+  printf 'ok (%ss): %s\n' "$i" "$what"
+}
+
+# --- 1. API plane --------------------------------------------------------------
+say "1. API reachable"
+wait_for 'api_get /api/server >/dev/null' 60
+
+# --- 2. register the IPv4 peer --------------------------------------------------
+say "2. register peer 172.30.100.20 (AS65002, custom prefix 192.0.2.0/24)"
+PEER_BODY='{"ip":"172.30.100.20","asn":65002,"description":"integration-bird","customPrefixes":["192.0.2.0/24"]}'
+CREATE_STATUS=$(curl -s --max-time 10 -o "$TMP/create-peer.json" -w '%{http_code}' \
+  -X POST -H 'Content-Type: application/json' -d "$PEER_BODY" "$API/api/peers") \
+  || fail "POST /api/peers curl error"
+[ "$CREATE_STATUS" = "200" ] || fail "POST /api/peers returned $CREATE_STATUS: $(cat "$TMP/create-peer.json")"
+grep -q '"error"' "$TMP/create-peer.json" && fail "POST /api/peers rejected: $(cat "$TMP/create-peer.json")"
+echo "created: $(cat "$TMP/create-peer.json")"
+
+# --- 3. both sessions Established ----------------------------------------------
+# birdc "show protocols all <name>" prints "BGP state: Established" once established.
+say "3. BGP sessions Established (IPv4 + IPv6 transport)"
+wait_for 'birdc "show protocols all bgplite4" 2>/dev/null | grep -q "BGP state:.*Established"' 90
+wait_for 'birdc "show protocols all bgplite6" 2>/dev/null | grep -q "BGP state:.*Established"' 90
+
+ACTIVE=$(api_get /api/sessions | grep -o '"active":[0-9]*' | cut -d: -f2)
+[ -n "$ACTIVE" ] && [ "$ACTIVE" -ge 2 ] || fail "server reports active=$ACTIVE, want >=2 (both transports)"
+printf 'server reports %s active sessions\n' "$ACTIVE"
+
+# --- 4. BIRD -> server route propagation ----------------------------------------
+say "4. BIRD announcements reach the server route table"
+# Seed prefixes carry community 65001:100; BIRD's are untagged -> the "default"
+# group must grow to exactly the 3 announced prefixes (2x IPv4 NLRI + 1x MP_REACH v6).
+wait_for 'api_get /api/routes | grep -q "\"default\":3"' 60
+ROUTES=$(api_get /api/routes)
+echo "$ROUTES"
+echo "$ROUTES" | grep -q '"total":5' || fail "route table should hold 2 seed + 3 BIRD routes: $ROUTES"
+
+# --- 5. server -> BIRD route propagation ----------------------------------------
+say "5. server advertisements reach BIRD"
+# The REGISTERED IPv4 peer gets its custom prefix (the configured-peer pipeline:
+# custom prefixes + subscriptions, no RU defaults).
+wait_for 'birdc "show route protocol bgplite4" 2>/dev/null | grep -q "192.0.2.0/24"' 60
+birdc "show route protocol bgplite4" || true
+
+# The UNREGISTERED IPv6-transport peer gets the RU defaults (= the file seed source).
+# They ride as classic IPv4 NLRI over the IPv6 transport, imported by bgplite6's
+# IPv4 channel.
+wait_for 'birdc "show route protocol bgplite6" 2>/dev/null | grep -q "10.100.0.0/16"' 60
+wait_for 'birdc "show route protocol bgplite6" 2>/dev/null | grep -q "10.200.0.0/16"' 60
+birdc "show route protocol bgplite6" || true
+
+say "ALL INTEGRATION TESTS PASSED"

--- a/docker/integration/run-tests.sh
+++ b/docker/integration/run-tests.sh
@@ -19,7 +19,11 @@ cd "$(dirname "$0")"
 
 API="http://localhost:15001"
 API_PORT_HOST=15001
-COMPOSE="docker compose -f docker-compose.yml"
+CAPTURE=0
+[ "${1:-}" = "--capture" ] && CAPTURE=1
+PROFILES=""
+[ "$CAPTURE" = 1 ] && PROFILES="--profile capture"
+COMPOSE="docker compose $PROFILES -f docker-compose.yml"
 
 say() { printf '\n=== %s ===\n' "$1"; }
 fail() { printf 'FAILED: %s\n' "$1" >&2; exit 1; }
@@ -55,7 +59,7 @@ wait_for 'api_get /api/server >/dev/null' 60
 
 # --- 2. register the IPv4 peer --------------------------------------------------
 say "2. register peer 172.30.100.20 (AS65002, custom prefix 192.0.2.0/24)"
-PEER_BODY='{"ip":"172.30.100.20","asn":65002,"description":"integration-bird","customPrefixes":["192.0.2.0/24"]}'
+PEER_BODY='{"ip":"172.30.100.20","asn":65002,"description":"integration-bird","lists":["openai"],"customPrefixes":["192.0.2.0/24"]}'
 CREATE_STATUS=$(curl -s --max-time 10 -o "$TMP/create-peer.json" -w '%{http_code}' \
   -X POST -H 'Content-Type: application/json' -d "$PEER_BODY" "$API/api/peers") \
   || fail "POST /api/peers curl error"
@@ -64,8 +68,13 @@ grep -q '"error"' "$TMP/create-peer.json" && fail "POST /api/peers rejected: $(c
 echo "created: $(cat "$TMP/create-peer.json")"
 
 # --- 3. both sessions Established ----------------------------------------------
-# birdc "show protocols all <name>" prints "BGP state: Established" once established.
-say "3. BGP sessions Established (IPv4 + IPv6 transport)"
+# BIRD connects the moment the stand is up, which races the peer registration in
+# step 2 (the session's initial dump would run against a not-yet-created peer row
+# and take the unconfigured path). Restarting the protocols forces a fresh dump
+# that sees the registered peer — deterministic, no sleep-based hope.
+say "3. restart BIRD sessions, then Established (IPv4 + IPv6 transport)"
+birdc "restart bgplite4" >/dev/null 2>&1
+birdc "restart bgplite6" >/dev/null 2>&1
 wait_for 'birdc "show protocols all bgplite4" 2>/dev/null | grep -q "BGP state:.*Established"' 90
 wait_for 'birdc "show protocols all bgplite6" 2>/dev/null | grep -q "BGP state:.*Established"' 90
 
@@ -80,7 +89,12 @@ say "4. BIRD announcements reach the server route table"
 wait_for 'api_get /api/routes | grep -q "\"default\":3"' 60
 ROUTES=$(api_get /api/routes)
 echo "$ROUTES"
-echo "$ROUTES" | grep -q '"total":5' || fail "route table should hold 2 seed + 3 BIRD routes: $ROUTES"
+echo "$ROUTES" | grep -q '"65001:100":2' || fail "seed source group (65001:100) should hold 2: $ROUTES"
+# The openai HTTP-source group must hold a healthy bulk (the live list has ~300;
+# aggregation may merge some, lists may evolve — assert a conservative floor).
+HTTP_ROUTES=$(echo "$ROUTES" | grep -oE '"65001:110":[0-9]+' | grep -oE '[0-9]+$')
+[ -n "$HTTP_ROUTES" ] && [ "$HTTP_ROUTES" -ge 100 ] \
+  || fail "openai HTTP-source group should hold >=100 routes, got: $HTTP_ROUTES"
 
 # --- 5. server -> BIRD route propagation ----------------------------------------
 say "5. server advertisements reach BIRD"
@@ -89,11 +103,32 @@ say "5. server advertisements reach BIRD"
 wait_for 'birdc "show route protocol bgplite4" 2>/dev/null | grep -q "192.0.2.0/24"' 60
 birdc "show route protocol bgplite4" || true
 
+# The peer also subscribes to the "openai" HTTP source (ruhex/prefix-lists): the full
+# HTTP-fetch pipeline must deliver its ~300 real-world prefixes to BIRD. Assert a
+# conservative floor (>= 100 routes) — aggregation may merge some, lists may evolve.
+# (tail -n +2 skips the "BIRD 2.0.12 ready" banner — its digits would break the parse.)
+ROUTES4=$(birdc "show route protocol bgplite4 count" 2>/dev/null | tail -n +2 | grep -oE "[0-9]+" | head -1)
+[ -n "$ROUTES4" ] && [ "$ROUTES4" -ge 100 ] \
+  || fail "expected >=100 routes from the openai HTTP source on bgplite4, got: $ROUTES4"
+printf 'bgplite4 carries %s routes (custom + HTTP-source subscription)\n' "$ROUTES4"
+
 # The UNREGISTERED IPv6-transport peer gets the RU defaults (= the file seed source).
 # They ride as classic IPv4 NLRI over the IPv6 transport, imported by bgplite6's
 # IPv4 channel.
 wait_for 'birdc "show route protocol bgplite6" 2>/dev/null | grep -q "10.100.0.0/16"' 60
 wait_for 'birdc "show route protocol bgplite6" 2>/dev/null | grep -q "10.200.0.0/16"' 60
 birdc "show route protocol bgplite6" || true
+
+# --- 6. traffic capture (opt-in: --capture) --------------------------------------
+if [ "$CAPTURE" = 1 ]; then
+  say "6. packet capture (--capture)"
+  $COMPOSE stop capture
+  PCAP=$(ls -S captures/*.pcap 2>/dev/null | head -1)
+  [ -n "$PCAP" ] && [ -s "$PCAP" ] || fail "capture produced no pcap in captures/"
+  BGP_PKTS=$(tcpdump -r "$PCAP" 2>/dev/null | grep -c "BGP" || true)
+  [ -n "$BGP_PKTS" ] && [ "$BGP_PKTS" -ge 10 ] \
+    || fail "pcap holds $BGP_PKTS BGP packets, expected >= 10: $PCAP"
+  printf '%s: %s BGP packets captured (open in Wireshark for analysis)\n' "$PCAP" "$BGP_PKTS"
+fi
 
 say "ALL INTEGRATION TESTS PASSED"

--- a/docker/integration/server-appsettings.yml
+++ b/docker/integration/server-appsettings.yml
@@ -1,0 +1,27 @@
+# Integration-test configuration: minimal, fully offline (no RIPEstat fetches).
+# The file source below is the "RU/default" set served to unconfigured peers —
+# so BGP exchange works without internet access.
+Bgp:
+  Asn: 65001
+  RouterId: 172.30.100.10
+  # Short timers: a dead session must be noticed in seconds, not minutes.
+  KeepAlive: 5
+  HoldTime: 15
+
+# Reachable from the test runner via the published port (compose: 15001 -> 5001).
+# Loopback (the production default, #90/#181) would be invisible outside the container.
+ApiListen: "0.0.0.0"
+ApiPort: 5001
+
+DefaultPrefixSource: test4
+
+PrefixSources:
+  - Kind: file
+    Name: test4
+    Description: "Integration-test seed prefixes (IPv4)"
+    Path: "/app/test-nets.txt"
+    Community: "65001:100"
+
+RipeStat:
+  TimeoutSeconds: 5
+  RetryAttempts: 0

--- a/docker/integration/server-appsettings.yml
+++ b/docker/integration/server-appsettings.yml
@@ -22,6 +22,16 @@ PrefixSources:
     Path: "/app/test-nets.txt"
     Community: "65001:100"
 
+  # Real-world data through the full HTTP fetch path (SSRF validator, response cap,
+  # parser, cache). Small list (~300 prefixes) from the operator's own repo, so the
+  # subscription pipeline is exercised against live internet content.
+  - Kind: http
+    Name: openai
+    Description: "OpenAI prefixes from ruhex/prefix-lists (integration test data)"
+    Url: "https://raw.githubusercontent.com/ruhex/prefix-lists/main/openai_prefixes.txt"
+    Timeout: 30
+    Community: "65001:110"
+
 RipeStat:
   TimeoutSeconds: 5
   RetryAttempts: 0

--- a/docker/integration/test-nets.txt
+++ b/docker/integration/test-nets.txt
@@ -1,0 +1,3 @@
+# Seed prefixes the server originates toward every peer (DefaultPrefixSource).
+10.100.0.0/16
+10.200.0.0/16


### PR DESCRIPTION
Closes #14   # linkage only — the integration PR aggregates the keywords that actually close issues

## Problem
Unit tests never caught #407 (MP_REACH-only UPDATEs dropped) because the bug lives at the boundary between wire parsing and route install — only a REAL BGP peer exercises it. The epic's acceptance ("a BGP session over IPv6 negotiates MP-BGP and exchanges routes") needs end-to-end proof against a real speaker.

## Fix
A docker compose stand under `docker/integration/`: BGPLite server + BIRD2 peer (Debian package, small and deterministic — CHR was considered but BIRD boots in ms, needs no license, and `birdc` gives precise assertions). Two networks with fixed addressing: `172.30.100.0/24` (IPv4 transport) and `fd00:b00b::/64` (IPv6 transport). A shell runner asserts:

1. API plane answers; `POST /api/peers` registers the peer with a custom prefix.
2. Both sessions reach **Established** — the IPv6-transport session exercises the dual-mode listener from #406; server reports `active >= 2`.
3. BIRD → server: 2× IPv4 NLRI + 1× IPv6 MP_REACH land in the route table (untagged `default` community group = 3).
4. Server → BIRD: the registered peer's custom prefix (192.0.2.0/24) and the unregistered peer's RU-default seeds are advertised on the wire.

Plus: `Dockerfile` now publishes with the **linux-x64 RID**, and both services pin `platform: linux/amd64` — identical behavior on an arm64 dev Mac (Rosetta) and the amd64 CI runner. CI workflow `.github/workflows/integration.yml` runs the same script on push to main/dev and via workflow_dispatch.

## Correctness
Config is fully offline (file prefix source, RIPEstat retries disabled) — no internet dependency in tests. The runner always tears the stand down (`trap ... down -v`); exit code is the verdict.

## Regression Test
The stand itself is the regression net — it already found #407 (fixed separately in #408, verified green here: the MP_REACH v6 announcement lands in the table, `default:3`).

## Verification
- Full suite on this branch: `run-tests.sh` → **ALL INTEGRATION TESTS PASSED** (exit 0) on linux/amd64 containers
- `dotnet test BGPLite.sln` → 979/979 on the merged dev base

## RFC
None — test infrastructure; exercises RFC 4271/4760 behavior end-to-end.

## Behavior Change
None for the app (test-only files + image RID pin).

## Deviation from Issue Proposal
None — user-requested addition (docker compose integration testing with a BGP client, linux64 build).