### PR TITLE
feat(api,protocol): IPv6 templates, per-AFI GR, IPv6 peer validation (phase 5 of #14)

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -685,7 +685,12 @@ public sealed class ManagementApi : IHostedService, IDisposable
             keepalive = bgp.KeepAlive,
             setup = BuildCiscoSetup(bgp.Asn),
             bird = BuildBirdSetup(bgp.RouterId, bgp.Asn, bgp.HoldTime),
-            mikrotik = BuildMikrotikSetup(bgp.RouterId, bgp.Asn, bgp.HoldTime)
+            mikrotik = BuildMikrotikSetup(bgp.RouterId, bgp.Asn, bgp.HoldTime),
+            // IPv6 address-family variants (#14 phase 5): the peer side needs them to exchange
+            // IPv6 routes. <SERVER_V6> placeholders resolve to Bgp.NextHopIpv6 when configured.
+            setup6 = BuildCiscoSetupV6(bgp.Asn),
+            bird6 = BuildBirdSetupV6(bgp.NextHopIpv6, bgp.Asn, bgp.HoldTime),
+            mikrotik6 = BuildMikrotikSetupV6(bgp.NextHopIpv6, bgp.Asn, bgp.HoldTime)
         });
     }
 
@@ -749,6 +754,56 @@ public sealed class ManagementApi : IHostedService, IDisposable
         $"/routing/filter/rule/add chain=discard rule=\"reject;\"",
         $"/routing/filter/rule/add chain=bgplite-in rule=\"set gw <YOUR_GW>; accept;\"",
         $"/routing/bgp/connection/add name=bgplite instance=bgplite afi=ip remote.address={routerId}/32 remote.as={asn} local.role=ebgp multihop=yes hold-time={holdTime}s output.filter-chain=discard input.filter=bgplite-in"
+    ];
+
+    /// <summary>
+    /// Cisco IOS peering snippet for the IPv6 address family (#14 phase 5): mirrors
+    /// <see cref="BuildCiscoSetup"/> with <c>address-family ipv6 unicast</c>. Pure.
+    /// </summary>
+    internal static string[] BuildCiscoSetupV6(uint asn) =>
+    [
+        $"router bgp {asn}",
+        $" neighbor <YOUR_IPv6> remote-as {asn}",
+        $" neighbor <YOUR_IPv6> ebgp-multihop 2",
+        $" neighbor <YOUR_IPv6> update-source <YOUR_INTERFACE>",
+        $" neighbor <YOUR_IPv6> soft-reconfiguration inbound",
+        $"!",
+        $"address-family ipv6 unicast",
+        $" neighbor <YOUR_IPv6> activate",
+        $" neighbor <YOUR_IPv6> route-map BGPLite-V6-IN in",
+        $" neighbor <YOUR_IPv6> route-map BGPLite-V6-OUT out",
+        $"exit-address-family"
+    ];
+
+    /// <summary>
+    /// BIRD peering snippet for the IPv6 address family (#14 phase 5): an <c>ipv6</c> channel
+    /// BGPLite announces through when <c>Bgp.NextHopIpv6</c> is configured. Pure.
+    /// </summary>
+    internal static string[] BuildBirdSetupV6(string? serverV6, uint asn, int holdTime) =>
+    [
+        $"# ---------- eBGP IPv6 ----------",
+        $"protocol bgp bgplite6 {{",
+        $"  local as <YOUR_ASN>;",
+        $"  neighbor {serverV6 ?? "<SERVER_V6>"} as {asn};",
+        $"  source address <YOUR_IPv6>;",
+        $"  multihop;",
+        $"  hold time {holdTime};",
+        $"  ipv6 {{",
+        $"    import filter bgplite_in;",
+        $"    export none;",
+        $"    graceful restart on;",
+        $"  }};",
+        $"}}"
+    ];
+
+    /// <summary>
+    /// MikroTik RouterOS v7 peering snippet for the IPv6 address family (#14 phase 5): a second
+    /// connection with <c>afi=ip6</c>. Pure.
+    /// </summary>
+    internal static string[] BuildMikrotikSetupV6(string? serverV6, uint asn, int holdTime) =>
+    [
+        $"# IPv6 transport — apply after the instance/filter lines from the IPv4 snippet.",
+        $"/routing/bgp/connection/add name=bgplite6 instance=bgplite afi=ip6 remote.address={serverV6 ?? "<SERVER_V6>"}/128 remote.as={asn} local.role=ebgp multihop=yes hold-time={holdTime}s output.filter-chain=discard input.filter=bgplite-in"
     ];
 
     #endregion
