### PR TITLE
feat(protocol,server): outbound MP_REACH + dual-stack prefix pipeline (phase 4b of #14)

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -1211,8 +1211,8 @@ public sealed class ManagementApi : IHostedService, IDisposable
             try
             {
                 var fetched = await _prefixService.GetPrefixesForAsns(asns, ct);
-                foreach (var (prefix, length, _) in fetched)
-                    prefixes.Add($"{BgpConstants.UintToIPAddress(prefix)}/{length}");
+                foreach (var p in fetched)
+                    prefixes.Add(new IpPrefix(p.Prefix, p.Length, p.IsIpv4).ToString());
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#337: only shutdown cancellation — a provider-timeout OCE (live token) is a fetch failure below
             catch (Exception ex) { _logger.LogWarning(ex, "CollectPeerPrefixes: ASN fetch failed"); }
@@ -1224,8 +1224,8 @@ public sealed class ManagementApi : IHostedService, IDisposable
             try
             {
                 var ruPrefixes = await _prefixService.GetRuPrefixesAsync(ct);
-                foreach (var (prefix, length, _) in ruPrefixes)
-                    prefixes.Add($"{BgpConstants.UintToIPAddress(prefix)}/{length}");
+                foreach (var p in ruPrefixes)
+                    prefixes.Add(new IpPrefix(p.Prefix, p.Length, p.IsIpv4).ToString());
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#337: only shutdown cancellation — a provider-timeout OCE (live token) is a fetch failure below
             catch (Exception ex) { _logger.LogWarning(ex, "CollectPeerPrefixes: RU prefix fetch failed"); }

--- a/BGPLite.Configuration/BgpConfig.cs
+++ b/BGPLite.Configuration/BgpConfig.cs
@@ -12,6 +12,29 @@ public sealed class BgpConfig
     [YamlMember(Alias = "RouterId")]
     public string RouterId { get; init; } = "0.0.0.0";
 
+    /// <summary>
+    /// Optional global IPv6 next hop advertised to MP-BGP IPv6/Unicast peers (#14 phase 4,
+    /// RFC 2545 §3: the MP_REACH next hop is the speaker's GLOBAL address — the IPv4 router-id
+    /// cannot serve the IPv6 address family). Unset = IPv6 routes are never advertised to any
+    /// peer (suppressed with a warning per send); set = each MP-IPv6-negotiated session
+    /// announces its IPv6 routes with this next hop.
+    /// </summary>
+    [YamlMember(Alias = "NextHopIpv6")]
+    public string? NextHopIpv6 { get; init; }
+
+    /// <summary>
+    /// Whether <paramref name="value"/> parses as a GLOBAL IPv6 unicast address (2000::/3) —
+    /// the RFC 2545 §3 requirement for the MP_REACH next hop. Shared by <see cref="Validate"/>
+    /// and the session's send-time gate (a hand-built config record skips Validate, so the gate
+    /// must not trust the string blindly).
+    /// </summary>
+    public static bool IsGlobalUnicastV6([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] string? value) =>
+        IPAddress.TryParse(value, out var v6)
+        && v6.AddressFamily == AddressFamily.InterNetworkV6
+        && !v6.IsIPv4MappedToIPv6
+        && v6.ScopeId == 0
+        && (v6.GetAddressBytes()[0] & 0xE0) == 0x20; // 2000::/3
+
     [YamlMember(Alias = "KeepAlive")]
     public int KeepAlive { get; init; } = 60;
 
@@ -129,5 +152,22 @@ public sealed class BgpConfig
         if (MaxPrefixesPerPeer < 0)
             throw new InvalidOperationException(
                 $"Invalid configuration: Bgp.MaxPrefixesPerPeer must be >= 0, 0 = unlimited (got {MaxPrefixesPerPeer}).");
+
+        // #14 phase 4: when an IPv6 next hop is configured it must be a GLOBAL IPv6 unicast
+        // address — RFC 2545 §3 requires the (first) MP_REACH next hop to be global, and the
+        // 16-byte form we advertise has no room for interface semantics (a link-local address
+        // is only meaningful on a shared link, which a route-server session is not required to
+        // be). Global unicast space is 2000::/3 — that single check also rejects the unspecified
+        // address, loopback (::1), link-local (fe80::/10), ULA (fc00::/7) and multicast (ff00::/8).
+        // Unset stays legal: it simply disables IPv6 advertisements (fail-visible at send time),
+        // never a startup failure for IPv4-only deployments.
+        if (!string.IsNullOrWhiteSpace(NextHopIpv6))
+        {
+            if (!IsGlobalUnicastV6(NextHopIpv6))
+                throw new InvalidOperationException(
+                    "Invalid configuration: Bgp.NextHopIpv6 must be a global unicast IPv6 address (2000::/3 — " +
+                    $"not link-local, multicast, ULA or mapped) when set (got '{NextHopIpv6}'). " +
+                    "Leave it unset to disable IPv6 advertisements.");
+        }
     }
 }

--- a/BGPLite.Contracts/IPrefixService.cs
+++ b/BGPLite.Contracts/IPrefixService.cs
@@ -5,14 +5,21 @@ namespace BGPLite.Contracts;
 /// concrete <c>PrefixService</c> implementation (BGPLite.Providers, a data layer) can implement it
 /// without depending upward on BGPLite.Server — Server (the consumer) depends on this contract,
 /// giving the dependency direction Server→Configuration←Providers as peers (#88).
+/// <para>
+/// Prefixes are family-tagged tuples <c>(UInt128 Prefix, byte Length, bool IsIpv4)</c> (#14
+/// phase 4) — the same layout as <c>Route.Key</c>. IPv4 addresses live in the LOW 32 bits of
+/// <c>Prefix</c> with <c>IsIpv4 = true</c>; IPv6 uses the full 128 bits. (The tuple carries the
+/// family instead of the Protocol layer's <c>IpPrefix</c> type because Contracts is a
+/// dependency-free leaf.)
+/// </para>
 /// </summary>
 public interface IPrefixService
 {
-    Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default);
-    Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default);
+    Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetPrefixesAsync(uint asn, CancellationToken ct = default);
+    Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default);
     Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default);
-    Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default);
-    Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default);
+    Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default);
     /// <summary>
     /// Fetches a per-peer user-supplied URL prefix-list source (epic #143 / issue #147). Unlike
     /// <see cref="GetSourcePrefixesAsync"/> (named, config-keyed, cache-through), this loads an
@@ -20,6 +27,6 @@ public interface IPrefixService
     /// <c>AppConfig.PrefixSources</c>, so it is not name-resolvable and not cached. SSRF defense
     /// (#144) is inherited from the http named client's <c>ConnectCallback</c>.
     /// </summary>
-    Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default);
+    Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default);
     Task WarmUpAsync(CancellationToken ct = default);
 }

--- a/BGPLite.Protocol/AttributeHelper.cs
+++ b/BGPLite.Protocol/AttributeHelper.cs
@@ -1,4 +1,5 @@
 using System.Buffers.Binary;
+using System.Collections.Generic;
 
 namespace BGPLite.Protocol;
 
@@ -134,6 +135,35 @@ public static class AttributeHelper
                 BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.OptionalAttributeError);
 
         return asn;
+    }
+
+    /// <summary>
+    /// Builds the MP_REACH_NLRI (type 14) attribute for IPv6/Unicast announcements — optional
+    /// non-transitive per RFC 4760 §4; the value carries the global next hop (RFC 2545 §3,
+    /// 16-byte form) plus the NLRI list. The IPv6 analogue of <see cref="WriteNextHop"/>: it is
+    /// where the outbound next hop lives for the IPv6 address family.
+    /// </summary>
+    public static PathAttribute WriteMpReachNlriV6(UInt128 nextHop, IReadOnlyList<IpPrefix> prefixes)
+    {
+        return new PathAttribute
+        {
+            Flags = BgpConstants.Attribute.FlagOptional,
+            TypeCode = MpReachCodec.MpReachNlriType,
+            Data = MpReachCodec.EncodeMpReachV6(nextHop, prefixes)
+        };
+    }
+
+    /// <summary>Builds the MP_UNREACH_NLRI (type 15) attribute for IPv6/Unicast withdrawals —
+    /// optional non-transitive per RFC 4760 §4 (the IPv6 counterpart of the withdrawn-routes
+    /// field).</summary>
+    public static PathAttribute WriteMpUnreachNlriV6(IReadOnlyList<IpPrefix> prefixes)
+    {
+        return new PathAttribute
+        {
+            Flags = BgpConstants.Attribute.FlagOptional,
+            TypeCode = MpReachCodec.MpUnreachNlriType,
+            Data = MpReachCodec.EncodeMpUnreachV6(prefixes)
+        };
     }
 
     public static PathAttribute WriteNextHop(uint nextHop)

--- a/BGPLite.Protocol/PrefixCidr.cs
+++ b/BGPLite.Protocol/PrefixCidr.cs
@@ -6,21 +6,23 @@ namespace BGPLite.Protocol;
 /// <summary>
 /// The single canonical CIDR parser for the project (#236). Every input path — operator file
 /// sources (<c>PrefixListParser</c>), the management API (<c>ParseCustomPrefix</c>), and the
-/// BGP send path's DB-load (<c>RouteAssembler</c>) — routes through <see cref="TryParse"/> so the
-/// validation and masking policy is defined in exactly one place. Three divergent parsers
-/// previously caused dedup/aggregation breakage (the same network submitted two ways was stored as
-/// two distinct keys) and a route-leak vector (the API accepted <c>/0</c>, the default route).
+/// BGP send path's DB-load (<c>RouteAssembler</c>) — routes through one of the <see cref="TryParse"/>
+/// overloads so the validation and masking policy is defined in exactly one place. Three divergent
+/// parsers previously caused dedup/aggregation breakage (the same network submitted two ways was
+/// stored as two distinct keys) and a route-leak vector (the API accepted <c>/0</c>, the default route).
 /// <para>
 /// <b>Policy</b> (locked down here, recorded in #236):
 /// <list type="bullet">
 /// <item><b>Host-bit masking is ALWAYS applied</b> — <c>10.0.0.5/24</c> normalizes to
 /// <c>10.0.0.0/24</c>. Without this the route table, the aggregator, and the duplicate-NLRI
-/// merger key on the raw <c>(uint, byte)</c> and treat the two forms as distinct networks.</item>
-/// <item><b>Length range is 1..32</b> by default. <c>/0</c> (the default route) is rejected for
-/// user-supplied sources — a route server must not originate a default. <c>allowDefault: true</c>
-/// permits <c>/0</c> for the rare operator-config default-route case (kept for completeness; no
-/// caller currently uses it).</item>
-/// <item><b>IPv4 only.</b> IPv6 is rejected (the route table stores <c>(uint, byte)</c> IPv4 keys).</item>
+/// merger key on the raw form and treat the two forms as distinct networks.</item>
+/// <item><b>Length range is 1..32 (IPv4) / 1..128 (IPv6)</b>. <c>/0</c> (the default route) is
+/// rejected for user-supplied sources — a route server must not originate a default.
+/// <c>allowDefault: true</c> permits <c>/0</c> for the rare operator-config default-route case
+/// (kept for completeness; no caller currently uses it).</item>
+/// <item><b>Family</b>: the <see cref="TryParse(string?, out IpPrefix, bool)"/> overload accepts
+/// both families (#14 phase 4); the <see cref="TryParse(string?, out uint, out byte, bool)"/>
+/// overload stays IPv4-only — the management API's custom-prefix path is still IPv4-scoped.</item>
 /// <item><b>Garbage is rejected, never thrown.</b> Returns <c>false</c> on any malformed input so
 /// callers can surface a clean 400 / skip the line, rather than propagating a <c>FormatException</c>.</item>
 /// </list>
@@ -28,6 +30,51 @@ namespace BGPLite.Protocol;
 /// </summary>
 public static class PrefixCidr
 {
+    /// <summary>
+    /// Parses a CIDR string into a family-aware <see cref="IpPrefix"/> (IPv4 1..32, IPv6 1..128),
+    /// applying the canonical policy (host-bit masking, length range). Returns <c>false</c> (with
+    /// <paramref name="prefix"/> zeroed) on any malformed or out-of-policy input — callers should
+    /// report/skip, not throw.
+    /// </summary>
+    /// <param name="cidr">The CIDR string to parse ("a.b.c.d/len" or "2001:db8::/48").</param>
+    /// <param name="prefix">On success, the masked network prefix (family carried by <see cref="IpPrefix.IsIpv4"/>).</param>
+    /// <param name="allowDefault">When <c>true</c>, accept <c>/0</c> (the default route). Default
+    /// <c>false</c> — user-supplied sources (API/file/URL) must not originate a default.</param>
+    /// <returns><c>true</c> if the string is a valid CIDR within policy; <c>false</c> otherwise.</returns>
+    public static bool TryParse(string? cidr, out IpPrefix prefix, bool allowDefault = false)
+    {
+        prefix = default;
+
+        if (string.IsNullOrWhiteSpace(cidr))
+            return false;
+
+        var slash = cidr.IndexOf('/');
+        if (slash <= 0 || slash == cidr.Length - 1)
+            return false;
+
+        if (!IPAddress.TryParse(cidr[..slash], out var addr))
+            return false;
+
+        // IPv4-mapped forms (::ffff:a.b.c.d) are NOT accepted as IPv6 prefixes: they name the
+        // IPv4 address space through the v6 syntax and never appear as a legitimate origin
+        // prefix — rejecting them here matches the NextHopIpv6 config validation.
+        var isIpv4 = addr.AddressFamily == AddressFamily.InterNetwork;
+        var isIpv6 = addr.AddressFamily == AddressFamily.InterNetworkV6 && !addr.IsIPv4MappedToIPv6;
+        if (!isIpv4 && !isIpv6)
+            return false;
+
+        var maxLength = isIpv4 ? 32 : 128;
+        if (!byte.TryParse(cidr[(slash + 1)..], out var len) || len > maxLength)
+            return false;
+        if (len == 0 && !allowDefault)
+            return false;
+
+        // The IpPrefix constructor canonicalizes: host bits masked to the network address,
+        // family stored explicitly (IPv4 in the low 32 bits, IPv6 as the full 128).
+        prefix = new IpPrefix(BgpConstants.ToUInt128(addr), len, isIpv4);
+        return true;
+    }
+
     /// <summary>
     /// Parses a CIDR string ("<c>a.b.c.d/len</c>") into a packed IPv4 prefix + mask length, applying
     /// the canonical policy (host-bit masking, length range, IPv4-only). Returns <c>false</c> (with

--- a/BGPLite.Protocol/UpdateCodec.cs
+++ b/BGPLite.Protocol/UpdateCodec.cs
@@ -70,6 +70,32 @@ public static class UpdateCodec
     }
 
     /// <summary>
+    /// Builds outbound UPDATE path attributes for the IPv6 address family (RFC 4760 §5):
+    /// ORIGIN, AS_PATH (+AS4_PATH tunneling), optional COMMUNITY — and NO classic NEXT_HOP.
+    /// For MP_REACH-carried routes the next hop rides inside the MP_REACH_NLRI attribute
+    /// (attached per batch by <see cref="WithMpReachV6Attribute"/>, since it embeds that
+    /// batch's NLRI); the classic NEXT_HOP is defined only for the IPv4 NLRI field.
+    /// </summary>
+    public static List<PathAttribute> BuildV6UpdateAttributes(uint localAsn, bool localFourByteAsn, IReadOnlyList<uint> communities)
+    {
+        var attrs = new List<PathAttribute>(4)
+        {
+            AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+        };
+
+        var asPathAttrs = BuildAsPathAttributes(localAsn, localFourByteAsn);
+        attrs.Add(asPathAttrs[0]);
+
+        if (communities.Count > 0)
+            attrs.Add(AttributeHelper.WriteCommunities(communities));
+
+        if (asPathAttrs.Count > 1)
+            attrs.Add(asPathAttrs[1]);
+
+        return attrs;
+    }
+
+    /// <summary>
     /// Creates a per-send cache of built UPDATE path attributes, keyed by community set. The
     /// cache is scoped to a single send invocation: the ASN/nextHop inputs are constant for that
     /// whole send, so identical community sets yield byte-identical <see cref="PathAttribute"/>