@@ -1444,7 +1499,12 @@ public sealed class ManagementApi : IHostedService, IDisposable
     {
         if (string.IsNullOrWhiteSpace(ip)) return null;
         if (!IPAddress.TryParse(ip, out var address)) return null;
-        if (address.AddressFamily != AddressFamily.InterNetwork) return null;
+        // IPv4-mapped IPv6 (::ffff:a.b.c.d) names the IPv4 address space — normalize to the
+        // plain IPv4 form so the row matches the address form the dual-mode listener reports.
+        if (address.IsIPv4MappedToIPv6)
+            address = address.MapToIPv4();
+        // Both families are accepted (#14 phase 5): a peer may be an IPv6 host; the canonical
+        // ToString form matches what the accept loop stores.
         return address.ToString();
     }
 

--- a/BGPLite.Protocol/BgpCapabilityInfo.cs
+++ b/BGPLite.Protocol/BgpCapabilityInfo.cs
@@ -34,41 +34,56 @@ public sealed class BgpCapabilityInfo
     };
 
     /// <summary>
-    /// Graceful Restart capability (RFC 4724, code 64) for IPv4/Unicast. Value layout:
-    /// byte 0 = Restart Flags (bit 7 = R) | high 4 bits of Restart Time,
-    /// byte 1 = low 8 bits of Restart Time, then per-AF [AFI(2), SAFI(1), AF Flags(bit 7 = F)].
+    /// Graceful Restart capability (RFC 4724, code 64) with per-family tuples for IPv4/Unicast
+    /// AND IPv6/Unicast (#14 phase 5). Value layout: byte 0 = Restart Flags (bit 7 = R) |
+    /// high 4 bits of Restart Time, byte 1 = low 8 bits of Restart Time, then per-AF
+    /// [AFI(2), SAFI(1), AF Flags(bit 7 = F)].
     /// </summary>
-    public static BgpCapabilityInfo GracefulRestart(bool restartState, ushort restartTime, bool forwardingState)
+    /// <remarks>Note (D6): this capability is deliberately NOT advertised by BGPLite sessions
+    /// while the receiving-speaker half of RFC 4724 §4.2 is unimplemented. The factory and the
+    /// parser are per-family so that enabling advertisement later is a one-line change, and so
+    /// peer payloads carrying IPv6 tuples are understood.</remarks>
+    public static BgpCapabilityInfo GracefulRestart(bool restartState, ushort restartTime, bool ipv4Forwarding, bool ipv6Forwarding = false)
     {
         // RFC 4724 §2.2: Restart Time is a 12-bit field (0..4095). Clamp defensively so no caller
         // can silently truncate an out-of-range value into a wrong on-wire timer.
         var time = Math.Min(restartTime, (ushort)4095);
-        var data = new byte[6];
+        var data = new byte[10];
         data[0] = (byte)((restartState ? BgpConstants.GracefulRestartFlag.RestartState : 0x00) | ((time >> 8) & 0x0F));
         data[1] = (byte)(time & 0xFF);
         data[2] = (byte)(BgpConstants.Afi.IPv4 >> 8);
         data[3] = (byte)BgpConstants.Afi.IPv4;
         data[4] = BgpConstants.Safi.Unicast;
-        data[5] = (byte)(forwardingState ? BgpConstants.GracefulRestartFlag.ForwardingState : 0x00);
+        data[5] = (byte)(ipv4Forwarding ? BgpConstants.GracefulRestartFlag.ForwardingState : 0x00);
+        data[6] = (byte)(BgpConstants.Afi.IPv6 >> 8);
+        data[7] = (byte)BgpConstants.Afi.IPv6;
+        data[8] = BgpConstants.Safi.Unicast;
+        data[9] = (byte)(ipv6Forwarding ? BgpConstants.GracefulRestartFlag.ForwardingState : 0x00);
         return new BgpCapabilityInfo { Code = BgpConstants.Capability.GracefulRestart, Data = data };
     }
 
-    /// <summary>Parses a Graceful Restart capability value. Returns null if malformed.</summary>
-    public static (bool RestartState, ushort RestartTime, bool Ipv4UnicastForwarding)? TryParseGracefulRestart(ReadOnlySpan<byte> data)
+    /// <summary>Parses a Graceful Restart capability value, reporting the Forwarding State of
+    /// each family's tuple. Returns null if malformed. Payloads without an IPv6 tuple (legacy
+    /// v4-only speakers) report <c>Ipv6UnicastForwarding = false</c>.</summary>
+    public static (bool RestartState, ushort RestartTime, bool Ipv4UnicastForwarding, bool Ipv6UnicastForwarding)? TryParseGracefulRestart(ReadOnlySpan<byte> data)
     {
         if (data.Length < 2) return null;
         var restartState = (data[0] & BgpConstants.GracefulRestartFlag.RestartState) != 0;
         var restartTime = (ushort)(((data[0] & 0x0F) << 8) | data[1]);
         var ipv4UnicastForwarding = false;
+        var ipv6UnicastForwarding = false;
         var i = 2;
         while (i + 4 <= data.Length)
         {
             var afi = (ushort)((data[i] << 8) | data[i + 1]);
+            var forwarding = (data[i + 3] & BgpConstants.GracefulRestartFlag.ForwardingState) != 0;
             if (afi == BgpConstants.Afi.IPv4 && data[i + 2] == BgpConstants.Safi.Unicast)
-                ipv4UnicastForwarding |= (data[i + 3] & BgpConstants.GracefulRestartFlag.ForwardingState) != 0;
+                ipv4UnicastForwarding |= forwarding;
+            else if (afi == BgpConstants.Afi.IPv6 && data[i + 2] == BgpConstants.Safi.Unicast)
+                ipv6UnicastForwarding |= forwarding;
             i += 4;
         }
-        return (restartState, restartTime, ipv4UnicastForwarding);
+        return (restartState, restartTime, ipv4UnicastForwarding, ipv6UnicastForwarding);
     }
 
     public uint ReadAsn() => BinaryPrimitives.ReadUInt32BigEndian(Data);

--- a/BGPLite.Protocol/CapabilityHelper.cs
+++ b/BGPLite.Protocol/CapabilityHelper.cs
@@ -58,7 +58,7 @@ public static class CapabilityHelper
     }
 
     /// <summary>Returns the peer's Graceful Restart parameters, or null if not advertised / malformed.</summary>
-    public static (bool RestartState, ushort RestartTime, bool Ipv4UnicastForwarding)? GetGracefulRestart(BgpOpenMessage open)
+    public static (bool RestartState, ushort RestartTime, bool Ipv4UnicastForwarding, bool Ipv6UnicastForwarding)? GetGracefulRestart(BgpOpenMessage open)
     {
         foreach (var cap in open.Capabilities)
         {

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -1427,16 +1427,25 @@ public sealed class BgpSession : IDisposable
     };
 
     /// <summary>
-    /// End-of-RIB marker for IPv4 unicast (RFC 4724 §2): a minimum-length UPDATE (no withdrawn
-    /// routes, no path attributes, no NLRI). Signals completion of the initial routing update so
-    /// GR-capable peers finalize — replacing stale routes with what we re-advertised and purging
-    /// the rest. Lock is acquired inside SendMessageAsync.
+    /// End-of-RIB markers (RFC 4724 §2), one per advertised family: a minimum-length UPDATE for
+    /// IPv4 unicast, and — for MP-IPv6-negotiated peers — an UPDATE carrying an EMPTY
+    /// MP_UNREACH_NLRI (AFI=2/SAFI=1), which is the IPv6 family's EoR. Signals completion of the
+    /// initial routing update so GR-capable peers finalize — replacing stale routes with what we
+    /// re-advertised and purging the rest. Lock is acquired inside SendMessageAsync.
     /// </summary>
     private async Task SendEndOfRibAsync()
     {
         await SendMessageAsync(new BgpUpdateMessage());
         _metrics.UpdateSent();
         _logger.LogDebug("End-of-RIB sent to {Peer}", _peer);
+
+        if (_peerMpIpv6Unicast)
+        {
+            var eor = new BgpUpdateMessage { PathAttributes = UpdateCodec.WithMpUnreachV6Attribute([]) };
+            await SendMessageAsync(eor);
+            _metrics.UpdateSent();
+            _logger.LogDebug("End-of-RIB (IPv6/Unicast) sent to {Peer}", _peer);
+        }
     }
 
     #region Message I/O
@@ -1737,7 +1746,7 @@ public sealed class BgpSession : IDisposable
         _logger.LogInformation("Peer {Peer} Graceful Restart: {State}",
             _peer,
             peerGr.HasValue
-                ? $"supported (restartState={peerGr.Value.RestartState}, restartTime={peerGr.Value.RestartTime}s, IPv4/Unicast forwarding={peerGr.Value.Ipv4UnicastForwarding})"
+                ? $"supported (restartState={peerGr.Value.RestartState}, restartTime={peerGr.Value.RestartTime}s, IPv4/Unicast forwarding={peerGr.Value.Ipv4UnicastForwarding}, IPv6/Unicast forwarding={peerGr.Value.Ipv6UnicastForwarding})"
                 : "not supported");
     }
 