@@ -96,6 +122,31 @@ public static class UpdateCodec
         return attrs;
     }
 
+    /// <summary>The IPv6-family counterpart of <see cref="GetCachedUpdateAttributes"/>: cached
+    /// per-community attributes WITHOUT a classic NEXT_HOP (the MP_REACH attribute supplies it,
+    /// per batch, via <see cref="WithMpReachV6Attribute"/>). Uses its own cache instance — the
+    /// cached lists differ from the IPv4 ones by the absent NEXT_HOP, so sharing the IPv4 cache
+    /// would leak a stale next hop into v6 UPDATEs.</summary>
+    public static List<PathAttribute> GetCachedV6UpdateAttributes(
+        uint localAsn, bool localFourByteAsn, IReadOnlyList<uint> communities,
+        Dictionary<IReadOnlyList<uint>, List<PathAttribute>> cache)
+    {
+        if (cache.TryGetValue(communities, out var cached))
+            return cached;
+
+        var attrs = BuildV6UpdateAttributes(localAsn, localFourByteAsn, communities);
+        cache[communities] = attrs;
+        return attrs;
+    }
+
+    /// <summary>
+    /// Creates a per-send attribute cache for the IPv6 family (see
+    /// <see cref="GetCachedV6UpdateAttributes"/>). Scoped to a single send invocation like the
+    /// IPv4 counterpart (#87).
+    /// </summary>
+    public static Dictionary<IReadOnlyList<uint>, List<PathAttribute>> CreateV6UpdateAttributeCache() =>
+        new(CommunitySetComparer.Instance);
+
     /// <summary>
     /// Returns the path attributes for an UPDATE carrying the given Large Community set: the
     /// cached base attributes (ORIGIN/AS_PATH/NEXT_HOP/COMMUNITY/AS4_PATH) untouched when
@@ -116,6 +167,30 @@ public static class UpdateCodec
         withLarge.Add(AttributeHelper.WriteLargeCommunities(largeCommunities));
         return withLarge;
     }
+
+    /// <summary>
+    /// Appends the MP_REACH_NLRI attribute (global IPv6 next hop + this batch's NLRI) to the
+    /// cached base attributes. It must be attached PER BATCH — unlike the community-keyed base
+    /// attributes, the attribute value embeds the batch's NLRI bytes — and goes last, matching
+    /// the repo's append-per-batch idiom of <see cref="WithLargeCommunityAttribute"/>. Attribute
+    /// ordering is an implementation choice, not an RFC requirement (D15); MP_REACH is optional
+    /// non-transitive (RFC 4760 §4).
+    /// </summary>
+    public static List<PathAttribute> WithMpReachV6Attribute(
+        List<PathAttribute> baseAttrs, UInt128 nextHop, IReadOnlyList<IpPrefix> prefixes)
+    {
+        var with = new List<PathAttribute>(baseAttrs.Count + 1);
+        with.AddRange(baseAttrs);
+        with.Add(AttributeHelper.WriteMpReachNlriV6(nextHop, prefixes));
+        return with;
+    }
+
+    /// <summary>
+    /// Appends the MP_UNREACH_NLRI attribute withdrawing the given IPv6 prefixes to an otherwise
+    /// empty attribute list (RFC 4760 §7 — the IPv6 counterpart of the WITHDRAWN ROUTES field).
+    /// </summary>
+    public static List<PathAttribute> WithMpUnreachV6Attribute(IReadOnlyList<IpPrefix> prefixes) =>
+        [AttributeHelper.WriteMpUnreachNlriV6(prefixes)];
 
     /// <summary>
     /// Validates that a route announcement carried the mandatory well-known attributes

--- a/BGPLite.Providers/AsnPrefixProvider.cs
+++ b/BGPLite.Providers/AsnPrefixProvider.cs
@@ -50,6 +50,6 @@ public sealed class AsnPrefixProvider : IPrefixSourceProvider
         _logger.LogInformation(
             "Source '{Name}' (asn AS{Asn}): loaded {Count} prefixes via RIPEstat",
             source.Name, source.Asn.Value, prefixes.Count);
-        return SourceLoadResult.Ok(prefixes.Select(p => (Prefix: p.Prefix, Length: p.Length)).ToList());
+        return SourceLoadResult.Ok(prefixes.ToList());
     }
 }

--- a/BGPLite.Providers/IPrefixSourceService.cs
+++ b/BGPLite.Providers/IPrefixSourceService.cs
@@ -1,4 +1,5 @@
 using BGPLite.Configuration;
+using BGPLite.Protocol;
 
 namespace BGPLite.Providers;
 
@@ -10,13 +11,13 @@ namespace BGPLite.Providers;
 public interface IPrefixSourceService
 {
     /// <summary>All configured sources with their cached prefix lists.</summary>
-    Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>> LoadAllAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default);
 
     /// <summary>One source by name (cache-through). Empty list if missing or failed.</summary>
-    Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name, CancellationToken ct = default);
+    Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default);
 
     /// <summary>The source named by <c>AppConfig.DefaultPrefixSource</c>. Empty list if unset/missing.</summary>
-    Task<IReadOnlyList<(uint Prefix, byte Length)>> GetDefaultAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default);
 
     /// <summary>Prime the in-memory cache for all sources.</summary>
     Task WarmUpAsync(CancellationToken ct = default);

--- a/BGPLite.Providers/PrefixListParser.cs
+++ b/BGPLite.Providers/PrefixListParser.cs
@@ -3,22 +3,23 @@ using BGPLite.Protocol;
 namespace BGPLite.Providers;
 
 /// <summary>
-/// Parses a CIDR-per-line text blob into packed IPv4 prefixes.
-/// Blank lines and lines starting with <c>#</c> are ignored; malformed and non-IPv4
-/// lines are skipped silently (the route table only stores IPv4 <c>(uint, byte)</c> keys).
+/// Parses a CIDR-per-line text blob into family-aware prefixes (IPv4 and IPv6, #14 phase 4).
+/// Blank lines and lines starting with <c>#</c> are ignored; malformed lines are skipped
+/// silently so one bad line cannot take a whole source down.
 /// </summary>
 /// <remarks>
-/// <b>Length and host-bit handling (#162 / #236).</b> Validation, host-bit masking, and the IPv4-only
-/// constraint now live in the single canonical <see cref="PrefixCidr"/> parser — every CIDR input
+/// <b>Length and host-bit handling (#162 / #236).</b> Validation, host-bit masking, and the
+/// family handling live in the single canonical <see cref="PrefixCidr"/> parser — every CIDR input
 /// path (file, API, DB-load) routes through it so the policy is defined exactly once. <c>/0</c> is
-/// rejected (a route server must not originate a default route from a peer-supplied URL list, #147);
-/// host bits are masked so <c>10.0.0.5/24</c> normalizes to <c>10.0.0.0/24</c> and dedups correctly.
+/// rejected (a route server must not originate a default route from a peer-supplied URL list,
+/// #147); host bits are masked so <c>10.0.0.5/24</c> normalizes to <c>10.0.0.0/24</c> and dedups
+/// correctly; IPv6 entries (<c>2001:db8::/48</c>) are accepted alongside IPv4 ones.
 /// </remarks>
 public static class PrefixListParser
 {
-    public static IReadOnlyList<(uint Prefix, byte Length)> Parse(string text)
+    public static IReadOnlyList<IpPrefix> Parse(string text)
     {
-        var result = new List<(uint Prefix, byte Length)>();
+        var result = new List<IpPrefix>();
 
         // Strip a leading UTF-8 BOM (\uFEFF): string.Trim() does not remove it (it is not in the
         // Char.IsWhiteSpace set), so without this the first line of a BOM-prefixed list is silently
@@ -31,11 +32,12 @@ public static class PrefixListParser
             var line = raw.Trim();
             if (line.Length == 0 || line[0] == '#') continue;
 
-            // Delegate to the canonical parser (#236): host-bit masking, /0 rejection, IPv4-only,
-            // range 1..32 — one policy, shared with the API and the BGP send path.
-            if (!PrefixCidr.TryParse(line, out var prefix, out var length))
+            // Delegate to the canonical parser (#236): host-bit masking, /0 rejection, family
+            // handling (IPv4 1..32, IPv6 1..128) — one policy, shared with the API and the BGP
+            // send path.
+            if (!PrefixCidr.TryParse(line, out var prefix))
                 continue;
-            result.Add((prefix, length));
+            result.Add(prefix);
         }
 
         return result;

--- a/BGPLite.Providers/PrefixService.cs
+++ b/BGPLite.Providers/PrefixService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using BGPLite.Configuration;
+using BGPLite.Protocol;
 using Microsoft.Extensions.Logging;
 using BGPLite.Contracts;
 
@@ -64,7 +65,7 @@ public sealed class PrefixService : IPrefixService
     /// refreshes do not re-pay the budget.
     /// </para>
     /// </summary>
-    public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
+    public async Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
     {
         var source = new PrefixSourceConfig
         {
@@ -74,24 +75,25 @@ public sealed class PrefixService : IPrefixService
             Community = community,
             Timeout = _userSourceTimeoutSeconds
         };
-        return await _userSourceCache.GetOrLoadAsync(url, name, async ct =>
+        var prefixes = await _userSourceCache.GetOrLoadAsync(url, name, async ct =>
         {
             var result = await _httpProvider.LoadAsync(source, ct: ct);
-            return result.Prefixes;
+            return result.Prefixes;   // provider-native IpPrefix list
         }, ct);
+        return ToContract(prefixes);
     }
 
-    public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
+    public async Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
         // Per-ASN caching, stale-on-failure, negative TTL, fetch gates, and the #165 eviction
         // sweep all live in the shared cache (#267 item 5) — one wire fetch per ASN regardless
         // of which mechanism asked.
-        => _ripeStatCache.GetPrefixesAsync(asn, ct);
+        => ToContract(await _ripeStatCache.GetPrefixesAsync(asn, ct));
 
     /// <summary>Bounds how many ASNs are resolved against RIPEstat concurrently on a cold cache
     /// (warm traffic is cache-flat). Keeps cold-start fan-out from tripping RIPEstat rate limits.</summary>
     private const int MaxDegreeOfParallelism = 8;
 
-    public async Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
+    public async Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
     {
         // Materialize once: we enumerate for fan-out and again for ordered assembly.
         var asnList = asns as IList<uint> ?? asns.ToList();
@@ -102,7 +104,7 @@ public sealed class PrefixService : IPrefixService
         // per-ASN cache and double-fetch (CodeRabbit #130); output multiplicity is preserved below.
         // Each ASN keeps its own try/catch so one failure (incl. cancellation) can't drop the others.
         using var gate = new SemaphoreSlim(MaxDegreeOfParallelism, MaxDegreeOfParallelism);
-        var resolvedByAsn = new Dictionary<uint, Task<IReadOnlyList<(uint Prefix, byte Length)>>>();
+        var resolvedByAsn = new Dictionary<uint, Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>>();
         foreach (var asn in asnList.Distinct())
             resolvedByAsn[asn] = ResolveAsnAsync(asn, gate, ct);
 
@@ -112,14 +114,14 @@ public sealed class PrefixService : IPrefixService
         // prior sequential output, including for duplicate ASNs. Await each completed task (rather
         // than .Result) so a faulted task surfaces its real exception, not an AggregateException,
         // and never blocks the threadpool thread.
-        var result = new List<(uint Prefix, byte Length, uint Asn)>();
+        var result = new List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>();
         foreach (var asn in asnList)
-            foreach (var (prefix, length) in await resolvedByAsn[asn])
-                result.Add((prefix, length, asn));
+            foreach (var p in await resolvedByAsn[asn])
+                result.Add((p.Prefix, p.Length, p.IsIpv4, asn));
         return result;
     }
 
-    private async Task<IReadOnlyList<(uint Prefix, byte Length)>> ResolveAsnAsync(uint asn, SemaphoreSlim gate, CancellationToken ct)
+    private async Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> ResolveAsnAsync(uint asn, SemaphoreSlim gate, CancellationToken ct)
     {
         try
         {
@@ -177,10 +179,10 @@ public sealed class PrefixService : IPrefixService
     /// stale-on-failure serves the last good copy on a transient fetch error (#163 parity).
     /// </para>
     /// </summary>
-    private sealed record RuCacheEntry(List<(uint Prefix, byte Length, uint Asn)> Projected, long CachedAtTicks);
+    private sealed record RuCacheEntry(List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)> Projected, long CachedAtTicks);
     private RuCacheEntry? _ruCache;
 
-    public async Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
+    public async Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
     {
         // Fast path: fresh entry. A single Volatile.Read of the immutable entry reference gives a
         // consistent (projection, ticks) snapshot — no two-field torn read.
@@ -198,11 +200,11 @@ public sealed class PrefixService : IPrefixService
             if (cached is not null && _timeProvider.GetUtcNow().UtcDateTime.Ticks - cached.CachedAtTicks < _ruCacheTtl.Ticks)
                 return cached.Projected;
 
-            List<(uint Prefix, byte Length, uint Asn)> projected;
+            List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)> projected;
             try
             {
                 var prefixes = await _prefixSources.GetDefaultAsync(ct);
-                projected = prefixes.Select(p => (p.Prefix, p.Length, 0u)).ToList();
+                projected = prefixes.Select(p => (p.Address, p.Length, p.IsIpv4, 0u)).ToList();
             }
             catch (OperationCanceledException) { throw; }
             catch (Exception ex)
@@ -233,8 +235,13 @@ public sealed class PrefixService : IPrefixService
     }
 
     /// <summary>Prefixes of a configured source by name (cache-through).</summary>
-    public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default) =>
-        _prefixSources.GetAsync(name, ct);
+    public async Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default) =>
+        ToContract(await _prefixSources.GetAsync(name, ct));
+
+    /// <summary>Provider-native <see cref="IpPrefix"/> values mapped onto the Contracts tuple
+    /// layout (Contracts is a dependency-free leaf and cannot see the Protocol type).</summary>
+    private static IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)> ToContract(IReadOnlyList<IpPrefix> prefixes) =>
+        prefixes.Select(p => (p.Address, p.Length, p.IsIpv4)).ToList();
 
     public async Task WarmUpAsync(CancellationToken ct = default)
     {

--- a/BGPLite.Providers/PrefixSourceService.cs
+++ b/BGPLite.Providers/PrefixSourceService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using BGPLite.Configuration;
+using BGPLite.Protocol;
 using Microsoft.Extensions.Logging;
 
 namespace BGPLite.Providers;
@@ -60,7 +61,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
         _sourcesByName = config.PrefixSources.ToDictionary(s => s.Name);
     }
 
-    public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name, CancellationToken ct = default)
+    public async Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default)
     {
         if (!_sourcesByName.TryGetValue(name, out var source))
         {
@@ -77,7 +78,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
         }
     }
 
-    public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetDefaultAsync(CancellationToken ct = default)
+    public async Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default)
     {
         var defaultName = _config.DefaultPrefixSource;
         if (string.IsNullOrWhiteSpace(defaultName))
@@ -98,12 +99,12 @@ public sealed class PrefixSourceService : IPrefixSourceService
         }
     }
 