--- a/BGPLite.Tests/BgpSessionV6AdvertiseTests.cs
+++ b/BGPLite.Tests/BgpSessionV6AdvertiseTests.cs
@@ -1,0 +1,238 @@
+using BGPLite.Configuration;
+using BGPLite.Contracts;
+using BGPLite.Protocol;
+using BGPLite.Routing;
+using BGPLite.Server;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #14 phase 4: outbound IPv6 advertisement — the family split at the send path. IPv4 rides
+/// classic NLRI with a NEXT_HOP (RFC 4271 §4.3); IPv6 rides MP_REACH_NLRI with the next hop
+/// inside the attribute (RFC 4760 §5, RFC 2545 §3) and ONLY when the peer negotiated
+/// MP IPv6/Unicast AND Bgp.NextHopIpv6 is configured. Withdrawals mirror the split (RFC 4760 §7).
+/// </summary>
+public class BgpSessionV6AdvertiseTests
+{
+    private static readonly UInt128 V6NextHop = ((UInt128)0x2001 << 112) | ((UInt128)0x0DB8 << 96) | 1;
+    private static readonly UInt128 V6PrefixNet = ((UInt128)0x2001 << 112) | ((UInt128)0x0DB8 << 96);
+
+    private static BgpConfig Config(bool withV6NextHop = true) => new()
+    {
+        Asn = 65001,
+        RouterId = "127.0.0.1",
+        HoldTime = 0,
+        KeepAlive = 0,
+        NextHopIpv6 = withV6NextHop ? "2001:db8::1" : null
+    };
+
+    private static Route V6Route() => new()
+    {
+        Prefix = V6PrefixNet,
+        IsIpv4 = false,
+        PrefixLength = 48,
+        NextHop = V6NextHop
+    };
+
+    private static async Task<(BgpSession Session, Task Run, ScriptedConnection Conn)> EstablishAsync(
+        RouteTable routeTable, BgpConfig? config = null, bool negotiateMpV6 = true)
+    {
+        var conn = new ScriptedConnection();
+        var session = new BgpSession(
+            conn,
+            new PeerConfig { Address = "127.0.0.1" },
+            config ?? Config(),
+            routeTable,
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            NullLogger<BgpSession>.Instance);
+
+        var run = session.RunAsync();
+        var capabilities = new List<BgpCapabilityInfo> { BgpCapabilityInfo.FourOctetAsn(65002) };
+        if (negotiateMpV6)
+            capabilities.Add(BgpCapabilityInfo.MultiprotocolIpv6Unicast());
+        conn.EnqueueMessage(new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = 0,
+            RouterId = 0x0A000002,
+            Capabilities = capabilities
+        });
+        conn.EnqueueMessage(BgpKeepaliveMessage.Instance);
+
+        for (var i = 0; i < 200 && !session.IsEstablished; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        Assert.True(session.IsEstablished, "session must reach Established");
+        return (session, run, conn);
+    }
+
+    private static async Task TeardownAsync(BgpSession session, Task run)
+    {
+        session.Dispose();
+        try { await run.WaitAsync(TimeSpan.FromSeconds(2)); } catch (TimeoutException) { }
+    }
+
+    /// <summary>All UPDATEs the session put on the wire, polled until the expected frame shows
+    /// up (the initial dump runs concurrently with the test thread).</summary>
+    private static async Task<List<BgpUpdateMessage>> SentUpdatesAsync(ScriptedConnection conn, Func<BgpUpdateMessage, bool> until)
+    {
+        var updates = new List<BgpUpdateMessage>();
+        for (var i = 0; i < 200; i++)
+        {
+            updates.Clear();
+            foreach (var frame in conn.Sent)
+                if (BgpMessageReader.ReadMessage(frame) is BgpUpdateMessage u)
+                    updates.Add(u);
+            if (updates.Any(until)) break;
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        }
+        return updates;
+    }
+
+    [Fact]
+    public async Task Negotiated_WithNextHop_V6RoutesRideMpReach()
+    {
+        var routeTable = new RouteTable();
+        routeTable.AddOrUpdate(V6Route());                       // unowned seed → shared-table dump
+        routeTable.AddOrUpdate(new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 1 });
+
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        var updates = await SentUpdatesAsync(conn, u => u.MpReachV6 is not null);
+        var v6Update = Assert.Single(updates, u => u.MpReachV6 is not null);
+        Assert.Equal(V6NextHop, v6Update.MpReachV6!.Value.NextHop);
+        var pfx = Assert.Single(v6Update.MpReachV6!.Value.Prefixes);
+        Assert.Equal((V6PrefixNet, (byte)48), (pfx.Address, pfx.Length));
+        // RFC 4760 §5: the MP_REACH UPDATE carries no classic NLRI and no classic NEXT_HOP.
+        Assert.Empty(v6Update.Nlri);
+        Assert.DoesNotContain(v6Update.PathAttributes, a => a.TypeCode == BgpConstants.Attribute.NextHop);
+        // ...while the IPv4 route still rides the classic path.
+        Assert.Contains(updates, u => u.Nlri.Any(p => p.Address == 0x0A000000 && p.Length == 8));
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task V6Announcement_IsRoundTrippable_ByTheRealReader()
+    {
+        // The wire shape must survive our own reader: AFI/SAFI 2/1, global next hop, prefixes.
+        var routeTable = new RouteTable();
+        routeTable.AddOrUpdate(V6Route());
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        var mp = Assert.Single(await SentUpdatesAsync(conn, u => u.MpReachV6 is not null), u => u.MpReachV6 is not null).MpReachV6!.Value;
+        var value = MpReachCodec.EncodeMpReachV6(mp.NextHop, mp.Prefixes);
+        var decoded = MpReachCodec.DecodeMpReachV6(value);
+        Assert.Equal(V6NextHop, decoded.NextHop);
+        Assert.Equal(48, Assert.Single(decoded.Prefixes).Length);
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task NoNegotiation_V6RoutesSuppressed_Ipv4Untouched()
+    {
+        var routeTable = new RouteTable();
+        routeTable.AddOrUpdate(V6Route());
+        routeTable.AddOrUpdate(new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 1 });
+
+        var (session, run, conn) = await EstablishAsync(routeTable, negotiateMpV6: false);
+
+        var updates = await SentUpdatesAsync(conn, u => u.Nlri.Any(p => p.Address == 0x0A000000));
+        Assert.DoesNotContain(updates, u => u.MpReachV6 is not null);
+        Assert.DoesNotContain(updates, u => u.Nlri.Any(p => !p.IsIpv4));
+        Assert.Contains(updates, u => u.Nlri.Any(p => p.Address == 0x0A000000)); // v4 unaffected
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task NoConfiguredNextHop_V6RoutesSuppressed()
+    {
+        var routeTable = new RouteTable();
+        routeTable.AddOrUpdate(V6Route());
+
+        var (session, run, conn) = await EstablishAsync(routeTable, config: Config(withV6NextHop: false));
+
+        // The End-of-RIB empty UPDATE always follows Established, so "any UPDATE seen" is the
+        // reachable condition; the assertion is that none of them carries MP_REACH.
+        Assert.DoesNotContain(await SentUpdatesAsync(conn, u => u.Nlri.Count == 0 && u.WithdrawnRoutes.Count == 0), u => u.MpReachV6 is not null);
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task Withdrawal_V6PrefixesRideMpUnreach_OnTheWire()
+    {
+        // The refresh cycle withdraws EVERYTHING it advertised, then re-sends. After the table
+        // is drained the withdrawal pass must split by family: the v4 seed via the classic
+        // withdrawn field, the v6 seed via an MP_UNREACH-only UPDATE (RFC 4760 §7).
+        var routeTable = new RouteTable();
+        routeTable.AddOrUpdate(V6Route());
+        routeTable.AddOrUpdate(new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 1 });
+
+        var (session, run, conn) = await EstablishAsync(routeTable);
+        // Let the initial dump finish (its MP_REACH UPDATE is the completion signal) — a refresh
+        // racing the dump would withdraw a half-filled mirror and prove nothing.
+        await SentUpdatesAsync(conn, u => u.MpReachV6 is not null);
+        await session.RefreshRoutesAsync(); // withdraw-all + resend against the same table
+
+        var updates = await SentUpdatesAsync(conn, u => u.MpUnreachV6 is { Count: > 0 });
+        Assert.True(updates.Any(u => u.MpUnreachV6 is { Count: > 0 }),
+            "no MP_UNREACH UPDATE on the wire; sent updates: " +
+            string.Join("; ", updates.Select(u =>
+                $"Wd={u.WithdrawnRoutes.Count} Nlri={u.Nlri.Count} Reach={(u.MpReachV6 is null ? "-" : u.MpReachV6.Value.Prefixes.Count.ToString())} Unreach={u.MpUnreachV6?.Count.ToString() ?? "-"}")));
+        var mpUnreach = Assert.Single(updates, u => u.MpUnreachV6 is { Count: > 0 });
+        Assert.Empty(mpUnreach.WithdrawnRoutes);                          // v6 never rides the classic field
+        // (the reader moves the type-15 attribute into MpUnreachV6, so PathAttributes is empty here)
+        var withdrawn = Assert.Single(mpUnreach.MpUnreachV6!);
+        Assert.Equal((V6PrefixNet, (byte)48), (withdrawn.Address, withdrawn.Length));
+        // ...and the v4 seed's withdrawal still rides the classic withdrawn field.
+        Assert.Contains(updates, u => u.WithdrawnRoutes.Any(w => w.Address == 0x0A000000 && w.Length == 8));
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task EndOfRib_Ipv6Family_SentAfterInitialDump()
+    {
+        // RFC 4724 §2: End-of-RIB per AFI. The IPv6 EoR is an UPDATE carrying an EMPTY
+        // MP_UNREACH_NLRI (AFI=2/SAFI=1) — sent after the initial dump to MP-IPv6 peers.
+        var routeTable = new RouteTable();
+        routeTable.AddOrUpdate(V6Route());
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        var eor = await SentUpdatesAsync(conn, u => u.MpUnreachV6 is { Count: 0 });
+        var mpEor = Assert.Single(eor, u => u.MpUnreachV6 is { Count: 0 });
+        Assert.Empty(mpEor.Nlri);
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public void MpUnreachAttribute_IsOptionalNonTransitive()
+    {
+        var attr = UpdateCodec.WithMpUnreachV6Attribute([new IpPrefix(V6PrefixNet, 48, isIpv4: false)]).Single();
+        Assert.Equal(MpReachCodec.MpUnreachNlriType, attr.TypeCode);
+        Assert.True(attr.Optional);
+        Assert.False(attr.Transitive);
+        Assert.True(MpReachCodec.DecodeMpUnreachV6(attr.Data).Single().IsIpv4 == false);
+    }
+
+    [Fact]
+    public void NextHopIpv6_Validation()
+    {
+        // Global unicast (2000::/3) is accepted; link-local, ULA, multicast, mapped and garbage
+        // are rejected with a message that names the knob.
+        new BgpConfig { Asn = 65001, RouterId = "1.2.3.4", NextHopIpv6 = "2001:db8::1" }.Validate();
+
+        foreach (var bad in new[] { "fe80::1", "fc00::1", "ff02::1", "::ffff:192.0.2.1", "2001:db8::1/48", "1.2.3.4", "not-an-address" })
+        {
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => new BgpConfig { Asn = 65001, RouterId = "1.2.3.4", NextHopIpv6 = bad }.Validate());
+            Assert.Contains("NextHopIpv6", ex.Message);
+        }
+    }
+}

--- a/BGPLite.Tests/GracefulRestartTests.cs
+++ b/BGPLite.Tests/GracefulRestartTests.cs
@@ -12,22 +12,30 @@ public class GracefulRestartTests
         //   byte0 = 0x80 (R) | 0x01 (high nibble of 0x1FF) = 0x81
         //   byte1 = 0xFF (low byte of 0x1FF)
         //   IPv4(0x00,0x01) + Unicast(0x01) + AF flags 0x80 (F)
-        var cap = BgpCapabilityInfo.GracefulRestart(restartState: true, restartTime: 0x1FF, forwardingState: true);
+        //   IPv6(0x00,0x02) + Unicast(0x01) + AF flags 0x80 (F)
+        var cap = BgpCapabilityInfo.GracefulRestart(restartState: true, restartTime: 0x1FF, ipv4Forwarding: true, ipv6Forwarding: true);
 
         Assert.Equal(BgpConstants.Capability.GracefulRestart, cap.Code);
-        Assert.Equal(new byte[] { 0x81, 0xFF, 0x00, 0x01, 0x01, 0x80 }, cap.Data);
+        Assert.Equal(new byte[] { 0x81, 0xFF, 0x00, 0x01, 0x01, 0x80, 0x00, 0x02, 0x01, 0x80 }, cap.Data);
+
+        // A legacy v4-only payload (one tuple, no IPv6) still parses — v6 forwarding = false.
+        var legacy = BgpCapabilityInfo.TryParseGracefulRestart(new byte[] { 0x81, 0xFF, 0x00, 0x01, 0x01, 0x80 });
+        Assert.NotNull(legacy);
+        Assert.True(legacy!.Value.Ipv4UnicastForwarding);
+        Assert.False(legacy.Value.Ipv6UnicastForwarding);
     }
 
     [Fact]
     public void Capability_RoundTrips_Through_Parser()
     {
-        var cap = BgpCapabilityInfo.GracefulRestart(true, 120, true);
+        var cap = BgpCapabilityInfo.GracefulRestart(true, 120, true, ipv6Forwarding: true);
         var parsed = BgpCapabilityInfo.TryParseGracefulRestart(cap.Data);
 
         Assert.NotNull(parsed);
         Assert.True(parsed!.Value.RestartState);
         Assert.Equal((ushort)120, parsed.Value.RestartTime);
         Assert.True(parsed.Value.Ipv4UnicastForwarding);
+        Assert.True(parsed.Value.Ipv6UnicastForwarding);
     }
 
     [Fact]
@@ -41,7 +49,8 @@ public class GracefulRestartTests
         Assert.Equal((ushort)60, parsed.Value.RestartTime);
         Assert.False(parsed.Value.Ipv4UnicastForwarding);
         Assert.Equal(0x00, cap.Data[0]);   // no R, no high time bits
-        Assert.Equal(0x00, cap.Data[5]);   // no F
+        Assert.Equal(0x00, cap.Data[5]);   // no IPv4 F
+        Assert.Equal(0x00, cap.Data[9]);   // no IPv6 F
     }
 
     [Fact]