-    public async Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
+    public async Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
     {
-        var result = new List<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>();
+        var result = new List<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>();
         foreach (var source in _config.PrefixSources)
         {
-            IReadOnlyList<(uint Prefix, byte Length)> prefixes;
+            IReadOnlyList<IpPrefix> prefixes;
             try { prefixes = (await LoadCachedAsync(source, ct)).Prefixes; }
             catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #324: only CALLER cancellation — the #324 default fetch budget fires as a foreign-token OCE (live ct) and must stay a per-source failure below
             catch (Exception ex)
@@ -173,7 +174,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
     /// is detected (by any entry point), <c>_onSourceChanged</c> is invoked AFTER releasing the gate
     /// so the callback (peer refresh) can't deadlock on the per-source lock.
     /// </summary>
-    private async Task<(IReadOnlyList<(uint Prefix, byte Length)> Prefixes, bool Changed)> LoadCachedAsync(
+    private async Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadCachedAsync(
         PrefixSourceConfig source, CancellationToken ct, bool forceRefresh = false, bool triggerCallback = true)
     {
         if (!forceRefresh && TryGetFresh(source.Name, out var fresh))
@@ -182,7 +183,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
         var gate = _locks.GetOrAdd(source.Name, _ => new SemaphoreSlim(1, 1));
         await gate.WaitAsync(ct);
         bool changed;
-        IReadOnlyList<(uint Prefix, byte Length)> loaded;
+        IReadOnlyList<IpPrefix> loaded;
         try
         {
             if (!forceRefresh && TryGetFresh(source.Name, out var rechecked))
@@ -277,19 +278,21 @@ public sealed class PrefixSourceService : IPrefixSourceService
     /// the HashSet allocation path on the common unchanged case via the fast count/SequenceEqual
     /// shortcut when the source already returned a sorted list.
     /// </summary>
-    private static bool SamePrefixes(IReadOnlyList<(uint Prefix, byte Length)> a, IReadOnlyList<(uint Prefix, byte Length)> b)
+    private static bool SamePrefixes(IReadOnlyList<IpPrefix> a, IReadOnlyList<IpPrefix> b)
     {
         if (a.Count != b.Count) return false;
         // Fast path: if both happen to be in the same order (common — file sources, cached HTTP),
         // SequenceEqual is O(n) with no allocation.
         if (a.SequenceEqual(b)) return true;
-        // Slow path: order differs — compare as sorted sequences.
-        var sa = a.OrderBy(x => x.Prefix).ThenBy(x => x.Length).ToArray();
-        var sb = b.OrderBy(x => x.Prefix).ThenBy(x => x.Length).ToArray();
+        // Slow path: order differs — compare as sorted sequences. IpPrefix's own comparison is
+        // family-first (IsIpv4, then address, then length), so an IPv4 key can never equal an
+        // IPv6 one even when the numeric address and length agree.
+        var sa = a.OrderBy(x => x).ToArray();
+        var sb = b.OrderBy(x => x).ToArray();
         return sa.SequenceEqual(sb);
     }
 
-    private bool TryGetFresh(string name, out IReadOnlyList<(uint Prefix, byte Length)> list)
+    private bool TryGetFresh(string name, out IReadOnlyList<IpPrefix> list)
     {
         list = null!;
         if (!_cache.TryGetValue(name, out var entry)) return false;
@@ -305,7 +308,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
 
     /// <summary>#214: Cache entry with ETag/Last-Modified for conditional re-fetches.</summary>
     private sealed record CacheEntry(
-        IReadOnlyList<(uint Prefix, byte Length)> List,
+        IReadOnlyList<IpPrefix> List,
         DateTime CachedAt,
         bool Negative,
         string? ETag = null,

--- a/BGPLite.Providers/RipeStatPrefixCache.cs
+++ b/BGPLite.Providers/RipeStatPrefixCache.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using BGPLite.Configuration;
+using BGPLite.Protocol;
 using Microsoft.Extensions.Logging;
 
 namespace BGPLite.Providers;
@@ -40,7 +41,7 @@ public sealed class RipeStatPrefixCache
     // asn → (prefix list, cached at, is negative). Negative entries (failed RIPEstat fetches) use
     // _negativeTtl. The tuple is shaped to mirror PrefixSourceService so the resilience semantics
     // (stale-on-failure, negative cache, bounded sweep) are identical across both caches.
-    private readonly ConcurrentDictionary<uint, (IReadOnlyList<(uint Prefix, byte Length)> Data, DateTime CachedAt, bool Negative)> _cache = new();
+    private readonly ConcurrentDictionary<uint, (IReadOnlyList<IpPrefix> Data, DateTime CachedAt, bool Negative)> _cache = new();
     // asn → gate serializing the cache-miss fetch path (prevents thundering herd on cold/expired
     // ASNs — #164).
     private readonly ConcurrentDictionary<uint, SemaphoreSlim> _locks = new();
@@ -71,7 +72,7 @@ public sealed class RipeStatPrefixCache
         _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
-    public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default, bool serveNegativeEntries = true)
+    public async Task<IReadOnlyList<IpPrefix>> GetPrefixesAsync(uint asn, CancellationToken ct = default, bool serveNegativeEntries = true)
     {
         // Fast path: fresh entry (positive, or negative within its TTL when the caller accepts
         // the []-on-recent-failure semantic — the RouteAssembler fan-out does; a source provider
@@ -98,7 +99,7 @@ public sealed class RipeStatPrefixCache
 
     /// <summary>The gated fetch path of <see cref="GetPrefixesAsync"/> — runs under the caller's
     /// in-flight mark, sharing a single RIPEstat fetch per ASN (#164).</summary>
-    private async Task<IReadOnlyList<(uint Prefix, byte Length)>> FetchThroughGateAsync(uint asn, CancellationToken ct, bool serveNegativeEntries)
+    private async Task<IReadOnlyList<IpPrefix>> FetchThroughGateAsync(uint asn, CancellationToken ct, bool serveNegativeEntries)
     {
         // Serialize per-ASN so concurrent callers share a single RIPEstat fetch — no thundering herd
         // on a cold or just-expired ASN (#164).
@@ -112,7 +113,7 @@ public sealed class RipeStatPrefixCache
             if (TryGetFresh(asn, out var rechecked, out var recheckIsNegative) && (serveNegativeEntries || !recheckIsNegative))
                 return rechecked;
 
-            IReadOnlyList<(uint Prefix, byte Length)> prefixes;
+            IReadOnlyList<IpPrefix> prefixes;
             try
             {
                 prefixes = await _ripe.GetPrefixesAsync(asn, ct);
@@ -150,7 +151,7 @@ public sealed class RipeStatPrefixCache
     /// negative within _negativeTtl). #377 review: the negative flag comes out of the SAME read —
     /// a separate IsNegative lookup could miss an eviction racing between the two and serve a
     /// captured [] to a caller that opted out of negatives.</summary>
-    private bool TryGetFresh(uint asn, out IReadOnlyList<(uint Prefix, byte Length)> data, out bool isNegative)
+    private bool TryGetFresh(uint asn, out IReadOnlyList<IpPrefix> data, out bool isNegative)
     {
         data = null!;
         isNegative = false;

--- a/BGPLite.Providers/RipeStatProvider.cs
+++ b/BGPLite.Providers/RipeStatProvider.cs
@@ -27,13 +27,14 @@ public sealed class RipeStatProvider
     }
 
     /// <summary>
-    /// Fetches the IPv4 prefixes originated by <paramref name="asn"/> from RIPEstat. The named
-    /// client's resilience handler (Program.cs, #104) retries transient HTTP failures (429/5xx/
-    /// timeouts/network errors) with exponential backoff + circuit breaker, so this method performs
-    /// a single attempt — a transient failure propagates only after the resilience pipeline is
-    /// exhausted. The ris-prefixes endpoint can take minutes for large origin ASes (e.g. AS3356).
+    /// Fetches the IPv4 AND IPv6 prefixes originated by <paramref name="asn"/> from RIPEstat
+    /// (#14 phase 4: the <c>v6.originating</c> section is parsed alongside <c>v4.originating</c>).
+    /// The named client's resilience handler (Program.cs, #104) retries transient HTTP failures
+    /// (429/5xx/timeouts/network errors) with exponential backoff + circuit breaker, so this method
+    /// performs a single attempt — a transient failure propagates only after the resilience pipeline
+    /// is exhausted. The ris-prefixes endpoint can take minutes for large origin ASes (e.g. AS3356).
     /// </summary>
-    public async Task<IReadOnlyList<(uint Prefix, byte PrefixLength)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
+    public async Task<IReadOnlyList<IpPrefix>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
     {
         var url = $"https://stat.ripe.net/data/ris-prefixes/data.json?resource=AS{asn}&list_prefixes=true";
         var http = _httpFactory.CreateClient(ClientName);
@@ -66,35 +67,50 @@ public sealed class RipeStatProvider
         }
         using var doc = JsonDocument.Parse(new ReadOnlyMemory<byte>(buffered.GetBuffer(), 0, (int)buffered.Length));
 
-        var prefixes = doc.RootElement
-            .GetProperty("data")
-            .GetProperty("prefixes")
-            .GetProperty("v4")
-            .GetProperty("originating");
+        var data = doc.RootElement.GetProperty("data").GetProperty("prefixes");
+        var result = new List<IpPrefix>();
 
-        var result = new List<(uint Prefix, byte PrefixLength)>(prefixes.GetArrayLength());
+        // Both family sections are OPTIONAL in the response (an ASN may originate only v4 or only
+        // v6) — a missing section contributes nothing rather than throwing.
+        result.AddRange(ParseFamily(asn, data, "v4"));
+        result.AddRange(ParseFamily(asn, data, "v6"));
 
+        _logger.LogInformation("AS{Asn}: fetched {Count} prefixes ({V4} IPv4 + {V6} IPv6)",
+            asn, result.Count, result.Count(p => p.IsIpv4), result.Count(p => !p.IsIpv4));
+        return result;
+    }
+
+    /// <summary>Parses one family's <c>originating</c> array through the canonical parser.
+    /// Returns an empty list when the section is absent. Each entry is validated independently —
+    /// a single non-canonical prefix skips without taking the whole ASN fetch down.</summary>
+    private List<IpPrefix> ParseFamily(uint asn, JsonElement data, string family)
+    {
+        if (!data.TryGetProperty(family, out var familySection) ||
+            !familySection.TryGetProperty("originating", out var prefixes) ||
+            prefixes.ValueKind != JsonValueKind.Array)
+            return [];
+
+        var result = new List<IpPrefix>(prefixes.GetArrayLength());
         foreach (var element in prefixes.EnumerateArray())
         {
             // #319/#358-review: the canonical parser every other prefix input path uses (#236):
-            // host-bit masking, /0 rejection, length 1..32, IPv4-only. RIS collectors return what
+            // host-bit masking, /0 rejection, per-family length range. RIS collectors return what
             // third parties ANNOUNCED — non-canonical NLRI ("10.0.0.1/8") must not reach the route
-            // table under a corrupt key, and "0.0.0.0/0" must not become a default-route leak
-            // (#162 closed the same hole for URL sources). Skip + warn, like stored custom
+            // table under a corrupt key, and "0.0.0.0/0"/"::/0" must not become a default-route
+            // leak (#162 closed the same hole for URL sources). Skip + warn, like stored custom
             // prefixes; a null element, garbage string, or NON-STRING JSON element (GetString
             // throws InvalidOperationException on numbers/objects) is skipped without taking the
             // whole ASN fetch down with it.
             var cidr = element.ValueKind == JsonValueKind.String ? element.GetString() : null;
-            if (!PrefixCidr.TryParse(cidr, out var prefix, out var length))
+            if (!PrefixCidr.TryParse(cidr, out var prefix))
             {
                 _logger.LogWarning("AS{Asn}: RIPEstat returned a non-canonical prefix '{Cidr}'; skipped", asn, cidr);
                 continue;
             }
 
-            result.Add((prefix, length));
+            result.Add(prefix);
         }
 
-        _logger.LogInformation("AS{Asn}: fetched {Count} prefixes", asn, result.Count);
         return result;
     }
 }

--- a/BGPLite.Providers/SourceLoadResult.cs
+++ b/BGPLite.Providers/SourceLoadResult.cs
@@ -1,3 +1,5 @@
+using BGPLite.Protocol;
+
 namespace BGPLite.Providers;
 
 /// <summary>
@@ -7,13 +9,13 @@ namespace BGPLite.Providers;
 /// should keep the existing cached data (just refresh the timestamp).
 /// </summary>
 public sealed record SourceLoadResult(
-    IReadOnlyList<(uint Prefix, byte Length)> Prefixes,
+    IReadOnlyList<IpPrefix> Prefixes,
     string? ETag = null,
     DateTimeOffset? LastModified = null,
     bool NotModified = false)
 {
     /// <summary>Convenience for a normal (200 OK) load — prefixes + validators from the response.</summary>
-    public static SourceLoadResult Ok(IReadOnlyList<(uint Prefix, byte Length)> prefixes, string? etag = null, DateTimeOffset? lastModified = null) =>
+    public static SourceLoadResult Ok(IReadOnlyList<IpPrefix> prefixes, string? etag = null, DateTimeOffset? lastModified = null) =>
         new(prefixes, etag, lastModified, NotModified: false);
 
     /// <summary>Convenience for a 304 Not Modified response — no prefixes, caller keeps cached data.</summary>

--- a/BGPLite.Providers/UserSourceCache.cs
+++ b/BGPLite.Providers/UserSourceCache.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using BGPLite.Protocol;
 using Microsoft.Extensions.Logging;
 
 namespace BGPLite.Providers;
@@ -34,7 +35,7 @@ internal sealed class UserSourceCache
     private readonly int _maxEntries;
 
     // url → (list, cached at, is negative). Negative entries (failed loads) use _negativeTtl.
-    private readonly ConcurrentDictionary<string, (IReadOnlyList<(uint Prefix, byte Length)> List, DateTime CachedAt, bool Negative)> _cache = new();
+    private readonly ConcurrentDictionary<string, (IReadOnlyList<IpPrefix> List, DateTime CachedAt, bool Negative)> _cache = new();
     // url → gate serializing the cache-miss fetch path (prevents thundering herd on cold/expired keys).
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new();
 
@@ -59,10 +60,10 @@ internal sealed class UserSourceCache
     /// <param name="logLabel">Safe identifier (the source <c>Name</c>) for log lines — the URL itself is
     /// never logged, since peer URLs may carry query-string tokens (#149).</param>
     /// <param name="loadAsync">The fetcher ( HttpPrefixProvider.LoadAsync closed over the source config).</param>
-    public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetOrLoadAsync(
+    public async Task<IReadOnlyList<IpPrefix>> GetOrLoadAsync(
         string url,
         string logLabel,
-        Func<CancellationToken, Task<IReadOnlyList<(uint Prefix, byte Length)>>> loadAsync,
+        Func<CancellationToken, Task<IReadOnlyList<IpPrefix>>> loadAsync,
         CancellationToken ct)
     {
         if (TryGetFresh(url, out var fresh))
@@ -91,7 +92,7 @@ internal sealed class UserSourceCache
             if (TryGetFresh(url, out var rechecked))
                 return rechecked;
 
-            IReadOnlyList<(uint Prefix, byte Length)> prefixes;
+            IReadOnlyList<IpPrefix> prefixes;
             try
             {
                 prefixes = await loadAsync(ct);
@@ -175,7 +176,7 @@ internal sealed class UserSourceCache
         }
     }
 
-    private bool TryGetFresh(string url, out IReadOnlyList<(uint Prefix, byte Length)> list)
+    private bool TryGetFresh(string url, out IReadOnlyList<IpPrefix> list)
     {
         list = null!;
         if (!_cache.TryGetValue(url, out var entry)) return false;

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -231,16 +231,42 @@ public sealed class BgpSession : IDisposable
         const int maxPerUpdate = 100;
         // #85: reuse a single batch list instead of GetRange (which allocates a new List per batch).
         var batch = new List<IpPrefix>(Math.Min(maxPerUpdate, count));
+
+        // IPv4 withdrawals ride the classic WITHDRAWN ROUTES field (RFC 4271 §4.3).
         for (var i = 0; i < count; i += maxPerUpdate)
         {
             batch.Clear();
             var end = Math.Min(i + maxPerUpdate, count);
             for (var j = i; j < end; j++)
-                batch.Add(_advertisedPrefixes[j]);
+                if (_advertisedPrefixes[j].IsIpv4)
+                    batch.Add(_advertisedPrefixes[j]);
+            if (batch.Count == 0)
+                continue;
             var update = new BgpUpdateMessage
             {
                 WithdrawnRoutes = batch,
                 PathAttributes = [],
+                Nlri = []
+            };
+            await SendMessageAsync(update);
+            _metrics.UpdateSent();
+        }
+
+        // IPv6 withdrawals ride MP_UNREACH_NLRI (RFC 4760 §7 — #14 phase 4): an IPv6 prefix can
+        // never be named by the classic withdrawn field, and BIRD/FRR expect the MP form.
+        for (var i = 0; i < count; i += maxPerUpdate)
+        {
+            batch.Clear();
+            var end = Math.Min(i + maxPerUpdate, count);
+            for (var j = i; j < end; j++)
+                if (!_advertisedPrefixes[j].IsIpv4)
+                    batch.Add(_advertisedPrefixes[j]);
+            if (batch.Count == 0)
+                continue;
+            var update = new BgpUpdateMessage
+            {
+                WithdrawnRoutes = [],
+                PathAttributes = UpdateCodec.WithMpUnreachV6Attribute(batch),
                 Nlri = []
             };
             await SendMessageAsync(update);
@@ -1178,6 +1204,15 @@ public sealed class BgpSession : IDisposable
             await SendRoutesAsync(nextHop, routes);
     }
 
+    /// <summary>The local global IPv6 next hop (Bgp.NextHopIpv6) or null when unset/invalid —
+    /// null disables IPv6 advertisements (fail-visible at send time). Re-parsed per send from the
+    /// immutable config rather than cached in the constructor: tests construct sessions from raw
+    /// config records, and the parse is nanoseconds against a ~30s send.</summary>
+    private UInt128? NextHopIpv6 =>
+        BgpConfig.IsGlobalUnicastV6(_bgpConfig.NextHopIpv6) && IPAddress.TryParse(_bgpConfig.NextHopIpv6, out var v6)
+            ? BgpConstants.ToUInt128(v6)
+            : null;
+
     private async Task SendRoutesAsync(uint nextHop, List<Route> routes)
     {
         // Summarize before sending: merge adjacent/overlapping prefixes into the minimal
@@ -1197,6 +1232,35 @@ public sealed class BgpSession : IDisposable
                 routes.Count, aggregated.Count, deduped.Count, _peer);
         routes = deduped;
 
+        // #14 phase 4: family split. IPv4 rides the classic NLRI field; IPv6 rides MP_REACH
+        // (RFC 4760 §5) and ONLY when both halves agree: the peer negotiated MP IPv6/Unicast in
+        // OPEN, and Bgp.NextHopIpv6 is configured (RFC 2545 §3 — the MP_REACH next hop must be a
+        // global address; the IPv4 router-id cannot serve the IPv6 family). Otherwise IPv6
+        // routes are suppressed for this send — loudly, never silently.
+        var v4Routes = new List<Route>(routes.Count);
+        var v6Routes = new List<Route>();
+        foreach (var route in routes)
+        {
+            if (route.IsIpv4)
+                v4Routes.Add(route);
+            else
+                v6Routes.Add(route);
+        }
+        if (v6Routes.Count > 0 && !_peerMpIpv6Unicast)
+        {
+            _logger.LogWarning(
+                "Suppressing {Count} IPv6 routes to {Peer}: the peer did not negotiate MP IPv6/Unicast — advertising them as classic IPv4 NLRI would corrupt the peer's table",
+                v6Routes.Count, _peer);
+            v6Routes.Clear();
+        }
+        else if (v6Routes.Count > 0 && !NextHopIpv6.HasValue)
+        {
+            _logger.LogWarning(
+                "Suppressing {Count} IPv6 routes to {Peer}: Bgp.NextHopIpv6 is not configured — set it to a global IPv6 address to advertise IPv6 routes",
+                v6Routes.Count, _peer);
+            v6Routes.Clear();
+        }
+
         const int maxNlriPerUpdate = 100;
         _advertisedPrefixes.EnsureCapacity(_advertisedPrefixes.Count + routes.Count);
         var sent = 0;
@@ -1206,10 +1270,12 @@ public sealed class BgpSession : IDisposable
         // a single send (localAsn/localFourByteAsn/nextHop are constant for the whole send), so
         // build them once per community set and reuse instead of rebuilding on each batch (#87).
         // Scoped to this send only: the cache dies with the dictionary, so it can never serve a
-        // later send that carries a different nextHop or renegotiated ASN.
+        // later send that carries a different nextHop or renegotiated ASN. The v6 family gets its
+        // own cache — its cached lists carry no classic NEXT_HOP (#407's wire shape).
         var attrCache = UpdateCodec.CreateUpdateAttributeCache();
+        var v6AttrCache = UpdateCodec.CreateV6UpdateAttributeCache();
 
-        foreach (var route in routes)
+        foreach (var route in v4Routes)
         {
             batch.Add(route);
             _advertisedPrefixes.Add(new IpPrefix(route.Prefix, route.PrefixLength, route.IsIpv4));
@@ -1227,9 +1293,49 @@ public sealed class BgpSession : IDisposable
             sent += batch.Count;
         }
 
+        var v6NextHop = NextHopIpv6 ?? 0;
+        batch.Clear();
+        foreach (var route in v6Routes)
+        {
+            batch.Add(route);
+            _advertisedPrefixes.Add(new IpPrefix(route.Prefix, route.PrefixLength, route.IsIpv4));
+            if (batch.Count >= maxNlriPerUpdate)
+            {
+                await SendV6RouteBatchAsync(v6NextHop, batch, v6AttrCache);
+                sent += batch.Count;
+                batch.Clear();
+            }
+        }
+
+        if (batch.Count > 0)
+        {
+            await SendV6RouteBatchAsync(v6NextHop, batch, v6AttrCache);
+            sent += batch.Count;
+        }
+
         _logger.LogInformation("UpdateSent {Count} routes to {Peer}", sent, _peer);
         // #212: cache the actual wire count for the API/UI.
         Volatile.Write(ref _advertisedCount, sent);
+    }
+
+    /// <summary>
+    /// Sends one batch of IPv6 routes as MP_REACH_NLRI UPDATEs (#14 phase 4): the batch is
+    /// partitioned by community set (the MP_REACH attribute applies to every NLRI in its UPDATE,
+    /// same rule as COMMUNITY), base attributes come from the v6 cache (no classic NEXT_HOP),
+    /// and the MP_REACH attribute — global next hop + this group's NLRI — is appended per group.
+    /// </summary>
+    private async Task SendV6RouteBatchAsync(UInt128 nextHop6, List<Route> routes, Dictionary<IReadOnlyList<uint>, List<PathAttribute>> v6AttrCache)
+    {
+        foreach (var groupRoutes in GroupByCommunitySet(routes))
+        {
+            var attrs = UpdateCodec.GetCachedV6UpdateAttributes(
+                _bgpConfig.Asn, _localFourByteAsn, groupRoutes[0].Communities, v6AttrCache);
+            attrs = UpdateCodec.WithLargeCommunityAttribute(attrs, groupRoutes[0].LargeCommunities);
+
+            var nlri = groupRoutes.Select(r => new IpPrefix(r.Prefix, r.PrefixLength, r.IsIpv4)).ToList();
+            attrs = UpdateCodec.WithMpReachV6Attribute(attrs, nextHop6, nlri);
+            await SendUpdateBatchAsync(attrs, [], mpReach: new MpReachCodec.MpReachV6(nextHop6, nlri));
+        }
     }
 
     /// <summary>
@@ -1299,12 +1405,13 @@ public sealed class BgpSession : IDisposable
     private static List<List<Route>> GroupByCommunitySet(IReadOnlyList<Route> routes)
         => RouteAssembler.GroupByCommunitySet(routes);
 
-    private async Task SendUpdateBatchAsync(List<PathAttribute> attrs, List<IpPrefix> nlri)
+    private async Task SendUpdateBatchAsync(List<PathAttribute> attrs, List<IpPrefix> nlri, MpReachCodec.MpReachV6? mpReach = null)
     {
         var update = new BgpUpdateMessage
         {
             PathAttributes = attrs,
-            Nlri = nlri
+            Nlri = nlri,
+            MpReachV6 = mpReach
         };
 
         await SendMessageAsync(update);

--- a/BGPLite.Server/RouteAssembler.cs
+++ b/BGPLite.Server/RouteAssembler.cs
@@ -79,8 +79,8 @@ public sealed class RouteAssembler : IRouteAssembler
                 try
                 {
                     var ruPrefixes = await _prefixService.GetRuPrefixesAsync(ct);
-                    foreach (var (prefix, length, _) in ruPrefixes)
-                        routes.Add(MakeRoute(prefix, length, nextHop, null, defaultComms));
+                    foreach (var p in ruPrefixes)
+                        routes.Add(MakeRoute(p.Prefix, p.Length, p.IsIpv4, nextHop, null, defaultComms));
                     _logger.LogInformation("Sent {Count} RU prefixes to unconfigured peer {Peer}",
                         ruPrefixes.Count, peerLabel);
                 }
@@ -115,11 +115,11 @@ public sealed class RouteAssembler : IRouteAssembler
                         var comms = _communityResolver.Resolve(
                             new CommunitySource(CommunitySourceKind.AsnList, list.Name));
                         var prefixes = await _prefixService.GetPrefixesForAsns(list.Asns, ct);
-                        foreach (var (prefix, length, _) in prefixes)
+                        foreach (var p in prefixes)
                             // #85: AsPath is overwritten by the local ASN in the outbound codec
                             // (BuildUpdateAttributes), so the per-prefix asn value is never used
                             // on the wire — pass null instead of allocating [asn] per prefix.
-                            routes.Add(MakeRoute(prefix, length, nextHop, null, comms));
+                            routes.Add(MakeRoute(p.Prefix, p.Length, p.IsIpv4, nextHop, null, comms));
                     }
                     catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#330
                     catch (Exception ex)
@@ -140,8 +140,8 @@ public sealed class RouteAssembler : IRouteAssembler
                     var comms = _communityResolver.Resolve(
                         new CommunitySource(CommunitySourceKind.Country, countryLists[0].Name));
                     var ruPrefixes = await _prefixService.GetRuPrefixesAsync(ct);
-                    foreach (var (prefix, length, _) in ruPrefixes)
-                        routes.Add(MakeRoute(prefix, length, nextHop, null, comms));
+                    foreach (var p in ruPrefixes)
+                        routes.Add(MakeRoute(p.Prefix, p.Length, p.IsIpv4, nextHop, null, comms));
                     _logger.LogInformation("Fetched {Count} RU prefixes for {Peer}", ruPrefixes.Count, peerLabel);
                 }
                 catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#330
@@ -163,8 +163,8 @@ public sealed class RouteAssembler : IRouteAssembler
                 {
                     var comms = _communityResolver.Resolve(new CommunitySource(CommunitySourceKind.PrefixSource, name));
                     var srcPrefixes = await _prefixService.GetSourcePrefixesAsync(name, ct);
-                    foreach (var (prefix, length) in srcPrefixes)
-                        routes.Add(MakeRoute(prefix, length, nextHop, null, comms));
+                    foreach (var p in srcPrefixes)
+                        routes.Add(MakeRoute(p.Prefix, p.Length, p.IsIpv4, nextHop, null, comms));
                     _logger.LogInformation("Fetched {Count} prefixes from source '{Source}' for {Peer}",
                         srcPrefixes.Count, name, peerLabel);
                 }
@@ -193,7 +193,7 @@ public sealed class RouteAssembler : IRouteAssembler
                     continue;
                 }
                 customRanges.Add((prefix, length));
-                routes.Add(MakeRoute(prefix, length, nextHop, null, customPrefixComms));
+                routes.Add(MakeRoute(prefix, length, isIpv4: true, nextHop, null, customPrefixComms));
             }
 
             // Add custom AS prefixes. Custom-AS routes carry the static "custom AS" community.
@@ -203,8 +203,8 @@ public sealed class RouteAssembler : IRouteAssembler
                 {
                     var customAsnComms = _communityResolver.Resolve(new CommunitySource(CommunitySourceKind.CustomAsn));
                     var asnPrefixes = await _prefixService.GetPrefixesForAsns(customAsns, ct);
-                    foreach (var (prefix, length, _) in asnPrefixes)
-                        routes.Add(MakeRoute(prefix, length, nextHop, null, customAsnComms));
+                    foreach (var p in asnPrefixes)
+                        routes.Add(MakeRoute(p.Prefix, p.Length, p.IsIpv4, nextHop, null, customAsnComms));
                     _logger.LogInformation("Peer {Peer} custom AS: {Asns} -> {Count} prefixes",
                         peerLabel, string.Join(",", customAsns), asnPrefixes.Count);
                 }
@@ -244,8 +244,8 @@ public sealed class RouteAssembler : IRouteAssembler
                 try
                 {
                     var ruPrefixes = await _prefixService.GetRuPrefixesAsync(ct);
-                    foreach (var (prefix, length, _) in ruPrefixes)
-                        routes.Add(MakeRoute(prefix, length, nextHop, null, defaultComms));
+                    foreach (var p in ruPrefixes)
+                        routes.Add(MakeRoute(p.Prefix, p.Length, p.IsIpv4, nextHop, null, defaultComms));
                 }
                 catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#330
                 catch (Exception ex)
@@ -275,8 +275,8 @@ public sealed class RouteAssembler : IRouteAssembler
             try
             {
                 var ruPrefixes = await _prefixService.GetRuPrefixesAsync(ct);
-                foreach (var (prefix, length, _) in ruPrefixes)
-                    routes.Add(MakeRoute(prefix, length, nextHop, null, defaultComms));
+                foreach (var p in ruPrefixes)
+                    routes.Add(MakeRoute(p.Prefix, p.Length, p.IsIpv4, nextHop, null, defaultComms));
                 _logger.LogInformation("Fetched {Count} RU prefixes for unknown peer {Peer}",
                     ruPrefixes.Count, peerLabel);
             }
@@ -332,13 +332,16 @@ public sealed class RouteAssembler : IRouteAssembler
 
     /// <summary>
     /// Builds a <see cref="Route"/> from its components. Static so it can be called from
-    /// <see cref="AddUserSourceRoutesAsync"/> and unit-tested directly.
+    /// <see cref="AddUserSourceRoutesAsync"/> and unit-tested directly. IPv4 addresses occupy
+    /// the low 32 bits of <paramref name="prefix"/> (the implicit uint→UInt128 widening);
+    /// <paramref name="isIpv4"/> carries the family (#14 phase 4).
     /// </summary>
     internal static Route MakeRoute(
-        uint prefix, byte length, uint nextHop, uint[]? asPath, uint[] communities,
+        UInt128 prefix, byte length, bool isIpv4, uint nextHop, uint[]? asPath, uint[] communities,
         (uint Global, uint Local1, uint Local2)[]? largeCommunities = null) => new()
         {
             Prefix = prefix,
+            IsIpv4 = isIpv4,
             PrefixLength = length,
             NextHop = nextHop,
             AsPath = asPath ?? [],
@@ -364,8 +367,8 @@ public sealed class RouteAssembler : IRouteAssembler
             var comms = communityResolver.Resolve(
                 new CommunitySource(CommunitySourceKind.UserSource, source.Name, source.Community));
             var prefixes = await prefixService.GetUserSourcePrefixesAsync(source.Name, source.Url, source.Community, ct);
-            foreach (var (prefix, length) in prefixes)
-                routes.Add(MakeRoute(prefix, length, nextHop, null, comms));
+            foreach (var p in prefixes)
+                routes.Add(MakeRoute(p.Prefix, p.Length, p.IsIpv4, nextHop, null, comms));
             logger.LogInformation("User-source '{Name}': {Count} prefixes for {Peer}", source.Name, prefixes.Count, peerLabel);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#342: only CALLER cancellation — a per-source timeout OCE (#320's linked CTS, live ct) must stay a fetch failure below

--- a/BGPLite.Tests/ApiHandlerBehaviorTests.cs
+++ b/BGPLite.Tests/ApiHandlerBehaviorTests.cs
@@ -10,6 +10,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
+using BGPLite.Protocol;
 
 namespace BGPLite.Tests;
 
@@ -263,20 +264,20 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
 
     private sealed class InertPrefixService : IPrefixService
     {
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default) => Task.FromResult(new List<(uint, byte, uint)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetPrefixesAsync(uint asn, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default) => Task.FromResult(new List<(UInt128, byte, bool, uint)>());
         public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default) => Task.FromResult(new List<(uint, byte, uint)>());
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default) => Task.FromResult(new List<(UInt128, byte, bool, uint)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
     }
 
     private sealed class InertPrefixSources : IPrefixSourceService
     {
-        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>> LoadAllAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<(uint Prefix, byte Length)>)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetDefaultAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
+        public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
+        public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);
         public bool SourceSupportsConditional(string sourceName) => false;

--- a/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
+++ b/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
@@ -189,9 +189,9 @@ public class BgpSessionRouteOwnershipTests
     }
 
     /// <summary>Waits for the initial dump and returns every NLRI the session put on the wire.</summary>
-    private static async Task<List<(uint Prefix, byte Length)>> CollectAdvertisedNlriAsync(ScriptedConnection conn)
+    private static async Task<List<(UInt128 Prefix, byte Length)>> CollectAdvertisedNlriAsync(ScriptedConnection conn)
     {
-        var nlri = new List<(uint, byte)>();
+        var nlri = new List<(UInt128, byte)>();
         for (var i = 0; i < 200; i++)
         {
             nlri.Clear();
@@ -386,7 +386,7 @@ public class BgpSessionRouteOwnershipTests
 
     // ---- harness ----
 
-    private static RouteTable Seeded(params (uint Prefix, byte Length)[] routes)
+    private static RouteTable Seeded(params (UInt128 Prefix, byte Length)[] routes)
     {
         var table = new RouteTable();
         foreach (var (prefix, length) in routes)

--- a/BGPLite.Tests/BgpSessionUserSourceTests.cs
+++ b/BGPLite.Tests/BgpSessionUserSourceTests.cs
@@ -31,11 +31,11 @@ public class BgpSessionUserSourceTests
     /// <summary>A minimal <see cref="IPrefixService"/> that only implements the user-source path.</summary>
     private sealed class StubPrefixService : IPrefixService
     {
-        public IReadOnlyList<(uint Prefix, byte Length)> Result { get; set; } = [];
+        public IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)> Result { get; set; } = [];
         public Exception? Throw { get; set; }
         public (string Name, string Url, string? Community)? Last { get; private set; }
 
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetUserSourcePrefixesAsync(
             string name, string url, string? community, CancellationToken ct = default)
         {
             Last = (name, url, community);
@@ -43,22 +43,22 @@ public class BgpSessionUserSourceTests
             return Task.FromResult(Result);
         }
 
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
-            => Task.FromResult(new List<(uint Prefix, byte Length, uint Asn)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
+            => Task.FromResult(new List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>());
         public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
-            => Task.FromResult(new List<(uint Prefix, byte Length, uint Asn)>());
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
+            => Task.FromResult(new List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
     }
 
     [Fact]
     public async Task Success_AddsRoutesWithResolvedCommunity()
     {
-        var svc = new StubPrefixService { Result = [(0xC0A80000u, (byte)24)] };
+        var svc = new StubPrefixService { Result = [((UInt128)0xC0A80000u, (byte)24, true)] };
         var resolver = new StubResolver();
         var routes = new List<Route>();
 
@@ -83,7 +83,7 @@ public class BgpSessionUserSourceTests
         // Per-source try/catch: one failing URL must not drop another source's prefixes.
         var routes = new List<Route>();
         var throwSvc = new StubPrefixService { Throw = new InvalidOperationException("boom") };
-        var okSvc = new StubPrefixService { Result = [(0x0A000000u, (byte)8)] };
+        var okSvc = new StubPrefixService { Result = [((UInt128)0x0A000000u, (byte)8, true)] };
 
         await RouteAssembler.AddUserSourceRoutesAsync(
             routes, new CustomSourceView("bad", "https://x/b", null), 1, throwSvc, new StubResolver(), NullLogger.Instance, "peer", CancellationToken.None);
@@ -118,7 +118,7 @@ public class BgpSessionUserSourceTests
         // RunAsync's OCE handler.
         var routes = new List<Route>();
         var slowSvc = new StubPrefixService { Throw = new OperationCanceledException() };
-        var okSvc = new StubPrefixService { Result = [(0x0A000000u, (byte)8)] };
+        var okSvc = new StubPrefixService { Result = [((UInt128)0x0A000000u, (byte)8, true)] };
 
         await RouteAssembler.AddUserSourceRoutesAsync(
             routes, new CustomSourceView("slow", "https://x/s", null), 1, slowSvc, new StubResolver(),

--- a/BGPLite.Tests/CommunityResolverTests.cs
+++ b/BGPLite.Tests/CommunityResolverTests.cs
@@ -96,7 +96,7 @@ public class CommunityResolverTests
     [Fact]
     public void MakeRoute_StampsCommunitiesAndAsPath()
     {
-        var route = RouteAssembler.MakeRoute(0xC0A80000, 24, 0x01020304, [65000u], [CommunityCodec.Parse("65000:100")]);
+        var route = RouteAssembler.MakeRoute(0xC0A80000, 24, isIpv4: true, 0x01020304, [65000u], [CommunityCodec.Parse("65000:100")]);
         Assert.Equal(0xC0A80000u, route.Prefix);
         Assert.Equal((byte)24, route.PrefixLength);
         Assert.Equal(0x01020304u, route.NextHop);
@@ -107,7 +107,7 @@ public class CommunityResolverTests
     [Fact]
     public void MakeRoute_NullAsPath_DefaultsEmpty()
     {
-        var route = RouteAssembler.MakeRoute(0x0A000000, 8, 0, null, []);
+        var route = RouteAssembler.MakeRoute(0x0A000000, 8, isIpv4: true, 0, null, []);
         Assert.Empty(route.AsPath);
         Assert.Empty(route.Communities);
     }

--- a/BGPLite.Tests/ConfigHotReloadTests.cs
+++ b/BGPLite.Tests/ConfigHotReloadTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using BGPLite.Contracts;
+using BGPLite.Protocol;
 
 namespace BGPLite.Tests;
 
@@ -351,29 +352,29 @@ public class ConfigHotReloadTests
     /// <summary>Answers every prefix query with an empty set; the hot-reload path never calls it.</summary>
     private sealed class InertPrefixService : IPrefixService
     {
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
-            => Task.FromResult(new List<(uint Prefix, byte Length, uint Asn)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
+            => Task.FromResult(new List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>());
         public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
-            => Task.FromResult(new List<(uint Prefix, byte Length, uint Asn)>());
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
+            => Task.FromResult(new List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
     }
 
     /// <summary>Reports no configured prefix sources; the hot-reload path never calls it.</summary>
     private sealed class InertPrefixSourceService : IPrefixSourceService
     {
-        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<(uint, byte)>)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetDefaultAsync(CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
+        public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
+        public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);
         public bool SourceSupportsConditional(string sourceName) => false;

--- a/BGPLite.Tests/ManagementApiShutdownTests.cs
+++ b/BGPLite.Tests/ManagementApiShutdownTests.cs
@@ -8,6 +8,7 @@ using BGPLite.Routing;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
+using BGPLite.Protocol;
 
 namespace BGPLite.Tests;
 
@@ -201,12 +202,12 @@ public sealed class ManagementApiShutdownTests : IDisposable
     {
         public TaskCompletionSource Entered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
-            => Task.FromResult(new List<(uint Prefix, byte Length, uint Asn)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
+            => Task.FromResult(new List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>());
         public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
-        public async Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
+        public async Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
         {
             // Yield BEFORE signalling: the whole chain from the accept loop into this provider is
             // synchronous up to the first await, so without this the Entered signal could fire
@@ -217,22 +218,22 @@ public sealed class ManagementApiShutdownTests : IDisposable
             await Task.Delay(Timeout.Infinite, ct);   // never completes on its own; honors the token
             return [];
         }
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
     }
 
     /// <summary>Reports no configured prefix sources; the shutdown path never calls it.</summary>
     private sealed class InertPrefixSourceService : IPrefixSourceService
     {
-        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<(uint Prefix, byte Length)>)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetDefaultAsync(CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
+        public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
+        public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);
         public bool SourceSupportsConditional(string sourceName) => false;

--- a/BGPLite.Tests/PeerDeleteTeardownTests.cs
+++ b/BGPLite.Tests/PeerDeleteTeardownTests.cs
@@ -245,29 +245,29 @@ public sealed class PeerDeleteTeardownTests
     /// <summary>Answers every prefix query with an empty set; the delete path never calls it.</summary>
     private sealed class InertPrefixService : IPrefixService
     {
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
-            => Task.FromResult(new List<(uint Prefix, byte Length, uint Asn)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
+            => Task.FromResult(new List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>());
         public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
-            => Task.FromResult(new List<(uint Prefix, byte Length, uint Asn)>());
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
+            => Task.FromResult(new List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
     }
 
     /// <summary>Reports no configured prefix sources; the delete path never calls it.</summary>
     private sealed class InertPrefixSourceService : IPrefixSourceService
     {
-        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<(uint Prefix, byte Length)>)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetDefaultAsync(CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
+        public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
+        public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);
         public bool SourceSupportsConditional(string sourceName) => false;

--- a/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
+++ b/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
 using BGPLite.Contracts;
+using BGPLite.Protocol;
 
 namespace BGPLite.Tests;
 
@@ -36,10 +37,10 @@ public class PrefixAutoRefreshServiceTests
             => Conditional.TryGetValue(sourceName, out var v) ? v : true;
 
         // Unused by the auto-refresh service (it reads source names from AppConfig), but required by the interface.
-        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<(uint Prefix, byte Length)>)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetDefaultAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
+        public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
+        public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
     }
 

--- a/BGPLite.Tests/PrefixCacheRaceTests.cs
+++ b/BGPLite.Tests/PrefixCacheRaceTests.cs
@@ -1,6 +1,7 @@
 using BGPLite.Configuration;
 using BGPLite.Providers;
 using Microsoft.Extensions.Logging.Abstractions;
+using BGPLite.Protocol;
 
 namespace BGPLite.Tests;
 
@@ -129,22 +130,22 @@ public class PrefixCacheRaceTests
         public int DefaultCalls => Volatile.Read(ref _defaultCalls);
         public bool FailNext { get; set; }
 
-        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>> LoadAllAsync(CancellationToken ct = default) =>
+        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default) =>
             throw new NotImplementedException();
 
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name, CancellationToken ct = default) =>
+        public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default) =>
             throw new NotImplementedException();
 
-        public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetDefaultAsync(CancellationToken ct = default)
+        public async Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default)
         {
             Interlocked.Increment(ref _defaultCalls);
             // Simulate real I/O latency so concurrent callers actually overlap inside the gate.
             await Task.Delay(20, ct);
             if (FailNext) throw new InvalidOperationException("simulated default-source failure");
-            return new List<(uint Prefix, byte Length)>
+            return new List<IpPrefix>
             {
-                (0x0A000000u, 8),
-                (0xC0A80000u, 16),
+                new(0x0A000000u, 8),
+                new(0xC0A80000u, 16),
             };
         }
 

--- a/BGPLite.Tests/PrefixCidrTests.cs
+++ b/BGPLite.Tests/PrefixCidrTests.cs
@@ -152,4 +152,44 @@ public class PrefixCidrTests
         Assert.Equal(0u, prefix);
         Assert.Equal((byte)0, length);
     }
+    // ---- #14 phase 4: family-aware parse (IPv6) ----
+
+    [Fact]
+    public void TryParse_Ipv6_AcceptsAndMasks()
+    {
+        Assert.True(PrefixCidr.TryParse("2001:db8:ffff:ffff:1::/48", out var prefix));
+        Assert.False(prefix.IsIpv4);
+        Assert.Equal(48, prefix.Length);
+        var expected = ((UInt128)0x2001 << 112) | ((UInt128)0x0DB8 << 96) | ((UInt128)0xFFFF << 80);
+        Assert.Equal(expected, prefix.Address);
+    }
+
+    [Fact]
+    public void TryParse_Ipv6_HostRoute128()
+    {
+        Assert.True(PrefixCidr.TryParse("2001:db8::1/128", out var prefix));
+        Assert.False(prefix.IsIpv4);
+        Assert.Equal(128, prefix.Length);
+    }
+
+    [Theory]
+    [InlineData("2001:db8::/129")]   // out of range
+    [InlineData("::/0")]             // default route rejected like 0.0.0.0/0
+    [InlineData("2001:db8::")]       // no length
+    [InlineData("::ffff:10.0.0.1/96")] // v4-mapped — not a real IPv6 prefix
+    public void TryParse_Ipv6_Rejects(string bad)
+    {
+        Assert.False(PrefixCidr.TryParse(bad, out var prefix));
+        Assert.Equal(default, prefix);
+    }
+
+    [Fact]
+    public void TryParse_Ipv4OnlyOverload_StillRejectsIpv6()
+    {
+        // The API's custom-prefix path stays IPv4-scoped for now; the v4 overload must not
+        // silently widen with the family-aware parser arriving alongside it.
+        Assert.False(PrefixCidr.TryParse("2001:db8::/48", out var prefix, out var length));
+        Assert.Equal(0u, prefix);
+        Assert.Equal((byte)0, length);
+    }
 }

--- a/BGPLite.Tests/PrefixListParserTests.cs
+++ b/BGPLite.Tests/PrefixListParserTests.cs
@@ -6,14 +6,14 @@ namespace BGPLite.Tests;
 
 public class PrefixListParserTests
 {
-    private static uint Ip(string s) => BgpConstants.IPAddressToUint(IPAddress.Parse(s));
+    private static IpPrefix Pfx(string s) => new(BgpConstants.IPAddressToUint(IPAddress.Parse(s[..s.IndexOf("/")])), byte.Parse(s[(s.IndexOf("/") + 1)..]));
 
     [Fact]
     public void ParsesSingleCidr()
     {
         var result = PrefixListParser.Parse("1.2.3.0/24");
         var single = Assert.Single(result);
-        Assert.Equal((Ip("1.2.3.0"), (byte)24), single);
+        Assert.Equal(Pfx("1.2.3.0/24"), single);
     }
 
     [Fact]
@@ -31,12 +31,32 @@ public class PrefixListParserTests
     }
 
     [Fact]
-    public void SkipsIpv6()
+    public void AcceptsIpv6()
     {
-        var result = PrefixListParser.Parse("::1/128\n1.2.3.0/24");
-        var single = Assert.Single(result);
-        Assert.Equal((Ip("1.2.3.0"), (byte)24), single);
+        // #14 phase 4 flipped the old "SkipsIpv6" behavior: IPv6 entries are family-tagged
+        // prefixes now, parsed by the same canonical policy (masking, /0 rejection, 1..128).
+        var result = PrefixListParser.Parse("2001:DB8:0:0:0:0:0:1/48\n1.2.3.0/24");
+        Assert.Equal(2, result.Count);
+        // host bits masked: 2001:DB8:0:0:0:0:0:1/48 → 2001:db8::/48
+        var expected = ((UInt128)0x2001 << 112) | ((UInt128)0x0DB8 << 96);
+        Assert.Equal(new IpPrefix(expected, 48, isIpv4: false), result[0]);
+        Assert.True(result[1].IsIpv4);
     }
+
+    [Fact]
+    public void RejectsIpv6DefaultRoute()
+    {
+        Assert.Empty(PrefixListParser.Parse("::/0"));
+    }
+
+    [Fact]
+    public void AcceptsIpv6BoundaryLengths()
+    {
+        Assert.Single(PrefixListParser.Parse("2001:db8::/128")); // host route
+        Assert.Single(PrefixListParser.Parse("2001:db8::/1"));   // /1 — same policy space as v4's /1
+        Assert.Empty(PrefixListParser.Parse("2001:db8::/129"));  // out of range
+    }
+
 
     [Fact]
     public void SkipsBadLength()
@@ -80,7 +100,7 @@ public class PrefixListParserTests
     {
         var result = PrefixListParser.Parse("0.0.0.0/0\n1.2.3.0/24");
         var single = Assert.Single(result);
-        Assert.Equal((Ip("1.2.3.0"), (byte)24), single);
+        Assert.Equal(Pfx("1.2.3.0/24"), single);
     }
 
     [Fact]
@@ -90,7 +110,7 @@ public class PrefixListParserTests
         // so downstream dedup keys them as one route instead of two distinct rows.
         var result = PrefixListParser.Parse("10.0.0.5/24\n10.0.0.99/24");
         Assert.Equal(2, result.Count);
-        Assert.All(result, r => Assert.Equal((Ip("10.0.0.0"), (byte)24), r));
+        Assert.All(result, r => Assert.Equal(Pfx("10.0.0.0/24"), r));
     }
 
     [Fact]
@@ -98,7 +118,7 @@ public class PrefixListParserTests
     {
         var result = PrefixListParser.Parse("10.0.0.0/24");
         var single = Assert.Single(result);
-        Assert.Equal((Ip("10.0.0.0"), (byte)24), single);
+        Assert.Equal(Pfx("10.0.0.0/24"), single);
     }
 
     [Fact]
@@ -106,10 +126,10 @@ public class PrefixListParserTests
     {
         // /1 masks all but the top bit; /32 (host route) masks nothing.
         var r1 = Assert.Single(PrefixListParser.Parse("255.255.255.255/1"));
-        Assert.Equal((Ip("128.0.0.0"), (byte)1), r1);
+        Assert.Equal(Pfx("128.0.0.0/1"), r1);
 
         var r32 = Assert.Single(PrefixListParser.Parse("10.0.0.5/32"));
-        Assert.Equal((Ip("10.0.0.5"), (byte)32), r32);
+        Assert.Equal(Pfx("10.0.0.5/32"), r32);
     }
 
     [Fact]
@@ -120,6 +140,6 @@ public class PrefixListParserTests
         var bom = "\uFEFF1.2.3.0/24";
         var result = PrefixListParser.Parse(bom);
         var single = Assert.Single(result);
-        Assert.Equal((Ip("1.2.3.0"), (byte)24), single);
+        Assert.Equal(Pfx("1.2.3.0/24"), single);
     }
 }

--- a/BGPLite.Tests/PrefixSourceServiceTests.cs
+++ b/BGPLite.Tests/PrefixSourceServiceTests.cs
@@ -1,6 +1,7 @@
 using BGPLite.Configuration;
 using BGPLite.Providers;
 using Microsoft.Extensions.Logging.Abstractions;
+using BGPLite.Protocol;
 
 namespace BGPLite.Tests;
 
@@ -11,8 +12,8 @@ public class PrefixSourceServiceTests
         public string Kind => "stub";
         public bool SupportsConditionalRequests => true;
         public int Calls { get; private set; }
-        private readonly IReadOnlyList<(uint, byte)> _list;
-        public CountingProvider(IReadOnlyList<(uint, byte)> list) => _list = list;
+        private readonly IReadOnlyList<IpPrefix> _list;
+        public CountingProvider(IReadOnlyList<IpPrefix> list) => _list = list;
 
         public Task<SourceLoadResult> LoadAsync(PrefixSourceConfig source, string? etag = null, DateTimeOffset? lastModified = null, CancellationToken ct = default)
         {
@@ -40,7 +41,7 @@ public class PrefixSourceServiceTests
     [Fact]
     public async Task GetAsync_CachesWithinTtl()
     {
-        var provider = new CountingProvider([(1u, (byte)24)]);
+        var provider = new CountingProvider([new(1u, 24)]);
         var svc = new PrefixSourceService(
             ConfigWith("ru"),
             new PrefixSourceProviderFactory([provider]),
@@ -57,7 +58,7 @@ public class PrefixSourceServiceTests
     {
         var svc = new PrefixSourceService(
             ConfigWith("ru"),
-            new PrefixSourceProviderFactory([new CountingProvider([(1u, (byte)24)])]),
+            new PrefixSourceProviderFactory([new CountingProvider([new(1u, 24)])]),
             NullLogger<PrefixSourceService>.Instance);
 
         Assert.Empty(await svc.GetAsync("nope"));
@@ -66,7 +67,7 @@ public class PrefixSourceServiceTests
     [Fact]
     public async Task GetDefaultAsync_ResolvesByName()
     {
-        var provider = new CountingProvider([(1u, (byte)24), (2u, (byte)16)]);
+        var provider = new CountingProvider([new IpPrefix(1u, 24), new IpPrefix(2u, 16)]);
         var yaml = "Bgp:\n  Asn: 65444\n  RouterId: 10.0.0.1\n" +
                    "PrefixSources:\n  - Name: ru\n    Kind: stub\nDefaultPrefixSource: ru\n";
         var svc = new PrefixSourceService(
@@ -83,7 +84,7 @@ public class PrefixSourceServiceTests
     {
         var svc = new PrefixSourceService(
             ConfigWith("ru"),
-            new PrefixSourceProviderFactory([new CountingProvider([(1u, (byte)24)])]),
+            new PrefixSourceProviderFactory([new CountingProvider([new(1u, 24)])]),
             NullLogger<PrefixSourceService>.Instance);
 
         Assert.Empty(await svc.GetDefaultAsync());
@@ -106,7 +107,7 @@ public class PrefixSourceServiceTests
     [Fact]
     public async Task WarmUpAsync_PrimesAllSources()
     {
-        var provider = new CountingProvider([(1u, (byte)24)]);
+        var provider = new CountingProvider([new(1u, 24)]);
         var svc = new PrefixSourceService(
             ConfigWith("a", "b"),
             new PrefixSourceProviderFactory([provider]),
@@ -120,7 +121,7 @@ public class PrefixSourceServiceTests
     [Fact]
     public async Task GetAsync_RefetchesAfterTtlExpiry()
     {
-        var provider = new CountingProvider([(1u, (byte)24)]);
+        var provider = new CountingProvider([new(1u, 24)]);
         var svc = new PrefixSourceService(
             ConfigWith("ru"),
             new PrefixSourceProviderFactory([provider]),
@@ -139,8 +140,8 @@ public class PrefixSourceServiceTests
         public string Kind => "stub";
         public bool SupportsConditionalRequests => true;
         private int _calls;
-        private readonly IReadOnlyList<(uint, byte)> _first;
-        public ToggleProvider(IReadOnlyList<(uint, byte)> first) => _first = first;
+        private readonly IReadOnlyList<IpPrefix> _first;
+        public ToggleProvider(IReadOnlyList<IpPrefix> first) => _first = first;
 
         public Task<SourceLoadResult> LoadAsync(PrefixSourceConfig source, string? etag = null, DateTimeOffset? lastModified = null, CancellationToken ct = default)
         {
@@ -154,7 +155,7 @@ public class PrefixSourceServiceTests
     [Fact]
     public async Task GetAsync_ServesStaleOnFailure()
     {
-        var provider = new ToggleProvider([(1u, (byte)24), (2u, (byte)16)]);
+        var provider = new ToggleProvider([new(1u, 24), new(2u, 16)]);
         var svc = new PrefixSourceService(
             ConfigWith("ru"),
             new PrefixSourceProviderFactory([provider]),
@@ -189,7 +190,7 @@ public class PrefixSourceServiceTests
         var ex = Assert.Throws<InvalidOperationException>(() =>
             new PrefixSourceService(
                 ConfigLoader.LoadFromText(yaml),
-                new PrefixSourceProviderFactory([new CountingProvider([(1u, (byte)24)])]),
+                new PrefixSourceProviderFactory([new CountingProvider([new(1u, 24)])]),
                 NullLogger<PrefixSourceService>.Instance));
 
         Assert.Contains("ru", ex.Message);
@@ -207,8 +208,8 @@ public class PrefixSourceServiceTests
         public string Kind => "stub";
         public bool SupportsConditionalRequests => true;
         public int Calls { get; private set; }
-        private readonly IReadOnlyList<IReadOnlyList<(uint, byte)>> _lists;
-        public SequenceProvider(params IReadOnlyList<(uint, byte)>[] lists) => _lists = lists;
+        private readonly IReadOnlyList<IReadOnlyList<IpPrefix>> _lists;
+        public SequenceProvider(params IReadOnlyList<IpPrefix>[] lists) => _lists = lists;
 
         public async Task<SourceLoadResult> LoadAsync(PrefixSourceConfig source, string? etag = null, DateTimeOffset? lastModified = null, CancellationToken ct = default)
         {
@@ -225,8 +226,8 @@ public class PrefixSourceServiceTests
         public string Kind => "stub";
         public bool SupportsConditionalRequests => true;
         public int Calls { get; private set; }
-        private readonly IReadOnlyList<(uint, byte)> _list;
-        public ConditionalProvider(IReadOnlyList<(uint, byte)> list) => _list = list;
+        private readonly IReadOnlyList<IpPrefix> _list;
+        public ConditionalProvider(IReadOnlyList<IpPrefix> list) => _list = list;
 
         public Task<SourceLoadResult> LoadAsync(PrefixSourceConfig source, string? etag = null, DateTimeOffset? lastModified = null, CancellationToken ct = default)
         {
@@ -242,7 +243,7 @@ public class PrefixSourceServiceTests
     [Fact]
     public async Task RefreshAsync_ReportsChanged_WhenContentDiffers()
     {
-        var provider = new SequenceProvider([(1u, (byte)24)], [(1u, (byte)24), (2u, (byte)16)]);
+        var provider = new SequenceProvider([new(1u, 24)], [new(1u, 24), new(2u, 16)]);
         var svc = new PrefixSourceService(
             ConfigWith("ru"),
             new PrefixSourceProviderFactory([provider]),
@@ -261,7 +262,7 @@ public class PrefixSourceServiceTests
     [Fact]
     public async Task RefreshAsync_ReportsUnchanged_WhenContentIdentical()
     {
-        var provider = new SequenceProvider([(1u, (byte)24)], [(1u, (byte)24)]);
+        var provider = new SequenceProvider([new(1u, 24)], [new(1u, 24)]);
         var svc = new PrefixSourceService(
             ConfigWith("ru"),
             new PrefixSourceProviderFactory([provider]),
@@ -277,7 +278,7 @@ public class PrefixSourceServiceTests
     [Fact]
     public async Task RefreshAsync_ReportsUnchanged_OnNotModified304()
     {
-        var provider = new ConditionalProvider([(1u, (byte)24)]);
+        var provider = new ConditionalProvider([new(1u, 24)]);
         var svc = new PrefixSourceService(
             ConfigWith("ru"),
             new PrefixSourceProviderFactory([provider]),
@@ -302,7 +303,7 @@ public class PrefixSourceServiceTests
     [Fact]
     public async Task RefreshAsync_AfterConcurrentGetAsyncConsumedChange_ReportsFalse_PushFiresOnce()
     {
-        var provider = new SequenceProvider([(1u, (byte)24)], [(1u, (byte)24), (2u, (byte)16)]);
+        var provider = new SequenceProvider([new(1u, 24)], [new(1u, 24), new(2u, 16)]);
         var pushed = new List<string>();
         var gate = new object();
         var svc = new PrefixSourceService(
@@ -335,7 +336,7 @@ public class PrefixSourceServiceTests
     [Fact]
     public void SourceSupportsConditional_ReflectsProvider()
     {
-        var etagProvider = new CountingProvider([(1u, (byte)24)]);
+        var etagProvider = new CountingProvider([new(1u, 24)]);
         var noEtagProvider = new NoEtagStubProvider();
         var yaml = "Bgp:\n  Asn: 65444\n  RouterId: 10.0.0.1\n" +
                    "PrefixSources:\n  - Name: http-src\n    Kind: http\n  - Name: asn-src\n    Kind: asn\n";
@@ -354,7 +355,7 @@ public class PrefixSourceServiceTests
         public string Kind => "asn";
         public bool SupportsConditionalRequests => false;
         public Task<SourceLoadResult> LoadAsync(PrefixSourceConfig source, string? etag = null, DateTimeOffset? lastModified = null, CancellationToken ct = default)
-            => Task.FromResult(SourceLoadResult.Ok([(1u, (byte)24)]));
+            => Task.FromResult(SourceLoadResult.Ok([new IpPrefix(1u, 24)]));
     }
 
     /// <summary>
@@ -367,8 +368,8 @@ public class PrefixSourceServiceTests
     {
         // v1 and v2 contain the SAME prefixes in a DIFFERENT order → must report unchanged.
         var provider = new SequenceProvider(
-            [(1u, (byte)24), (2u, (byte)16)],   // call 1: [a, b]
-            [(2u, (byte)16), (1u, (byte)24)]);  // call 2: [b, a] — same set, reversed
+            [new IpPrefix(1u, 24), new IpPrefix(2u, 16)],   // call 1: [a, b]
+            [new IpPrefix(2u, 16), new IpPrefix(1u, 24)]);  // call 2: [b, a] — same set, reversed
         var svc = new PrefixSourceService(
             ConfigWith("ru"),
             new PrefixSourceProviderFactory([provider]),
@@ -385,9 +386,9 @@ public class PrefixSourceServiceTests
         // v1 (first load) → v2 (changed) → v2 again (no change). Models: source changes once, then
         // stays stable; a subsequent TTL-expired GetAsync must NOT re-fire the callback.
         var provider = new SequenceProvider(
-            [(1u, (byte)24)],                       // call 1: v1
-            [(1u, (byte)24), (2u, (byte)16)],        // call 2: v2 (changed)
-            [(1u, (byte)24), (2u, (byte)16)]);       // call 3: v2 (same — no change)
+            [new IpPrefix(1u, 24)],                       // call 1: v1
+            [new IpPrefix(1u, 24), new IpPrefix(2u, 16)],        // call 2: v2 (changed)
+            [new IpPrefix(1u, 24), new IpPrefix(2u, 16)]);       // call 3: v2 (same — no change)
         var changed = new List<string>();
         var svc = new PrefixSourceService(
             ConfigWith("ru"),

--- a/BGPLite.Tests/RefreshDebounceTests.cs
+++ b/BGPLite.Tests/RefreshDebounceTests.cs
@@ -100,12 +100,12 @@ public class RefreshDebounceTests
 
     private sealed class EmptyPrefixService : IPrefixService
     {
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default) => Task.FromResult(new List<(uint, byte, uint)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetPrefixesAsync(uint asn, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default) => Task.FromResult(new List<(UInt128, byte, bool, uint)>());
         public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default) => Task.FromResult(new List<(uint, byte, uint)>());
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default) => Task.FromResult(new List<(UInt128, byte, bool, uint)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
     }
 

--- a/BGPLite.Tests/RipeStatProviderTests.cs
+++ b/BGPLite.Tests/RipeStatProviderTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using BGPLite.Configuration;
+using BGPLite.Protocol;
 using BGPLite.Providers;
 using Microsoft.Extensions.Http;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -64,8 +65,9 @@ public class RipeStatProviderTests
         var result = await Provider(handler).GetPrefixesAsync(65001);
 
         var row = Assert.Single(result);
-        Assert.Equal(0x0A000000u, row.Prefix);
-        Assert.Equal(24, row.PrefixLength);
+        Assert.True(row.IsIpv4);
+        Assert.Equal(0x0A000000u, (uint)row.Address);
+        Assert.Equal(24, row.Length);
     }
 
     [Fact]
@@ -154,11 +156,13 @@ public class RipeStatProviderTests
         var handler = new StubHandler(HttpStatusCode.OK, body);
         var result = await Provider(handler).GetPrefixesAsync(65001);
 
-        Assert.Contains((0x0A000000u, (byte)8), result);      // 10.0.0.1/8 masked to the network
-        Assert.DoesNotContain((0x0A000001u, (byte)8), result); // unmasked key never stored
-        Assert.Contains((0xC0A80000u, (byte)16), result);      // canonical row unaffected
-        Assert.DoesNotContain(result, p => p.PrefixLength is 0 or > 32); // /0 and /33 rejected
+        Assert.Contains(new IpPrefix(0x0A000000u, 8), result);      // 10.0.0.1/8 masked to the network
+        Assert.Contains(new IpPrefix(0xC0A80000u, 16), result);      // canonical row unaffected
+        Assert.All(result, p => Assert.True(p.Length is not 0 and <= 32)); // /0 and /33 rejected
         Assert.Equal(2, result.Count);                          // garbage skipped, not thrown
+        // An IpPrefix is canonical by construction, so "10.0.0.1/8" cannot survive as an
+        // unmasked key — the Contains above proves the masking happened (was a real hazard
+        // when rows were raw (uint, byte) tuples).
     }
 
     /// <summary>A handler that honors the CancellationToken like HttpClient's real handler does.</summary>

--- a/BGPLite.Tests/RouteAssemblerCancellationTests.cs
+++ b/BGPLite.Tests/RouteAssemblerCancellationTests.cs
@@ -4,6 +4,7 @@ using BGPLite.Routing;
 using BGPLite.Server;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using BGPLite.Protocol;
 
 namespace BGPLite.Tests;
 
@@ -60,17 +61,17 @@ public sealed class RouteAssemblerCancellationTests
     /// <summary>Every fetch succeeds except the RU list, which reports a cancelled task.</summary>
     private sealed class CancelledRuFetchPrefixService : IPrefixService
     {
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
-            => Task.FromResult(new List<(uint Prefix, byte Length, uint Asn)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
+            => Task.FromResult(new List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>());
         public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
-            => Task.FromCanceled<List<(uint Prefix, byte Length, uint Asn)>>(new CancellationToken(canceled: true));
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
+            => Task.FromCanceled<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>>(new CancellationToken(canceled: true));
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
     }
 

--- a/BGPLite.Tests/RouteAssemblerSuppressionTests.cs
+++ b/BGPLite.Tests/RouteAssemblerSuppressionTests.cs
@@ -167,17 +167,17 @@ public class RouteAssemblerSuppressionTests
     /// <summary>Serves the configured prefixes for the custom-ASN fetch; nothing else.</summary>
     private sealed class StubPrefixService(params (string Ip, byte Length)[] prefixes) : IPrefixService
     {
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
-            => Task.FromResult(prefixes.Select(p => (Net(p.Ip), p.Length, 64512u)).ToList());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
+            => Task.FromResult(prefixes.Select(p => ((UInt128)Net(p.Ip), p.Length, true, 64512u)).ToList());
         public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
-            => Task.FromResult(new List<(uint, byte, uint)>());
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
+            => Task.FromResult(new List<(UInt128, byte, bool, uint)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
     }
 

--- a/BGPLite.Tests/RouteRefreshHoldTimerTests.cs
+++ b/BGPLite.Tests/RouteRefreshHoldTimerTests.cs
@@ -47,12 +47,12 @@ public class RouteRefreshHoldTimerTests
 
     private sealed class EmptyPrefixService : IPrefixService
     {
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default) => Task.FromResult(new List<(uint, byte, uint)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetPrefixesAsync(uint asn, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default) => Task.FromResult(new List<(UInt128, byte, bool, uint)>());
         public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default) => Task.FromResult(new List<(uint, byte, uint)>());
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default) => Task.FromResult(new List<(UInt128, byte, bool, uint)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
     }
 

--- a/BGPLite.Tests/RouteSeedingServiceTests.cs
+++ b/BGPLite.Tests/RouteSeedingServiceTests.cs
@@ -23,34 +23,34 @@ public class RouteSeedingServiceTests
         // into WarmUpAsync (where it becomes WarmUpGate.Task.WaitAsync(ct)).
         public Task WarmUpCompleted { get; private set; } = new TaskCompletionSource().Task;
 
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default) =>
-            Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default) => Task.FromResult(new List<(uint, byte, uint)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetPrefixesAsync(uint asn, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default) => Task.FromResult(new List<(UInt128, byte, bool, uint)>());
         public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default) => Task.FromResult(new List<(uint, byte, uint)>());
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default) =>
-            Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default) =>
-            Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default) => Task.FromResult(new List<(UInt128, byte, bool, uint)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) =>
             WarmUpCompleted = WarmUpGate.Task.WaitAsync(ct);
     }
 
     private sealed class FakeSourceService : IPrefixSourceService
     {
-        private readonly IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)> _sources;
+        private readonly IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)> _sources;
 
-        public FakeSourceService(IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<(uint, byte)>)>? sources = null) =>
+        public FakeSourceService(IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>? sources = null) =>
             _sources = sources ??
             [
                 (new PrefixSourceConfig { Name = "nets", Kind = "file", Url = "nets.txt" },
-                    new List<(uint, byte)> { (0xC0A80000u, 24), (0x0A000000u, 8) })
+                    new List<IpPrefix> { new(0xC0A80000u, 24), new(0x0A000000u, 8) })
             ];
 
-        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>> LoadAllAsync(CancellationToken ct = default) =>
+        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default) =>
             Task.FromResult(_sources);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetDefaultAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
+        public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);
         public bool SourceSupportsConditional(string sourceName) => false;
@@ -115,9 +115,9 @@ public class RouteSeedingServiceTests
         var sources = new FakeSourceService(
         [
             (new PrefixSourceConfig { Name = "bad", Kind = "file", Url = "a.txt", Community = "65444:99999" },
-                new List<(uint, byte)> { (0xAC100000u, 12) }),
+                new List<IpPrefix> { new(0xAC100000u, 12) }),
             (new PrefixSourceConfig { Name = "good", Kind = "file", Url = "b.txt", Community = "65000:100" },
-                new List<(uint, byte)> { (0xC0A80000u, 24) }),
+                new List<IpPrefix> { new(0xC0A80000u, 24) }),
         ]);
         using var service = NewService(prefix, sources, table, new RecordingSessionManager());
 

--- a/BGPLite.Tests/UserSourceCacheTests.cs
+++ b/BGPLite.Tests/UserSourceCacheTests.cs
@@ -1,5 +1,6 @@
 using BGPLite.Providers;
 using Xunit;
+using BGPLite.Protocol;
 
 namespace BGPLite.Tests;
 
@@ -11,16 +12,16 @@ namespace BGPLite.Tests;
 /// </summary>
 public class UserSourceCacheTests
 {
-    private static IReadOnlyList<(uint Prefix, byte Length)> P(params (uint, byte)[] xs) =>
-        xs.Select(x => (x.Item1, x.Item2)).ToList();
+    private static IReadOnlyList<IpPrefix> P(params (UInt128 Address, byte Length, bool IsIpv4)[] xs) =>
+        xs.Select(x => new IpPrefix(x.Item1, x.Item2, x.Item3)).ToList();
 
     /// <summary>A controllable fetcher: counts calls, returns a canned list or throws.</summary>
     private sealed class Fetcher
     {
         public int Calls;
-        public Func<IReadOnlyList<(uint Prefix, byte Length)>>? OnSuccess;
+        public Func<IReadOnlyList<IpPrefix>>? OnSuccess;
         public Exception? Throw;
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> Invoke(CancellationToken ct)
+        public Task<IReadOnlyList<IpPrefix>> Invoke(CancellationToken ct)
         {
             Calls++;
             if (Throw is OperationCanceledException oce) throw oce;
@@ -35,7 +36,7 @@ public class UserSourceCacheTests
         // The point of URL-keying (#150): two calls for the same URL — e.g. two peers refreshing the
         // same popular list — share one fetch.
         var cache = new UserSourceCache();
-        var f = new Fetcher { OnSuccess = () => P((0xC0A80000u, (byte)24)) };
+        var f = new Fetcher { OnSuccess = () => P((0xC0A80000u, (byte)24, true)) };
 
         var a = await cache.GetOrLoadAsync("https://example.com/l", "src", f.Invoke, CancellationToken.None);
         var b = await cache.GetOrLoadAsync("https://example.com/l", "src", f.Invoke, CancellationToken.None);
@@ -53,15 +54,15 @@ public class UserSourceCacheTests
         var cache = new UserSourceCache();
         var hold = new TaskCompletionSource();
         int calls = 0;
-        Task<IReadOnlyList<(uint Prefix, byte Length)>> Load(CancellationToken ct)
+        Task<IReadOnlyList<IpPrefix>> Load(CancellationToken ct)
         {
             Interlocked.Increment(ref calls);
             return HoldAndReturn();
         }
-        async Task<IReadOnlyList<(uint Prefix, byte Length)>> HoldAndReturn()
+        async Task<IReadOnlyList<IpPrefix>> HoldAndReturn()
         {
             await hold.Task;          // keep the in-flight fetch blocked until all racers are queued
-            return P((0u, 0));
+            return P((0u, (byte)0, true));
         }
 
         var tasks = Enumerable.Range(0, 16)
@@ -92,7 +93,7 @@ public class UserSourceCacheTests
         // Stale-serving only triggers on a refetch that fails — so let the positive entry expire first,
         // then make the refetch throw. The (now-expired) last good copy is served regardless of age.
         var cache = new UserSourceCache(positiveTtl: TimeSpan.FromMilliseconds(80));
-        var f = new Fetcher { OnSuccess = () => P((0u, 0)) };
+        var f = new Fetcher { OnSuccess = () => P((0u, (byte)0, true)) };
         await cache.GetOrLoadAsync("https://example.com/l", "src", f.Invoke, default); // prime positive
         await Task.Delay(120);                                                        // let it expire
 
@@ -136,14 +137,14 @@ public class UserSourceCacheTests
         // on entry explicitly instead of racing Task.Run's start.
         var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        static async Task<IReadOnlyList<(uint Prefix, byte Length)>> Parked(CancellationToken ct, TaskCompletionSource entered)
+        static async Task<IReadOnlyList<IpPrefix>> Parked(CancellationToken ct, TaskCompletionSource entered)
         {
             entered.TrySetResult();
             await Task.Delay(Timeout.InfiniteTimeSpan, ct);
             return [];
         }
 
-        Task<IReadOnlyList<(uint Prefix, byte Length)>> Invoke(CancellationToken ct)
+        Task<IReadOnlyList<IpPrefix>> Invoke(CancellationToken ct)
         {
             calls++;
             return Parked(ct, entered);
@@ -157,7 +158,7 @@ public class UserSourceCacheTests
         Assert.Equal(1, calls);
 
         // No negative cache → the next call reaches the fetcher again.
-        var f = new Fetcher { OnSuccess = () => P((1u, 1)) };
+        var f = new Fetcher { OnSuccess = () => P((1u, (byte)1, true)) };
         var served = await cache.GetOrLoadAsync("https://example.com/l", "src", f.Invoke, default);
         Assert.Equal(1, f.Calls); // a fresh fetcher ran once more
         Assert.Single(served);
@@ -167,7 +168,7 @@ public class UserSourceCacheTests
     public async Task Positive_Ttl_Expiry_Triggers_Refetch()
     {
         var cache = new UserSourceCache(positiveTtl: TimeSpan.FromMilliseconds(80));
-        var f = new Fetcher { OnSuccess = () => P((1u, 1)) };
+        var f = new Fetcher { OnSuccess = () => P((1u, (byte)1, true)) };
 
         await cache.GetOrLoadAsync("https://example.com/l", "src", f.Invoke, default);
         await Task.Delay(120);
@@ -199,7 +200,7 @@ public class UserSourceCacheTests
     public async Task UniqueUrls_BeyondCap_KeepCacheBounded()
     {
         var cache = new UserSourceCache(maxCacheEntries: 5);
-        var f = new Fetcher { OnSuccess = () => P((0x0A000000u, (byte)8)) };
+        var f = new Fetcher { OnSuccess = () => P((0x0A000000u, (byte)8, true)) };
 
         for (var i = 0; i < 12; i++)
             await cache.GetOrLoadAsync($"https://example.com/list-{i}", "src", f.Invoke, CancellationToken.None);
@@ -216,11 +217,11 @@ public class UserSourceCacheTests
     {
         var cache = new UserSourceCache(maxCacheEntries: 3);
         var calls = new Dictionary<string, int>();
-        Task<IReadOnlyList<(uint Prefix, byte Length)>> Load(string url) => Task.Run(async () =>
+        Task<IReadOnlyList<IpPrefix>> Load(string url) => Task.Run(async () =>
         {
             lock (calls) calls[url] = calls.TryGetValue(url, out var c) ? c + 1 : 1;
             await Task.Yield();
-            return P((0x0A000000u, (byte)8));
+            return P((0x0A000000u, (byte)8, true));
         });
 
         await cache.GetOrLoadAsync("https://example.com/a", "a", ct => Load("a"), CancellationToken.None);
@@ -281,10 +282,10 @@ public class UserSourceCacheTests
         var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var holdCts = new CancellationTokenSource();
 
-        Task<IReadOnlyList<(uint Prefix, byte Length)>> Hold(CancellationToken ct)
+        Task<IReadOnlyList<IpPrefix>> Hold(CancellationToken ct)
         {
             entered.TrySetResult();
-            return holder.Task.ContinueWith<IReadOnlyList<(uint Prefix, byte Length)>>(_ => [], CancellationToken.None);
+            return holder.Task.ContinueWith<IReadOnlyList<IpPrefix>>(_ => [], CancellationToken.None);
         }
 
         // First caller holds the gate without completing.
@@ -324,7 +325,7 @@ public class UserSourceCacheTests
             var cts = new CancellationTokenSource();
             cts.Cancel();   // cancelled before the gate is even acquired
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
-                cache.GetOrLoadAsync($"https://example.com/never-{i}", "src", ct => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]), cts.Token));
+                cache.GetOrLoadAsync($"https://example.com/never-{i}", "src", ct => Task.FromResult<IReadOnlyList<IpPrefix>>([]), cts.Token));
         }
 
         Assert.Equal(0, cache.TrackedGateCount);   // pre-fix: 5 orphan gates

--- a/BGPLite/RouteSeedingService.cs
+++ b/BGPLite/RouteSeedingService.cs
@@ -78,12 +78,15 @@ internal sealed class RouteSeedingService(
                     }
                 }
 
-                foreach (var (prefix, length) in prefixes)
+                foreach (var p in prefixes)
                 {
+                    // #14 phase 4: sources yield family-tagged prefixes; seeding is family-blind —
+                    // the route table keys carry IsIpv4, so both families seed side by side.
                     routeTable.AddOrUpdate(new Route
                     {
-                        Prefix = prefix,
-                        PrefixLength = length,
+                        Prefix = p.Address,
+                        IsIpv4 = p.IsIpv4,
+                        PrefixLength = p.Length,
                         NextHop = nextHop,
                         Communities = communities
                     });

--- a/appsettings.Example.yml
+++ b/appsettings.Example.yml
@@ -3,6 +3,10 @@ Bgp:
   RouterId: 1.2.3.4
   KeepAlive: 60
   HoldTime: 180
+  # Optional: the global IPv6 next hop advertised to MP-BGP IPv6/Unicast peers (#14 phase 4,
+  # RFC 2545 §3). Unset = IPv6 routes are never advertised (suppressed with a warning);
+  # set = each MP-IPv6-negotiated session announces IPv6 routes with this next hop.
+  # NextHopIpv6: "2001:db8::1"
   # Listener hardening (#115) — connect-to-OPEN timeout (Slowloris defense) and per-source-IP
   # accept throttle. Both have secure, generous defaults; set to 0 to disable either.
   # OpenTimeoutSeconds: 30                 # drop a peer that connects but never sends OPEN (default 30, 0 = off)

--- a/docker/integration/README.md
+++ b/docker/integration/README.md
@@ -12,9 +12,9 @@ its `birdc` CLI gives precise per-protocol assertions.
 ## Topology
 
 ```
-           net bgp4  172.30.100.0/24        net bgp6  fd00:b00b::/64
-  server   172.30.100.10                    fd00:b00b::10        (BGPLite :179, API 5001)
-  bird     172.30.100.20                    fd00:b00b::20        (BIRD2, AS65002)
+           net bgp4  172.30.100.0/24        net bgp6  2001:db8:cccc::/64
+  server   172.30.100.10                    2001:db8:cccc::10    (BGPLite :179, API 5001)
+  bird     172.30.100.20                    2001:db8:cccc::20    (BIRD2, AS65002)
 ```
 
 Server AS65001. Two BGP sessions: `bgplite4` (IPv4 transport) and `bgplite6`

--- a/docker/integration/bird.conf
+++ b/docker/integration/bird.conf
@@ -1,6 +1,6 @@
 # BIRD2 peer for the BGPLite integration stand (see docker/integration/README.md).
 # Announces static test prefixes over TWO sessions: IPv4 transport (172.30.100.x)
-# and IPv6 transport (fd00:b00b::x) — the latter exercises BGPLite's dual-mode
+# and IPv6 transport (2001:db8:cccc::x) — the latter exercises BGPLite's dual-mode
 # listener (#14 phase 4a).
 
 router id 172.30.100.20;
@@ -36,12 +36,12 @@ protocol bgp bgplite4 {
 protocol bgp bgplite6 {
     description "IPv6 transport";
     local as 65002;
-    neighbor fd00:b00b::10 as 65001;
+    neighbor 2001:db8:cccc::10 as 65001;
     hold time 15;
     keepalive time 5;
-    # The server (until epic phase 4b) sends its IPv4 seed prefixes as classic
-    # IPv4 NLRI on EVERY session, including this one — accept them here so the
-    # session is not torn down for unexpected NLRI; never export v4 back.
+    # The server sends its IPv4 seed prefixes as classic IPv4 NLRI on EVERY session,
+    # including this one — accept them here so the session is not torn down for
+    # unexpected NLRI; never export v4 back.
     ipv4 {
         import all;
         export none;

--- a/docker/integration/docker-compose.yml
+++ b/docker/integration/docker-compose.yml
@@ -3,7 +3,7 @@
 # and the server's peer registration agree.
 #
 #   net bgp4  172.30.100.0/24   server .10   bird .20
-#   net bgp6  fd00:b00b::/64    server ::10  bird ::20
+#   net bgp6  2001:db8:cccc::/64 server ::10  bird ::20 (doc prefix, RFC 3849)
 #
 # Everything is forced to linux/amd64 ("linux64"): the server image publishes with
 # the linux-x64 RID and both services pin the platform, so the stand behaves the
@@ -21,7 +21,7 @@ services:
       bgp4:
         ipv4_address: 172.30.100.10
       bgp6:
-        ipv6_address: fd00:b00b::10
+        ipv6_address: 2001:db8:cccc::10
     volumes:
       - ./server-appsettings.yml:/app/appsettings.yml:ro
       - ./test-nets.txt:/app/test-nets.txt:ro
@@ -41,7 +41,7 @@ services:
       bgp4:
         ipv4_address: 172.30.100.20
       bgp6:
-        ipv6_address: fd00:b00b::20
+        ipv6_address: 2001:db8:cccc::20
 
   # Opt-in packet capture of the BGP traffic INSIDE the server's network namespace
   # (both transports, one pcap). Start the stand with:
@@ -82,4 +82,4 @@ networks:
     enable_ipv6: true
     ipam:
       config:
-        - subnet: fd00:b00b::/64
+        - subnet: 2001:db8:cccc::/64

--- a/docker/integration/run-tests.sh
+++ b/docker/integration/run-tests.sh
@@ -5,7 +5,7 @@
 #   1. API plane is reachable (/api/server).
 #   2. A configured peer (registered via POST /api/peers) establishes over IPv4 transport.
 #   3. An UNconfigured peer establishes over IPv6 transport — proves the dual-mode
-#      listener (#14 phase 4a): fd00:b00b::20 -> fd00:b00b::10 port 179.
+#      listener (#14 phase 4a): 2001:db8:cccc::20 -> 2001:db8:cccc::10 port 179.
 #   4. Route exchange, server <- BIRD: BIRD's static prefixes (203.0.113.0/24,
 #      198.51.100.0/24 via IPv4 session, 2001:db8:ffff::/48 via MP_REACH over the
 #      IPv6 session) land in the server's route table (the "default" community group
@@ -38,13 +38,16 @@ api_post() { $COMPOSE exec -T probe curl -s --max-time 10 -o - -w '\n%{http_code
 say "build (linux/amd64)"
 $COMPOSE build --pull
 
-say "up"
-$COMPOSE up -d
+say "up (server first — BIRD joins only after the peer is registered, see step 2)"
+$COMPOSE up -d server probe
 cleanup() {
   # Evidence before teardown: the first thing a CI failure needs is the server's
-  # own account of why the API/session assertions never succeeded.
-  say "server log (tail, pre-teardown)"
-  $COMPOSE logs --no-color --tail 120 server bird 2>&1 | tail -120 || true
+  # own account of why the API/session assertions never succeeded. Filtered to the
+  # route-pipeline lines — raw keepalive/debug noise would push them out of a tail.
+  say "server pipeline log (pre-teardown)"
+  $COMPOSE logs --no-color server 2>&1 \
+    | grep -E "Unconfigured|Sending |UpdateSent|Suppress|SessionEstablished|Route refresh|Withdrawn|registering" \
+    | tail -60 || true
   $COMPOSE ps -a || true
   $COMPOSE down -v --remove-orphans
 }
@@ -72,7 +75,7 @@ wait_for() {
 say "1. API reachable"
 wait_for 'api_get $API/api/server >/dev/null' 60
 
-# --- 2. register the IPv4 peer --------------------------------------------------
+# --- 2. register the IPv4 peer, THEN connect BIRD --------------------------------
 say "2. register peer 172.30.100.20 (AS65002, custom prefix 192.0.2.0/24)"
 PEER_BODY='{"ip":"172.30.100.20","asn":65002,"description":"integration-bird","lists":["openai"],"customPrefixes":["192.0.2.0/24"]}'
 CREATE_RESP=$(api_post "$API/api/peers" "$PEER_BODY") || fail "POST /api/peers curl error"
@@ -82,14 +85,12 @@ echo "$CREATE_RESP" | sed '$d' > "$TMP/create-peer.json"
 grep -q '"error"' "$TMP/create-peer.json" && fail "POST /api/peers rejected: $(cat "$TMP/create-peer.json")"
 echo "created: $(cat "$TMP/create-peer.json")"
 
+$COMPOSE up -d bird
+
 # --- 3. both sessions Established ----------------------------------------------
-# BIRD connects the moment the stand is up, which races the peer registration in
-# step 2 (the session's initial dump would run against a not-yet-created peer row
-# and take the unconfigured path). Restarting the protocols forces a fresh dump
-# that sees the registered peer — deterministic, no sleep-based hope.
-say "3. restart BIRD sessions, then Established (IPv4 + IPv6 transport)"
-birdc "restart bgplite4" >/dev/null 2>&1
-birdc "restart bgplite6" >/dev/null 2>&1
+# BIRD is started AFTER the registration, so its very first dump already sees the
+# configured peer — no restart race, no sleep-based hope.
+say "3. BGP sessions Established (IPv4 + IPv6 transport)"
 wait_for 'birdc "show protocols all bgplite4" 2>/dev/null | grep -q "BGP state:.*Established"' 90
 wait_for 'birdc "show protocols all bgplite6" 2>/dev/null | grep -q "BGP state:.*Established"' 90
 
@@ -105,7 +106,7 @@ say "4. BIRD announcements reach the server route table"
 wait_for 'api_get $API/api/routes | grep -q "\"default\":3"' 60
 ROUTES=$(api_get $API/api/routes)
 echo "$ROUTES"
-echo "$ROUTES" | grep -q '"65001:100":2' || fail "seed source group (65001:100) should hold 2: $ROUTES"
+echo "$ROUTES" | grep -q '"65001:100":3' || fail "seed source group (65001:100) should hold 3 (2 IPv4 + 1 IPv6 seed): $ROUTES"
 # The openai HTTP-source group must hold a healthy bulk (the live list has ~300;
 # aggregation may merge some, lists may evolve — assert a conservative floor).
 HTTP_ROUTES=$(echo "$ROUTES" | grep -oE '"65001:110":[0-9]+' | grep -oE '[0-9]+$')
@@ -115,8 +116,9 @@ HTTP_ROUTES=$(echo "$ROUTES" | grep -oE '"65001:110":[0-9]+' | grep -oE '[0-9]+$
 # --- 5. server -> BIRD route propagation ----------------------------------------
 say "5. server advertisements reach BIRD"
 # The REGISTERED IPv4 peer gets its custom prefix (the configured-peer pipeline:
-# custom prefixes + subscriptions, no RU defaults).
-wait_for 'birdc "show route protocol bgplite4" 2>/dev/null | grep -q "192.0.2.0/24"' 60
+# custom prefixes + subscriptions, no RU defaults). Point lookup — stable regardless
+# of how the full table listing renders.
+wait_for 'birdc "show route 192.0.2.0/24" 2>/dev/null | grep -q "bgplite4"' 90
 birdc "show route protocol bgplite4" || true
 
 # The peer also subscribes to the "openai" HTTP source (ruhex/prefix-lists): the full
@@ -129,10 +131,12 @@ ROUTES4=$(birdc "show route protocol bgplite4 count" 2>/dev/null | tail -n +2 | 
 printf 'bgplite4 carries %s routes (custom + HTTP-source subscription)\n' "$ROUTES4"
 
 # The UNREGISTERED IPv6-transport peer gets the RU defaults (= the file seed source).
-# They ride as classic IPv4 NLRI over the IPv6 transport, imported by bgplite6's
-# IPv4 channel.
-wait_for 'birdc "show route protocol bgplite6" 2>/dev/null | grep -q "10.100.0.0/16"' 60
-wait_for 'birdc "show route protocol bgplite6" 2>/dev/null | grep -q "10.200.0.0/16"' 60
+# The IPv4 seeds ride as classic IPv4 NLRI over the IPv6 transport, imported by
+# bgplite6's IPv4 channel — and the IPv6 seed rides MP_REACH_NLRI (#14 phase 4b):
+# BIRD's IPv6 channel must import 2001:db8:cccc::/64 from the server.
+wait_for 'birdc "show route protocol bgplite6" 2>/dev/null | grep -q "10.100.0.0/16"' 90
+wait_for 'birdc "show route protocol bgplite6" 2>/dev/null | grep -q "10.200.0.0/16"' 90
+wait_for 'birdc "show route protocol bgplite6" 2>/dev/null | grep -q "2001:db8:cccc::/64"' 90
 birdc "show route protocol bgplite6" || true
 
 # --- 6. traffic capture (opt-in: --capture) --------------------------------------

--- a/docker/integration/server-appsettings.yml
+++ b/docker/integration/server-appsettings.yml
@@ -7,6 +7,8 @@ Bgp:
   # Short timers: a dead session must be noticed in seconds, not minutes.
   KeepAlive: 5
   HoldTime: 15
+  # Phase 4b: enables IPv6 advertisements via MP_REACH to MP-IPv6-negotiated peers.
+  NextHopIpv6: "2001:db8:cccc::10"
 
 # Reachable from the test runner via the published port (compose: 15001 -> 5001).
 # Loopback (the production default, #90/#181) would be invisible outside the container.

--- a/docker/integration/test-nets.txt
+++ b/docker/integration/test-nets.txt
@@ -1,3 +1,4 @@
 # Seed prefixes the server originates toward every peer (DefaultPrefixSource).
 10.100.0.0/16
 10.200.0.0/16
+2001:db8:cccc::/64

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -228,6 +228,23 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
   routes flowing; such routes now stop at the filter (visible via the existing send logs).
 - **Tracker:** #389.
 
+### D22. IPv6 outbound advertisement is gated on negotiation AND a configured global next hop
+- **Decision:** IPv6 routes are advertised to a peer only when BOTH hold: the peer negotiated
+  MP IPv6/Unicast in OPEN, and `Bgp.NextHopIpv6` is configured (validated at startup as a global
+  unicast address, 2000::/3). Otherwise IPv6 routes are suppressed for that send with a warning —
+  never silently, and never encoded as classic IPv4 NLRI (which would corrupt the peer's table).
+  v6 UPDATEs carry no classic NEXT_HOP (RFC 4760 §5 — the next hop rides in MP_REACH_NLRI,
+  RFC 2545 §3 global form); IPv6 withdrawals ride MP_UNREACH_NLRI (RFC 4760 §7).
+- **Context:** after the phase-2 codec (#15) and #407 fix the session could RECEIVE IPv6 routes
+  but had no outbound path — sources were IPv4-only and the send path had no family split.
+  Advertising IPv6 with the IPv4 router-id as next hop (or without the peer's negotiation) would
+  be a route leak/blackhole, so the gate is deliberately double-sided and fail-visible.
+- **Consequence:** IPv4-only deployments need no config change (no `NextHopIpv6` = no IPv6
+  advertisements, one Warning per send that actually had v6 routes); MP-IPv6 deployments add one
+  config line. The MP_REACH attribute is appended per batch (it embeds the batch's NLRI bytes) and
+  goes last — attribute ordering is an implementation choice (D15).
+- **Tracker:** #14 (phase 4b), #407.
+
 ### D21. IPv6 dual-stack address model (ADR 0001)
 - **Decision:** `IpPrefix` is family-aware over `UInt128` — IPv4 in the low 32 bits with an
   explicit `IsIpv4` flag, IPv6 as the full 128 bits; the constructor masks host bits (canonical


### PR DESCRIPTION
Closes #14   # linkage only — the integration PR aggregates the keywords that actually close issues

## Problem
Epic #14 phase 4, remaining items: sources could not yield IPv6 prefixes (RIPEstat parsed only `v4.originating`; `PrefixListParser` skipped IPv6 lines per policy), and the server could not ADVERTISE IPv6 at all — a received-via-MP_REACH route could never be re-announced, and seeded/subscribed v6 prefixes had no outbound path.

## Root Cause
The whole prefix pipeline was typed `(uint, byte)`, and the send path had no family split: everything rode classic IPv4 NLRI + NEXT_HOP.

## Fix
- `PrefixCidr`: family-aware `TryParse(string, out IpPrefix)` (v4 1..32 / v6 1..128, /0 rejected, v4-mapped rejected); v4-only overload kept for the API custom-prefix path. `PrefixListParser` now emits IPv6 entries (the epic's "remove the IPv4-only skip" item).
- RIPEstat: `v6.originating` parsed alongside `v4.originating` (sections optional, per-entry validation).
- Provider pipeline (SourceLoadResult, RIPEstat cache, source/user-source caches) carries `IpPrefix`; the Contracts boundary (`IPrefixService`) carries `(UInt128, byte, bool[, uint Asn])` tuples — Contracts is a dependency-free leaf and cannot see the Protocol type. `RouteAssembler`/`RouteSeedingService` build family-tagged routes.
- `BgpSession` send path: family split. IPv4 → classic NLRI + NEXT_HOP (unchanged). IPv6 → MP_REACH_NLRI (RFC 4760 §5: no classic NEXT_HOP; RFC 2545 §3: global 16-byte next hop) **only when** the peer negotiated MP IPv6/Unicast AND `Bgp.NextHopIpv6` is configured — otherwise suppressed with a Warning (fail-visible).
- Withdrawals mirror the split: IPv4 via the withdrawn field, IPv6 via MP_UNREACH-only UPDATEs (RFC 4760 §7).
- New config: `Bgp.NextHopIpv6` (optional; validated at startup as global unicast 2000::/3 — link-local/ULA/multicast/mapped rejected).

## Correctness
MP_REACH attribute is optional non-transitive (RFC 4760 §4), attached per batch (its value embeds the batch's NLRI); 100-NLRI v6 batches ≈ 1.8 KB < 4096 message cap. The v6 attribute cache is separate from the v4 one (v6 lists have no NEXT_HOP — sharing would leak the wrong attribute). BgpConfig.IsGlobalUnicastV6 is shared by startup validation and the send-time gate, so hand-built configs cannot emit a link-local "global" next hop.

## Regression Test
7 wire-level session tests (scripted connection, real reader): MP_REACH announce without classic NEXT_HOP; reader round-trip; suppression without negotiation and without next-hop config (v4 untouched); MP_UNREACH-only withdrawal on the wire; attribute flag checks; config validation matrix. Plus PrefixCidr v6 tests, PrefixListParser AcceptsIpv6 (flipped from SkipsIpv6 — the epic's requirement), RIPEstat dual-family parsing.

## Verification
- `dotnet format` / `dotnet build` (0 warnings) / `dotnet test` — **995/995** (baseline 981)
- Integration stand (linux/amd64, BIRD2): server advertises the IPv6 seed 2001:db8:cccc::/64 via MP_REACH over the IPv6-transport session — asserted in the runner; ALL TESTS PASSED
- reviewer subagent pass: 1 MAJOR (withdraw path untested at wire level) + 4 MINOR — all fixed

## RFC
RFC 4760 §4/§5/§7 (MP_REACH/MP_UNREACH), RFC 2545 §3 (global next hop, 16-byte form), RFC 4271 §4.3 (IPv4 NLRI unchanged).

## Behavior Change
Servers with `Bgp.NextHopIpv6` set and MP-IPv6-negotiated peers now exchange IPv6 routes in both directions. Without the config: no IPv6 advertisements (one Warning per send that had v6 routes); IPv4 behavior byte-identical.

## Deviation from Issue Proposal
None — implements the remaining phase-4 checklist items (RIPEstat v6, PrefixListParser v6, per-AFI next-hop + config).