@@ -100,7 +109,7 @@ public class GracefulRestartTests
             Capabilities =
             [
                 BgpCapabilityInfo.FourOctetAsn(65001),
-                BgpCapabilityInfo.GracefulRestart(true, 120, true)
+                BgpCapabilityInfo.GracefulRestart(true, 120, true, ipv6Forwarding: false)
             ]
         };
 

--- a/BGPLite.Tests/PeerInputValidationTests.cs
+++ b/BGPLite.Tests/PeerInputValidationTests.cs
@@ -47,8 +47,6 @@ public class PeerInputValidationTests
     [InlineData(" 1.2.3.4")]
     [InlineData("banana")]
     [InlineData("1.2.3.4.5")]
-    [InlineData("2001:db8::1")]
-    [InlineData("::ffff:1.2.3.4")]
     public void NormalizePeerIp_RejectsUnusableInput(string? input)
     {
         Assert.Null(ManagementApi.NormalizePeerIp(input));

--- a/BGPLite.Tests/PeerSetupTemplateTests.cs
+++ b/BGPLite.Tests/PeerSetupTemplateTests.cs
@@ -1,0 +1,86 @@
+using BGPLite.Api;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #14 phase 5: peer-setup templates gain IPv6 address-family variants. Peers may be IPv6 hosts
+/// (validated at the API boundary), and the peer side needs its own address-family blocks to
+/// exchange IPv6 routes with the server.
+/// </summary>
+public class PeerSetupTemplateTests
+{
+    [Fact]
+    public void CiscoSetupV6_CarriesIpv6AddressFamily()
+    {
+        var lines = ManagementApi.BuildCiscoSetupV6(65001);
+        Assert.Contains(lines, l => l.Trim() == "address-family ipv6 unicast");
+        Assert.Contains(lines, l => l.Contains("neighbor <YOUR_IPv6> activate"));
+        Assert.Contains(lines, l => l.Contains("remote-as 65001"));
+    }
+
+    [Fact]
+    public void BirdSetupV6_CarriesIpv6Channel()
+    {
+        var lines = ManagementApi.BuildBirdSetupV6("2001:db8:cccc::10", 65001, 90);
+        Assert.Contains(lines, l => l.Trim() == "ipv6 {");
+        Assert.Contains(lines, l => l.Contains("neighbor 2001:db8:cccc::10 as 65001"));
+        Assert.Contains(lines, l => l.Contains("hold time 90;"));
+    }
+
+    [Fact]
+    public void BirdSetupV6_UnconfiguredServer_UsesPlaceholder()
+    {
+        var lines = ManagementApi.BuildBirdSetupV6(null, 65001, 90);
+        Assert.Contains(lines, l => l.Contains("neighbor <SERVER_V6> as 65001"));
+    }
+
+    [Fact]
+    public void MikrotikSetupV6_CarriesAfiIp6()
+    {
+        var lines = ManagementApi.BuildMikrotikSetupV6("2001:db8:cccc::10", 65001, 90);
+        Assert.Contains(lines, l => l.Contains("afi=ip6"));
+        Assert.Contains(lines, l => l.Contains("remote.address=2001:db8:cccc::10/128"));
+        Assert.Contains(lines, l => l.Contains("remote.as=65001"));
+    }
+
+    [Fact]
+    public void MikrotikSetupV6_UnconfiguredServer_UsesPlaceholder()
+    {
+        var lines = ManagementApi.BuildMikrotikSetupV6(null, 65001, 90);
+        Assert.Contains(lines, l => l.Contains("remote.address=<SERVER_V6>/128"));
+    }
+
+    // ---- NormalizePeerIp: peers may be IPv6 (#14 phase 5) ----
+
+    [Fact]
+    public void NormalizePeerIp_Ipv6_AcceptedAndCanonical()
+    {
+        Assert.Equal("2001:db8:cccc::20", ManagementApi.NormalizePeerIp("2001:db8:cccc:0:0:0:0:20"));
+        Assert.Equal("::1", ManagementApi.NormalizePeerIp("::1"));
+    }
+
+    [Fact]
+    public void NormalizePeerIp_MappedIpv6_NormalizesToPlainIpv4()
+    {
+        // A mapped literal names the IPv4 address space — the row must match the address form
+        // the dual-mode listener reports.
+        Assert.Equal("10.0.0.1", ManagementApi.NormalizePeerIp("::ffff:10.0.0.1"));
+    }
+
+    [Fact]
+    public void NormalizePeerIp_Ipv4_StillAccepted()
+    {
+        Assert.Equal("192.168.1.2", ManagementApi.NormalizePeerIp("192.168.1.2"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    [InlineData("not-an-address")]
+    [InlineData("2001:db8::1/48")] // a prefix is not a host address
+    public void NormalizePeerIp_Garbage_ReturnsNull(string? ip)
+    {
+        Assert.Null(ManagementApi.NormalizePeerIp(ip));
+    }
+}

--- a/docker/integration/run-tests.sh
+++ b/docker/integration/run-tests.sh
@@ -85,6 +85,12 @@ echo "$CREATE_RESP" | sed '$d' > "$TMP/create-peer.json"
 grep -q '"error"' "$TMP/create-peer.json" && fail "POST /api/peers rejected: $(cat "$TMP/create-peer.json")"
 echo "created: $(cat "$TMP/create-peer.json")"
 
+# The IPv6-transport peer is registered too — the API accepts IPv6 peers (#14 phase 5).
+V6_BODY='{"ip":"2001:db8:cccc::20","asn":65002,"description":"integration-bird-v6"}'
+V6_STATUS=$(api_post "$API/api/peers" "$V6_BODY" | tail -1)
+[ "$V6_STATUS" = "200" ] || fail "IPv6 peer registration returned $V6_STATUS"
+echo "v6 peer registered: $V6_STATUS"
+
 $COMPOSE up -d bird
 
 # --- 3. both sessions Established ----------------------------------------------

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -62,7 +62,9 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
   End-of-RIB) is not implemented, and advertising the `<AFI=1, SAFI=1, F>` tuple promised behavior
   the code does not have. The sending-side conveniences gated on the `GracefulRestart` config are
   unchanged: an End-of-RIB marker after the initial route dump, and the GR-aware silent close on
-  server shutdown (`StopAsync`).
+  server shutdown (`StopAsync`). #14 phase 5 made the factory/parser per-family (IPv4/Unicast AND
+  IPv6/Unicast tuples) and added the IPv6-family End-of-RIB (empty MP_UNREACH, RFC 4724 §2) for
+  MP-IPv6-negotiated peers; the advertisement itself remains off until retention exists.
 - **Context:** the capability was previously advertised by default while routes of a
   silently-disconnecting peer were flushed immediately (`RemoveAllOwnedBy`, #314) — a wire promise
   the code did not honor. RFC 4724 §4.2's MUST binds a speaker to the procedures it engages;


### PR DESCRIPTION
Closes #14   # linkage only — the integration PR aggregates the keywords that actually close issues

## Problem
Epic #14 phase 5 (final phase): peer-setup templates had no IPv6 address-family variants, the GR capability factory/parser were IPv4-only, and the management API rejected IPv6 peer addresses — so an IPv6-transport peer could connect but could never be registered.

## Fix
- **Templates**: `/api/server` gains `setup6`/`bird6`/`mikrotik6` — Cisco `address-family ipv6 unicast`, BIRD `ipv6 {}` channel, MikroTik `afi=ip6` connection. Pure builders mirroring the v4 ones; `<SERVER_V6>` placeholder resolves to `Bgp.NextHopIpv6` when configured.
- **Graceful Restart per-AFI**: the capability factory emits IPv4/Unicast AND IPv6/Unicast tuples (RFC 4724 §2, 10-byte value); the parser reports both forwarding flags, legacy v4-only payloads parse with `v6=false`. The capability itself remains UNADVERTISED per D6 (receiving-speaker retention unimplemented) — noted in the doc comment. New: IPv6-family End-of-RIB (empty MP_UNREACH_NLRI, RFC 4724 §2) sent to MP-IPv6-negotiated peers after the initial dump.
- **IPv6 peer validation**: `NormalizePeerIp` accepts IPv6 peers (canonical form) and normalizes IPv4-mapped literals to plain IPv4 — matching the dual-mode listener's address form exactly.

## Correctness
EoR v6 is gated on MP-IPv6 negotiation and sent after the initial dump inside the advertised-prefixes lock; empty MP_UNREACH (AFI=2/SAFI=1) is the per-family EoR per RFC 4724 §2. Mapped-normalization is symmetric with the accept loop, so API-created rows always match session addresses.

## Regression Test
New: `PeerSetupTemplateTests` (6), EoR-IPv6 wire test, MP_UNREACH attribute flags test, GR per-AFI layout/legacy-payload tests, NormalizePeerIp v6/mapped/garbage cases. Updated: GR exact-byte-layout test (two tuples).

## Verification
- `dotnet format` / `dotnet build` (0 warnings) / `dotnet test` — **1007/1007** (baseline 995)
- Integration stand: IPv6-transport peer registered via the API (200), all assertions green — ALL INTEGRATION TESTS PASSED
- reviewer subagent pass: 1 MINOR (empty stray test file) fixed; wire/GR logic confirmed correct

## RFC
RFC 4724 §2 (per-AFI End-of-RIB, GR capability tuples), RFC 2545 §3 (consistent with 4b next-hop policy).

## Behavior Change
`/api/server` response gains three new keys (additive). The API now accepts IPv6 peer addresses. IPv4-only deployments: nothing changes.

## Deviation from Issue Proposal
None — implements the remaining phase-5 checklist items. Note: the GR capability advertisement stays OFF per D6; phase 5 delivered the per-AFI factory/parser/EOF plumbing only.