### PR TITLE
chore: integrate dev — IPv6 epic #14 phases 3-5 + integration stand (#405-#412)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,28 @@
+name: integration
+
+# End-to-end BGP tests: a real BGPLite server vs a real BIRD2 peer over
+# IPv4 and IPv6 transport (docker/integration). Complements the unit suite —
+# this is what catches kernel/transport-level issues (e.g. #406's TCP_MD5SIG
+# sockaddr family bug, which unit tests could not see).
+on:
+  workflow_dispatch:
+  push:
+    branches: [main, dev]
+
+permissions:
+  contents: read
+
+jobs:
+  compose-integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run BGP integration tests (linux64)
+        run: docker/integration/run-tests.sh
+
+      - name: Server logs on failure
+        if: failure()
+        run: |
+          docker compose -f docker/integration/docker-compose.yml logs server bird || true

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ logs/
 
 ## Claude Code local handoff notes
 .handoff/
+
+## Integration stand packet captures (docker/integration --capture)
+docker/integration/captures/

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -1211,8 +1211,8 @@ public sealed class ManagementApi : IHostedService, IDisposable
             try
             {
                 var fetched = await _prefixService.GetPrefixesForAsns(asns, ct);
-                foreach (var (prefix, length, _) in fetched)
-                    prefixes.Add($"{BgpConstants.UintToIPAddress(prefix)}/{length}");
+                foreach (var p in fetched)
+                    prefixes.Add(new IpPrefix(p.Prefix, p.Length, p.IsIpv4).ToString());
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#337: only shutdown cancellation — a provider-timeout OCE (live token) is a fetch failure below
             catch (Exception ex) { _logger.LogWarning(ex, "CollectPeerPrefixes: ASN fetch failed"); }
@@ -1224,8 +1224,8 @@ public sealed class ManagementApi : IHostedService, IDisposable
             try
             {
                 var ruPrefixes = await _prefixService.GetRuPrefixesAsync(ct);
-                foreach (var (prefix, length, _) in ruPrefixes)
-                    prefixes.Add($"{BgpConstants.UintToIPAddress(prefix)}/{length}");
+                foreach (var p in ruPrefixes)
+                    prefixes.Add(new IpPrefix(p.Prefix, p.Length, p.IsIpv4).ToString());
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#337: only shutdown cancellation — a provider-timeout OCE (live token) is a fetch failure below
             catch (Exception ex) { _logger.LogWarning(ex, "CollectPeerPrefixes: RU prefix fetch failed"); }

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -685,7 +685,12 @@ public sealed class ManagementApi : IHostedService, IDisposable
             keepalive = bgp.KeepAlive,
             setup = BuildCiscoSetup(bgp.Asn),
             bird = BuildBirdSetup(bgp.RouterId, bgp.Asn, bgp.HoldTime),
-            mikrotik = BuildMikrotikSetup(bgp.RouterId, bgp.Asn, bgp.HoldTime)
+            mikrotik = BuildMikrotikSetup(bgp.RouterId, bgp.Asn, bgp.HoldTime),
+            // IPv6 address-family variants (#14 phase 5): the peer side needs them to exchange
+            // IPv6 routes. <SERVER_V6> placeholders resolve to Bgp.NextHopIpv6 when configured.
+            setup6 = BuildCiscoSetupV6(bgp.Asn),
+            bird6 = BuildBirdSetupV6(bgp.NextHopIpv6, bgp.Asn, bgp.HoldTime),
+            mikrotik6 = BuildMikrotikSetupV6(bgp.NextHopIpv6, bgp.Asn, bgp.HoldTime)
         });
     }
 
@@ -749,6 +754,56 @@ public sealed class ManagementApi : IHostedService, IDisposable
         $"/routing/filter/rule/add chain=discard rule=\"reject;\"",
         $"/routing/filter/rule/add chain=bgplite-in rule=\"set gw <YOUR_GW>; accept;\"",
         $"/routing/bgp/connection/add name=bgplite instance=bgplite afi=ip remote.address={routerId}/32 remote.as={asn} local.role=ebgp multihop=yes hold-time={holdTime}s output.filter-chain=discard input.filter=bgplite-in"
+    ];
+
+    /// <summary>
+    /// Cisco IOS peering snippet for the IPv6 address family (#14 phase 5): mirrors
+    /// <see cref="BuildCiscoSetup"/> with <c>address-family ipv6 unicast</c>. Pure.
+    /// </summary>
+    internal static string[] BuildCiscoSetupV6(uint asn) =>
+    [
+        $"router bgp {asn}",
+        $" neighbor <YOUR_IPv6> remote-as {asn}",
+        $" neighbor <YOUR_IPv6> ebgp-multihop 2",
+        $" neighbor <YOUR_IPv6> update-source <YOUR_INTERFACE>",
+        $" neighbor <YOUR_IPv6> soft-reconfiguration inbound",
+        $"!",
+        $"address-family ipv6 unicast",
+        $" neighbor <YOUR_IPv6> activate",
+        $" neighbor <YOUR_IPv6> route-map BGPLite-V6-IN in",
+        $" neighbor <YOUR_IPv6> route-map BGPLite-V6-OUT out",
+        $"exit-address-family"
+    ];
+
+    /// <summary>
+    /// BIRD peering snippet for the IPv6 address family (#14 phase 5): an <c>ipv6</c> channel
+    /// BGPLite announces through when <c>Bgp.NextHopIpv6</c> is configured. Pure.
+    /// </summary>
+    internal static string[] BuildBirdSetupV6(string? serverV6, uint asn, int holdTime) =>
+    [
+        $"# ---------- eBGP IPv6 ----------",
+        $"protocol bgp bgplite6 {{",
+        $"  local as <YOUR_ASN>;",
+        $"  neighbor {serverV6 ?? "<SERVER_V6>"} as {asn};",
+        $"  source address <YOUR_IPv6>;",
+        $"  multihop;",
+        $"  hold time {holdTime};",
+        $"  ipv6 {{",
+        $"    import filter bgplite_in;",
+        $"    export none;",
+        $"    graceful restart on;",
+        $"  }};",
+        $"}}"
+    ];
+
+    /// <summary>
+    /// MikroTik RouterOS v7 peering snippet for the IPv6 address family (#14 phase 5): a second
+    /// connection with <c>afi=ip6</c>. Pure.
+    /// </summary>
+    internal static string[] BuildMikrotikSetupV6(string? serverV6, uint asn, int holdTime) =>
+    [
+        $"# IPv6 transport — apply after the instance/filter lines from the IPv4 snippet.",
+        $"/routing/bgp/connection/add name=bgplite6 instance=bgplite afi=ip6 remote.address={serverV6 ?? "<SERVER_V6>"}/128 remote.as={asn} local.role=ebgp multihop=yes hold-time={holdTime}s output.filter-chain=discard input.filter=bgplite-in"
     ];
 
     #endregion
@@ -1444,7 +1499,12 @@ public sealed class ManagementApi : IHostedService, IDisposable
     {
         if (string.IsNullOrWhiteSpace(ip)) return null;
         if (!IPAddress.TryParse(ip, out var address)) return null;
-        if (address.AddressFamily != AddressFamily.InterNetwork) return null;
+        // IPv4-mapped IPv6 (::ffff:a.b.c.d) names the IPv4 address space — normalize to the
+        // plain IPv4 form so the row matches the address form the dual-mode listener reports.
+        if (address.IsIPv4MappedToIPv6)
+            address = address.MapToIPv4();
+        // Both families are accepted (#14 phase 5): a peer may be an IPv6 host; the canonical
+        // ToString form matches what the accept loop stores.
         return address.ToString();
     }
 

--- a/BGPLite.Configuration/BgpConfig.cs
+++ b/BGPLite.Configuration/BgpConfig.cs
@@ -12,6 +12,29 @@ public sealed class BgpConfig
     [YamlMember(Alias = "RouterId")]
     public string RouterId { get; init; } = "0.0.0.0";
 
+    /// <summary>
+    /// Optional global IPv6 next hop advertised to MP-BGP IPv6/Unicast peers (#14 phase 4,
+    /// RFC 2545 §3: the MP_REACH next hop is the speaker's GLOBAL address — the IPv4 router-id
+    /// cannot serve the IPv6 address family). Unset = IPv6 routes are never advertised to any
+    /// peer (suppressed with a warning per send); set = each MP-IPv6-negotiated session
+    /// announces its IPv6 routes with this next hop.
+    /// </summary>
+    [YamlMember(Alias = "NextHopIpv6")]
+    public string? NextHopIpv6 { get; init; }
+
+    /// <summary>
+    /// Whether <paramref name="value"/> parses as a GLOBAL IPv6 unicast address (2000::/3) —
+    /// the RFC 2545 §3 requirement for the MP_REACH next hop. Shared by <see cref="Validate"/>
+    /// and the session's send-time gate (a hand-built config record skips Validate, so the gate
+    /// must not trust the string blindly).
+    /// </summary>
+    public static bool IsGlobalUnicastV6([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] string? value) =>
+        IPAddress.TryParse(value, out var v6)
+        && v6.AddressFamily == AddressFamily.InterNetworkV6
+        && !v6.IsIPv4MappedToIPv6
+        && v6.ScopeId == 0
+        && (v6.GetAddressBytes()[0] & 0xE0) == 0x20; // 2000::/3
+
     [YamlMember(Alias = "KeepAlive")]
     public int KeepAlive { get; init; } = 60;
 
@@ -129,5 +152,22 @@ public sealed class BgpConfig
         if (MaxPrefixesPerPeer < 0)
             throw new InvalidOperationException(
                 $"Invalid configuration: Bgp.MaxPrefixesPerPeer must be >= 0, 0 = unlimited (got {MaxPrefixesPerPeer}).");
+
+        // #14 phase 4: when an IPv6 next hop is configured it must be a GLOBAL IPv6 unicast
+        // address — RFC 2545 §3 requires the (first) MP_REACH next hop to be global, and the
+        // 16-byte form we advertise has no room for interface semantics (a link-local address
+        // is only meaningful on a shared link, which a route-server session is not required to
+        // be). Global unicast space is 2000::/3 — that single check also rejects the unspecified
+        // address, loopback (::1), link-local (fe80::/10), ULA (fc00::/7) and multicast (ff00::/8).
+        // Unset stays legal: it simply disables IPv6 advertisements (fail-visible at send time),
+        // never a startup failure for IPv4-only deployments.
+        if (!string.IsNullOrWhiteSpace(NextHopIpv6))
+        {
+            if (!IsGlobalUnicastV6(NextHopIpv6))
+                throw new InvalidOperationException(
+                    "Invalid configuration: Bgp.NextHopIpv6 must be a global unicast IPv6 address (2000::/3 — " +
+                    $"not link-local, multicast, ULA or mapped) when set (got '{NextHopIpv6}'). " +
+                    "Leave it unset to disable IPv6 advertisements.");
+        }
     }
 }

--- a/BGPLite.Contracts/BGPLite.Contracts.csproj
+++ b/BGPLite.Contracts/BGPLite.Contracts.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="BGPLite.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/BGPLite.Contracts/IPrefixService.cs
+++ b/BGPLite.Contracts/IPrefixService.cs
@@ -5,14 +5,21 @@ namespace BGPLite.Contracts;
 /// concrete <c>PrefixService</c> implementation (BGPLite.Providers, a data layer) can implement it
 /// without depending upward on BGPLite.Server — Server (the consumer) depends on this contract,
 /// giving the dependency direction Server→Configuration←Providers as peers (#88).
+/// <para>
+/// Prefixes are family-tagged tuples <c>(UInt128 Prefix, byte Length, bool IsIpv4)</c> (#14
+/// phase 4) — the same layout as <c>Route.Key</c>. IPv4 addresses live in the LOW 32 bits of
+/// <c>Prefix</c> with <c>IsIpv4 = true</c>; IPv6 uses the full 128 bits. (The tuple carries the
+/// family instead of the Protocol layer's <c>IpPrefix</c> type because Contracts is a
+/// dependency-free leaf.)
+/// </para>
 /// </summary>
 public interface IPrefixService
 {
-    Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default);
-    Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default);
+    Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetPrefixesAsync(uint asn, CancellationToken ct = default);
+    Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default);
     Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default);
-    Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default);
-    Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default);
+    Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default);
     /// <summary>
     /// Fetches a per-peer user-supplied URL prefix-list source (epic #143 / issue #147). Unlike
     /// <see cref="GetSourcePrefixesAsync"/> (named, config-keyed, cache-through), this loads an
@@ -20,6 +27,6 @@ public interface IPrefixService
     /// <c>AppConfig.PrefixSources</c>, so it is not name-resolvable and not cached. SSRF defense
     /// (#144) is inherited from the http named client's <c>ConnectCallback</c>.
     /// </summary>
-    Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default);
+    Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default);
     Task WarmUpAsync(CancellationToken ct = default);
 }

--- a/BGPLite.Contracts/TcpMd5.cs
+++ b/BGPLite.Contracts/TcpMd5.cs
@@ -98,26 +98,39 @@ public static class TcpMd5
         return buffer;
     }
 
-    /// <summary>Writes a sockaddr_storage-shaped sockaddr_in/inn6 for the peer, port 0 = "any port".</summary>
-    private static void WriteSockaddr(IPEndPoint peer, Span<byte> destination)
+    /// <summary>Writes a sockaddr_storage-shaped sockaddr_in/inn6 for the peer, port 0 = "any port".
+    /// <para>
+    /// The address family constants are the KERNEL's, not .NET's <see cref="AddressFamily"/> values
+    /// (which follow Winsock: InterNetworkV6 = 23). Linux wants AF_INET6 = 10, Darwin 28 — writing
+    /// 23 makes the kernel's md5 parse path reject the entry with EINVAL
+    /// (<c>sin6_family != AF_INET6</c>), which no v4 test could catch because AF_INET = 2 happens
+    /// to agree everywhere. The accepted-socket runtime checks are the OS guard: TCP-MD5 is only
+    /// ever applied on Linux/macOS.
+    /// </para>
+    /// </summary>
+    internal static void WriteSockaddr(IPEndPoint peer, Span<byte> destination)
     {
         destination.Clear();
         var port = (ushort)peer.Port;
         if (peer.Address.AddressFamily == AddressFamily.InterNetwork)
         {
-            destination[0] = (byte)AddressFamily.InterNetwork;        // AF_INET (little-endian host order)
+            destination[0] = AfInet;                                  // AF_INET: 2 on Linux and Darwin
             destination[2] = (byte)(port >> 8);                       // port, network byte order
             destination[3] = (byte)port;
             peer.Address.TryWriteBytes(destination.Slice(4, 4), out _);
         }
         else
         {
-            destination[0] = (byte)AddressFamily.InterNetworkV6;      // AF_INET6
+            destination[0] = AfInet6;                                 // AF_INET6: 10 (Linux) / 28 (Darwin)
             destination[2] = (byte)(port >> 8);
             destination[3] = (byte)port;
             peer.Address.TryWriteBytes(destination.Slice(8, 16), out _);
         }
     }
+
+    private static byte AfInet => 2;
+
+    private static byte AfInet6 => OperatingSystem.IsMacOS() ? (byte)28 : (byte)10;
 
     /// <summary>True when <paramref name="password"/> would be accepted as a TCP-MD5 key.</summary>
     public static bool IsValidPassword(string? password) =>

--- a/BGPLite.Contracts/TcpMd5.cs
+++ b/BGPLite.Contracts/TcpMd5.cs
@@ -100,28 +100,39 @@ public static class TcpMd5
 
     /// <summary>Writes a sockaddr_storage-shaped sockaddr_in/inn6 for the peer, port 0 = "any port".
     /// <para>
-    /// The address family constants are the KERNEL's, not .NET's <see cref="AddressFamily"/> values
-    /// (which follow Winsock: InterNetworkV6 = 23). Linux wants AF_INET6 = 10, Darwin 28 — writing
-    /// 23 makes the kernel's md5 parse path reject the entry with EINVAL
-    /// (<c>sin6_family != AF_INET6</c>), which no v4 test could catch because AF_INET = 2 happens
-    /// to agree everywhere. The accepted-socket runtime checks are the OS guard: TCP-MD5 is only
-    /// ever applied on Linux/macOS.
+    /// Two per-OS differences live here:
+    /// <list type="bullet">
+    /// <item><b>Address family constants are the KERNEL's</b>, not .NET's <see cref="AddressFamily"/>
+    /// values (which follow Winsock: InterNetworkV6 = 23). Linux wants AF_INET6 = 10, Darwin 28 —
+    /// writing 23 makes Linux's md5 parse path reject the entry with EINVAL
+    /// (<c>sin6_family != AF_INET6</c>).</item>
+    /// <item><b>Darwin sockaddr_in/in6 carry a length byte first</b> (<c>sin_len</c>/<c>sin6_len</c>),
+    /// with the family in byte 1; Linux has no length byte and keeps the family in bytes 0-1.
+    /// Darwin's own tcpmd5sig path reads that length field, so omitting it (or writing the family
+    /// into byte 0) breaks key lookup there.</item>
+    /// </list>
     /// </para>
     /// </summary>
     internal static void WriteSockaddr(IPEndPoint peer, Span<byte> destination)
     {
         destination.Clear();
         var port = (ushort)peer.Port;
-        if (peer.Address.AddressFamily == AddressFamily.InterNetwork)
+        var isV4 = peer.Address.AddressFamily == AddressFamily.InterNetwork;
+        var darwin = OperatingSystem.IsMacOS();
+        if (isV4)
         {
-            destination[0] = AfInet;                                  // AF_INET: 2 on Linux and Darwin
+            var af = AfInet;
+            if (darwin) { destination[0] = 16; destination[1] = af; } // sin_len, sin_family
+            else { destination[0] = af; }                             // Linux: family, host order
             destination[2] = (byte)(port >> 8);                       // port, network byte order
             destination[3] = (byte)port;
             peer.Address.TryWriteBytes(destination.Slice(4, 4), out _);
         }
         else
         {
-            destination[0] = AfInet6;                                 // AF_INET6: 10 (Linux) / 28 (Darwin)
+            var af = AfInet6;
+            if (darwin) { destination[0] = 28; destination[1] = af; } // sin6_len, sin6_family
+            else { destination[0] = af; }
             destination[2] = (byte)(port >> 8);
             destination[3] = (byte)port;
             peer.Address.TryWriteBytes(destination.Slice(8, 16), out _);

--- a/BGPLite.Protocol/AttributeHelper.cs
+++ b/BGPLite.Protocol/AttributeHelper.cs
@@ -1,4 +1,5 @@
 using System.Buffers.Binary;
+using System.Collections.Generic;
 
 namespace BGPLite.Protocol;
 
@@ -134,6 +135,35 @@ public static class AttributeHelper
                 BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.OptionalAttributeError);
 
         return asn;
+    }
+
+    /// <summary>
+    /// Builds the MP_REACH_NLRI (type 14) attribute for IPv6/Unicast announcements — optional
+    /// non-transitive per RFC 4760 §4; the value carries the global next hop (RFC 2545 §3,
+    /// 16-byte form) plus the NLRI list. The IPv6 analogue of <see cref="WriteNextHop"/>: it is
+    /// where the outbound next hop lives for the IPv6 address family.
+    /// </summary>
+    public static PathAttribute WriteMpReachNlriV6(UInt128 nextHop, IReadOnlyList<IpPrefix> prefixes)
+    {
+        return new PathAttribute
+        {
+            Flags = BgpConstants.Attribute.FlagOptional,
+            TypeCode = MpReachCodec.MpReachNlriType,
+            Data = MpReachCodec.EncodeMpReachV6(nextHop, prefixes)
+        };
+    }
+
+    /// <summary>Builds the MP_UNREACH_NLRI (type 15) attribute for IPv6/Unicast withdrawals —
+    /// optional non-transitive per RFC 4760 §4 (the IPv6 counterpart of the withdrawn-routes
+    /// field).</summary>
+    public static PathAttribute WriteMpUnreachNlriV6(IReadOnlyList<IpPrefix> prefixes)
+    {
+        return new PathAttribute
+        {
+            Flags = BgpConstants.Attribute.FlagOptional,
+            TypeCode = MpReachCodec.MpUnreachNlriType,
+            Data = MpReachCodec.EncodeMpUnreachV6(prefixes)
+        };
     }
 
     public static PathAttribute WriteNextHop(uint nextHop)

--- a/BGPLite.Protocol/BgpCapabilityInfo.cs
+++ b/BGPLite.Protocol/BgpCapabilityInfo.cs
@@ -34,41 +34,56 @@ public sealed class BgpCapabilityInfo
     };
 
     /// <summary>
-    /// Graceful Restart capability (RFC 4724, code 64) for IPv4/Unicast. Value layout:
-    /// byte 0 = Restart Flags (bit 7 = R) | high 4 bits of Restart Time,
-    /// byte 1 = low 8 bits of Restart Time, then per-AF [AFI(2), SAFI(1), AF Flags(bit 7 = F)].
+    /// Graceful Restart capability (RFC 4724, code 64) with per-family tuples for IPv4/Unicast
+    /// AND IPv6/Unicast (#14 phase 5). Value layout: byte 0 = Restart Flags (bit 7 = R) |
+    /// high 4 bits of Restart Time, byte 1 = low 8 bits of Restart Time, then per-AF
+    /// [AFI(2), SAFI(1), AF Flags(bit 7 = F)].
     /// </summary>
-    public static BgpCapabilityInfo GracefulRestart(bool restartState, ushort restartTime, bool forwardingState)
+    /// <remarks>Note (D6): this capability is deliberately NOT advertised by BGPLite sessions
+    /// while the receiving-speaker half of RFC 4724 §4.2 is unimplemented. The factory and the
+    /// parser are per-family so that enabling advertisement later is a one-line change, and so
+    /// peer payloads carrying IPv6 tuples are understood.</remarks>
+    public static BgpCapabilityInfo GracefulRestart(bool restartState, ushort restartTime, bool ipv4Forwarding, bool ipv6Forwarding = false)
     {
         // RFC 4724 §2.2: Restart Time is a 12-bit field (0..4095). Clamp defensively so no caller
         // can silently truncate an out-of-range value into a wrong on-wire timer.
         var time = Math.Min(restartTime, (ushort)4095);
-        var data = new byte[6];
+        var data = new byte[10];
         data[0] = (byte)((restartState ? BgpConstants.GracefulRestartFlag.RestartState : 0x00) | ((time >> 8) & 0x0F));
         data[1] = (byte)(time & 0xFF);
         data[2] = (byte)(BgpConstants.Afi.IPv4 >> 8);
         data[3] = (byte)BgpConstants.Afi.IPv4;
         data[4] = BgpConstants.Safi.Unicast;
-        data[5] = (byte)(forwardingState ? BgpConstants.GracefulRestartFlag.ForwardingState : 0x00);
+        data[5] = (byte)(ipv4Forwarding ? BgpConstants.GracefulRestartFlag.ForwardingState : 0x00);
+        data[6] = (byte)(BgpConstants.Afi.IPv6 >> 8);
+        data[7] = (byte)BgpConstants.Afi.IPv6;
+        data[8] = BgpConstants.Safi.Unicast;
+        data[9] = (byte)(ipv6Forwarding ? BgpConstants.GracefulRestartFlag.ForwardingState : 0x00);
         return new BgpCapabilityInfo { Code = BgpConstants.Capability.GracefulRestart, Data = data };
     }
 
-    /// <summary>Parses a Graceful Restart capability value. Returns null if malformed.</summary>
-    public static (bool RestartState, ushort RestartTime, bool Ipv4UnicastForwarding)? TryParseGracefulRestart(ReadOnlySpan<byte> data)
+    /// <summary>Parses a Graceful Restart capability value, reporting the Forwarding State of
+    /// each family's tuple. Returns null if malformed. Payloads without an IPv6 tuple (legacy
+    /// v4-only speakers) report <c>Ipv6UnicastForwarding = false</c>.</summary>
+    public static (bool RestartState, ushort RestartTime, bool Ipv4UnicastForwarding, bool Ipv6UnicastForwarding)? TryParseGracefulRestart(ReadOnlySpan<byte> data)
     {
         if (data.Length < 2) return null;
         var restartState = (data[0] & BgpConstants.GracefulRestartFlag.RestartState) != 0;
         var restartTime = (ushort)(((data[0] & 0x0F) << 8) | data[1]);
         var ipv4UnicastForwarding = false;
+        var ipv6UnicastForwarding = false;
         var i = 2;
         while (i + 4 <= data.Length)
         {
             var afi = (ushort)((data[i] << 8) | data[i + 1]);
+            var forwarding = (data[i + 3] & BgpConstants.GracefulRestartFlag.ForwardingState) != 0;
             if (afi == BgpConstants.Afi.IPv4 && data[i + 2] == BgpConstants.Safi.Unicast)
-                ipv4UnicastForwarding |= (data[i + 3] & BgpConstants.GracefulRestartFlag.ForwardingState) != 0;
+                ipv4UnicastForwarding |= forwarding;
+            else if (afi == BgpConstants.Afi.IPv6 && data[i + 2] == BgpConstants.Safi.Unicast)
+                ipv6UnicastForwarding |= forwarding;
             i += 4;
         }
-        return (restartState, restartTime, ipv4UnicastForwarding);
+        return (restartState, restartTime, ipv4UnicastForwarding, ipv6UnicastForwarding);
     }
 
     public uint ReadAsn() => BinaryPrimitives.ReadUInt32BigEndian(Data);

--- a/BGPLite.Protocol/BgpCapabilityInfo.cs
+++ b/BGPLite.Protocol/BgpCapabilityInfo.cs
@@ -68,6 +68,9 @@ public sealed class BgpCapabilityInfo
     public static (bool RestartState, ushort RestartTime, bool Ipv4UnicastForwarding, bool Ipv6UnicastForwarding)? TryParseGracefulRestart(ReadOnlySpan<byte> data)
     {
         if (data.Length < 2) return null;
+        // RFC 4724 §2: the value is the 2-byte header followed by COMPLETE 4-byte <AFI, SAFI, F>
+        // tuples — a trailing partial tuple means a malformed capability, not "ignore the tail".
+        if ((data.Length - 2) % 4 != 0) return null;
         var restartState = (data[0] & BgpConstants.GracefulRestartFlag.RestartState) != 0;
         var restartTime = (ushort)(((data[0] & 0x0F) << 8) | data[1]);
         var ipv4UnicastForwarding = false;

--- a/BGPLite.Protocol/CapabilityHelper.cs
+++ b/BGPLite.Protocol/CapabilityHelper.cs
@@ -58,7 +58,7 @@ public static class CapabilityHelper
     }
 
     /// <summary>Returns the peer's Graceful Restart parameters, or null if not advertised / malformed.</summary>
-    public static (bool RestartState, ushort RestartTime, bool Ipv4UnicastForwarding)? GetGracefulRestart(BgpOpenMessage open)
+    public static (bool RestartState, ushort RestartTime, bool Ipv4UnicastForwarding, bool Ipv6UnicastForwarding)? GetGracefulRestart(BgpOpenMessage open)
     {
         foreach (var cap in open.Capabilities)
         {

--- a/BGPLite.Protocol/PrefixCidr.cs
+++ b/BGPLite.Protocol/PrefixCidr.cs
@@ -6,21 +6,23 @@ namespace BGPLite.Protocol;
 /// <summary>
 /// The single canonical CIDR parser for the project (#236). Every input path — operator file
 /// sources (<c>PrefixListParser</c>), the management API (<c>ParseCustomPrefix</c>), and the
-/// BGP send path's DB-load (<c>RouteAssembler</c>) — routes through <see cref="TryParse"/> so the
-/// validation and masking policy is defined in exactly one place. Three divergent parsers
-/// previously caused dedup/aggregation breakage (the same network submitted two ways was stored as
-/// two distinct keys) and a route-leak vector (the API accepted <c>/0</c>, the default route).
+/// BGP send path's DB-load (<c>RouteAssembler</c>) — routes through one of the <see cref="TryParse"/>
+/// overloads so the validation and masking policy is defined in exactly one place. Three divergent
+/// parsers previously caused dedup/aggregation breakage (the same network submitted two ways was
+/// stored as two distinct keys) and a route-leak vector (the API accepted <c>/0</c>, the default route).
 /// <para>
 /// <b>Policy</b> (locked down here, recorded in #236):
 /// <list type="bullet">
 /// <item><b>Host-bit masking is ALWAYS applied</b> — <c>10.0.0.5/24</c> normalizes to
 /// <c>10.0.0.0/24</c>. Without this the route table, the aggregator, and the duplicate-NLRI
-/// merger key on the raw <c>(uint, byte)</c> and treat the two forms as distinct networks.</item>
-/// <item><b>Length range is 1..32</b> by default. <c>/0</c> (the default route) is rejected for
-/// user-supplied sources — a route server must not originate a default. <c>allowDefault: true</c>
-/// permits <c>/0</c> for the rare operator-config default-route case (kept for completeness; no
-/// caller currently uses it).</item>
-/// <item><b>IPv4 only.</b> IPv6 is rejected (the route table stores <c>(uint, byte)</c> IPv4 keys).</item>
+/// merger key on the raw form and treat the two forms as distinct networks.</item>
+/// <item><b>Length range is 1..32 (IPv4) / 1..128 (IPv6)</b>. <c>/0</c> (the default route) is
+/// rejected for user-supplied sources — a route server must not originate a default.
+/// <c>allowDefault: true</c> permits <c>/0</c> for the rare operator-config default-route case
+/// (kept for completeness; no caller currently uses it).</item>
+/// <item><b>Family</b>: the <see cref="TryParse(string?, out IpPrefix, bool)"/> overload accepts
+/// both families (#14 phase 4); the <see cref="TryParse(string?, out uint, out byte, bool)"/>
+/// overload stays IPv4-only — the management API's custom-prefix path is still IPv4-scoped.</item>
 /// <item><b>Garbage is rejected, never thrown.</b> Returns <c>false</c> on any malformed input so
 /// callers can surface a clean 400 / skip the line, rather than propagating a <c>FormatException</c>.</item>
 /// </list>
@@ -28,6 +30,51 @@ namespace BGPLite.Protocol;
 /// </summary>
 public static class PrefixCidr
 {
+    /// <summary>
+    /// Parses a CIDR string into a family-aware <see cref="IpPrefix"/> (IPv4 1..32, IPv6 1..128),
+    /// applying the canonical policy (host-bit masking, length range). Returns <c>false</c> (with
+    /// <paramref name="prefix"/> zeroed) on any malformed or out-of-policy input — callers should
+    /// report/skip, not throw.
+    /// </summary>
+    /// <param name="cidr">The CIDR string to parse ("a.b.c.d/len" or "2001:db8::/48").</param>
+    /// <param name="prefix">On success, the masked network prefix (family carried by <see cref="IpPrefix.IsIpv4"/>).</param>
+    /// <param name="allowDefault">When <c>true</c>, accept <c>/0</c> (the default route). Default
+    /// <c>false</c> — user-supplied sources (API/file/URL) must not originate a default.</param>
+    /// <returns><c>true</c> if the string is a valid CIDR within policy; <c>false</c> otherwise.</returns>
+    public static bool TryParse(string? cidr, out IpPrefix prefix, bool allowDefault = false)
+    {
+        prefix = default;
+
+        if (string.IsNullOrWhiteSpace(cidr))
+            return false;
+
+        var slash = cidr.IndexOf('/');
+        if (slash <= 0 || slash == cidr.Length - 1)
+            return false;
+
+        if (!IPAddress.TryParse(cidr[..slash], out var addr))
+            return false;
+
+        // IPv4-mapped forms (::ffff:a.b.c.d) are NOT accepted as IPv6 prefixes: they name the
+        // IPv4 address space through the v6 syntax and never appear as a legitimate origin
+        // prefix — rejecting them here matches the NextHopIpv6 config validation.
+        var isIpv4 = addr.AddressFamily == AddressFamily.InterNetwork;
+        var isIpv6 = addr.AddressFamily == AddressFamily.InterNetworkV6 && !addr.IsIPv4MappedToIPv6;
+        if (!isIpv4 && !isIpv6)
+            return false;
+
+        var maxLength = isIpv4 ? 32 : 128;
+        if (!byte.TryParse(cidr[(slash + 1)..], out var len) || len > maxLength)
+            return false;
+        if (len == 0 && !allowDefault)
+            return false;
+
+        // The IpPrefix constructor canonicalizes: host bits masked to the network address,
+        // family stored explicitly (IPv4 in the low 32 bits, IPv6 as the full 128).
+        prefix = new IpPrefix(BgpConstants.ToUInt128(addr), len, isIpv4);
+        return true;
+    }
+
     /// <summary>
     /// Parses a CIDR string ("<c>a.b.c.d/len</c>") into a packed IPv4 prefix + mask length, applying
     /// the canonical policy (host-bit masking, length range, IPv4-only). Returns <c>false</c> (with

--- a/BGPLite.Protocol/UpdateCodec.cs
+++ b/BGPLite.Protocol/UpdateCodec.cs
@@ -70,6 +70,32 @@ public static class UpdateCodec
     }
 
     /// <summary>
+    /// Builds outbound UPDATE path attributes for the IPv6 address family (RFC 4760 §5):
+    /// ORIGIN, AS_PATH (+AS4_PATH tunneling), optional COMMUNITY — and NO classic NEXT_HOP.
+    /// For MP_REACH-carried routes the next hop rides inside the MP_REACH_NLRI attribute
+    /// (attached per batch by <see cref="WithMpReachV6Attribute"/>, since it embeds that
+    /// batch's NLRI); the classic NEXT_HOP is defined only for the IPv4 NLRI field.
+    /// </summary>
+    public static List<PathAttribute> BuildV6UpdateAttributes(uint localAsn, bool localFourByteAsn, IReadOnlyList<uint> communities)
+    {
+        var attrs = new List<PathAttribute>(4)
+        {
+            AttributeHelper.WriteOrigin(BgpOrigin.Igp),
+        };
+
+        var asPathAttrs = BuildAsPathAttributes(localAsn, localFourByteAsn);
+        attrs.Add(asPathAttrs[0]);
+
+        if (communities.Count > 0)
+            attrs.Add(AttributeHelper.WriteCommunities(communities));
+
+        if (asPathAttrs.Count > 1)
+            attrs.Add(asPathAttrs[1]);
+
+        return attrs;
+    }
+
+    /// <summary>
     /// Creates a per-send cache of built UPDATE path attributes, keyed by community set. The
     /// cache is scoped to a single send invocation: the ASN/nextHop inputs are constant for that
     /// whole send, so identical community sets yield byte-identical <see cref="PathAttribute"/>
@@ -96,6 +122,31 @@ public static class UpdateCodec
         return attrs;
     }
 
+    /// <summary>The IPv6-family counterpart of <see cref="GetCachedUpdateAttributes"/>: cached
+    /// per-community attributes WITHOUT a classic NEXT_HOP (the MP_REACH attribute supplies it,
+    /// per batch, via <see cref="WithMpReachV6Attribute"/>). Uses its own cache instance — the
+    /// cached lists differ from the IPv4 ones by the absent NEXT_HOP, so sharing the IPv4 cache
+    /// would leak a stale next hop into v6 UPDATEs.</summary>
+    public static List<PathAttribute> GetCachedV6UpdateAttributes(
+        uint localAsn, bool localFourByteAsn, IReadOnlyList<uint> communities,
+        Dictionary<IReadOnlyList<uint>, List<PathAttribute>> cache)
+    {
+        if (cache.TryGetValue(communities, out var cached))
+            return cached;
+
+        var attrs = BuildV6UpdateAttributes(localAsn, localFourByteAsn, communities);
+        cache[communities] = attrs;
+        return attrs;
+    }
+
+    /// <summary>
+    /// Creates a per-send attribute cache for the IPv6 family (see
+    /// <see cref="GetCachedV6UpdateAttributes"/>). Scoped to a single send invocation like the
+    /// IPv4 counterpart (#87).
+    /// </summary>
+    public static Dictionary<IReadOnlyList<uint>, List<PathAttribute>> CreateV6UpdateAttributeCache() =>
+        new(CommunitySetComparer.Instance);
+
     /// <summary>
     /// Returns the path attributes for an UPDATE carrying the given Large Community set: the
     /// cached base attributes (ORIGIN/AS_PATH/NEXT_HOP/COMMUNITY/AS4_PATH) untouched when
@@ -116,6 +167,30 @@ public static class UpdateCodec
         withLarge.Add(AttributeHelper.WriteLargeCommunities(largeCommunities));
         return withLarge;
     }
+
+    /// <summary>
+    /// Appends the MP_REACH_NLRI attribute (global IPv6 next hop + this batch's NLRI) to the
+    /// cached base attributes. It must be attached PER BATCH — unlike the community-keyed base
+    /// attributes, the attribute value embeds the batch's NLRI bytes — and goes last, matching
+    /// the repo's append-per-batch idiom of <see cref="WithLargeCommunityAttribute"/>. Attribute
+    /// ordering is an implementation choice, not an RFC requirement (D15); MP_REACH is optional
+    /// non-transitive (RFC 4760 §4).
+    /// </summary>
+    public static List<PathAttribute> WithMpReachV6Attribute(
+        List<PathAttribute> baseAttrs, UInt128 nextHop, IReadOnlyList<IpPrefix> prefixes)
+    {
+        var with = new List<PathAttribute>(baseAttrs.Count + 1);
+        with.AddRange(baseAttrs);
+        with.Add(AttributeHelper.WriteMpReachNlriV6(nextHop, prefixes));
+        return with;
+    }
+
+    /// <summary>
+    /// Appends the MP_UNREACH_NLRI attribute withdrawing the given IPv6 prefixes to an otherwise
+    /// empty attribute list (RFC 4760 §7 — the IPv6 counterpart of the WITHDRAWN ROUTES field).
+    /// </summary>
+    public static List<PathAttribute> WithMpUnreachV6Attribute(IReadOnlyList<IpPrefix> prefixes) =>
+        [AttributeHelper.WriteMpUnreachNlriV6(prefixes)];
 
     /// <summary>
     /// Validates that a route announcement carried the mandatory well-known attributes

--- a/BGPLite.Providers/AsnPrefixProvider.cs
+++ b/BGPLite.Providers/AsnPrefixProvider.cs
@@ -50,6 +50,6 @@ public sealed class AsnPrefixProvider : IPrefixSourceProvider
         _logger.LogInformation(
             "Source '{Name}' (asn AS{Asn}): loaded {Count} prefixes via RIPEstat",
             source.Name, source.Asn.Value, prefixes.Count);
-        return SourceLoadResult.Ok(prefixes.Select(p => (Prefix: p.Prefix, Length: p.Length)).ToList());
+        return SourceLoadResult.Ok(prefixes.ToList());
     }
 }

--- a/BGPLite.Providers/IPrefixSourceService.cs
+++ b/BGPLite.Providers/IPrefixSourceService.cs
@@ -1,4 +1,5 @@
 using BGPLite.Configuration;
+using BGPLite.Protocol;
 
 namespace BGPLite.Providers;
 
@@ -10,13 +11,13 @@ namespace BGPLite.Providers;
 public interface IPrefixSourceService
 {
     /// <summary>All configured sources with their cached prefix lists.</summary>
-    Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>> LoadAllAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default);
 
     /// <summary>One source by name (cache-through). Empty list if missing or failed.</summary>
-    Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name, CancellationToken ct = default);
+    Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default);
 
     /// <summary>The source named by <c>AppConfig.DefaultPrefixSource</c>. Empty list if unset/missing.</summary>
-    Task<IReadOnlyList<(uint Prefix, byte Length)>> GetDefaultAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default);
 
     /// <summary>Prime the in-memory cache for all sources.</summary>
     Task WarmUpAsync(CancellationToken ct = default);

--- a/BGPLite.Providers/PrefixListParser.cs
+++ b/BGPLite.Providers/PrefixListParser.cs
@@ -3,22 +3,23 @@ using BGPLite.Protocol;
 namespace BGPLite.Providers;
 
 /// <summary>
-/// Parses a CIDR-per-line text blob into packed IPv4 prefixes.
-/// Blank lines and lines starting with <c>#</c> are ignored; malformed and non-IPv4
-/// lines are skipped silently (the route table only stores IPv4 <c>(uint, byte)</c> keys).
+/// Parses a CIDR-per-line text blob into family-aware prefixes (IPv4 and IPv6, #14 phase 4).
+/// Blank lines and lines starting with <c>#</c> are ignored; malformed lines are skipped
+/// silently so one bad line cannot take a whole source down.
 /// </summary>
 /// <remarks>
-/// <b>Length and host-bit handling (#162 / #236).</b> Validation, host-bit masking, and the IPv4-only
-/// constraint now live in the single canonical <see cref="PrefixCidr"/> parser — every CIDR input
+/// <b>Length and host-bit handling (#162 / #236).</b> Validation, host-bit masking, and the
+/// family handling live in the single canonical <see cref="PrefixCidr"/> parser — every CIDR input
 /// path (file, API, DB-load) routes through it so the policy is defined exactly once. <c>/0</c> is
-/// rejected (a route server must not originate a default route from a peer-supplied URL list, #147);
-/// host bits are masked so <c>10.0.0.5/24</c> normalizes to <c>10.0.0.0/24</c> and dedups correctly.
+/// rejected (a route server must not originate a default route from a peer-supplied URL list,
+/// #147); host bits are masked so <c>10.0.0.5/24</c> normalizes to <c>10.0.0.0/24</c> and dedups
+/// correctly; IPv6 entries (<c>2001:db8::/48</c>) are accepted alongside IPv4 ones.
 /// </remarks>
 public static class PrefixListParser
 {
-    public static IReadOnlyList<(uint Prefix, byte Length)> Parse(string text)
+    public static IReadOnlyList<IpPrefix> Parse(string text)
     {
-        var result = new List<(uint Prefix, byte Length)>();
+        var result = new List<IpPrefix>();
 
         // Strip a leading UTF-8 BOM (\uFEFF): string.Trim() does not remove it (it is not in the
         // Char.IsWhiteSpace set), so without this the first line of a BOM-prefixed list is silently
@@ -31,11 +32,12 @@ public static class PrefixListParser
             var line = raw.Trim();
             if (line.Length == 0 || line[0] == '#') continue;
 
-            // Delegate to the canonical parser (#236): host-bit masking, /0 rejection, IPv4-only,
-            // range 1..32 — one policy, shared with the API and the BGP send path.
-            if (!PrefixCidr.TryParse(line, out var prefix, out var length))
+            // Delegate to the canonical parser (#236): host-bit masking, /0 rejection, family
+            // handling (IPv4 1..32, IPv6 1..128) — one policy, shared with the API and the BGP
+            // send path.
+            if (!PrefixCidr.TryParse(line, out var prefix))
                 continue;
-            result.Add((prefix, length));
+            result.Add(prefix);
         }
 
         return result;

--- a/BGPLite.Providers/PrefixService.cs
+++ b/BGPLite.Providers/PrefixService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using BGPLite.Configuration;
+using BGPLite.Protocol;
 using Microsoft.Extensions.Logging;
 using BGPLite.Contracts;
 
@@ -64,7 +65,7 @@ public sealed class PrefixService : IPrefixService
     /// refreshes do not re-pay the budget.
     /// </para>
     /// </summary>
-    public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
+    public async Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
     {
         var source = new PrefixSourceConfig
         {
@@ -74,24 +75,25 @@ public sealed class PrefixService : IPrefixService
             Community = community,
             Timeout = _userSourceTimeoutSeconds
         };
-        return await _userSourceCache.GetOrLoadAsync(url, name, async ct =>
+        var prefixes = await _userSourceCache.GetOrLoadAsync(url, name, async ct =>
         {
             var result = await _httpProvider.LoadAsync(source, ct: ct);
-            return result.Prefixes;
+            return result.Prefixes;   // provider-native IpPrefix list
         }, ct);
+        return ToContract(prefixes);
     }
 
-    public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
+    public async Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
         // Per-ASN caching, stale-on-failure, negative TTL, fetch gates, and the #165 eviction
         // sweep all live in the shared cache (#267 item 5) — one wire fetch per ASN regardless
         // of which mechanism asked.
-        => _ripeStatCache.GetPrefixesAsync(asn, ct);
+        => ToContract(await _ripeStatCache.GetPrefixesAsync(asn, ct));
 
     /// <summary>Bounds how many ASNs are resolved against RIPEstat concurrently on a cold cache
     /// (warm traffic is cache-flat). Keeps cold-start fan-out from tripping RIPEstat rate limits.</summary>
     private const int MaxDegreeOfParallelism = 8;
 
-    public async Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
+    public async Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
     {
         // Materialize once: we enumerate for fan-out and again for ordered assembly.
         var asnList = asns as IList<uint> ?? asns.ToList();
@@ -102,7 +104,7 @@ public sealed class PrefixService : IPrefixService
         // per-ASN cache and double-fetch (CodeRabbit #130); output multiplicity is preserved below.
         // Each ASN keeps its own try/catch so one failure (incl. cancellation) can't drop the others.
         using var gate = new SemaphoreSlim(MaxDegreeOfParallelism, MaxDegreeOfParallelism);
-        var resolvedByAsn = new Dictionary<uint, Task<IReadOnlyList<(uint Prefix, byte Length)>>>();
+        var resolvedByAsn = new Dictionary<uint, Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>>();
         foreach (var asn in asnList.Distinct())
             resolvedByAsn[asn] = ResolveAsnAsync(asn, gate, ct);
 
@@ -112,14 +114,14 @@ public sealed class PrefixService : IPrefixService
         // prior sequential output, including for duplicate ASNs. Await each completed task (rather
         // than .Result) so a faulted task surfaces its real exception, not an AggregateException,
         // and never blocks the threadpool thread.
-        var result = new List<(uint Prefix, byte Length, uint Asn)>();
+        var result = new List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>();
         foreach (var asn in asnList)
-            foreach (var (prefix, length) in await resolvedByAsn[asn])
-                result.Add((prefix, length, asn));
+            foreach (var p in await resolvedByAsn[asn])
+                result.Add((p.Prefix, p.Length, p.IsIpv4, asn));
         return result;
     }
 
-    private async Task<IReadOnlyList<(uint Prefix, byte Length)>> ResolveAsnAsync(uint asn, SemaphoreSlim gate, CancellationToken ct)
+    private async Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> ResolveAsnAsync(uint asn, SemaphoreSlim gate, CancellationToken ct)
     {
         try
         {
@@ -177,10 +179,10 @@ public sealed class PrefixService : IPrefixService
     /// stale-on-failure serves the last good copy on a transient fetch error (#163 parity).
     /// </para>
     /// </summary>
-    private sealed record RuCacheEntry(List<(uint Prefix, byte Length, uint Asn)> Projected, long CachedAtTicks);
+    private sealed record RuCacheEntry(List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)> Projected, long CachedAtTicks);
     private RuCacheEntry? _ruCache;
 
-    public async Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
+    public async Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
     {
         // Fast path: fresh entry. A single Volatile.Read of the immutable entry reference gives a
         // consistent (projection, ticks) snapshot — no two-field torn read.
@@ -198,11 +200,11 @@ public sealed class PrefixService : IPrefixService
             if (cached is not null && _timeProvider.GetUtcNow().UtcDateTime.Ticks - cached.CachedAtTicks < _ruCacheTtl.Ticks)
                 return cached.Projected;
 
-            List<(uint Prefix, byte Length, uint Asn)> projected;
+            List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)> projected;
             try
             {
                 var prefixes = await _prefixSources.GetDefaultAsync(ct);
-                projected = prefixes.Select(p => (p.Prefix, p.Length, 0u)).ToList();
+                projected = prefixes.Select(p => (p.Address, p.Length, p.IsIpv4, 0u)).ToList();
             }
             catch (OperationCanceledException) { throw; }
             catch (Exception ex)
@@ -233,8 +235,13 @@ public sealed class PrefixService : IPrefixService
     }
 
     /// <summary>Prefixes of a configured source by name (cache-through).</summary>
-    public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default) =>
-        _prefixSources.GetAsync(name, ct);
+    public async Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default) =>
+        ToContract(await _prefixSources.GetAsync(name, ct));
+
+    /// <summary>Provider-native <see cref="IpPrefix"/> values mapped onto the Contracts tuple
+    /// layout (Contracts is a dependency-free leaf and cannot see the Protocol type).</summary>
+    private static IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)> ToContract(IReadOnlyList<IpPrefix> prefixes) =>
+        prefixes.Select(p => (p.Address, p.Length, p.IsIpv4)).ToList();
 
     public async Task WarmUpAsync(CancellationToken ct = default)
     {

--- a/BGPLite.Providers/PrefixSourceService.cs
+++ b/BGPLite.Providers/PrefixSourceService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using BGPLite.Configuration;
+using BGPLite.Protocol;
 using Microsoft.Extensions.Logging;
 
 namespace BGPLite.Providers;
@@ -60,7 +61,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
         _sourcesByName = config.PrefixSources.ToDictionary(s => s.Name);
     }
 
-    public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name, CancellationToken ct = default)
+    public async Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default)
     {
         if (!_sourcesByName.TryGetValue(name, out var source))
         {
@@ -77,7 +78,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
         }
     }
 
-    public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetDefaultAsync(CancellationToken ct = default)
+    public async Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default)
     {
         var defaultName = _config.DefaultPrefixSource;
         if (string.IsNullOrWhiteSpace(defaultName))
@@ -98,12 +99,12 @@ public sealed class PrefixSourceService : IPrefixSourceService
         }
     }
 
-    public async Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
+    public async Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
     {
-        var result = new List<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>();
+        var result = new List<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>();
         foreach (var source in _config.PrefixSources)
         {
-            IReadOnlyList<(uint Prefix, byte Length)> prefixes;
+            IReadOnlyList<IpPrefix> prefixes;
             try { prefixes = (await LoadCachedAsync(source, ct)).Prefixes; }
             catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #324: only CALLER cancellation — the #324 default fetch budget fires as a foreign-token OCE (live ct) and must stay a per-source failure below
             catch (Exception ex)
@@ -173,7 +174,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
     /// is detected (by any entry point), <c>_onSourceChanged</c> is invoked AFTER releasing the gate
     /// so the callback (peer refresh) can't deadlock on the per-source lock.
     /// </summary>
-    private async Task<(IReadOnlyList<(uint Prefix, byte Length)> Prefixes, bool Changed)> LoadCachedAsync(
+    private async Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadCachedAsync(
         PrefixSourceConfig source, CancellationToken ct, bool forceRefresh = false, bool triggerCallback = true)
     {
         if (!forceRefresh && TryGetFresh(source.Name, out var fresh))
@@ -182,7 +183,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
         var gate = _locks.GetOrAdd(source.Name, _ => new SemaphoreSlim(1, 1));
         await gate.WaitAsync(ct);
         bool changed;
-        IReadOnlyList<(uint Prefix, byte Length)> loaded;
+        IReadOnlyList<IpPrefix> loaded;
         try
         {
             if (!forceRefresh && TryGetFresh(source.Name, out var rechecked))
@@ -277,19 +278,21 @@ public sealed class PrefixSourceService : IPrefixSourceService
     /// the HashSet allocation path on the common unchanged case via the fast count/SequenceEqual
     /// shortcut when the source already returned a sorted list.
     /// </summary>
-    private static bool SamePrefixes(IReadOnlyList<(uint Prefix, byte Length)> a, IReadOnlyList<(uint Prefix, byte Length)> b)
+    private static bool SamePrefixes(IReadOnlyList<IpPrefix> a, IReadOnlyList<IpPrefix> b)
     {
         if (a.Count != b.Count) return false;
         // Fast path: if both happen to be in the same order (common — file sources, cached HTTP),
         // SequenceEqual is O(n) with no allocation.
         if (a.SequenceEqual(b)) return true;
-        // Slow path: order differs — compare as sorted sequences.
-        var sa = a.OrderBy(x => x.Prefix).ThenBy(x => x.Length).ToArray();
-        var sb = b.OrderBy(x => x.Prefix).ThenBy(x => x.Length).ToArray();
+        // Slow path: order differs — compare as sorted sequences. IpPrefix's own comparison is
+        // family-first (IsIpv4, then address, then length), so an IPv4 key can never equal an
+        // IPv6 one even when the numeric address and length agree.
+        var sa = a.OrderBy(x => x).ToArray();
+        var sb = b.OrderBy(x => x).ToArray();
         return sa.SequenceEqual(sb);
     }
 
-    private bool TryGetFresh(string name, out IReadOnlyList<(uint Prefix, byte Length)> list)
+    private bool TryGetFresh(string name, out IReadOnlyList<IpPrefix> list)
     {
         list = null!;
         if (!_cache.TryGetValue(name, out var entry)) return false;
@@ -305,7 +308,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
 
     /// <summary>#214: Cache entry with ETag/Last-Modified for conditional re-fetches.</summary>
     private sealed record CacheEntry(
-        IReadOnlyList<(uint Prefix, byte Length)> List,
+        IReadOnlyList<IpPrefix> List,
         DateTime CachedAt,
         bool Negative,
         string? ETag = null,

--- a/BGPLite.Providers/RipeStatPrefixCache.cs
+++ b/BGPLite.Providers/RipeStatPrefixCache.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using BGPLite.Configuration;
+using BGPLite.Protocol;
 using Microsoft.Extensions.Logging;
 
 namespace BGPLite.Providers;
@@ -40,7 +41,7 @@ public sealed class RipeStatPrefixCache
     // asn → (prefix list, cached at, is negative). Negative entries (failed RIPEstat fetches) use
     // _negativeTtl. The tuple is shaped to mirror PrefixSourceService so the resilience semantics
     // (stale-on-failure, negative cache, bounded sweep) are identical across both caches.
-    private readonly ConcurrentDictionary<uint, (IReadOnlyList<(uint Prefix, byte Length)> Data, DateTime CachedAt, bool Negative)> _cache = new();
+    private readonly ConcurrentDictionary<uint, (IReadOnlyList<IpPrefix> Data, DateTime CachedAt, bool Negative)> _cache = new();
     // asn → gate serializing the cache-miss fetch path (prevents thundering herd on cold/expired
     // ASNs — #164).
     private readonly ConcurrentDictionary<uint, SemaphoreSlim> _locks = new();
@@ -71,7 +72,7 @@ public sealed class RipeStatPrefixCache
         _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
-    public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default, bool serveNegativeEntries = true)
+    public async Task<IReadOnlyList<IpPrefix>> GetPrefixesAsync(uint asn, CancellationToken ct = default, bool serveNegativeEntries = true)
     {
         // Fast path: fresh entry (positive, or negative within its TTL when the caller accepts
         // the []-on-recent-failure semantic — the RouteAssembler fan-out does; a source provider
@@ -98,7 +99,7 @@ public sealed class RipeStatPrefixCache
 
     /// <summary>The gated fetch path of <see cref="GetPrefixesAsync"/> — runs under the caller's
     /// in-flight mark, sharing a single RIPEstat fetch per ASN (#164).</summary>
-    private async Task<IReadOnlyList<(uint Prefix, byte Length)>> FetchThroughGateAsync(uint asn, CancellationToken ct, bool serveNegativeEntries)
+    private async Task<IReadOnlyList<IpPrefix>> FetchThroughGateAsync(uint asn, CancellationToken ct, bool serveNegativeEntries)
     {
         // Serialize per-ASN so concurrent callers share a single RIPEstat fetch — no thundering herd
         // on a cold or just-expired ASN (#164).
@@ -112,7 +113,7 @@ public sealed class RipeStatPrefixCache
             if (TryGetFresh(asn, out var rechecked, out var recheckIsNegative) && (serveNegativeEntries || !recheckIsNegative))
                 return rechecked;
 
-            IReadOnlyList<(uint Prefix, byte Length)> prefixes;
+            IReadOnlyList<IpPrefix> prefixes;
             try
             {
                 prefixes = await _ripe.GetPrefixesAsync(asn, ct);
@@ -150,7 +151,7 @@ public sealed class RipeStatPrefixCache
     /// negative within _negativeTtl). #377 review: the negative flag comes out of the SAME read —
     /// a separate IsNegative lookup could miss an eviction racing between the two and serve a
     /// captured [] to a caller that opted out of negatives.</summary>
-    private bool TryGetFresh(uint asn, out IReadOnlyList<(uint Prefix, byte Length)> data, out bool isNegative)
+    private bool TryGetFresh(uint asn, out IReadOnlyList<IpPrefix> data, out bool isNegative)
     {
         data = null!;
         isNegative = false;

--- a/BGPLite.Providers/RipeStatProvider.cs
+++ b/BGPLite.Providers/RipeStatProvider.cs
@@ -27,13 +27,14 @@ public sealed class RipeStatProvider
     }
 
     /// <summary>
-    /// Fetches the IPv4 prefixes originated by <paramref name="asn"/> from RIPEstat. The named
-    /// client's resilience handler (Program.cs, #104) retries transient HTTP failures (429/5xx/
-    /// timeouts/network errors) with exponential backoff + circuit breaker, so this method performs
-    /// a single attempt — a transient failure propagates only after the resilience pipeline is
-    /// exhausted. The ris-prefixes endpoint can take minutes for large origin ASes (e.g. AS3356).
+    /// Fetches the IPv4 AND IPv6 prefixes originated by <paramref name="asn"/> from RIPEstat
+    /// (#14 phase 4: the <c>v6.originating</c> section is parsed alongside <c>v4.originating</c>).
+    /// The named client's resilience handler (Program.cs, #104) retries transient HTTP failures
+    /// (429/5xx/timeouts/network errors) with exponential backoff + circuit breaker, so this method
+    /// performs a single attempt — a transient failure propagates only after the resilience pipeline
+    /// is exhausted. The ris-prefixes endpoint can take minutes for large origin ASes (e.g. AS3356).
     /// </summary>
-    public async Task<IReadOnlyList<(uint Prefix, byte PrefixLength)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
+    public async Task<IReadOnlyList<IpPrefix>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
     {
         var url = $"https://stat.ripe.net/data/ris-prefixes/data.json?resource=AS{asn}&list_prefixes=true";
         var http = _httpFactory.CreateClient(ClientName);
@@ -66,35 +67,50 @@ public sealed class RipeStatProvider
         }
         using var doc = JsonDocument.Parse(new ReadOnlyMemory<byte>(buffered.GetBuffer(), 0, (int)buffered.Length));
 
-        var prefixes = doc.RootElement
-            .GetProperty("data")
-            .GetProperty("prefixes")
-            .GetProperty("v4")
-            .GetProperty("originating");
+        var data = doc.RootElement.GetProperty("data").GetProperty("prefixes");
+        var result = new List<IpPrefix>();
 
-        var result = new List<(uint Prefix, byte PrefixLength)>(prefixes.GetArrayLength());
+        // Both family sections are OPTIONAL in the response (an ASN may originate only v4 or only
+        // v6) — a missing section contributes nothing rather than throwing.
+        result.AddRange(ParseFamily(asn, data, "v4"));
+        result.AddRange(ParseFamily(asn, data, "v6"));
 
+        _logger.LogInformation("AS{Asn}: fetched {Count} prefixes ({V4} IPv4 + {V6} IPv6)",
+            asn, result.Count, result.Count(p => p.IsIpv4), result.Count(p => !p.IsIpv4));
+        return result;
+    }
+
+    /// <summary>Parses one family's <c>originating</c> array through the canonical parser.
+    /// Returns an empty list when the section is absent. Each entry is validated independently —
+    /// a single non-canonical prefix skips without taking the whole ASN fetch down.</summary>
+    private List<IpPrefix> ParseFamily(uint asn, JsonElement data, string family)
+    {
+        if (!data.TryGetProperty(family, out var familySection) ||
+            !familySection.TryGetProperty("originating", out var prefixes) ||
+            prefixes.ValueKind != JsonValueKind.Array)
+            return [];
+
+        var result = new List<IpPrefix>(prefixes.GetArrayLength());
         foreach (var element in prefixes.EnumerateArray())
         {
             // #319/#358-review: the canonical parser every other prefix input path uses (#236):
-            // host-bit masking, /0 rejection, length 1..32, IPv4-only. RIS collectors return what
+            // host-bit masking, /0 rejection, per-family length range. RIS collectors return what
             // third parties ANNOUNCED — non-canonical NLRI ("10.0.0.1/8") must not reach the route
-            // table under a corrupt key, and "0.0.0.0/0" must not become a default-route leak
-            // (#162 closed the same hole for URL sources). Skip + warn, like stored custom
+            // table under a corrupt key, and "0.0.0.0/0"/"::/0" must not become a default-route
+            // leak (#162 closed the same hole for URL sources). Skip + warn, like stored custom
             // prefixes; a null element, garbage string, or NON-STRING JSON element (GetString
             // throws InvalidOperationException on numbers/objects) is skipped without taking the
             // whole ASN fetch down with it.
             var cidr = element.ValueKind == JsonValueKind.String ? element.GetString() : null;
-            if (!PrefixCidr.TryParse(cidr, out var prefix, out var length))
+            if (!PrefixCidr.TryParse(cidr, out var prefix))
             {
                 _logger.LogWarning("AS{Asn}: RIPEstat returned a non-canonical prefix '{Cidr}'; skipped", asn, cidr);
                 continue;
             }
 
-            result.Add((prefix, length));
+            result.Add(prefix);
         }
 
-        _logger.LogInformation("AS{Asn}: fetched {Count} prefixes", asn, result.Count);
         return result;
     }
 }

--- a/BGPLite.Providers/SourceLoadResult.cs
+++ b/BGPLite.Providers/SourceLoadResult.cs
@@ -1,3 +1,5 @@
+using BGPLite.Protocol;
+
 namespace BGPLite.Providers;
 
 /// <summary>
@@ -7,13 +9,13 @@ namespace BGPLite.Providers;
 /// should keep the existing cached data (just refresh the timestamp).
 /// </summary>
 public sealed record SourceLoadResult(
-    IReadOnlyList<(uint Prefix, byte Length)> Prefixes,
+    IReadOnlyList<IpPrefix> Prefixes,
     string? ETag = null,
     DateTimeOffset? LastModified = null,
     bool NotModified = false)
 {
     /// <summary>Convenience for a normal (200 OK) load — prefixes + validators from the response.</summary>
-    public static SourceLoadResult Ok(IReadOnlyList<(uint Prefix, byte Length)> prefixes, string? etag = null, DateTimeOffset? lastModified = null) =>
+    public static SourceLoadResult Ok(IReadOnlyList<IpPrefix> prefixes, string? etag = null, DateTimeOffset? lastModified = null) =>
         new(prefixes, etag, lastModified, NotModified: false);
 
     /// <summary>Convenience for a 304 Not Modified response — no prefixes, caller keeps cached data.</summary>

--- a/BGPLite.Providers/UserSourceCache.cs
+++ b/BGPLite.Providers/UserSourceCache.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using BGPLite.Protocol;
 using Microsoft.Extensions.Logging;
 
 namespace BGPLite.Providers;
@@ -34,7 +35,7 @@ internal sealed class UserSourceCache
     private readonly int _maxEntries;
 
     // url → (list, cached at, is negative). Negative entries (failed loads) use _negativeTtl.
-    private readonly ConcurrentDictionary<string, (IReadOnlyList<(uint Prefix, byte Length)> List, DateTime CachedAt, bool Negative)> _cache = new();
+    private readonly ConcurrentDictionary<string, (IReadOnlyList<IpPrefix> List, DateTime CachedAt, bool Negative)> _cache = new();
     // url → gate serializing the cache-miss fetch path (prevents thundering herd on cold/expired keys).
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new();
 
@@ -59,10 +60,10 @@ internal sealed class UserSourceCache
     /// <param name="logLabel">Safe identifier (the source <c>Name</c>) for log lines — the URL itself is
     /// never logged, since peer URLs may carry query-string tokens (#149).</param>
     /// <param name="loadAsync">The fetcher ( HttpPrefixProvider.LoadAsync closed over the source config).</param>
-    public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetOrLoadAsync(
+    public async Task<IReadOnlyList<IpPrefix>> GetOrLoadAsync(
         string url,
         string logLabel,
-        Func<CancellationToken, Task<IReadOnlyList<(uint Prefix, byte Length)>>> loadAsync,
+        Func<CancellationToken, Task<IReadOnlyList<IpPrefix>>> loadAsync,
         CancellationToken ct)
     {
         if (TryGetFresh(url, out var fresh))
@@ -91,7 +92,7 @@ internal sealed class UserSourceCache
             if (TryGetFresh(url, out var rechecked))
                 return rechecked;
 
-            IReadOnlyList<(uint Prefix, byte Length)> prefixes;
+            IReadOnlyList<IpPrefix> prefixes;
             try
             {
                 prefixes = await loadAsync(ct);
@@ -175,7 +176,7 @@ internal sealed class UserSourceCache
         }
     }
 
-    private bool TryGetFresh(string url, out IReadOnlyList<(uint Prefix, byte Length)> list)
+    private bool TryGetFresh(string url, out IReadOnlyList<IpPrefix> list)
     {
         list = null!;
         if (!_cache.TryGetValue(url, out var entry)) return false;

--- a/BGPLite.Routing/ExactUnionPrefixAggregator.cs
+++ b/BGPLite.Routing/ExactUnionPrefixAggregator.cs
@@ -1,12 +1,15 @@
 using System.Numerics;
+using BGPLite.Protocol;
 
 namespace BGPLite.Routing;
 
 /// <summary>
-/// Default <see cref="IPrefixAggregator"/>. Merges adjacent/overlapping IPv4 prefixes
-/// into the minimal equivalent set whose address range is EXACTLY the union of the
-/// inputs — never a single address more. Injectable as a strategy; inject
-/// <see cref="NoOpPrefixAggregator"/> to disable summarization.
+/// Default <see cref="IPrefixAggregator"/>. Merges adjacent/overlapping prefixes into the
+/// minimal equivalent set whose address range is EXACTLY the union of the inputs — never a
+/// single address more. Dual-stack (#14 phase 3): IPv4 (/0..32) and IPv6 (/0..128) are
+/// aggregated with the same exact-union semantics but never merged together — IPv4 and
+/// IPv6 routes stay in separate groups even with identical tags (ADR 0001 §6). Injectable
+/// as a strategy; inject <see cref="NoOpPrefixAggregator"/> to disable summarization.
 /// </summary>
 /// <remarks>
 /// Algorithm: (1) mask host bits and form inclusive <c>[start, end]</c> intervals,
@@ -61,11 +64,13 @@ public sealed class ExactUnionPrefixAggregator : IPrefixAggregator
         foreach (var (key, group) in groups)
         {
             var template = group[0];
-            foreach (var (prefix, length) in AggregatePrefixes(group))
+            var isIpv4 = key.IsIpv4;
+            foreach (var (prefix, length) in AggregatePrefixes(group, isIpv4))
             {
                 result.Add(new Route
                 {
                     Prefix = prefix,
+                    IsIpv4 = isIpv4,
                     PrefixLength = length,
                     NextHop = template.NextHop,
                     Communities = template.Communities,
@@ -77,32 +82,39 @@ public sealed class ExactUnionPrefixAggregator : IPrefixAggregator
         return result;
     }
 
-    /// <summary>Exact-union CIDR merge of the prefixes carried by a group of routes.</summary>
-    private static List<(uint Prefix, byte Length)> AggregatePrefixes(IReadOnlyList<Route> routes)
+    /// <summary>Exact-union CIDR merge of the prefixes carried by a family-homogeneous group of
+    /// routes (the group key includes <c>IsIpv4</c>, so every route here shares a family).</summary>
+    private static List<(UInt128 Prefix, byte Length)> AggregatePrefixes(IReadOnlyList<Route> routes, bool isIpv4)
     {
-        // 1. Mask host bits and build inclusive [start, end] intervals. ulong so a /0 fits.
-        var intervals = new List<(ulong Start, ulong End)>(routes.Count);
+        // 1. Mask host bits and build inclusive [start, end] intervals. UInt128 so an IPv6 /0 fits.
+        var intervals = new List<(UInt128 Start, UInt128 End)>(routes.Count);
         for (var i = 0; i < routes.Count; i++)
         {
             var prefix = routes[i].Prefix;
             var length = routes[i].PrefixLength;
-            if (length > 32) continue; // defensive: skip malformed prefixes
-            var mask = length == 0 ? 0u : (0xFFFFFFFFu << (32 - length));
-            var start = (ulong)(prefix & mask);
-            var size = length == 0 ? (1UL << 32) : (1UL << (32 - length));
-            intervals.Add((start, start + size - 1));
+            if (!IpPrefix.IsValidLength(length, isIpv4)) continue; // defensive: skip malformed prefixes
+            // /0 spans the whole address space: 2^128 itself overflows, so that end is stated
+            // directly rather than computed as start + size - 1.
+            var start = prefix & IpPrefix.Mask(length, isIpv4);
+            var end = length == 0
+                ? (isIpv4 ? (UInt128)0xFFFFFFFFu : UInt128.MaxValue)
+                : start + ((UInt128)1 << (isIpv4 ? 32 : 128) - length) - 1;
+            intervals.Add((start, end));
         }
         if (intervals.Count == 0)
             return [];
 
         // 2. Sort and merge overlapping/adjacent intervals into a disjoint union.
         intervals.Sort((a, b) => a.Start.CompareTo(b.Start));
-        var merged = new List<(ulong Start, ulong End)>(intervals.Count) { intervals[0] };
+        var merged = new List<(UInt128 Start, UInt128 End)>(intervals.Count) { intervals[0] };
         for (var i = 1; i < intervals.Count; i++)
         {
             var (start, end) = intervals[i];
             var last = merged[^1];
-            if (start <= last.End + 1) // overlap or directly adjacent
+            // Overlap, or directly adjacent — spelled without last.End + 1 because an interval
+            // ending at UInt128.MaxValue would wrap the increment to zero.
+            var adjacent = last.End != UInt128.MaxValue && start == last.End + 1;
+            if (start <= last.End || adjacent)
             {
                 if (end > last.End) merged[^1] = (last.Start, end);
             }
@@ -113,9 +125,9 @@ public sealed class ExactUnionPrefixAggregator : IPrefixAggregator
         }
 
         // 3. Emit the minimal exact CIDR cover for each merged interval.
-        var result = new List<(uint, byte)>();
+        var result = new List<(UInt128, byte)>();
         foreach (var (start, end) in merged)
-            EmitRange(start, end, result);
+            EmitRange(start, end, isIpv4, result);
         return result;
     }
 
@@ -125,39 +137,60 @@ public sealed class ExactUnionPrefixAggregator : IPrefixAggregator
     /// that is both aligned at <c>start</c> and fits inside the remaining range, so the
     /// emitted blocks tile the range with neither gaps nor overlaps.
     /// </summary>
-    private static void EmitRange(ulong start, ulong end, List<(uint, byte)> result)
+    private static void EmitRange(UInt128 start, UInt128 end, bool isIpv4, List<(UInt128, byte)> result)
     {
-        while (start <= end)
+        var maxLength = isIpv4 ? 32 : 128;
+        var maxAddress = isIpv4 ? (UInt128)0xFFFFFFFFu : UInt128.MaxValue;
+        while (true)
         {
-            var aligned = start == 0 ? (1UL << 32) : start & (~start + 1); // largest pow2 dividing start
-            var fits = HighestPowerOfTwo(end - start + 1);                 // largest pow2 ≤ remaining
-            var size = Math.Min(aligned, fits);
-            result.Add(((uint)start, (byte)(32 - BitOperations.Log2(size))));
+            // The whole address space is one /0 block; stating it directly keeps the span
+            // computation below free of the 2^128 overflow.
+            if (start == UInt128.Zero && end == maxAddress)
+            {
+                result.Add((UInt128.Zero, 0));
+                return;
+            }
+
+            var span = end - start + 1;                                   // < 2^128 here
+            // LeadingZeroCount/Log2 return UInt128 (IBinaryInteger); the values fit an int here
+            // (span < 2^128 ⇒ lzc ≤ 127, size < 2^128 ⇒ log2 ≤ 127).
+            var fits = UInt128.One << (127 - (int)UInt128.LeadingZeroCount(span)); // largest pow2 ≤ span
+            var size = start == UInt128.Zero
+                ? fits                                                    // 0 is aligned to anything
+                : UInt128.Min(start & (~start + 1), fits);                // largest pow2 dividing start
+            result.Add((start, (byte)(maxLength - (int)UInt128.Log2(size))));
+            if (size == span)
+                return;
             start += size;
         }
     }
 
-    private static ulong HighestPowerOfTwo(ulong value) =>
-        1UL << (63 - BitOperations.LeadingZeroCount(value));
-
-    /// <summary>Value-equality key over a route's communities (sorted, set semantics).</summary>
+    /// <summary>Value-equality key over a route's family and communities (communities sorted,
+    /// set semantics). The family participates in the key so IPv4 and IPv6 prefixes never merge
+    /// into one summary even with identical tags (ADR 0001 §6) — a 32-bit merge of an IPv6
+    /// prefix would summarize the wrong address space.</summary>
     private readonly struct AttributeKey : IEquatable<AttributeKey>
     {
         private readonly uint[] _communities;
         private readonly (uint Global, uint Local1, uint Local2)[] _largeCommunities;
 
-        private AttributeKey(uint[] communities, (uint Global, uint Local1, uint Local2)[] largeCommunities)
+        public bool IsIpv4 { get; }
+
+        private AttributeKey(uint[] communities,
+            (uint Global, uint Local1, uint Local2)[] largeCommunities, bool isIpv4)
         {
             _communities = communities;
             _largeCommunities = largeCommunities;
+            IsIpv4 = isIpv4;
         }
 
         // #238: Route collections are IReadOnlyList — the key holds privately-owned normalized
         // arrays so it never aliases a route's (shared) backing array. Building them is
         // KeyNormalizer's job.
         internal static AttributeKey Create(
-            uint[] communities, (uint Global, uint Local1, uint Local2)[] largeCommunities) =>
-            new(communities, largeCommunities);
+            uint[] communities, (uint Global, uint Local1, uint Local2)[] largeCommunities,
+            bool isIpv4) =>
+            new(communities, largeCommunities, isIpv4);
 
         internal static int LargeCommunityComparison(
             (uint Global, uint Local1, uint Local2) a, (uint Global, uint Local1, uint Local2) b)
@@ -171,6 +204,7 @@ public sealed class ExactUnionPrefixAggregator : IPrefixAggregator
 
         public bool Equals(AttributeKey other)
         {
+            if (IsIpv4 != other.IsIpv4) return false;
             if (_communities.Length != other._communities.Length) return false;
             for (var i = 0; i < _communities.Length; i++)
                 if (_communities[i] != other._communities[i]) return false;
@@ -185,6 +219,7 @@ public sealed class ExactUnionPrefixAggregator : IPrefixAggregator
         public override int GetHashCode()
         {
             var hc = new HashCode();
+            hc.Add(IsIpv4);
             foreach (var c in _communities) hc.Add(c);
             foreach (var l in _largeCommunities) hc.Add(l);
             return hc.ToHashCode();
@@ -216,7 +251,8 @@ public sealed class ExactUnionPrefixAggregator : IPrefixAggregator
         private Dictionary<object, (uint Global, uint Local1, uint Local2)[]>? _largeCommunities;
 
         public AttributeKey KeyFor(Route route) =>
-            AttributeKey.Create(Normalize(route.Communities), NormalizeLarge(route.LargeCommunities));
+            AttributeKey.Create(Normalize(route.Communities), NormalizeLarge(route.LargeCommunities),
+                route.IsIpv4);
 
         /// <summary>Communities are a set: dedup and sort so set-equivalent routes key together.</summary>
         private uint[] Normalize(IReadOnlyList<uint> communities)

--- a/BGPLite.Routing/RouteTable.cs
+++ b/BGPLite.Routing/RouteTable.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using BGPLite.Protocol;
 
 namespace BGPLite.Routing;
 
@@ -169,6 +170,27 @@ public sealed class RouteTable
 
     public Route? Get(UInt128 prefix, byte length, bool isIpv4 = true) =>
         _routes.TryGetValue((prefix, length, isIpv4), out var entry) ? entry.Route : null;
+
+    /// <summary>
+    /// Longest-prefix-match lookup (#14 phase 3): the stored route whose network most
+    /// specifically contains <paramref name="address"/>, or null. Probes candidate prefix
+    /// lengths from the family maximum down to /0 — at most 33 (IPv4) / 129 (IPv6) dictionary
+    /// lookups — and is family-scoped: an IPv6 address never matches an IPv4 entry and vice
+    /// versa (the family is part of the key). Read-only: it never installs or replaces anything,
+    /// unlike <see cref="AddOrUpdate"/>. There is no per-packet consumer today (a route server
+    /// does not forward); this is the lookup the epic's routing layer requires for /0..128
+    /// coverage checks and policy decisions.
+    /// </summary>
+    public Route? GetLongestPrefixMatch(UInt128 address, bool isIpv4 = true)
+    {
+        for (var length = isIpv4 ? 32 : 128; length >= 0; length--)
+        {
+            var network = address & IpPrefix.Mask((byte)length, isIpv4);
+            if (_routes.TryGetValue((network, (byte)length, isIpv4), out var entry))
+                return entry.Route;
+        }
+        return null;
+    }
 
     public IReadOnlyList<Route> GetAll()
     {

--- a/BGPLite.Server/BgpServer.cs
+++ b/BGPLite.Server/BgpServer.cs
@@ -60,19 +60,32 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        // #14 phase 4: a dual-mode IPv6 listener accepts both IPv6 peers and IPv4 peers — the
-        // kernel surfaces the latter as IPv4-mapped addresses, normalized in AcceptLoopAsync.
-        // DualMode must be set before Bind.
-        _listener = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
-        _listener.DualMode = true;
-        _listener.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
-        _listener.Bind(new IPEndPoint(IPAddress.IPv6Any, BgpConstants.BgpPort));
+        // #14 phase 4: prefer the dual-mode IPv6 listener — it accepts both IPv6 peers and IPv4
+        // peers (the kernel surfaces the latter as IPv4-mapped addresses, normalized in
+        // AcceptLoopAsync). DualMode must be set before Bind. On hosts with IPv6 disabled we fall
+        // back to the pre-phase-4 IPv4 listener instead of refusing to start: serving IPv4-only
+        // beats not serving at all, and the capability difference is announced loudly.
+        var useDualMode = Socket.OSSupportsIPv6;
+        if (useDualMode)
+        {
+            _listener = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
+            _listener.DualMode = true;
+            _listener.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+            _listener.Bind(new IPEndPoint(IPAddress.IPv6Any, BgpConstants.BgpPort));
+        }
+        else
+        {
+            _listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            _listener.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+            _listener.Bind(new IPEndPoint(IPAddress.Any, BgpConstants.BgpPort));
+            _logger.LogWarning("IPv6 is not available on this host — serving IPv4 peers only");
+        }
         // #344: after a restart every peer reconnects at once; backlog 16 dropped SYNs and pushed
         // peers into their own retry backoff, stretching reconvergence for no benefit. A few
         // hundred pending accepts costs nothing on a route-server host.
         _listener.Listen(512);
 
-        _logger.LogInformation("BGP server listening on [::]:{Port} (dual-mode IPv6+IPv4)", BgpConstants.BgpPort);
+        _logger.LogInformation("BGP server listening on {Address}:{Port}", useDualMode ? "[::]" : "0.0.0.0", BgpConstants.BgpPort);
         _logger.LogInformation("Local ASN={Asn}, RouterId={RouterId}", _config.Bgp.Asn, _config.Bgp.RouterId);
 
         _acceptTask = AcceptLoopAsync(_cts.Token);

--- a/BGPLite.Server/BgpServer.cs
+++ b/BGPLite.Server/BgpServer.cs
@@ -60,15 +60,19 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        _listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        // #14 phase 4: a dual-mode IPv6 listener accepts both IPv6 peers and IPv4 peers — the
+        // kernel surfaces the latter as IPv4-mapped addresses, normalized in AcceptLoopAsync.
+        // DualMode must be set before Bind.
+        _listener = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
+        _listener.DualMode = true;
         _listener.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
-        _listener.Bind(new IPEndPoint(IPAddress.Any, BgpConstants.BgpPort));
+        _listener.Bind(new IPEndPoint(IPAddress.IPv6Any, BgpConstants.BgpPort));
         // #344: after a restart every peer reconnects at once; backlog 16 dropped SYNs and pushed
         // peers into their own retry backoff, stretching reconvergence for no benefit. A few
         // hundred pending accepts costs nothing on a route-server host.
         _listener.Listen(512);
 
-        _logger.LogInformation("BGP server listening on port {Port}", BgpConstants.BgpPort);
+        _logger.LogInformation("BGP server listening on [::]:{Port} (dual-mode IPv6+IPv4)", BgpConstants.BgpPort);
         _logger.LogInformation("Local ASN={Asn}, RouterId={RouterId}", _config.Bgp.Asn, _config.Bgp.RouterId);
 
         _acceptTask = AcceptLoopAsync(_cts.Token);
@@ -184,12 +188,13 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
     {
         if (socket is null)
             return;
+        var wire = Md5WireAddress(socket.AddressFamily, peer);
         try
         {
             if (key is null)
-                TcpMd5.Clear(socket, peer);
+                TcpMd5.Clear(socket, wire);
             else
-                TcpMd5.Apply(socket, peer, key);
+                TcpMd5.Apply(socket, wire, key);
         }
         catch (Exception ex)
         {
@@ -199,6 +204,30 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
         }
     }
 
+    /// <summary>
+    /// Normalizes the remote address of an accepted connection for identity/lookup use — the
+    /// session key, the PeerStore string address, the accept throttle and the MD5 key table all
+    /// key on the plain form. A dual-mode listener surfaces IPv4 peers as IPv4-mapped IPv6
+    /// (<c>::ffff:a.b.c.d</c>); configured peers are plain IPv4, so the mapped form would break
+    /// every lookup. internal static for unit tests.
+    /// </summary>
+    internal static IPAddress NormalizeAcceptedAddress(IPAddress address) =>
+        address.IsIPv4MappedToIPv6 ? address.MapToIPv4() : address;
+
+    /// <summary>
+    /// The address form a TCP-MD5 key must be stored under on <paramref name="socketFamily"/>.
+    /// The kernel resolves the key through the socket's own parse path, which demands the
+    /// SOCKET's family in the sockaddr: on Linux an IPv6 socket's
+    /// <c>tcp_v6_parse_md5_keys</c> rejects an AF_INET entry (EINVAL) but accepts the
+    /// IPv4-mapped form (<c>ipv6_addr_v4mapped</c>, prefixlen 32) — so an IPv4 peer maps to
+    /// <c>::ffff:a.b.c.d</c> on a v6 (dual-mode) socket. A v4 socket and real v6 peers pass
+    /// through unchanged. Pure; internal static for unit tests.
+    /// </summary>
+    internal static IPAddress Md5WireAddress(AddressFamily socketFamily, IPAddress peer) =>
+        socketFamily == AddressFamily.InterNetworkV6 && peer.AddressFamily == AddressFamily.InterNetwork
+            ? peer.MapToIPv6()
+            : peer;
+
     private async Task AcceptLoopAsync(CancellationToken cancellationToken)
     {
         while (!cancellationToken.IsCancellationRequested)
@@ -207,12 +236,19 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
             {
                 var socket = await _listener!.AcceptAsync(cancellationToken);
                 var remoteEndpoint = (IPEndPoint)socket.RemoteEndPoint!;
+                // A dual-mode listener surfaces IPv4 peers as IPv4-mapped IPv6 addresses
+                // (::ffff:a.b.c.d). Normalize BEFORE anything keys on the address: the session
+                // key, the PeerStore string address, the accept throttle and the MD5 key table
+                // all key on the plain IPv4 form, so configured peer "10.0.0.1" matches the
+                // connection it configured. The RAW address stays the MD5 wire form — see
+                // Md5WireAddress for why it must NOT be normalized there (#14 phase 4).
+                var address = NormalizeAcceptedAddress(remoteEndpoint.Address);
                 // Session identity = the accepted TCP connection (remote IP + remote source port),
                 // so peers sharing a source IP but on different source ports get distinct slots and
                 // coexist (RFC 4271 §8.2.1; issue #18). peerAddress stays the IP-only form for the
                 // PeerStore, which is still keyed by IP.
-                var key = new SessionKey(remoteEndpoint.Address, remoteEndpoint.Port);
-                var peerAddress = remoteEndpoint.Address.ToString();
+                var key = new SessionKey(address, remoteEndpoint.Port);
+                var peerAddress = address.ToString();
 
                 // Per-source-IP accept throttle (#115): defend one-IP accept floods. If this IP has
                 // already exceeded MaxAcceptsPerIpPerMinute within the rolling 60s window, close the
@@ -236,7 +272,9 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
 
                 // #36: the accepted socket inherits the listener's TCP-MD5 key on Linux; re-apply
                 // for the known peer so enforcement does not depend on inheritance semantics.
-                if (_md5Keys.TryGetValue(remoteEndpoint.Address, out var md5Key))
+                // The lookup keys on the normalized address (the table is keyed by the configured
+                // form); ApplyMd5 re-maps to the socket's wire form itself.
+                if (_md5Keys.TryGetValue(address, out var md5Key))
                     ApplyMd5(socket, remoteEndpoint.Address, md5Key);
 
                 var session = _sessionFactory.Create(new SocketBgpConnection(socket), peerConfig);

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -1427,16 +1427,25 @@ public sealed class BgpSession : IDisposable
     };
 
     /// <summary>
-    /// End-of-RIB marker for IPv4 unicast (RFC 4724 §2): a minimum-length UPDATE (no withdrawn
-    /// routes, no path attributes, no NLRI). Signals completion of the initial routing update so
-    /// GR-capable peers finalize — replacing stale routes with what we re-advertised and purging
-    /// the rest. Lock is acquired inside SendMessageAsync.
+    /// End-of-RIB markers (RFC 4724 §2), one per advertised family: a minimum-length UPDATE for
+    /// IPv4 unicast, and — for MP-IPv6-negotiated peers — an UPDATE carrying an EMPTY
+    /// MP_UNREACH_NLRI (AFI=2/SAFI=1), which is the IPv6 family's EoR. Signals completion of the
+    /// initial routing update so GR-capable peers finalize — replacing stale routes with what we
+    /// re-advertised and purging the rest. Lock is acquired inside SendMessageAsync.
     /// </summary>
     private async Task SendEndOfRibAsync()
     {
         await SendMessageAsync(new BgpUpdateMessage());
         _metrics.UpdateSent();
         _logger.LogDebug("End-of-RIB sent to {Peer}", _peer);
+
+        if (_peerMpIpv6Unicast)
+        {
+            var eor = new BgpUpdateMessage { PathAttributes = UpdateCodec.WithMpUnreachV6Attribute([]) };
+            await SendMessageAsync(eor);
+            _metrics.UpdateSent();
+            _logger.LogDebug("End-of-RIB (IPv6/Unicast) sent to {Peer}", _peer);
+        }
     }
 
     #region Message I/O
@@ -1737,7 +1746,7 @@ public sealed class BgpSession : IDisposable
         _logger.LogInformation("Peer {Peer} Graceful Restart: {State}",
             _peer,
             peerGr.HasValue
-                ? $"supported (restartState={peerGr.Value.RestartState}, restartTime={peerGr.Value.RestartTime}s, IPv4/Unicast forwarding={peerGr.Value.Ipv4UnicastForwarding})"
+                ? $"supported (restartState={peerGr.Value.RestartState}, restartTime={peerGr.Value.RestartTime}s, IPv4/Unicast forwarding={peerGr.Value.Ipv4UnicastForwarding}, IPv6/Unicast forwarding={peerGr.Value.Ipv6UnicastForwarding})"
                 : "not supported");
     }
 

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -231,16 +231,42 @@ public sealed class BgpSession : IDisposable
         const int maxPerUpdate = 100;
         // #85: reuse a single batch list instead of GetRange (which allocates a new List per batch).
         var batch = new List<IpPrefix>(Math.Min(maxPerUpdate, count));
+
+        // IPv4 withdrawals ride the classic WITHDRAWN ROUTES field (RFC 4271 §4.3).
         for (var i = 0; i < count; i += maxPerUpdate)
         {
             batch.Clear();
             var end = Math.Min(i + maxPerUpdate, count);
             for (var j = i; j < end; j++)
-                batch.Add(_advertisedPrefixes[j]);
+                if (_advertisedPrefixes[j].IsIpv4)
+                    batch.Add(_advertisedPrefixes[j]);
+            if (batch.Count == 0)
+                continue;
             var update = new BgpUpdateMessage
             {
                 WithdrawnRoutes = batch,
                 PathAttributes = [],
+                Nlri = []
+            };
+            await SendMessageAsync(update);
+            _metrics.UpdateSent();
+        }
+
+        // IPv6 withdrawals ride MP_UNREACH_NLRI (RFC 4760 §7 — #14 phase 4): an IPv6 prefix can
+        // never be named by the classic withdrawn field, and BIRD/FRR expect the MP form.
+        for (var i = 0; i < count; i += maxPerUpdate)
+        {
+            batch.Clear();
+            var end = Math.Min(i + maxPerUpdate, count);
+            for (var j = i; j < end; j++)
+                if (!_advertisedPrefixes[j].IsIpv4)
+                    batch.Add(_advertisedPrefixes[j]);
+            if (batch.Count == 0)
+                continue;
+            var update = new BgpUpdateMessage
+            {
+                WithdrawnRoutes = [],
+                PathAttributes = UpdateCodec.WithMpUnreachV6Attribute(batch),
                 Nlri = []
             };
             await SendMessageAsync(update);
@@ -1178,6 +1204,15 @@ public sealed class BgpSession : IDisposable
             await SendRoutesAsync(nextHop, routes);
     }
 
+    /// <summary>The local global IPv6 next hop (Bgp.NextHopIpv6) or null when unset/invalid —
+    /// null disables IPv6 advertisements (fail-visible at send time). Re-parsed per send from the
+    /// immutable config rather than cached in the constructor: tests construct sessions from raw
+    /// config records, and the parse is nanoseconds against a ~30s send.</summary>
+    private UInt128? NextHopIpv6 =>
+        BgpConfig.IsGlobalUnicastV6(_bgpConfig.NextHopIpv6) && IPAddress.TryParse(_bgpConfig.NextHopIpv6, out var v6)
+            ? BgpConstants.ToUInt128(v6)
+            : null;
+
     private async Task SendRoutesAsync(uint nextHop, List<Route> routes)
     {
         // Summarize before sending: merge adjacent/overlapping prefixes into the minimal
@@ -1197,6 +1232,35 @@ public sealed class BgpSession : IDisposable
                 routes.Count, aggregated.Count, deduped.Count, _peer);
         routes = deduped;
 
+        // #14 phase 4: family split. IPv4 rides the classic NLRI field; IPv6 rides MP_REACH
+        // (RFC 4760 §5) and ONLY when both halves agree: the peer negotiated MP IPv6/Unicast in
+        // OPEN, and Bgp.NextHopIpv6 is configured (RFC 2545 §3 — the MP_REACH next hop must be a
+        // global address; the IPv4 router-id cannot serve the IPv6 family). Otherwise IPv6
+        // routes are suppressed for this send — loudly, never silently.
+        var v4Routes = new List<Route>(routes.Count);
+        var v6Routes = new List<Route>();
+        foreach (var route in routes)
+        {
+            if (route.IsIpv4)
+                v4Routes.Add(route);
+            else
+                v6Routes.Add(route);
+        }
+        if (v6Routes.Count > 0 && !_peerMpIpv6Unicast)
+        {
+            _logger.LogWarning(
+                "Suppressing {Count} IPv6 routes to {Peer}: the peer did not negotiate MP IPv6/Unicast — advertising them as classic IPv4 NLRI would corrupt the peer's table",
+                v6Routes.Count, _peer);
+            v6Routes.Clear();
+        }
+        else if (v6Routes.Count > 0 && !NextHopIpv6.HasValue)
+        {
+            _logger.LogWarning(
+                "Suppressing {Count} IPv6 routes to {Peer}: Bgp.NextHopIpv6 is not configured — set it to a global IPv6 address to advertise IPv6 routes",
+                v6Routes.Count, _peer);
+            v6Routes.Clear();
+        }
+
         const int maxNlriPerUpdate = 100;
         _advertisedPrefixes.EnsureCapacity(_advertisedPrefixes.Count + routes.Count);
         var sent = 0;
@@ -1206,10 +1270,12 @@ public sealed class BgpSession : IDisposable
         // a single send (localAsn/localFourByteAsn/nextHop are constant for the whole send), so
         // build them once per community set and reuse instead of rebuilding on each batch (#87).
         // Scoped to this send only: the cache dies with the dictionary, so it can never serve a
-        // later send that carries a different nextHop or renegotiated ASN.
+        // later send that carries a different nextHop or renegotiated ASN. The v6 family gets its
+        // own cache — its cached lists carry no classic NEXT_HOP (#407's wire shape).
         var attrCache = UpdateCodec.CreateUpdateAttributeCache();
+        var v6AttrCache = UpdateCodec.CreateV6UpdateAttributeCache();
 
-        foreach (var route in routes)
+        foreach (var route in v4Routes)
         {
             batch.Add(route);
             _advertisedPrefixes.Add(new IpPrefix(route.Prefix, route.PrefixLength, route.IsIpv4));
@@ -1227,9 +1293,49 @@ public sealed class BgpSession : IDisposable
             sent += batch.Count;
         }
 
+        var v6NextHop = NextHopIpv6 ?? 0;
+        batch.Clear();
+        foreach (var route in v6Routes)
+        {
+            batch.Add(route);
+            _advertisedPrefixes.Add(new IpPrefix(route.Prefix, route.PrefixLength, route.IsIpv4));
+            if (batch.Count >= maxNlriPerUpdate)
+            {
+                await SendV6RouteBatchAsync(v6NextHop, batch, v6AttrCache);
+                sent += batch.Count;
+                batch.Clear();
+            }
+        }
+
+        if (batch.Count > 0)
+        {
+            await SendV6RouteBatchAsync(v6NextHop, batch, v6AttrCache);
+            sent += batch.Count;
+        }
+
         _logger.LogInformation("UpdateSent {Count} routes to {Peer}", sent, _peer);
         // #212: cache the actual wire count for the API/UI.
         Volatile.Write(ref _advertisedCount, sent);
+    }
+
+    /// <summary>
+    /// Sends one batch of IPv6 routes as MP_REACH_NLRI UPDATEs (#14 phase 4): the batch is
+    /// partitioned by community set (the MP_REACH attribute applies to every NLRI in its UPDATE,
+    /// same rule as COMMUNITY), base attributes come from the v6 cache (no classic NEXT_HOP),
+    /// and the MP_REACH attribute — global next hop + this group's NLRI — is appended per group.
+    /// </summary>
+    private async Task SendV6RouteBatchAsync(UInt128 nextHop6, List<Route> routes, Dictionary<IReadOnlyList<uint>, List<PathAttribute>> v6AttrCache)
+    {
+        foreach (var groupRoutes in GroupByCommunitySet(routes))
+        {
+            var attrs = UpdateCodec.GetCachedV6UpdateAttributes(
+                _bgpConfig.Asn, _localFourByteAsn, groupRoutes[0].Communities, v6AttrCache);
+            attrs = UpdateCodec.WithLargeCommunityAttribute(attrs, groupRoutes[0].LargeCommunities);
+
+            var nlri = groupRoutes.Select(r => new IpPrefix(r.Prefix, r.PrefixLength, r.IsIpv4)).ToList();
+            attrs = UpdateCodec.WithMpReachV6Attribute(attrs, nextHop6, nlri);
+            await SendUpdateBatchAsync(attrs, [], mpReach: new MpReachCodec.MpReachV6(nextHop6, nlri));
+        }
     }
 
     /// <summary>
@@ -1299,12 +1405,13 @@ public sealed class BgpSession : IDisposable
     private static List<List<Route>> GroupByCommunitySet(IReadOnlyList<Route> routes)
         => RouteAssembler.GroupByCommunitySet(routes);
 
-    private async Task SendUpdateBatchAsync(List<PathAttribute> attrs, List<IpPrefix> nlri)
+    private async Task SendUpdateBatchAsync(List<PathAttribute> attrs, List<IpPrefix> nlri, MpReachCodec.MpReachV6? mpReach = null)
     {
         var update = new BgpUpdateMessage
         {
             PathAttributes = attrs,
-            Nlri = nlri
+            Nlri = nlri,
+            MpReachV6 = mpReach
         };
 
         await SendMessageAsync(update);

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -917,8 +917,10 @@ public sealed class BgpSession : IDisposable
         foreach (var w in update.WithdrawnRoutes)
             WithdrawIfOwned(w, "Route withdrawn");
 
-        // Process announcements
-        if (update.Nlri.Count > 0)
+        // Process announcements. The gate must accept MP_REACH-only UPDATEs (#407): the normal
+        // wire shape for an IPv6 announcement (RFC 4760 §5) leaves the classic NLRI field EMPTY —
+        // gating on Nlri.Count alone silently dropped every such announcement.
+        if (update.Nlri.Count > 0 || update.MpReachV6 is not null)
         {
             // #270: the inbound attribute pipeline (per-attribute validation, mandatory set,
             // AS4_PATH reconstruction, aggregator consistency — subcodes 3/6/8/9/11) lives in the
@@ -1033,14 +1035,6 @@ public sealed class BgpSession : IDisposable
                 }
             }
 
-            // #15 phase 2 (RFC 4760 §7): MP_UNREACH_NLRI (AFI=2/SAFI=1) withdraws IPv6 routes
-            // this session installed — same ownership rule as the classic withdrawal path (#289).
-            if (update.MpUnreachV6 is { Count: > 0 } v6Withdrawn)
-            {
-                foreach (var prefix in v6Withdrawn)
-                    WithdrawIfOwned(prefix, "Route withdrawn (MP_UNREACH)");
-            }
-
             // MP_REACH_NLRI (AFI=2/SAFI=1) announcements: same install pipeline as the classic
             // IPv4 NLRI loop — AS-loop exclusion, filter, cap, ownership (#15 phase 2).
             if (update.MpReachV6 is { } mpReach)
@@ -1084,6 +1078,16 @@ public sealed class BgpSession : IDisposable
                     }
                 }
             }
+        }
+
+        // #15 phase 2 (RFC 4760 §7): MP_UNREACH_NLRI (AFI=2/SAFI=1) withdraws IPv6 routes this
+        // session installed — same ownership rule as the classic withdrawal path (#289). Runs
+        // OUTSIDE the announcement block (#407): an MP_UNREACH-only UPDATE (a peer withdrawing
+        // its IPv6 routes) has no classic NLRI and no MP_REACH, and must not depend on either.
+        if (update.MpUnreachV6 is { Count: > 0 } v6Withdrawn)
+        {
+            foreach (var prefix in v6Withdrawn)
+                WithdrawIfOwned(prefix, "Route withdrawn (MP_UNREACH)");
         }
 
         _metrics.SetRouteCount(_routeTable.Count);

--- a/BGPLite.Server/RouteAssembler.cs
+++ b/BGPLite.Server/RouteAssembler.cs
@@ -79,8 +79,8 @@ public sealed class RouteAssembler : IRouteAssembler
                 try
                 {
                     var ruPrefixes = await _prefixService.GetRuPrefixesAsync(ct);
-                    foreach (var (prefix, length, _) in ruPrefixes)
-                        routes.Add(MakeRoute(prefix, length, nextHop, null, defaultComms));
+                    foreach (var p in ruPrefixes)
+                        routes.Add(MakeRoute(p.Prefix, p.Length, p.IsIpv4, nextHop, null, defaultComms));
                     _logger.LogInformation("Sent {Count} RU prefixes to unconfigured peer {Peer}",
                         ruPrefixes.Count, peerLabel);
                 }
@@ -115,11 +115,11 @@ public sealed class RouteAssembler : IRouteAssembler
                         var comms = _communityResolver.Resolve(
                             new CommunitySource(CommunitySourceKind.AsnList, list.Name));
                         var prefixes = await _prefixService.GetPrefixesForAsns(list.Asns, ct);
-                        foreach (var (prefix, length, _) in prefixes)
+                        foreach (var p in prefixes)
                             // #85: AsPath is overwritten by the local ASN in the outbound codec
                             // (BuildUpdateAttributes), so the per-prefix asn value is never used
                             // on the wire — pass null instead of allocating [asn] per prefix.
-                            routes.Add(MakeRoute(prefix, length, nextHop, null, comms));
+                            routes.Add(MakeRoute(p.Prefix, p.Length, p.IsIpv4, nextHop, null, comms));
                     }
                     catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#330
                     catch (Exception ex)
@@ -140,8 +140,8 @@ public sealed class RouteAssembler : IRouteAssembler
                     var comms = _communityResolver.Resolve(
                         new CommunitySource(CommunitySourceKind.Country, countryLists[0].Name));
                     var ruPrefixes = await _prefixService.GetRuPrefixesAsync(ct);
-                    foreach (var (prefix, length, _) in ruPrefixes)
-                        routes.Add(MakeRoute(prefix, length, nextHop, null, comms));
+                    foreach (var p in ruPrefixes)
+                        routes.Add(MakeRoute(p.Prefix, p.Length, p.IsIpv4, nextHop, null, comms));
                     _logger.LogInformation("Fetched {Count} RU prefixes for {Peer}", ruPrefixes.Count, peerLabel);
                 }
                 catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#330
@@ -163,8 +163,8 @@ public sealed class RouteAssembler : IRouteAssembler
                 {
                     var comms = _communityResolver.Resolve(new CommunitySource(CommunitySourceKind.PrefixSource, name));
                     var srcPrefixes = await _prefixService.GetSourcePrefixesAsync(name, ct);
-                    foreach (var (prefix, length) in srcPrefixes)
-                        routes.Add(MakeRoute(prefix, length, nextHop, null, comms));
+                    foreach (var p in srcPrefixes)
+                        routes.Add(MakeRoute(p.Prefix, p.Length, p.IsIpv4, nextHop, null, comms));
                     _logger.LogInformation("Fetched {Count} prefixes from source '{Source}' for {Peer}",
                         srcPrefixes.Count, name, peerLabel);
                 }
@@ -193,7 +193,7 @@ public sealed class RouteAssembler : IRouteAssembler
                     continue;
                 }
                 customRanges.Add((prefix, length));
-                routes.Add(MakeRoute(prefix, length, nextHop, null, customPrefixComms));
+                routes.Add(MakeRoute(prefix, length, isIpv4: true, nextHop, null, customPrefixComms));
             }
 
             // Add custom AS prefixes. Custom-AS routes carry the static "custom AS" community.
@@ -203,8 +203,8 @@ public sealed class RouteAssembler : IRouteAssembler
                 {
                     var customAsnComms = _communityResolver.Resolve(new CommunitySource(CommunitySourceKind.CustomAsn));
                     var asnPrefixes = await _prefixService.GetPrefixesForAsns(customAsns, ct);
-                    foreach (var (prefix, length, _) in asnPrefixes)
-                        routes.Add(MakeRoute(prefix, length, nextHop, null, customAsnComms));
+                    foreach (var p in asnPrefixes)
+                        routes.Add(MakeRoute(p.Prefix, p.Length, p.IsIpv4, nextHop, null, customAsnComms));
                     _logger.LogInformation("Peer {Peer} custom AS: {Asns} -> {Count} prefixes",
                         peerLabel, string.Join(",", customAsns), asnPrefixes.Count);
                 }
@@ -244,8 +244,8 @@ public sealed class RouteAssembler : IRouteAssembler
                 try
                 {
                     var ruPrefixes = await _prefixService.GetRuPrefixesAsync(ct);
-                    foreach (var (prefix, length, _) in ruPrefixes)
-                        routes.Add(MakeRoute(prefix, length, nextHop, null, defaultComms));
+                    foreach (var p in ruPrefixes)
+                        routes.Add(MakeRoute(p.Prefix, p.Length, p.IsIpv4, nextHop, null, defaultComms));
                 }
                 catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#330
                 catch (Exception ex)
@@ -275,8 +275,8 @@ public sealed class RouteAssembler : IRouteAssembler
             try
             {
                 var ruPrefixes = await _prefixService.GetRuPrefixesAsync(ct);
-                foreach (var (prefix, length, _) in ruPrefixes)
-                    routes.Add(MakeRoute(prefix, length, nextHop, null, defaultComms));
+                foreach (var p in ruPrefixes)
+                    routes.Add(MakeRoute(p.Prefix, p.Length, p.IsIpv4, nextHop, null, defaultComms));
                 _logger.LogInformation("Fetched {Count} RU prefixes for unknown peer {Peer}",
                     ruPrefixes.Count, peerLabel);
             }
@@ -332,13 +332,16 @@ public sealed class RouteAssembler : IRouteAssembler
 
     /// <summary>
     /// Builds a <see cref="Route"/> from its components. Static so it can be called from
-    /// <see cref="AddUserSourceRoutesAsync"/> and unit-tested directly.
+    /// <see cref="AddUserSourceRoutesAsync"/> and unit-tested directly. IPv4 addresses occupy
+    /// the low 32 bits of <paramref name="prefix"/> (the implicit uint→UInt128 widening);
+    /// <paramref name="isIpv4"/> carries the family (#14 phase 4).
     /// </summary>
     internal static Route MakeRoute(
-        uint prefix, byte length, uint nextHop, uint[]? asPath, uint[] communities,
+        UInt128 prefix, byte length, bool isIpv4, uint nextHop, uint[]? asPath, uint[] communities,
         (uint Global, uint Local1, uint Local2)[]? largeCommunities = null) => new()
         {
             Prefix = prefix,
+            IsIpv4 = isIpv4,
             PrefixLength = length,
             NextHop = nextHop,
             AsPath = asPath ?? [],
@@ -364,8 +367,8 @@ public sealed class RouteAssembler : IRouteAssembler
             var comms = communityResolver.Resolve(
                 new CommunitySource(CommunitySourceKind.UserSource, source.Name, source.Community));
             var prefixes = await prefixService.GetUserSourcePrefixesAsync(source.Name, source.Url, source.Community, ct);
-            foreach (var (prefix, length) in prefixes)
-                routes.Add(MakeRoute(prefix, length, nextHop, null, comms));
+            foreach (var p in prefixes)
+                routes.Add(MakeRoute(p.Prefix, p.Length, p.IsIpv4, nextHop, null, comms));
             logger.LogInformation("User-source '{Name}': {Count} prefixes for {Peer}", source.Name, prefixes.Count, peerLabel);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#342: only CALLER cancellation — a per-source timeout OCE (#320's linked CTS, live ct) must stay a fetch failure below

--- a/BGPLite.Tests/ApiHandlerBehaviorTests.cs
+++ b/BGPLite.Tests/ApiHandlerBehaviorTests.cs
@@ -10,6 +10,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
+using BGPLite.Protocol;
 
 namespace BGPLite.Tests;
 
@@ -263,20 +264,20 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
 
     private sealed class InertPrefixService : IPrefixService
     {
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default) => Task.FromResult(new List<(uint, byte, uint)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetPrefixesAsync(uint asn, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default) => Task.FromResult(new List<(UInt128, byte, bool, uint)>());
         public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default) => Task.FromResult(new List<(uint, byte, uint)>());
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default) => Task.FromResult(new List<(UInt128, byte, bool, uint)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
     }
 
     private sealed class InertPrefixSources : IPrefixSourceService
     {
-        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>> LoadAllAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<(uint Prefix, byte Length)>)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetDefaultAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
+        public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
+        public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);
         public bool SourceSupportsConditional(string sourceName) => false;

--- a/BGPLite.Tests/BgpServerAcceptTests.cs
+++ b/BGPLite.Tests/BgpServerAcceptTests.cs
@@ -1,0 +1,146 @@
+using System.Net;
+using System.Net.Sockets;
+using BGPLite.Contracts;
+using BGPLite.Server;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #14 phase 4: the dual-mode listener surfaces IPv4 peers as IPv4-mapped IPv6 addresses —
+/// these cover the address-form conversions that keep session identity, the PeerStore lookup
+/// and TCP-MD5 keys working across both transport families.
+/// </summary>
+public class BgpServerAcceptTests
+{
+    private static readonly byte[] Key = "test-md5-key"u8.ToArray();
+
+    // ---- NormalizeAcceptedAddress: identity/lookup form ----
+
+    [Fact]
+    public void Normalize_MappedIpv4_BecomesPlainIpv4()
+    {
+        var mapped = IPAddress.Parse("::ffff:10.0.0.1");
+        Assert.Equal(IPAddress.Parse("10.0.0.1"), BgpServer.NormalizeAcceptedAddress(mapped));
+    }
+
+    [Fact]
+    public void Normalize_PlainIpv4_Unchanged()
+    {
+        Assert.Equal(IPAddress.Parse("192.168.1.2"), BgpServer.NormalizeAcceptedAddress(IPAddress.Parse("192.168.1.2")));
+    }
+
+    [Fact]
+    public void Normalize_Ipv6_Unchanged()
+    {
+        Assert.Equal(IPAddress.Parse("2001:db8::1"), BgpServer.NormalizeAcceptedAddress(IPAddress.Parse("2001:db8::1")));
+    }
+
+    /// <summary>The premise the normalization exists for: an IPv4 client connecting to a
+    /// dual-mode listener really does arrive as an IPv4-mapped endpoint, so without the
+    /// conversion the PeerStore key would read "::ffff:127.0.0.1" where the config says
+    /// "127.0.0.1". Drives a real dual-mode socket pair on a loopback high port.</summary>
+    [Fact]
+    public void Normalize_DualModeListener_Ipv4ClientArrivesMapped()
+    {
+        if (!Socket.OSSupportsIPv6) return; // same idiom as TcpMd5Tests' platform guard
+
+        using var listener = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
+        listener.DualMode = true;
+        // Wildcard bind (as BgpServer.StartAsync does) — a bind to a specific v6 address
+        // (::1) does not match IPv4 traffic even in dual mode.
+        listener.Bind(new IPEndPoint(IPAddress.IPv6Any, 0));
+        listener.Listen(1);
+
+        using var client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        client.Connect(new IPEndPoint(IPAddress.Loopback, ((IPEndPoint)listener.LocalEndPoint!).Port));
+        var accepted = listener.Accept();
+        try
+        {
+            var remote = ((IPEndPoint)accepted.RemoteEndPoint!).Address;
+            Assert.True(remote.IsIPv4MappedToIPv6, "expected an IPv4-mapped remote address on the dual-mode listener");
+            Assert.Equal(IPAddress.Loopback, BgpServer.NormalizeAcceptedAddress(remote));
+        }
+        finally
+        {
+            accepted.Dispose();
+        }
+    }
+
+    // ---- Md5WireAddress: the form a TCP-MD5 key is stored under ----
+
+    [Fact]
+    public void Md5WireAddress_V6Socket_Ipv4Peer_MapsToV6()
+    {
+        // Linux tcp_v6_parse_md5_keys rejects AF_INET on a v6 socket but accepts the
+        // IPv4-mapped form (prefixlen 32) — the key must be stored mapped.
+        var wire = BgpServer.Md5WireAddress(AddressFamily.InterNetworkV6, IPAddress.Parse("10.0.0.1"));
+        Assert.Equal(IPAddress.Parse("::ffff:10.0.0.1"), wire);
+    }
+
+    [Fact]
+    public void Md5WireAddress_V6Socket_Ipv6Peer_Unchanged()
+    {
+        var peer = IPAddress.Parse("2001:db8::1");
+        Assert.Equal(peer, BgpServer.Md5WireAddress(AddressFamily.InterNetworkV6, peer));
+    }
+
+    [Fact]
+    public void Md5WireAddress_V6Socket_AlreadyMappedPeer_Unchanged()
+    {
+        // The accept path passes the RAW remote address (already mapped for IPv4 peers);
+        // re-mapping must not double-map or alter it.
+        var peer = IPAddress.Parse("::ffff:10.0.0.1");
+        Assert.Equal(peer, BgpServer.Md5WireAddress(AddressFamily.InterNetworkV6, peer));
+    }
+
+    [Fact]
+    public void Md5WireAddress_V4Socket_Ipv4Peer_Unchanged()
+    {
+        var peer = IPAddress.Parse("10.0.0.1");
+        Assert.Equal(peer, BgpServer.Md5WireAddress(AddressFamily.InterNetwork, peer));
+    }
+
+    /// <summary>
+    /// Kernel-level proof of the dual-mode MD5 path (Linux loopback, same guarantees as
+    /// TcpMd5Tests' v4 handshake test): a key stored under the mapped form
+    /// (<see cref="BgpServer.Md5WireAddress"/>) on a dual-mode listener is enforced — an IPv4
+    /// client WITH the key completes the handshake, WITHOUT it the kernel drops the SYN.
+    /// Proves the AF_INET6+::ffff:a.b.c.d sockaddr actually matches a v4-mapped connection,
+    /// which no pure-function test can show.
+    /// </summary>
+    [Fact]
+    public async Task Linux_DualMode_Handshake_MappedKey_Connects_WithoutKey_IsDropped()
+    {
+        if (!OperatingSystem.IsLinux()) return;
+
+        using var listener = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
+        listener.DualMode = true;
+        listener.Bind(new IPEndPoint(IPAddress.IPv6Any, 0));
+        listener.Listen(2);
+        var serverPort = ((IPEndPoint)listener.LocalEndPoint!).Port;
+
+        // The key is stored under EXACTLY the form production code derives (Md5WireAddress).
+        var wirePeer = BgpServer.Md5WireAddress(listener.AddressFamily, IPAddress.Loopback);
+        Assert.Equal(IPAddress.Parse("::ffff:127.0.0.1"), wirePeer);
+        TcpMd5.Apply(listener, wirePeer, Key);
+
+        // IPv4 client WITH the key (attached for the server's v4 endpoint) completes the handshake.
+        var clientEp = new IPEndPoint(IPAddress.Loopback, serverPort);
+        using var goodClient = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        TcpMd5.Apply(goodClient, clientEp, Key);
+        var acceptTask = listener.AcceptAsync();
+        await goodClient.ConnectAsync(clientEp);
+        using var accepted = await acceptTask;
+        Assert.True(accepted.Connected);
+        Assert.True(goodClient.Connected);
+
+        // IPv4 client WITHOUT the key: its SYN is dropped by the kernel — no connection.
+        using var badClient = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        var connectTask = badClient.ConnectAsync(clientEp);
+        var timedOut = await Task.WhenAny(connectTask, Task.Delay(1500)) != connectTask;
+        Assert.True(timedOut || !badClient.Connected, "an unsigned client must not complete the handshake");
+
+        goodClient.Dispose();
+        accepted.Dispose();
+    }
+}

--- a/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
+++ b/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
@@ -189,9 +189,9 @@ public class BgpSessionRouteOwnershipTests
     }
 
     /// <summary>Waits for the initial dump and returns every NLRI the session put on the wire.</summary>
-    private static async Task<List<(uint Prefix, byte Length)>> CollectAdvertisedNlriAsync(ScriptedConnection conn)
+    private static async Task<List<(UInt128 Prefix, byte Length)>> CollectAdvertisedNlriAsync(ScriptedConnection conn)
     {
-        var nlri = new List<(uint, byte)>();
+        var nlri = new List<(UInt128, byte)>();
         for (var i = 0; i < 200; i++)
         {
             nlri.Clear();
@@ -386,7 +386,7 @@ public class BgpSessionRouteOwnershipTests
 
     // ---- harness ----
 
-    private static RouteTable Seeded(params (uint Prefix, byte Length)[] routes)
+    private static RouteTable Seeded(params (UInt128 Prefix, byte Length)[] routes)
     {
         var table = new RouteTable();
         foreach (var (prefix, length) in routes)

--- a/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
+++ b/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
@@ -877,6 +877,80 @@ public class BgpSessionRouteOwnershipTests
         await TeardownAsync(session, run);
     }
 
+    // ---- #407: MP_REACH/MP_UNREACH-only UPDATEs (RFC 4760 §5/§7) ----
+
+    /// <summary>2001:db8:ffff::/48 — the announced IPv6 prefix, full 128-bit form.</summary>
+    private static readonly UInt128 V6TestPrefix =
+        ((UInt128)0x2001 << 112) | ((UInt128)0x0DB8 << 96) | ((UInt128)0xFFFF << 80);
+
+    /// <summary>2001:db8::2 — the MP_REACH next hop.</summary>
+    private static readonly UInt128 V6TestNextHop =
+        ((UInt128)0x2001 << 112) | ((UInt128)0x0DB8 << 96) | 2;
+
+    /// <summary>
+    /// ORIGIN + AS_PATH + MP_REACH_NLRI carrying 2001:db8:ffff::/48, NO classic NLRI — the
+    /// normal wire shape for an IPv6 announcement (RFC 4760 §5: the next hop rides in the
+    /// attribute, the classic NLRI field stays empty).
+    /// </summary>
+    private static byte[] MpReachOnlyAnnounceFrame()
+    {
+        var value = MpReachCodec.EncodeMpReachV6(
+            V6TestNextHop, [new IpPrefix(V6TestPrefix, 48, isIpv4: false)]);
+        var attrs = new List<byte>
+        {
+            0x40, 0x01, 0x01, 0x00,                                 // ORIGIN igp
+            0x40, 0x02, 0x06, 0x02, 0x01, 0x00, 0x00, 0x00, 0x64,   // AS_PATH seq [100]
+            0x80, MpReachCodec.MpReachNlriType, (byte)value.Length, // MP_REACH: optional, non-transitive
+        };
+        attrs.AddRange(value);
+        var payload = new List<byte> { 0x00, 0x00, 0x00, (byte)attrs.Count };  // no withdrawn, no classic NLRI
+        payload.AddRange(attrs);
+        return Frame(BgpMessageType.Update, [.. payload]);
+    }
+
+    /// <summary>MP_UNREACH_NLRI-only UPDATE withdrawing 2001:db8:ffff::/48 (RFC 4760 §7).</summary>
+    private static byte[] MpUnreachOnlyWithdrawFrame()
+    {
+        var value = MpReachCodec.EncodeMpUnreachV6([new IpPrefix(V6TestPrefix, 48, isIpv4: false)]);
+        var attrs = new List<byte> { 0x80, MpReachCodec.MpUnreachNlriType, (byte)value.Length };
+        attrs.AddRange(value);
+        var payload = new List<byte> { 0x00, 0x00, 0x00, (byte)attrs.Count };  // no withdrawn, no classic NLRI
+        payload.AddRange(attrs);
+        return Frame(BgpMessageType.Update, [.. payload]);
+    }
+
+    [Fact]
+    public async Task MpReachOnly_Announcement_InstallsTheIpv6Route()
+    {
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        conn.EnqueueFrame(MpReachOnlyAnnounceFrame());
+        await SettleAsync(conn, () => routeTable.Count == 1);
+
+        var route = routeTable.Get(V6TestPrefix, 48, isIpv4: false);
+        Assert.NotNull(route);
+        Assert.Equal(V6TestNextHop, route.NextHop);
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task MpUnreachOnly_Withdrawal_RemovesTheIpv6Route()
+    {
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        conn.EnqueueFrame(MpReachOnlyAnnounceFrame());
+        await SettleAsync(conn, () => routeTable.Count == 1);
+
+        conn.EnqueueFrame(MpUnreachOnlyWithdrawFrame());
+        await SettleAsync(conn, () => routeTable.Count == 0);
+        Assert.Null(routeTable.Get(V6TestPrefix, 48, isIpv4: false));
+
+        await TeardownAsync(session, run);
+    }
+
     private sealed class RejectAllIncomingFilter : IRouteFilter
     {
         private static readonly IReadOnlySet<uint> Empty = new HashSet<uint>();

--- a/BGPLite.Tests/BgpSessionUserSourceTests.cs
+++ b/BGPLite.Tests/BgpSessionUserSourceTests.cs
@@ -31,11 +31,11 @@ public class BgpSessionUserSourceTests
     /// <summary>A minimal <see cref="IPrefixService"/> that only implements the user-source path.</summary>
     private sealed class StubPrefixService : IPrefixService
     {
-        public IReadOnlyList<(uint Prefix, byte Length)> Result { get; set; } = [];
+        public IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)> Result { get; set; } = [];
         public Exception? Throw { get; set; }
         public (string Name, string Url, string? Community)? Last { get; private set; }
 
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetUserSourcePrefixesAsync(
             string name, string url, string? community, CancellationToken ct = default)
         {
             Last = (name, url, community);
@@ -43,22 +43,22 @@ public class BgpSessionUserSourceTests
             return Task.FromResult(Result);
         }
 
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
-            => Task.FromResult(new List<(uint Prefix, byte Length, uint Asn)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
+            => Task.FromResult(new List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>());
         public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
-            => Task.FromResult(new List<(uint Prefix, byte Length, uint Asn)>());
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
+            => Task.FromResult(new List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
     }
 
     [Fact]
     public async Task Success_AddsRoutesWithResolvedCommunity()
     {
-        var svc = new StubPrefixService { Result = [(0xC0A80000u, (byte)24)] };
+        var svc = new StubPrefixService { Result = [((UInt128)0xC0A80000u, (byte)24, true)] };
         var resolver = new StubResolver();
         var routes = new List<Route>();
 
@@ -83,7 +83,7 @@ public class BgpSessionUserSourceTests
         // Per-source try/catch: one failing URL must not drop another source's prefixes.
         var routes = new List<Route>();
         var throwSvc = new StubPrefixService { Throw = new InvalidOperationException("boom") };
-        var okSvc = new StubPrefixService { Result = [(0x0A000000u, (byte)8)] };
+        var okSvc = new StubPrefixService { Result = [((UInt128)0x0A000000u, (byte)8, true)] };
 
         await RouteAssembler.AddUserSourceRoutesAsync(
             routes, new CustomSourceView("bad", "https://x/b", null), 1, throwSvc, new StubResolver(), NullLogger.Instance, "peer", CancellationToken.None);
@@ -118,7 +118,7 @@ public class BgpSessionUserSourceTests
         // RunAsync's OCE handler.
         var routes = new List<Route>();
         var slowSvc = new StubPrefixService { Throw = new OperationCanceledException() };
-        var okSvc = new StubPrefixService { Result = [(0x0A000000u, (byte)8)] };
+        var okSvc = new StubPrefixService { Result = [((UInt128)0x0A000000u, (byte)8, true)] };
 
         await RouteAssembler.AddUserSourceRoutesAsync(
             routes, new CustomSourceView("slow", "https://x/s", null), 1, slowSvc, new StubResolver(),

--- a/BGPLite.Tests/BgpSessionV6AdvertiseTests.cs
+++ b/BGPLite.Tests/BgpSessionV6AdvertiseTests.cs
@@ -1,0 +1,238 @@
+using BGPLite.Configuration;
+using BGPLite.Contracts;
+using BGPLite.Protocol;
+using BGPLite.Routing;
+using BGPLite.Server;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #14 phase 4: outbound IPv6 advertisement — the family split at the send path. IPv4 rides
+/// classic NLRI with a NEXT_HOP (RFC 4271 §4.3); IPv6 rides MP_REACH_NLRI with the next hop
+/// inside the attribute (RFC 4760 §5, RFC 2545 §3) and ONLY when the peer negotiated
+/// MP IPv6/Unicast AND Bgp.NextHopIpv6 is configured. Withdrawals mirror the split (RFC 4760 §7).
+/// </summary>
+public class BgpSessionV6AdvertiseTests
+{
+    private static readonly UInt128 V6NextHop = ((UInt128)0x2001 << 112) | ((UInt128)0x0DB8 << 96) | 1;
+    private static readonly UInt128 V6PrefixNet = ((UInt128)0x2001 << 112) | ((UInt128)0x0DB8 << 96);
+
+    private static BgpConfig Config(bool withV6NextHop = true) => new()
+    {
+        Asn = 65001,
+        RouterId = "127.0.0.1",
+        HoldTime = 0,
+        KeepAlive = 0,
+        NextHopIpv6 = withV6NextHop ? "2001:db8::1" : null
+    };
+
+    private static Route V6Route() => new()
+    {
+        Prefix = V6PrefixNet,
+        IsIpv4 = false,
+        PrefixLength = 48,
+        NextHop = V6NextHop
+    };
+
+    private static async Task<(BgpSession Session, Task Run, ScriptedConnection Conn)> EstablishAsync(
+        RouteTable routeTable, BgpConfig? config = null, bool negotiateMpV6 = true)
+    {
+        var conn = new ScriptedConnection();
+        var session = new BgpSession(
+            conn,
+            new PeerConfig { Address = "127.0.0.1" },
+            config ?? Config(),
+            routeTable,
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            NullLogger<BgpSession>.Instance);
+
+        var run = session.RunAsync();
+        var capabilities = new List<BgpCapabilityInfo> { BgpCapabilityInfo.FourOctetAsn(65002) };
+        if (negotiateMpV6)
+            capabilities.Add(BgpCapabilityInfo.MultiprotocolIpv6Unicast());
+        conn.EnqueueMessage(new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = 0,
+            RouterId = 0x0A000002,
+            Capabilities = capabilities
+        });
+        conn.EnqueueMessage(BgpKeepaliveMessage.Instance);
+
+        for (var i = 0; i < 200 && !session.IsEstablished; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        Assert.True(session.IsEstablished, "session must reach Established");
+        return (session, run, conn);
+    }
+
+    private static async Task TeardownAsync(BgpSession session, Task run)
+    {
+        session.Dispose();
+        try { await run.WaitAsync(TimeSpan.FromSeconds(2)); } catch (TimeoutException) { }
+    }
+
+    /// <summary>All UPDATEs the session put on the wire, polled until the expected frame shows
+    /// up (the initial dump runs concurrently with the test thread).</summary>
+    private static async Task<List<BgpUpdateMessage>> SentUpdatesAsync(ScriptedConnection conn, Func<BgpUpdateMessage, bool> until)
+    {
+        var updates = new List<BgpUpdateMessage>();
+        for (var i = 0; i < 200; i++)
+        {
+            updates.Clear();
+            foreach (var frame in conn.Sent)
+                if (BgpMessageReader.ReadMessage(frame) is BgpUpdateMessage u)
+                    updates.Add(u);
+            if (updates.Any(until)) break;
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        }
+        return updates;
+    }
+
+    [Fact]
+    public async Task Negotiated_WithNextHop_V6RoutesRideMpReach()
+    {
+        var routeTable = new RouteTable();
+        routeTable.AddOrUpdate(V6Route());                       // unowned seed → shared-table dump
+        routeTable.AddOrUpdate(new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 1 });
+
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        var updates = await SentUpdatesAsync(conn, u => u.MpReachV6 is not null);
+        var v6Update = Assert.Single(updates, u => u.MpReachV6 is not null);
+        Assert.Equal(V6NextHop, v6Update.MpReachV6!.Value.NextHop);
+        var pfx = Assert.Single(v6Update.MpReachV6!.Value.Prefixes);
+        Assert.Equal((V6PrefixNet, (byte)48), (pfx.Address, pfx.Length));
+        // RFC 4760 §5: the MP_REACH UPDATE carries no classic NLRI and no classic NEXT_HOP.
+        Assert.Empty(v6Update.Nlri);
+        Assert.DoesNotContain(v6Update.PathAttributes, a => a.TypeCode == BgpConstants.Attribute.NextHop);
+        // ...while the IPv4 route still rides the classic path.
+        Assert.Contains(updates, u => u.Nlri.Any(p => p.Address == 0x0A000000 && p.Length == 8));
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task V6Announcement_IsRoundTrippable_ByTheRealReader()
+    {
+        // The wire shape must survive our own reader: AFI/SAFI 2/1, global next hop, prefixes.
+        var routeTable = new RouteTable();
+        routeTable.AddOrUpdate(V6Route());
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        var mp = Assert.Single(await SentUpdatesAsync(conn, u => u.MpReachV6 is not null), u => u.MpReachV6 is not null).MpReachV6!.Value;
+        var value = MpReachCodec.EncodeMpReachV6(mp.NextHop, mp.Prefixes);
+        var decoded = MpReachCodec.DecodeMpReachV6(value);
+        Assert.Equal(V6NextHop, decoded.NextHop);
+        Assert.Equal(48, Assert.Single(decoded.Prefixes).Length);
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task NoNegotiation_V6RoutesSuppressed_Ipv4Untouched()
+    {
+        var routeTable = new RouteTable();
+        routeTable.AddOrUpdate(V6Route());
+        routeTable.AddOrUpdate(new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 1 });
+
+        var (session, run, conn) = await EstablishAsync(routeTable, negotiateMpV6: false);
+
+        var updates = await SentUpdatesAsync(conn, u => u.Nlri.Any(p => p.Address == 0x0A000000));
+        Assert.DoesNotContain(updates, u => u.MpReachV6 is not null);
+        Assert.DoesNotContain(updates, u => u.Nlri.Any(p => !p.IsIpv4));
+        Assert.Contains(updates, u => u.Nlri.Any(p => p.Address == 0x0A000000)); // v4 unaffected
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task NoConfiguredNextHop_V6RoutesSuppressed()
+    {
+        var routeTable = new RouteTable();
+        routeTable.AddOrUpdate(V6Route());
+
+        var (session, run, conn) = await EstablishAsync(routeTable, config: Config(withV6NextHop: false));
+
+        // The End-of-RIB empty UPDATE always follows Established, so "any UPDATE seen" is the
+        // reachable condition; the assertion is that none of them carries MP_REACH.
+        Assert.DoesNotContain(await SentUpdatesAsync(conn, u => u.Nlri.Count == 0 && u.WithdrawnRoutes.Count == 0), u => u.MpReachV6 is not null);
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task Withdrawal_V6PrefixesRideMpUnreach_OnTheWire()
+    {
+        // The refresh cycle withdraws EVERYTHING it advertised, then re-sends. After the table
+        // is drained the withdrawal pass must split by family: the v4 seed via the classic
+        // withdrawn field, the v6 seed via an MP_UNREACH-only UPDATE (RFC 4760 §7).
+        var routeTable = new RouteTable();
+        routeTable.AddOrUpdate(V6Route());
+        routeTable.AddOrUpdate(new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 1 });
+
+        var (session, run, conn) = await EstablishAsync(routeTable);
+        // Let the initial dump finish (its MP_REACH UPDATE is the completion signal) — a refresh
+        // racing the dump would withdraw a half-filled mirror and prove nothing.
+        await SentUpdatesAsync(conn, u => u.MpReachV6 is not null);
+        await session.RefreshRoutesAsync(); // withdraw-all + resend against the same table
+
+        var updates = await SentUpdatesAsync(conn, u => u.MpUnreachV6 is { Count: > 0 });
+        Assert.True(updates.Any(u => u.MpUnreachV6 is { Count: > 0 }),
+            "no MP_UNREACH UPDATE on the wire; sent updates: " +
+            string.Join("; ", updates.Select(u =>
+                $"Wd={u.WithdrawnRoutes.Count} Nlri={u.Nlri.Count} Reach={(u.MpReachV6 is null ? "-" : u.MpReachV6.Value.Prefixes.Count.ToString())} Unreach={u.MpUnreachV6?.Count.ToString() ?? "-"}")));
+        var mpUnreach = Assert.Single(updates, u => u.MpUnreachV6 is { Count: > 0 });
+        Assert.Empty(mpUnreach.WithdrawnRoutes);                          // v6 never rides the classic field
+        // (the reader moves the type-15 attribute into MpUnreachV6, so PathAttributes is empty here)
+        var withdrawn = Assert.Single(mpUnreach.MpUnreachV6!);
+        Assert.Equal((V6PrefixNet, (byte)48), (withdrawn.Address, withdrawn.Length));
+        // ...and the v4 seed's withdrawal still rides the classic withdrawn field.
+        Assert.Contains(updates, u => u.WithdrawnRoutes.Any(w => w.Address == 0x0A000000 && w.Length == 8));
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task EndOfRib_Ipv6Family_SentAfterInitialDump()
+    {
+        // RFC 4724 §2: End-of-RIB per AFI. The IPv6 EoR is an UPDATE carrying an EMPTY
+        // MP_UNREACH_NLRI (AFI=2/SAFI=1) — sent after the initial dump to MP-IPv6 peers.
+        var routeTable = new RouteTable();
+        routeTable.AddOrUpdate(V6Route());
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        var eor = await SentUpdatesAsync(conn, u => u.MpUnreachV6 is { Count: 0 });
+        var mpEor = Assert.Single(eor, u => u.MpUnreachV6 is { Count: 0 });
+        Assert.Empty(mpEor.Nlri);
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public void MpUnreachAttribute_IsOptionalNonTransitive()
+    {
+        var attr = UpdateCodec.WithMpUnreachV6Attribute([new IpPrefix(V6PrefixNet, 48, isIpv4: false)]).Single();
+        Assert.Equal(MpReachCodec.MpUnreachNlriType, attr.TypeCode);
+        Assert.True(attr.Optional);
+        Assert.False(attr.Transitive);
+        Assert.True(MpReachCodec.DecodeMpUnreachV6(attr.Data).Single().IsIpv4 == false);
+    }
+
+    [Fact]
+    public void NextHopIpv6_Validation()
+    {
+        // Global unicast (2000::/3) is accepted; link-local, ULA, multicast, mapped and garbage
+        // are rejected with a message that names the knob.
+        new BgpConfig { Asn = 65001, RouterId = "1.2.3.4", NextHopIpv6 = "2001:db8::1" }.Validate();
+
+        foreach (var bad in new[] { "fe80::1", "fc00::1", "ff02::1", "::ffff:192.0.2.1", "2001:db8::1/48", "1.2.3.4", "not-an-address" })
+        {
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => new BgpConfig { Asn = 65001, RouterId = "1.2.3.4", NextHopIpv6 = bad }.Validate());
+            Assert.Contains("NextHopIpv6", ex.Message);
+        }
+    }
+}

--- a/BGPLite.Tests/CommunityResolverTests.cs
+++ b/BGPLite.Tests/CommunityResolverTests.cs
@@ -96,7 +96,7 @@ public class CommunityResolverTests
     [Fact]
     public void MakeRoute_StampsCommunitiesAndAsPath()
     {
-        var route = RouteAssembler.MakeRoute(0xC0A80000, 24, 0x01020304, [65000u], [CommunityCodec.Parse("65000:100")]);
+        var route = RouteAssembler.MakeRoute(0xC0A80000, 24, isIpv4: true, 0x01020304, [65000u], [CommunityCodec.Parse("65000:100")]);
         Assert.Equal(0xC0A80000u, route.Prefix);
         Assert.Equal((byte)24, route.PrefixLength);
         Assert.Equal(0x01020304u, route.NextHop);
@@ -107,7 +107,7 @@ public class CommunityResolverTests
     [Fact]
     public void MakeRoute_NullAsPath_DefaultsEmpty()
     {
-        var route = RouteAssembler.MakeRoute(0x0A000000, 8, 0, null, []);
+        var route = RouteAssembler.MakeRoute(0x0A000000, 8, isIpv4: true, 0, null, []);
         Assert.Empty(route.AsPath);
         Assert.Empty(route.Communities);
     }

--- a/BGPLite.Tests/ConfigHotReloadTests.cs
+++ b/BGPLite.Tests/ConfigHotReloadTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using BGPLite.Contracts;
+using BGPLite.Protocol;
 
 namespace BGPLite.Tests;
 
@@ -351,29 +352,29 @@ public class ConfigHotReloadTests
     /// <summary>Answers every prefix query with an empty set; the hot-reload path never calls it.</summary>
     private sealed class InertPrefixService : IPrefixService
     {
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
-            => Task.FromResult(new List<(uint Prefix, byte Length, uint Asn)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
+            => Task.FromResult(new List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>());
         public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
-            => Task.FromResult(new List<(uint Prefix, byte Length, uint Asn)>());
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
+            => Task.FromResult(new List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
     }
 
     /// <summary>Reports no configured prefix sources; the hot-reload path never calls it.</summary>
     private sealed class InertPrefixSourceService : IPrefixSourceService
     {
-        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<(uint, byte)>)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetDefaultAsync(CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
+        public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
+        public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);
         public bool SourceSupportsConditional(string sourceName) => false;

--- a/BGPLite.Tests/GracefulRestartTests.cs
+++ b/BGPLite.Tests/GracefulRestartTests.cs
@@ -12,22 +12,30 @@ public class GracefulRestartTests
         //   byte0 = 0x80 (R) | 0x01 (high nibble of 0x1FF) = 0x81
         //   byte1 = 0xFF (low byte of 0x1FF)
         //   IPv4(0x00,0x01) + Unicast(0x01) + AF flags 0x80 (F)
-        var cap = BgpCapabilityInfo.GracefulRestart(restartState: true, restartTime: 0x1FF, forwardingState: true);
+        //   IPv6(0x00,0x02) + Unicast(0x01) + AF flags 0x80 (F)
+        var cap = BgpCapabilityInfo.GracefulRestart(restartState: true, restartTime: 0x1FF, ipv4Forwarding: true, ipv6Forwarding: true);
 
         Assert.Equal(BgpConstants.Capability.GracefulRestart, cap.Code);
-        Assert.Equal(new byte[] { 0x81, 0xFF, 0x00, 0x01, 0x01, 0x80 }, cap.Data);
+        Assert.Equal(new byte[] { 0x81, 0xFF, 0x00, 0x01, 0x01, 0x80, 0x00, 0x02, 0x01, 0x80 }, cap.Data);
+
+        // A legacy v4-only payload (one tuple, no IPv6) still parses — v6 forwarding = false.
+        var legacy = BgpCapabilityInfo.TryParseGracefulRestart(new byte[] { 0x81, 0xFF, 0x00, 0x01, 0x01, 0x80 });
+        Assert.NotNull(legacy);
+        Assert.True(legacy!.Value.Ipv4UnicastForwarding);
+        Assert.False(legacy.Value.Ipv6UnicastForwarding);
     }
 
     [Fact]
     public void Capability_RoundTrips_Through_Parser()
     {
-        var cap = BgpCapabilityInfo.GracefulRestart(true, 120, true);
+        var cap = BgpCapabilityInfo.GracefulRestart(true, 120, true, ipv6Forwarding: true);
         var parsed = BgpCapabilityInfo.TryParseGracefulRestart(cap.Data);
 
         Assert.NotNull(parsed);
         Assert.True(parsed!.Value.RestartState);
         Assert.Equal((ushort)120, parsed.Value.RestartTime);
         Assert.True(parsed.Value.Ipv4UnicastForwarding);
+        Assert.True(parsed.Value.Ipv6UnicastForwarding);
     }
 
     [Fact]
@@ -41,7 +49,8 @@ public class GracefulRestartTests
         Assert.Equal((ushort)60, parsed.Value.RestartTime);
         Assert.False(parsed.Value.Ipv4UnicastForwarding);
         Assert.Equal(0x00, cap.Data[0]);   // no R, no high time bits
-        Assert.Equal(0x00, cap.Data[5]);   // no F
+        Assert.Equal(0x00, cap.Data[5]);   // no IPv4 F
+        Assert.Equal(0x00, cap.Data[9]);   // no IPv6 F
     }
 
     [Fact]
@@ -100,7 +109,7 @@ public class GracefulRestartTests
             Capabilities =
             [
                 BgpCapabilityInfo.FourOctetAsn(65001),
-                BgpCapabilityInfo.GracefulRestart(true, 120, true)
+                BgpCapabilityInfo.GracefulRestart(true, 120, true, ipv6Forwarding: false)
             ]
         };
 

--- a/BGPLite.Tests/GracefulRestartTests.cs
+++ b/BGPLite.Tests/GracefulRestartTests.cs
@@ -58,6 +58,10 @@ public class GracefulRestartTests
     {
         Assert.Null(BgpCapabilityInfo.TryParseGracefulRestart([]));
         Assert.Null(BgpCapabilityInfo.TryParseGracefulRestart(new byte[] { 0x80 })); // only 1 byte
+        // RFC 4724 §2: the value is a 2-byte header plus COMPLETE 4-byte tuples — a trailing
+        // partial tuple is malformed, not a tail to ignore.
+        Assert.Null(BgpCapabilityInfo.TryParseGracefulRestart(new byte[] { 0x80, 0x3C, 0x00, 0x01, 0x01 }));
+        Assert.Null(BgpCapabilityInfo.TryParseGracefulRestart(new byte[] { 0x80, 0x3C, 0x00 }));
     }
 
     [Fact]

--- a/BGPLite.Tests/ManagementApiShutdownTests.cs
+++ b/BGPLite.Tests/ManagementApiShutdownTests.cs
@@ -8,6 +8,7 @@ using BGPLite.Routing;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
+using BGPLite.Protocol;
 
 namespace BGPLite.Tests;
 
@@ -201,12 +202,12 @@ public sealed class ManagementApiShutdownTests : IDisposable
     {
         public TaskCompletionSource Entered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
-            => Task.FromResult(new List<(uint Prefix, byte Length, uint Asn)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
+            => Task.FromResult(new List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>());
         public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
-        public async Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
+        public async Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
         {
             // Yield BEFORE signalling: the whole chain from the accept loop into this provider is
             // synchronous up to the first await, so without this the Entered signal could fire
@@ -217,22 +218,22 @@ public sealed class ManagementApiShutdownTests : IDisposable
             await Task.Delay(Timeout.Infinite, ct);   // never completes on its own; honors the token
             return [];
         }
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
     }
 
     /// <summary>Reports no configured prefix sources; the shutdown path never calls it.</summary>
     private sealed class InertPrefixSourceService : IPrefixSourceService
     {
-        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<(uint Prefix, byte Length)>)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetDefaultAsync(CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
+        public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
+        public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);
         public bool SourceSupportsConditional(string sourceName) => false;

--- a/BGPLite.Tests/PeerDeleteTeardownTests.cs
+++ b/BGPLite.Tests/PeerDeleteTeardownTests.cs
@@ -245,29 +245,29 @@ public sealed class PeerDeleteTeardownTests
     /// <summary>Answers every prefix query with an empty set; the delete path never calls it.</summary>
     private sealed class InertPrefixService : IPrefixService
     {
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
-            => Task.FromResult(new List<(uint Prefix, byte Length, uint Asn)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
+            => Task.FromResult(new List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>());
         public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
-            => Task.FromResult(new List<(uint Prefix, byte Length, uint Asn)>());
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
+            => Task.FromResult(new List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
     }
 
     /// <summary>Reports no configured prefix sources; the delete path never calls it.</summary>
     private sealed class InertPrefixSourceService : IPrefixSourceService
     {
-        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<(uint Prefix, byte Length)>)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetDefaultAsync(CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
+        public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
+        public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);
         public bool SourceSupportsConditional(string sourceName) => false;

--- a/BGPLite.Tests/PeerInputValidationTests.cs
+++ b/BGPLite.Tests/PeerInputValidationTests.cs
@@ -47,8 +47,6 @@ public class PeerInputValidationTests
     [InlineData(" 1.2.3.4")]
     [InlineData("banana")]
     [InlineData("1.2.3.4.5")]
-    [InlineData("2001:db8::1")]
-    [InlineData("::ffff:1.2.3.4")]
     public void NormalizePeerIp_RejectsUnusableInput(string? input)
     {
         Assert.Null(ManagementApi.NormalizePeerIp(input));

--- a/BGPLite.Tests/PeerSetupTemplateTests.cs
+++ b/BGPLite.Tests/PeerSetupTemplateTests.cs
@@ -1,0 +1,86 @@
+using BGPLite.Api;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #14 phase 5: peer-setup templates gain IPv6 address-family variants. Peers may be IPv6 hosts
+/// (validated at the API boundary), and the peer side needs its own address-family blocks to
+/// exchange IPv6 routes with the server.
+/// </summary>
+public class PeerSetupTemplateTests
+{
+    [Fact]
+    public void CiscoSetupV6_CarriesIpv6AddressFamily()
+    {
+        var lines = ManagementApi.BuildCiscoSetupV6(65001);
+        Assert.Contains(lines, l => l.Trim() == "address-family ipv6 unicast");
+        Assert.Contains(lines, l => l.Contains("neighbor <YOUR_IPv6> activate"));
+        Assert.Contains(lines, l => l.Contains("remote-as 65001"));
+    }
+
+    [Fact]
+    public void BirdSetupV6_CarriesIpv6Channel()
+    {
+        var lines = ManagementApi.BuildBirdSetupV6("2001:db8:cccc::10", 65001, 90);
+        Assert.Contains(lines, l => l.Trim() == "ipv6 {");
+        Assert.Contains(lines, l => l.Contains("neighbor 2001:db8:cccc::10 as 65001"));
+        Assert.Contains(lines, l => l.Contains("hold time 90;"));
+    }
+
+    [Fact]
+    public void BirdSetupV6_UnconfiguredServer_UsesPlaceholder()
+    {
+        var lines = ManagementApi.BuildBirdSetupV6(null, 65001, 90);
+        Assert.Contains(lines, l => l.Contains("neighbor <SERVER_V6> as 65001"));
+    }
+
+    [Fact]
+    public void MikrotikSetupV6_CarriesAfiIp6()
+    {
+        var lines = ManagementApi.BuildMikrotikSetupV6("2001:db8:cccc::10", 65001, 90);
+        Assert.Contains(lines, l => l.Contains("afi=ip6"));
+        Assert.Contains(lines, l => l.Contains("remote.address=2001:db8:cccc::10/128"));
+        Assert.Contains(lines, l => l.Contains("remote.as=65001"));
+    }
+
+    [Fact]
+    public void MikrotikSetupV6_UnconfiguredServer_UsesPlaceholder()
+    {
+        var lines = ManagementApi.BuildMikrotikSetupV6(null, 65001, 90);
+        Assert.Contains(lines, l => l.Contains("remote.address=<SERVER_V6>/128"));
+    }
+
+    // ---- NormalizePeerIp: peers may be IPv6 (#14 phase 5) ----
+
+    [Fact]
+    public void NormalizePeerIp_Ipv6_AcceptedAndCanonical()
+    {
+        Assert.Equal("2001:db8:cccc::20", ManagementApi.NormalizePeerIp("2001:db8:cccc:0:0:0:0:20"));
+        Assert.Equal("::1", ManagementApi.NormalizePeerIp("::1"));
+    }
+
+    [Fact]
+    public void NormalizePeerIp_MappedIpv6_NormalizesToPlainIpv4()
+    {
+        // A mapped literal names the IPv4 address space — the row must match the address form
+        // the dual-mode listener reports.
+        Assert.Equal("10.0.0.1", ManagementApi.NormalizePeerIp("::ffff:10.0.0.1"));
+    }
+
+    [Fact]
+    public void NormalizePeerIp_Ipv4_StillAccepted()
+    {
+        Assert.Equal("192.168.1.2", ManagementApi.NormalizePeerIp("192.168.1.2"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    [InlineData("not-an-address")]
+    [InlineData("2001:db8::1/48")] // a prefix is not a host address
+    public void NormalizePeerIp_Garbage_ReturnsNull(string? ip)
+    {
+        Assert.Null(ManagementApi.NormalizePeerIp(ip));
+    }
+}

--- a/BGPLite.Tests/PrefixAggregatorTests.cs
+++ b/BGPLite.Tests/PrefixAggregatorTests.cs
@@ -22,6 +22,52 @@ public class PrefixAggregatorTests
     private static List<(UInt128 Prefix, byte Length)> Pfx(IReadOnlyList<Route> routes) =>
         routes.Select(r => (r.Prefix, r.PrefixLength)).ToList();
 
+    /// <summary>IPv6 route builder. <paramref name="prefix"/> carries the network address in the
+    /// full 128 bits (<see cref="V6"/> composes one from leading hextets).</summary>
+    private static Route R6(UInt128 prefix, byte length, uint[]? communities = null) => new()
+    {
+        Prefix = prefix,
+        IsIpv4 = false,
+        PrefixLength = length,
+        NextHop = NextHop,
+        Communities = communities ?? []
+    };
+
+    /// <summary>Composes an IPv6 network address from its leading hextets (the rest are zero):
+    /// <c>V6(0x2001, 0x0DB8, 1)</c> is 2001:db8:1::.</summary>
+    private static UInt128 V6(ushort g0, ushort g1 = 0, ushort g2 = 0) =>
+        ((UInt128)g0 << 112) | ((UInt128)g1 << 96) | ((UInt128)g2 << 80);
+
+    /// <summary>Family-aware counterpart of <see cref="UnionRanges"/>: the sorted, merged
+    /// [start,end] intervals of an IPv6 prefix set (address space capped at 2^128-1).</summary>
+    private static List<(UInt128 Start, UInt128 End)> UnionRanges6(IEnumerable<(UInt128 Prefix, byte Length)> prefixes)
+    {
+        var intervals = new List<(UInt128 Start, UInt128 End)>();
+        foreach (var (prefix, length) in prefixes)
+        {
+            if (length > 128) continue;
+            var mask = length == 0 ? UInt128.Zero : UInt128.MaxValue << (128 - length);
+            var start = prefix & mask;
+            // /0 spans the whole space: 2^128 itself overflows, so the end is stated directly.
+            var end = length == 0 ? UInt128.MaxValue : start + ((UInt128)1 << (128 - length)) - 1;
+            intervals.Add((start, end));
+        }
+        intervals.Sort((a, b) => a.Start.CompareTo(b.Start));
+        var merged = new List<(UInt128 Start, UInt128 End)>();
+        foreach (var (s, e) in intervals)
+        {
+            if (merged.Count > 0 && (s <= merged[^1].End ||
+                                     (merged[^1].End != UInt128.MaxValue && s == merged[^1].End + 1)))
+            {
+                var newEnd = merged[^1].End > e ? merged[^1].End : e;
+                merged[^1] = (merged[^1].Start, newEnd);
+            }
+            else
+                merged.Add((s, e));
+        }
+        return merged;
+    }
+
     /// <summary>Independent reference implementation: the sorted, merged [start,end] intervals
     /// of a prefix set. Used to cross-check that aggregation adds no address and drops none.</summary>
     private static List<(UInt128 Start, UInt128 End)> UnionRanges(IEnumerable<(UInt128 Prefix, byte Length)> prefixes)
@@ -219,6 +265,125 @@ public class PrefixAggregatorTests
         ]);
         var route = Assert.Single(result);
         Assert.Equal(0xC0A80000u, route.Prefix);
+    }
+
+    // ---- #14 phase 3: IPv6 aggregation (family-aware, /0..128) ----
+
+    [Fact]
+    public void Ipv6_NestedPrefixes_CollapseToWidest()
+    {
+        // 2001:db8::/32 + nested 2001:db8:1::/48 → /32.
+        var result = _aggregator.Aggregate([
+            R6(V6(0x2001, 0xDB8), 32),
+            R6(V6(0x2001, 0xDB8, 1), 48),
+        ]);
+        Assert.Equal([(V6(0x2001, 0xDB8), (byte)32)], Pfx(result));
+        Assert.All(result, r => Assert.False(r.IsIpv4));
+    }
+
+    [Fact]
+    public void Ipv6_AdjacentPrefixes_MergeToSupernet()
+    {
+        // 2001:db8::/48 + 2001:db8:1::/48 → 2001:db8::/47. Regression: the 32-bit aggregator
+        // dropped every IPv6 prefix longer than /32, so the union lost BOTH routes entirely.
+        var result = _aggregator.Aggregate([
+            R6(V6(0x2001, 0xDB8), 48),
+            R6(V6(0x2001, 0xDB8, 1), 48),
+        ]);
+        var route = Assert.Single(result);
+        Assert.Equal((V6(0x2001, 0xDB8), (byte)47), (route.Prefix, route.PrefixLength));
+        Assert.False(route.IsIpv4);
+    }
+
+    [Fact]
+    public void Ipv6_HostBits_AreMasked()
+    {
+        var result = _aggregator.Aggregate([R6(V6(0x2001, 0xDB8) + 5, 32)]);
+        Assert.Equal([(V6(0x2001, 0xDB8), (byte)32)], Pfx(result));
+        Assert.False(result[0].IsIpv4);
+    }
+
+    [Fact]
+    public void Ipv6_Slash127Pair_MergesToSlash126()
+    {
+        var result = _aggregator.Aggregate([
+            R6(V6(0x2001, 0xDB8), 127),
+            R6(V6(0x2001, 0xDB8) + 2, 127),
+        ]);
+        var route = Assert.Single(result);
+        Assert.Equal((V6(0x2001, 0xDB8), (byte)126), (route.Prefix, route.PrefixLength));
+    }
+
+    [Fact]
+    public void Ipv6_Slash128_HostRoute_StaysUnchanged()
+    {
+        var result = _aggregator.Aggregate([R6(V6(0x2001, 0xDB8, 1) + 5, 128)]);
+        var route = Assert.Single(result);
+        Assert.Equal((V6(0x2001, 0xDB8, 1) + 5, (byte)128), (route.Prefix, route.PrefixLength));
+    }
+
+    [Fact]
+    public void Ipv6_DefaultRoute_Handled()
+    {
+        // ::/0 alone stays ::/0 with the IPv6 family (regression: it fell into the 32-bit
+        // interval math and came back out as 0.0.0.0/0 marked IPv4).
+        var single = Assert.Single(_aggregator.Aggregate([R6(0, 0)]));
+        Assert.Equal((UInt128.Zero, (byte)0), (single.Prefix, single.PrefixLength));
+        Assert.False(single.IsIpv4);
+
+        // The two /1 halves merge back into ::/0.
+        var merged = Assert.Single(_aggregator.Aggregate([
+            R6(0, 1),
+            R6((UInt128)1 << 127, 1),
+        ]));
+        Assert.Equal((UInt128.Zero, (byte)0), (merged.Prefix, merged.PrefixLength));
+        Assert.False(merged.IsIpv4);
+    }
+
+    [Fact]
+    public void Ipv6_UnionInvariant_NoExtraAndNoMissingIp()
+    {
+        // ::/0 swallows the whole set: the union must stay the full address space, emitted
+        // as exactly one route.
+        var input = new List<Route>
+        {
+            R6(V6(0x2001, 0xDB8), 48),
+            R6(V6(0x2001, 0xDB8, 1), 48),                      // adjacent /48s → /47
+            R6(V6(0x2001, 0xDB8, 2), 64),
+            R6(V6(0x2001, 0xDB8, 2) + ((UInt128)1 << 48), 64), // adjacent /64s → /63
+            R6(UInt128.Zero, 0),
+        };
+
+        var output = _aggregator.Aggregate(input);
+
+        Assert.Equal(UnionRanges6(input.Select(r => (r.Prefix, r.PrefixLength))),
+                     UnionRanges6(Pfx(output)));
+        Assert.True(output.Count <= input.Count);
+        Assert.All(output, r => Assert.False(r.IsIpv4));
+    }
+
+    [Fact]
+    public void Ipv4AndIpv6_SameCommunities_NeverMerge()
+    {
+        // Identical community sets, but IPv4 and IPv6 must never land in one summary
+        // (ADR 0001 §6). The two IPv6 /32s are the same network after host-bit masking and
+        // legitimately collapse to one; the point is the family split: pre-phase-3 the IPv6
+        // routes fell into the 32-bit interval space and the whole set collapsed into
+        // 0.0.0.0/0 marked IPv4.
+        var comm = new uint[] { 0x65 };
+        var result = _aggregator.Aggregate([
+            R(0xC0A80000, 24, comm),
+            R(0xC0A80100, 24, (uint[])comm.Clone()),
+            R6(V6(0x2001, 0xDB8), 32, (uint[])comm.Clone()),
+            R6(V6(0x2001, 0xDB8, 1), 32, (uint[])comm.Clone()),
+        ]);
+
+        Assert.Equal(2, result.Count);
+        var v4 = Assert.Single(result, r => r.IsIpv4);
+        Assert.Equal((0xC0A80000u, (byte)23), (v4.Prefix, v4.PrefixLength));
+        var v6 = Assert.Single(result, r => !r.IsIpv4);
+        Assert.Equal((V6(0x2001, 0xDB8), (byte)32), (v6.Prefix, v6.PrefixLength));
+        Assert.Equal([0x65u], v6.Communities);
     }
 
     // ---- #305: normalization is memoized per backing-array instance ----

--- a/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
+++ b/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
 using BGPLite.Contracts;
+using BGPLite.Protocol;
 
 namespace BGPLite.Tests;
 
@@ -36,10 +37,10 @@ public class PrefixAutoRefreshServiceTests
             => Conditional.TryGetValue(sourceName, out var v) ? v : true;
 
         // Unused by the auto-refresh service (it reads source names from AppConfig), but required by the interface.
-        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<(uint Prefix, byte Length)>)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetDefaultAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
+        public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
+        public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
     }
 

--- a/BGPLite.Tests/PrefixCacheRaceTests.cs
+++ b/BGPLite.Tests/PrefixCacheRaceTests.cs
@@ -1,6 +1,7 @@
 using BGPLite.Configuration;
 using BGPLite.Providers;
 using Microsoft.Extensions.Logging.Abstractions;
+using BGPLite.Protocol;
 
 namespace BGPLite.Tests;
 
@@ -129,22 +130,22 @@ public class PrefixCacheRaceTests
         public int DefaultCalls => Volatile.Read(ref _defaultCalls);
         public bool FailNext { get; set; }
 
-        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>> LoadAllAsync(CancellationToken ct = default) =>
+        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default) =>
             throw new NotImplementedException();
 
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name, CancellationToken ct = default) =>
+        public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default) =>
             throw new NotImplementedException();
 
-        public async Task<IReadOnlyList<(uint Prefix, byte Length)>> GetDefaultAsync(CancellationToken ct = default)
+        public async Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default)
         {
             Interlocked.Increment(ref _defaultCalls);
             // Simulate real I/O latency so concurrent callers actually overlap inside the gate.
             await Task.Delay(20, ct);
             if (FailNext) throw new InvalidOperationException("simulated default-source failure");
-            return new List<(uint Prefix, byte Length)>
+            return new List<IpPrefix>
             {
-                (0x0A000000u, 8),
-                (0xC0A80000u, 16),
+                new(0x0A000000u, 8),
+                new(0xC0A80000u, 16),
             };
         }
 

--- a/BGPLite.Tests/PrefixCidrTests.cs
+++ b/BGPLite.Tests/PrefixCidrTests.cs
@@ -152,4 +152,44 @@ public class PrefixCidrTests
         Assert.Equal(0u, prefix);
         Assert.Equal((byte)0, length);
     }
+    // ---- #14 phase 4: family-aware parse (IPv6) ----
+
+    [Fact]
+    public void TryParse_Ipv6_AcceptsAndMasks()
+    {
+        Assert.True(PrefixCidr.TryParse("2001:db8:ffff:ffff:1::/48", out var prefix));
+        Assert.False(prefix.IsIpv4);
+        Assert.Equal(48, prefix.Length);
+        var expected = ((UInt128)0x2001 << 112) | ((UInt128)0x0DB8 << 96) | ((UInt128)0xFFFF << 80);
+        Assert.Equal(expected, prefix.Address);
+    }
+
+    [Fact]
+    public void TryParse_Ipv6_HostRoute128()
+    {
+        Assert.True(PrefixCidr.TryParse("2001:db8::1/128", out var prefix));
+        Assert.False(prefix.IsIpv4);
+        Assert.Equal(128, prefix.Length);
+    }
+
+    [Theory]
+    [InlineData("2001:db8::/129")]   // out of range
+    [InlineData("::/0")]             // default route rejected like 0.0.0.0/0
+    [InlineData("2001:db8::")]       // no length
+    [InlineData("::ffff:10.0.0.1/96")] // v4-mapped — not a real IPv6 prefix
+    public void TryParse_Ipv6_Rejects(string bad)
+    {
+        Assert.False(PrefixCidr.TryParse(bad, out var prefix));
+        Assert.Equal(default, prefix);
+    }
+
+    [Fact]
+    public void TryParse_Ipv4OnlyOverload_StillRejectsIpv6()
+    {
+        // The API's custom-prefix path stays IPv4-scoped for now; the v4 overload must not
+        // silently widen with the family-aware parser arriving alongside it.
+        Assert.False(PrefixCidr.TryParse("2001:db8::/48", out var prefix, out var length));
+        Assert.Equal(0u, prefix);
+        Assert.Equal((byte)0, length);
+    }
 }

--- a/BGPLite.Tests/PrefixListParserTests.cs
+++ b/BGPLite.Tests/PrefixListParserTests.cs
@@ -6,14 +6,14 @@ namespace BGPLite.Tests;
 
 public class PrefixListParserTests
 {
-    private static uint Ip(string s) => BgpConstants.IPAddressToUint(IPAddress.Parse(s));
+    private static IpPrefix Pfx(string s) => new(BgpConstants.IPAddressToUint(IPAddress.Parse(s[..s.IndexOf("/")])), byte.Parse(s[(s.IndexOf("/") + 1)..]));
 
     [Fact]
     public void ParsesSingleCidr()
     {
         var result = PrefixListParser.Parse("1.2.3.0/24");
         var single = Assert.Single(result);
-        Assert.Equal((Ip("1.2.3.0"), (byte)24), single);
+        Assert.Equal(Pfx("1.2.3.0/24"), single);
     }
 
     [Fact]
@@ -31,12 +31,32 @@ public class PrefixListParserTests
     }
 
     [Fact]
-    public void SkipsIpv6()
+    public void AcceptsIpv6()
     {
-        var result = PrefixListParser.Parse("::1/128\n1.2.3.0/24");
-        var single = Assert.Single(result);
-        Assert.Equal((Ip("1.2.3.0"), (byte)24), single);
+        // #14 phase 4 flipped the old "SkipsIpv6" behavior: IPv6 entries are family-tagged
+        // prefixes now, parsed by the same canonical policy (masking, /0 rejection, 1..128).
+        var result = PrefixListParser.Parse("2001:DB8:0:0:0:0:0:1/48\n1.2.3.0/24");
+        Assert.Equal(2, result.Count);
+        // host bits masked: 2001:DB8:0:0:0:0:0:1/48 → 2001:db8::/48
+        var expected = ((UInt128)0x2001 << 112) | ((UInt128)0x0DB8 << 96);
+        Assert.Equal(new IpPrefix(expected, 48, isIpv4: false), result[0]);
+        Assert.True(result[1].IsIpv4);
     }
+
+    [Fact]
+    public void RejectsIpv6DefaultRoute()
+    {
+        Assert.Empty(PrefixListParser.Parse("::/0"));
+    }
+
+    [Fact]
+    public void AcceptsIpv6BoundaryLengths()
+    {
+        Assert.Single(PrefixListParser.Parse("2001:db8::/128")); // host route
+        Assert.Single(PrefixListParser.Parse("2001:db8::/1"));   // /1 — same policy space as v4's /1
+        Assert.Empty(PrefixListParser.Parse("2001:db8::/129"));  // out of range
+    }
+
 
     [Fact]
     public void SkipsBadLength()
@@ -80,7 +100,7 @@ public class PrefixListParserTests
     {
         var result = PrefixListParser.Parse("0.0.0.0/0\n1.2.3.0/24");
         var single = Assert.Single(result);
-        Assert.Equal((Ip("1.2.3.0"), (byte)24), single);
+        Assert.Equal(Pfx("1.2.3.0/24"), single);
     }
 
     [Fact]
@@ -90,7 +110,7 @@ public class PrefixListParserTests
         // so downstream dedup keys them as one route instead of two distinct rows.
         var result = PrefixListParser.Parse("10.0.0.5/24\n10.0.0.99/24");
         Assert.Equal(2, result.Count);
-        Assert.All(result, r => Assert.Equal((Ip("10.0.0.0"), (byte)24), r));
+        Assert.All(result, r => Assert.Equal(Pfx("10.0.0.0/24"), r));
     }
 
     [Fact]
@@ -98,7 +118,7 @@ public class PrefixListParserTests
     {
         var result = PrefixListParser.Parse("10.0.0.0/24");
         var single = Assert.Single(result);
-        Assert.Equal((Ip("10.0.0.0"), (byte)24), single);
+        Assert.Equal(Pfx("10.0.0.0/24"), single);
     }
 
     [Fact]
@@ -106,10 +126,10 @@ public class PrefixListParserTests
     {
         // /1 masks all but the top bit; /32 (host route) masks nothing.
         var r1 = Assert.Single(PrefixListParser.Parse("255.255.255.255/1"));
-        Assert.Equal((Ip("128.0.0.0"), (byte)1), r1);
+        Assert.Equal(Pfx("128.0.0.0/1"), r1);
 
         var r32 = Assert.Single(PrefixListParser.Parse("10.0.0.5/32"));
-        Assert.Equal((Ip("10.0.0.5"), (byte)32), r32);
+        Assert.Equal(Pfx("10.0.0.5/32"), r32);
     }
 
     [Fact]
@@ -120,6 +140,6 @@ public class PrefixListParserTests
         var bom = "\uFEFF1.2.3.0/24";
         var result = PrefixListParser.Parse(bom);
         var single = Assert.Single(result);
-        Assert.Equal((Ip("1.2.3.0"), (byte)24), single);
+        Assert.Equal(Pfx("1.2.3.0/24"), single);
     }
 }

--- a/BGPLite.Tests/PrefixSourceServiceTests.cs
+++ b/BGPLite.Tests/PrefixSourceServiceTests.cs
@@ -1,6 +1,7 @@
 using BGPLite.Configuration;
 using BGPLite.Providers;
 using Microsoft.Extensions.Logging.Abstractions;
+using BGPLite.Protocol;
 
 namespace BGPLite.Tests;
 
@@ -11,8 +12,8 @@ public class PrefixSourceServiceTests
         public string Kind => "stub";
         public bool SupportsConditionalRequests => true;
         public int Calls { get; private set; }
-        private readonly IReadOnlyList<(uint, byte)> _list;
-        public CountingProvider(IReadOnlyList<(uint, byte)> list) => _list = list;
+        private readonly IReadOnlyList<IpPrefix> _list;
+        public CountingProvider(IReadOnlyList<IpPrefix> list) => _list = list;
 
         public Task<SourceLoadResult> LoadAsync(PrefixSourceConfig source, string? etag = null, DateTimeOffset? lastModified = null, CancellationToken ct = default)
         {
@@ -40,7 +41,7 @@ public class PrefixSourceServiceTests
     [Fact]
     public async Task GetAsync_CachesWithinTtl()
     {
-        var provider = new CountingProvider([(1u, (byte)24)]);
+        var provider = new CountingProvider([new(1u, 24)]);
         var svc = new PrefixSourceService(
             ConfigWith("ru"),
             new PrefixSourceProviderFactory([provider]),
@@ -57,7 +58,7 @@ public class PrefixSourceServiceTests
     {
         var svc = new PrefixSourceService(
             ConfigWith("ru"),
-            new PrefixSourceProviderFactory([new CountingProvider([(1u, (byte)24)])]),
+            new PrefixSourceProviderFactory([new CountingProvider([new(1u, 24)])]),
             NullLogger<PrefixSourceService>.Instance);
 
         Assert.Empty(await svc.GetAsync("nope"));
@@ -66,7 +67,7 @@ public class PrefixSourceServiceTests
     [Fact]
     public async Task GetDefaultAsync_ResolvesByName()
     {
-        var provider = new CountingProvider([(1u, (byte)24), (2u, (byte)16)]);
+        var provider = new CountingProvider([new IpPrefix(1u, 24), new IpPrefix(2u, 16)]);
         var yaml = "Bgp:\n  Asn: 65444\n  RouterId: 10.0.0.1\n" +
                    "PrefixSources:\n  - Name: ru\n    Kind: stub\nDefaultPrefixSource: ru\n";
         var svc = new PrefixSourceService(
@@ -83,7 +84,7 @@ public class PrefixSourceServiceTests
     {
         var svc = new PrefixSourceService(
             ConfigWith("ru"),
-            new PrefixSourceProviderFactory([new CountingProvider([(1u, (byte)24)])]),
+            new PrefixSourceProviderFactory([new CountingProvider([new(1u, 24)])]),
             NullLogger<PrefixSourceService>.Instance);
 
         Assert.Empty(await svc.GetDefaultAsync());
@@ -106,7 +107,7 @@ public class PrefixSourceServiceTests
     [Fact]
     public async Task WarmUpAsync_PrimesAllSources()
     {
-        var provider = new CountingProvider([(1u, (byte)24)]);
+        var provider = new CountingProvider([new(1u, 24)]);
         var svc = new PrefixSourceService(
             ConfigWith("a", "b"),
             new PrefixSourceProviderFactory([provider]),
@@ -120,7 +121,7 @@ public class PrefixSourceServiceTests
     [Fact]
     public async Task GetAsync_RefetchesAfterTtlExpiry()
     {
-        var provider = new CountingProvider([(1u, (byte)24)]);
+        var provider = new CountingProvider([new(1u, 24)]);
         var svc = new PrefixSourceService(
             ConfigWith("ru"),
             new PrefixSourceProviderFactory([provider]),
@@ -139,8 +140,8 @@ public class PrefixSourceServiceTests
         public string Kind => "stub";
         public bool SupportsConditionalRequests => true;
         private int _calls;
-        private readonly IReadOnlyList<(uint, byte)> _first;
-        public ToggleProvider(IReadOnlyList<(uint, byte)> first) => _first = first;
+        private readonly IReadOnlyList<IpPrefix> _first;
+        public ToggleProvider(IReadOnlyList<IpPrefix> first) => _first = first;
 
         public Task<SourceLoadResult> LoadAsync(PrefixSourceConfig source, string? etag = null, DateTimeOffset? lastModified = null, CancellationToken ct = default)
         {
@@ -154,7 +155,7 @@ public class PrefixSourceServiceTests
     [Fact]
     public async Task GetAsync_ServesStaleOnFailure()
     {
-        var provider = new ToggleProvider([(1u, (byte)24), (2u, (byte)16)]);
+        var provider = new ToggleProvider([new(1u, 24), new(2u, 16)]);
         var svc = new PrefixSourceService(
             ConfigWith("ru"),
             new PrefixSourceProviderFactory([provider]),
@@ -189,7 +190,7 @@ public class PrefixSourceServiceTests
         var ex = Assert.Throws<InvalidOperationException>(() =>
             new PrefixSourceService(
                 ConfigLoader.LoadFromText(yaml),
-                new PrefixSourceProviderFactory([new CountingProvider([(1u, (byte)24)])]),
+                new PrefixSourceProviderFactory([new CountingProvider([new(1u, 24)])]),
                 NullLogger<PrefixSourceService>.Instance));
 
         Assert.Contains("ru", ex.Message);
@@ -207,8 +208,8 @@ public class PrefixSourceServiceTests
         public string Kind => "stub";
         public bool SupportsConditionalRequests => true;
         public int Calls { get; private set; }
-        private readonly IReadOnlyList<IReadOnlyList<(uint, byte)>> _lists;
-        public SequenceProvider(params IReadOnlyList<(uint, byte)>[] lists) => _lists = lists;
+        private readonly IReadOnlyList<IReadOnlyList<IpPrefix>> _lists;
+        public SequenceProvider(params IReadOnlyList<IpPrefix>[] lists) => _lists = lists;
 
         public async Task<SourceLoadResult> LoadAsync(PrefixSourceConfig source, string? etag = null, DateTimeOffset? lastModified = null, CancellationToken ct = default)
         {
@@ -225,8 +226,8 @@ public class PrefixSourceServiceTests
         public string Kind => "stub";
         public bool SupportsConditionalRequests => true;
         public int Calls { get; private set; }
-        private readonly IReadOnlyList<(uint, byte)> _list;
-        public ConditionalProvider(IReadOnlyList<(uint, byte)> list) => _list = list;
+        private readonly IReadOnlyList<IpPrefix> _list;
+        public ConditionalProvider(IReadOnlyList<IpPrefix> list) => _list = list;
 
         public Task<SourceLoadResult> LoadAsync(PrefixSourceConfig source, string? etag = null, DateTimeOffset? lastModified = null, CancellationToken ct = default)
         {
@@ -242,7 +243,7 @@ public class PrefixSourceServiceTests
     [Fact]
     public async Task RefreshAsync_ReportsChanged_WhenContentDiffers()
     {
-        var provider = new SequenceProvider([(1u, (byte)24)], [(1u, (byte)24), (2u, (byte)16)]);
+        var provider = new SequenceProvider([new(1u, 24)], [new(1u, 24), new(2u, 16)]);
         var svc = new PrefixSourceService(
             ConfigWith("ru"),
             new PrefixSourceProviderFactory([provider]),
@@ -261,7 +262,7 @@ public class PrefixSourceServiceTests
     [Fact]
     public async Task RefreshAsync_ReportsUnchanged_WhenContentIdentical()
     {
-        var provider = new SequenceProvider([(1u, (byte)24)], [(1u, (byte)24)]);
+        var provider = new SequenceProvider([new(1u, 24)], [new(1u, 24)]);
         var svc = new PrefixSourceService(
             ConfigWith("ru"),
             new PrefixSourceProviderFactory([provider]),
@@ -277,7 +278,7 @@ public class PrefixSourceServiceTests
     [Fact]
     public async Task RefreshAsync_ReportsUnchanged_OnNotModified304()
     {
-        var provider = new ConditionalProvider([(1u, (byte)24)]);
+        var provider = new ConditionalProvider([new(1u, 24)]);
         var svc = new PrefixSourceService(
             ConfigWith("ru"),
             new PrefixSourceProviderFactory([provider]),
@@ -302,7 +303,7 @@ public class PrefixSourceServiceTests
     [Fact]
     public async Task RefreshAsync_AfterConcurrentGetAsyncConsumedChange_ReportsFalse_PushFiresOnce()
     {
-        var provider = new SequenceProvider([(1u, (byte)24)], [(1u, (byte)24), (2u, (byte)16)]);
+        var provider = new SequenceProvider([new(1u, 24)], [new(1u, 24), new(2u, 16)]);
         var pushed = new List<string>();
         var gate = new object();
         var svc = new PrefixSourceService(
@@ -335,7 +336,7 @@ public class PrefixSourceServiceTests
     [Fact]
     public void SourceSupportsConditional_ReflectsProvider()
     {
-        var etagProvider = new CountingProvider([(1u, (byte)24)]);
+        var etagProvider = new CountingProvider([new(1u, 24)]);
         var noEtagProvider = new NoEtagStubProvider();
         var yaml = "Bgp:\n  Asn: 65444\n  RouterId: 10.0.0.1\n" +
                    "PrefixSources:\n  - Name: http-src\n    Kind: http\n  - Name: asn-src\n    Kind: asn\n";
@@ -354,7 +355,7 @@ public class PrefixSourceServiceTests
         public string Kind => "asn";
         public bool SupportsConditionalRequests => false;
         public Task<SourceLoadResult> LoadAsync(PrefixSourceConfig source, string? etag = null, DateTimeOffset? lastModified = null, CancellationToken ct = default)
-            => Task.FromResult(SourceLoadResult.Ok([(1u, (byte)24)]));
+            => Task.FromResult(SourceLoadResult.Ok([new IpPrefix(1u, 24)]));
     }
 
     /// <summary>
@@ -367,8 +368,8 @@ public class PrefixSourceServiceTests
     {
         // v1 and v2 contain the SAME prefixes in a DIFFERENT order → must report unchanged.
         var provider = new SequenceProvider(
-            [(1u, (byte)24), (2u, (byte)16)],   // call 1: [a, b]
-            [(2u, (byte)16), (1u, (byte)24)]);  // call 2: [b, a] — same set, reversed
+            [new IpPrefix(1u, 24), new IpPrefix(2u, 16)],   // call 1: [a, b]
+            [new IpPrefix(2u, 16), new IpPrefix(1u, 24)]);  // call 2: [b, a] — same set, reversed
         var svc = new PrefixSourceService(
             ConfigWith("ru"),
             new PrefixSourceProviderFactory([provider]),
@@ -385,9 +386,9 @@ public class PrefixSourceServiceTests
         // v1 (first load) → v2 (changed) → v2 again (no change). Models: source changes once, then
         // stays stable; a subsequent TTL-expired GetAsync must NOT re-fire the callback.
         var provider = new SequenceProvider(
-            [(1u, (byte)24)],                       // call 1: v1
-            [(1u, (byte)24), (2u, (byte)16)],        // call 2: v2 (changed)
-            [(1u, (byte)24), (2u, (byte)16)]);       // call 3: v2 (same — no change)
+            [new IpPrefix(1u, 24)],                       // call 1: v1
+            [new IpPrefix(1u, 24), new IpPrefix(2u, 16)],        // call 2: v2 (changed)
+            [new IpPrefix(1u, 24), new IpPrefix(2u, 16)]);       // call 3: v2 (same — no change)
         var changed = new List<string>();
         var svc = new PrefixSourceService(
             ConfigWith("ru"),

--- a/BGPLite.Tests/RefreshDebounceTests.cs
+++ b/BGPLite.Tests/RefreshDebounceTests.cs
@@ -100,12 +100,12 @@ public class RefreshDebounceTests
 
     private sealed class EmptyPrefixService : IPrefixService
     {
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default) => Task.FromResult(new List<(uint, byte, uint)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetPrefixesAsync(uint asn, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default) => Task.FromResult(new List<(UInt128, byte, bool, uint)>());
         public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default) => Task.FromResult(new List<(uint, byte, uint)>());
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default) => Task.FromResult(new List<(UInt128, byte, bool, uint)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
     }
 

--- a/BGPLite.Tests/RipeStatProviderTests.cs
+++ b/BGPLite.Tests/RipeStatProviderTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using BGPLite.Configuration;
+using BGPLite.Protocol;
 using BGPLite.Providers;
 using Microsoft.Extensions.Http;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -64,8 +65,9 @@ public class RipeStatProviderTests
         var result = await Provider(handler).GetPrefixesAsync(65001);
 
         var row = Assert.Single(result);
-        Assert.Equal(0x0A000000u, row.Prefix);
-        Assert.Equal(24, row.PrefixLength);
+        Assert.True(row.IsIpv4);
+        Assert.Equal(0x0A000000u, (uint)row.Address);
+        Assert.Equal(24, row.Length);
     }
 
     [Fact]
@@ -154,11 +156,13 @@ public class RipeStatProviderTests
         var handler = new StubHandler(HttpStatusCode.OK, body);
         var result = await Provider(handler).GetPrefixesAsync(65001);
 
-        Assert.Contains((0x0A000000u, (byte)8), result);      // 10.0.0.1/8 masked to the network
-        Assert.DoesNotContain((0x0A000001u, (byte)8), result); // unmasked key never stored
-        Assert.Contains((0xC0A80000u, (byte)16), result);      // canonical row unaffected
-        Assert.DoesNotContain(result, p => p.PrefixLength is 0 or > 32); // /0 and /33 rejected
+        Assert.Contains(new IpPrefix(0x0A000000u, 8), result);      // 10.0.0.1/8 masked to the network
+        Assert.Contains(new IpPrefix(0xC0A80000u, 16), result);      // canonical row unaffected
+        Assert.All(result, p => Assert.True(p.Length is not 0 and <= 32)); // /0 and /33 rejected
         Assert.Equal(2, result.Count);                          // garbage skipped, not thrown
+        // An IpPrefix is canonical by construction, so "10.0.0.1/8" cannot survive as an
+        // unmasked key — the Contains above proves the masking happened (was a real hazard
+        // when rows were raw (uint, byte) tuples).
     }
 
     /// <summary>A handler that honors the CancellationToken like HttpClient's real handler does.</summary>

--- a/BGPLite.Tests/RouteAssemblerCancellationTests.cs
+++ b/BGPLite.Tests/RouteAssemblerCancellationTests.cs
@@ -4,6 +4,7 @@ using BGPLite.Routing;
 using BGPLite.Server;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using BGPLite.Protocol;
 
 namespace BGPLite.Tests;
 
@@ -60,17 +61,17 @@ public sealed class RouteAssemblerCancellationTests
     /// <summary>Every fetch succeeds except the RU list, which reports a cancelled task.</summary>
     private sealed class CancelledRuFetchPrefixService : IPrefixService
     {
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
-            => Task.FromResult(new List<(uint Prefix, byte Length, uint Asn)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
+            => Task.FromResult(new List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>());
         public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
-            => Task.FromCanceled<List<(uint Prefix, byte Length, uint Asn)>>(new CancellationToken(canceled: true));
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
+            => Task.FromCanceled<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>>(new CancellationToken(canceled: true));
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
     }
 

--- a/BGPLite.Tests/RouteAssemblerSuppressionTests.cs
+++ b/BGPLite.Tests/RouteAssemblerSuppressionTests.cs
@@ -167,17 +167,17 @@ public class RouteAssemblerSuppressionTests
     /// <summary>Serves the configured prefixes for the custom-ASN fetch; nothing else.</summary>
     private sealed class StubPrefixService(params (string Ip, byte Length)[] prefixes) : IPrefixService
     {
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
-            => Task.FromResult(prefixes.Select(p => (Net(p.Ip), p.Length, 64512u)).ToList());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
+            => Task.FromResult(prefixes.Select(p => ((UInt128)Net(p.Ip), p.Length, true, 64512u)).ToList());
         public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
-            => Task.FromResult(new List<(uint, byte, uint)>());
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
+            => Task.FromResult(new List<(UInt128, byte, bool, uint)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
     }
 

--- a/BGPLite.Tests/RouteRefreshHoldTimerTests.cs
+++ b/BGPLite.Tests/RouteRefreshHoldTimerTests.cs
@@ -47,12 +47,12 @@ public class RouteRefreshHoldTimerTests
 
     private sealed class EmptyPrefixService : IPrefixService
     {
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default) => Task.FromResult(new List<(uint, byte, uint)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetPrefixesAsync(uint asn, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default) => Task.FromResult(new List<(UInt128, byte, bool, uint)>());
         public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default) => Task.FromResult(new List<(uint, byte, uint)>());
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default) => Task.FromResult(new List<(UInt128, byte, bool, uint)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
     }
 

--- a/BGPLite.Tests/RouteSeedingServiceTests.cs
+++ b/BGPLite.Tests/RouteSeedingServiceTests.cs
@@ -23,34 +23,34 @@ public class RouteSeedingServiceTests
         // into WarmUpAsync (where it becomes WarmUpGate.Task.WaitAsync(ct)).
         public Task WarmUpCompleted { get; private set; } = new TaskCompletionSource().Task;
 
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetPrefixesAsync(uint asn, CancellationToken ct = default) =>
-            Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default) => Task.FromResult(new List<(uint, byte, uint)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetPrefixesAsync(uint asn, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default) => Task.FromResult(new List<(UInt128, byte, bool, uint)>());
         public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
-        public Task<List<(uint Prefix, byte Length, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default) => Task.FromResult(new List<(uint, byte, uint)>());
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default) =>
-            Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default) =>
-            Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default) => Task.FromResult(new List<(UInt128, byte, bool, uint)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) =>
             WarmUpCompleted = WarmUpGate.Task.WaitAsync(ct);
     }
 
     private sealed class FakeSourceService : IPrefixSourceService
     {
-        private readonly IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)> _sources;
+        private readonly IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)> _sources;
 
-        public FakeSourceService(IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<(uint, byte)>)>? sources = null) =>
+        public FakeSourceService(IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>? sources = null) =>
             _sources = sources ??
             [
                 (new PrefixSourceConfig { Name = "nets", Kind = "file", Url = "nets.txt" },
-                    new List<(uint, byte)> { (0xC0A80000u, 24), (0x0A000000u, 8) })
+                    new List<IpPrefix> { new(0xC0A80000u, 24), new(0x0A000000u, 8) })
             ];
 
-        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<(uint Prefix, byte Length)> Prefixes)>> LoadAllAsync(CancellationToken ct = default) =>
+        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default) =>
             Task.FromResult(_sources);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> GetDefaultAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]);
+        public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
+        public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);
         public bool SourceSupportsConditional(string sourceName) => false;
@@ -115,9 +115,9 @@ public class RouteSeedingServiceTests
         var sources = new FakeSourceService(
         [
             (new PrefixSourceConfig { Name = "bad", Kind = "file", Url = "a.txt", Community = "65444:99999" },
-                new List<(uint, byte)> { (0xAC100000u, 12) }),
+                new List<IpPrefix> { new(0xAC100000u, 12) }),
             (new PrefixSourceConfig { Name = "good", Kind = "file", Url = "b.txt", Community = "65000:100" },
-                new List<(uint, byte)> { (0xC0A80000u, 24) }),
+                new List<IpPrefix> { new(0xC0A80000u, 24) }),
         ]);
         using var service = NewService(prefix, sources, table, new RecordingSessionManager());
 

--- a/BGPLite.Tests/RouteTableTests.cs
+++ b/BGPLite.Tests/RouteTableTests.cs
@@ -235,4 +235,127 @@ public class RouteTableTests
         Assert.InRange(actual, 0, keys);   // sanity: some subset of the key set survived
         Assert.Equal(actual, table.Count); // counter == dictionary truth (no drift, never negative)
     }
+
+    // ---- #14 phase 3: longest-prefix-match lookup ----
+
+    [Fact]
+    public void GetLongestPrefixMatch_MostSpecificPrefixWins()
+    {
+        var table = new RouteTable();
+        var lessSpecific = new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 1 };
+        var moreSpecific = new Route { Prefix = 0x0A010000, PrefixLength = 16, NextHop = 2 };
+        table.AddOrUpdate(lessSpecific);
+        table.AddOrUpdate(moreSpecific);
+
+        Assert.Same(moreSpecific, table.GetLongestPrefixMatch(0x0A010203)); // inside both → /16
+        Assert.Same(lessSpecific, table.GetLongestPrefixMatch(0x0A020304)); // inside /8 only
+    }
+
+    [Fact]
+    public void GetLongestPrefixMatch_NoMatch_ReturnsNull()
+    {
+        var table = new RouteTable();
+        table.AddOrUpdate(new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 1 });
+
+        Assert.Null(table.GetLongestPrefixMatch(0xC0A80001)); // 192.168.0.1 — outside 10/8
+    }
+
+    [Fact]
+    public void GetLongestPrefixMatch_EmptyTable_ReturnsNull()
+    {
+        Assert.Null(new RouteTable().GetLongestPrefixMatch(0x0A000001));
+    }
+
+    [Fact]
+    public void GetLongestPrefixMatch_DefaultRoute_CatchesEverything()
+    {
+        var table = new RouteTable();
+        var defaultRoute = new Route { Prefix = (UInt128)0, PrefixLength = 0, NextHop = 1 };
+        table.AddOrUpdate(defaultRoute);
+
+        Assert.Same(defaultRoute, table.GetLongestPrefixMatch(0xC0A80102));
+    }
+
+    [Fact]
+    public void GetLongestPrefixMatch_RemovedMoreSpecific_FallsBackToLessSpecific()
+    {
+        var table = new RouteTable();
+        var lessSpecific = new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 1 };
+        table.AddOrUpdate(lessSpecific);
+        table.AddOrUpdate(new Route { Prefix = 0x0A010000, PrefixLength = 16, NextHop = 2 });
+        table.Remove(0x0A010000, 16);
+
+        Assert.Same(lessSpecific, table.GetLongestPrefixMatch(0x0A010203));
+    }
+
+    [Fact]
+    public void GetLongestPrefixMatch_Ipv6_MostSpecificPrefixWins()
+    {
+        var table = new RouteTable();
+        var lessSpecific = new Route { Prefix = V6Net(0x2001, 0xDB8), IsIpv4 = false, PrefixLength = 32, NextHop = 1 };
+        var moreSpecific = new Route { Prefix = V6Net(0x2001, 0xDB8, 1), IsIpv4 = false, PrefixLength = 48, NextHop = 2 };
+        table.AddOrUpdate(lessSpecific);
+        table.AddOrUpdate(moreSpecific);
+
+        // Inside both → /48; inside the /32 but outside the /48 → /32; outside both → null.
+        var inBoth = V6Net(0x2001, 0xDB8, 1) + 1;
+        var inWide = V6Net(0x2001, 0xDB8, 2);
+        Assert.Same(moreSpecific, table.GetLongestPrefixMatch(inBoth, isIpv4: false));
+        Assert.Same(lessSpecific, table.GetLongestPrefixMatch(inWide, isIpv4: false));
+        Assert.Null(table.GetLongestPrefixMatch(V6Net(0x2001, 0xDB9), isIpv4: false));
+    }
+
+    [Fact]
+    public void GetLongestPrefixMatch_Ipv4_HostRouteBoundary()
+    {
+        // /32 is the family length maximum: the probe must hit the exact host route and
+        // nothing one address away.
+        var table = new RouteTable();
+        var host = new Route { Prefix = 0x0A000001, PrefixLength = 32, NextHop = 1 };
+        table.AddOrUpdate(host);
+
+        Assert.Same(host, table.GetLongestPrefixMatch(0x0A000001));
+        Assert.Null(table.GetLongestPrefixMatch(0x0A000002));
+    }
+
+    [Fact]
+    public void GetLongestPrefixMatch_Ipv6_HostAndDefaultBoundaries()
+    {
+        // Both IPv6 length extremes in one table: a /128 host route (probe starts at the
+        // family maximum) and ::/0 (probe ends at the minimum) — the address between them
+        // falls through 128..1 to the default.
+        var table = new RouteTable();
+        var hostRoute = new Route { Prefix = V6Net(0x2001, 0xDB8, 1) + 5, IsIpv4 = false, PrefixLength = 128, NextHop = 1 };
+        var defaultRoute = new Route { Prefix = (UInt128)0, IsIpv4 = false, PrefixLength = 0, NextHop = 2 };
+        table.AddOrUpdate(hostRoute);
+        table.AddOrUpdate(defaultRoute);
+
+        Assert.Same(hostRoute, table.GetLongestPrefixMatch(V6Net(0x2001, 0xDB8, 1) + 5, isIpv4: false));
+        Assert.Same(defaultRoute, table.GetLongestPrefixMatch(V6Net(0x2001, 0xDB9), isIpv4: false));
+    }
+
+    [Fact]
+    public void GetLongestPrefixMatch_Ipv6_NeverMatchesIpv4Entries()
+    {
+        // Family-scoped: the IPv4 key carries IsIpv4 = true, so an IPv6 address whose 128-bit
+        // value numerically contains the IPv4 network must not match it.
+        var table = new RouteTable();
+        table.AddOrUpdate(new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 1 });
+
+        Assert.Null(table.GetLongestPrefixMatch(0x0A000001, isIpv4: false));
+    }
+
+    [Fact]
+    public void GetLongestPrefixMatch_Ipv4_NeverMatchesIpv6Entries()
+    {
+        var table = new RouteTable();
+        table.AddOrUpdate(new Route { Prefix = V6Net(0x2001, 0xDB8), IsIpv4 = false, PrefixLength = 32, NextHop = 1 });
+
+        Assert.Null(table.GetLongestPrefixMatch(0x20010DB8, isIpv4: true));
+    }
+
+    /// <summary>Composes an IPv6 network address from its leading hextets (the rest are zero):
+    /// <c>V6Net(0x2001, 0xDB8, 1)</c> is 2001:db8:1::.</summary>
+    private static UInt128 V6Net(ushort g0, ushort g1, ushort g2 = 0) =>
+        ((UInt128)g0 << 112) | ((UInt128)g1 << 96) | ((UInt128)g2 << 80);
 }

--- a/BGPLite.Tests/TcpMd5Tests.cs
+++ b/BGPLite.Tests/TcpMd5Tests.cs
@@ -25,6 +25,27 @@ public class TcpMd5Tests
         Assert.False(TcpMd5.IsValidPassword(new string('é', 41)));  // 82 UTF-8 bytes
     }
 
+    /// <summary>
+    /// The sockaddr carries the KERNEL's address family, not .NET's (Winsock-derived) enum
+    /// value: Linux wants AF_INET6 = 10, but (byte)AddressFamily.InterNetworkV6 is 23 — the
+    /// kernel's md5 parse path rejects that with EINVAL (sin6_family != AF_INET6). The v4 path
+    /// could not catch this: AF_INET = 2 everywhere. Platform-dependent for the v6 value
+    /// (Darwin = 28), so asserted per-OS; the Linux branch is what CI proves.
+    /// </summary>
+    [Fact]
+    public void WriteSockaddr_V6Peer_CarriesKernelAddressFamily()
+    {
+        Span<byte> buffer = stackalloc byte[128];
+        TcpMd5.WriteSockaddr(new IPEndPoint(IPAddress.Parse("2001:db8::1"), 0), buffer);
+
+        var expectedFamily = OperatingSystem.IsLinux() ? 10 : OperatingSystem.IsMacOS() ? (byte)28 : 23;
+        Assert.Equal(expectedFamily, buffer[0]);
+        Assert.Equal(0, buffer[1]);
+
+        TcpMd5.WriteSockaddr(new IPEndPoint(IPAddress.Loopback, 0), buffer);
+        Assert.Equal(2, buffer[0]); // AF_INET = 2 on every supported platform
+    }
+
     [Fact]
     public void InvalidKeyLength_Throws()
     {

--- a/BGPLite.Tests/TcpMd5Tests.cs
+++ b/BGPLite.Tests/TcpMd5Tests.cs
@@ -35,15 +35,46 @@ public class TcpMd5Tests
     [Fact]
     public void WriteSockaddr_V6Peer_CarriesKernelAddressFamily()
     {
+        // TCP-MD5 is only ever applied on Linux/macOS; other platforms have no defined layout.
+        if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS()) return;
+
         Span<byte> buffer = stackalloc byte[128];
         TcpMd5.WriteSockaddr(new IPEndPoint(IPAddress.Parse("2001:db8::1"), 0), buffer);
 
-        var expectedFamily = OperatingSystem.IsLinux() ? 10 : OperatingSystem.IsMacOS() ? (byte)28 : 23;
+        var expectedFamily = OperatingSystem.IsLinux() ? 10 : 28;
         Assert.Equal(expectedFamily, buffer[0]);
-        Assert.Equal(0, buffer[1]);
+        // Linux keeps byte 1 zero (family is 2 bytes little-endian); Darwin's byte 1 is the family.
+        Assert.Equal(OperatingSystem.IsLinux() ? 0 : 28, buffer[1]);
 
         TcpMd5.WriteSockaddr(new IPEndPoint(IPAddress.Loopback, 0), buffer);
-        Assert.Equal(2, buffer[0]); // AF_INET = 2 on every supported platform
+        // v4 layout per OS: Linux = family in byte 0; Darwin = sin_len first, family in byte 1.
+        if (OperatingSystem.IsLinux())
+        {
+            Assert.Equal(2, buffer[0]);
+            Assert.Equal(0, buffer[1]);
+        }
+        else
+        {
+            Assert.Equal(16, buffer[0]); // sin_len
+            Assert.Equal(2, buffer[1]);  // sin_family
+        }
+    }
+
+    [Fact]
+    public void WriteSockaddr_Darwin_CarriesSinLenFirst()
+    {
+        // BSD sockaddr_in/in6 start with a LENGTH byte; the family follows in byte 1. Asserted
+        // only on Darwin, where the layout applies (the Linux expectations live above).
+        if (!OperatingSystem.IsMacOS()) return;
+
+        var buffer = new byte[128];
+        TcpMd5.WriteSockaddr(new IPEndPoint(IPAddress.Loopback, 0), buffer);
+        Assert.Equal(16, buffer[0]); // sin_len
+        Assert.Equal(2, buffer[1]);  // sin_family
+
+        TcpMd5.WriteSockaddr(new IPEndPoint(IPAddress.Parse("2001:db8::1"), 0), buffer);
+        Assert.Equal(28, buffer[0]); // sin6_len
+        Assert.Equal(28, buffer[1]); // sin6_family
     }
 
     [Fact]

--- a/BGPLite.Tests/UserSourceCacheTests.cs
+++ b/BGPLite.Tests/UserSourceCacheTests.cs
@@ -1,5 +1,6 @@
 using BGPLite.Providers;
 using Xunit;
+using BGPLite.Protocol;
 
 namespace BGPLite.Tests;
 
@@ -11,16 +12,16 @@ namespace BGPLite.Tests;
 /// </summary>
 public class UserSourceCacheTests
 {
-    private static IReadOnlyList<(uint Prefix, byte Length)> P(params (uint, byte)[] xs) =>
-        xs.Select(x => (x.Item1, x.Item2)).ToList();
+    private static IReadOnlyList<IpPrefix> P(params (UInt128 Address, byte Length, bool IsIpv4)[] xs) =>
+        xs.Select(x => new IpPrefix(x.Item1, x.Item2, x.Item3)).ToList();
 
     /// <summary>A controllable fetcher: counts calls, returns a canned list or throws.</summary>
     private sealed class Fetcher
     {
         public int Calls;
-        public Func<IReadOnlyList<(uint Prefix, byte Length)>>? OnSuccess;
+        public Func<IReadOnlyList<IpPrefix>>? OnSuccess;
         public Exception? Throw;
-        public Task<IReadOnlyList<(uint Prefix, byte Length)>> Invoke(CancellationToken ct)
+        public Task<IReadOnlyList<IpPrefix>> Invoke(CancellationToken ct)
         {
             Calls++;
             if (Throw is OperationCanceledException oce) throw oce;
@@ -35,7 +36,7 @@ public class UserSourceCacheTests
         // The point of URL-keying (#150): two calls for the same URL — e.g. two peers refreshing the
         // same popular list — share one fetch.
         var cache = new UserSourceCache();
-        var f = new Fetcher { OnSuccess = () => P((0xC0A80000u, (byte)24)) };
+        var f = new Fetcher { OnSuccess = () => P((0xC0A80000u, (byte)24, true)) };
 
         var a = await cache.GetOrLoadAsync("https://example.com/l", "src", f.Invoke, CancellationToken.None);
         var b = await cache.GetOrLoadAsync("https://example.com/l", "src", f.Invoke, CancellationToken.None);
@@ -53,15 +54,15 @@ public class UserSourceCacheTests
         var cache = new UserSourceCache();
         var hold = new TaskCompletionSource();
         int calls = 0;
-        Task<IReadOnlyList<(uint Prefix, byte Length)>> Load(CancellationToken ct)
+        Task<IReadOnlyList<IpPrefix>> Load(CancellationToken ct)
         {
             Interlocked.Increment(ref calls);
             return HoldAndReturn();
         }
-        async Task<IReadOnlyList<(uint Prefix, byte Length)>> HoldAndReturn()
+        async Task<IReadOnlyList<IpPrefix>> HoldAndReturn()
         {
             await hold.Task;          // keep the in-flight fetch blocked until all racers are queued
-            return P((0u, 0));
+            return P((0u, (byte)0, true));
         }
 
         var tasks = Enumerable.Range(0, 16)
@@ -92,7 +93,7 @@ public class UserSourceCacheTests
         // Stale-serving only triggers on a refetch that fails — so let the positive entry expire first,
         // then make the refetch throw. The (now-expired) last good copy is served regardless of age.
         var cache = new UserSourceCache(positiveTtl: TimeSpan.FromMilliseconds(80));
-        var f = new Fetcher { OnSuccess = () => P((0u, 0)) };
+        var f = new Fetcher { OnSuccess = () => P((0u, (byte)0, true)) };
         await cache.GetOrLoadAsync("https://example.com/l", "src", f.Invoke, default); // prime positive
         await Task.Delay(120);                                                        // let it expire
 
@@ -136,14 +137,14 @@ public class UserSourceCacheTests
         // on entry explicitly instead of racing Task.Run's start.
         var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        static async Task<IReadOnlyList<(uint Prefix, byte Length)>> Parked(CancellationToken ct, TaskCompletionSource entered)
+        static async Task<IReadOnlyList<IpPrefix>> Parked(CancellationToken ct, TaskCompletionSource entered)
         {
             entered.TrySetResult();
             await Task.Delay(Timeout.InfiniteTimeSpan, ct);
             return [];
         }
 
-        Task<IReadOnlyList<(uint Prefix, byte Length)>> Invoke(CancellationToken ct)
+        Task<IReadOnlyList<IpPrefix>> Invoke(CancellationToken ct)
         {
             calls++;
             return Parked(ct, entered);
@@ -157,7 +158,7 @@ public class UserSourceCacheTests
         Assert.Equal(1, calls);
 
         // No negative cache → the next call reaches the fetcher again.
-        var f = new Fetcher { OnSuccess = () => P((1u, 1)) };
+        var f = new Fetcher { OnSuccess = () => P((1u, (byte)1, true)) };
         var served = await cache.GetOrLoadAsync("https://example.com/l", "src", f.Invoke, default);
         Assert.Equal(1, f.Calls); // a fresh fetcher ran once more
         Assert.Single(served);
@@ -167,7 +168,7 @@ public class UserSourceCacheTests
     public async Task Positive_Ttl_Expiry_Triggers_Refetch()
     {
         var cache = new UserSourceCache(positiveTtl: TimeSpan.FromMilliseconds(80));
-        var f = new Fetcher { OnSuccess = () => P((1u, 1)) };
+        var f = new Fetcher { OnSuccess = () => P((1u, (byte)1, true)) };
 
         await cache.GetOrLoadAsync("https://example.com/l", "src", f.Invoke, default);
         await Task.Delay(120);
@@ -199,7 +200,7 @@ public class UserSourceCacheTests
     public async Task UniqueUrls_BeyondCap_KeepCacheBounded()
     {
         var cache = new UserSourceCache(maxCacheEntries: 5);
-        var f = new Fetcher { OnSuccess = () => P((0x0A000000u, (byte)8)) };
+        var f = new Fetcher { OnSuccess = () => P((0x0A000000u, (byte)8, true)) };
 
         for (var i = 0; i < 12; i++)
             await cache.GetOrLoadAsync($"https://example.com/list-{i}", "src", f.Invoke, CancellationToken.None);
@@ -216,11 +217,11 @@ public class UserSourceCacheTests
     {
         var cache = new UserSourceCache(maxCacheEntries: 3);
         var calls = new Dictionary<string, int>();
-        Task<IReadOnlyList<(uint Prefix, byte Length)>> Load(string url) => Task.Run(async () =>
+        Task<IReadOnlyList<IpPrefix>> Load(string url) => Task.Run(async () =>
         {
             lock (calls) calls[url] = calls.TryGetValue(url, out var c) ? c + 1 : 1;
             await Task.Yield();
-            return P((0x0A000000u, (byte)8));
+            return P((0x0A000000u, (byte)8, true));
         });
 
         await cache.GetOrLoadAsync("https://example.com/a", "a", ct => Load("a"), CancellationToken.None);
@@ -281,10 +282,10 @@ public class UserSourceCacheTests
         var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var holdCts = new CancellationTokenSource();
 
-        Task<IReadOnlyList<(uint Prefix, byte Length)>> Hold(CancellationToken ct)
+        Task<IReadOnlyList<IpPrefix>> Hold(CancellationToken ct)
         {
             entered.TrySetResult();
-            return holder.Task.ContinueWith<IReadOnlyList<(uint Prefix, byte Length)>>(_ => [], CancellationToken.None);
+            return holder.Task.ContinueWith<IReadOnlyList<IpPrefix>>(_ => [], CancellationToken.None);
         }
 
         // First caller holds the gate without completing.
@@ -324,7 +325,7 @@ public class UserSourceCacheTests
             var cts = new CancellationTokenSource();
             cts.Cancel();   // cancelled before the gate is even acquired
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
-                cache.GetOrLoadAsync($"https://example.com/never-{i}", "src", ct => Task.FromResult<IReadOnlyList<(uint Prefix, byte Length)>>([]), cts.Token));
+                cache.GetOrLoadAsync($"https://example.com/never-{i}", "src", ct => Task.FromResult<IReadOnlyList<IpPrefix>>([]), cts.Token));
         }
 
         Assert.Equal(0, cache.TrackedGateCount);   // pre-fix: 5 orphan gates

--- a/BGPLite/RouteSeedingService.cs
+++ b/BGPLite/RouteSeedingService.cs
@@ -78,12 +78,15 @@ internal sealed class RouteSeedingService(
                     }
                 }
 
-                foreach (var (prefix, length) in prefixes)
+                foreach (var p in prefixes)
                 {
+                    // #14 phase 4: sources yield family-tagged prefixes; seeding is family-blind —
+                    // the route table keys carry IsIpv4, so both families seed side by side.
                     routeTable.AddOrUpdate(new Route
                     {
-                        Prefix = prefix,
-                        PrefixLength = length,
+                        Prefix = p.Address,
+                        IsIpv4 = p.IsIpv4,
+                        PrefixLength = p.Length,
                         NextHop = nextHop,
                         Communities = communities
                     });

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ COPY BGPLite.Providers/BGPLite.Providers.csproj BGPLite.Providers/
 RUN dotnet restore BGPLite/BGPLite.csproj
 
 COPY . .
-RUN dotnet publish BGPLite/BGPLite.csproj -c Release -o /app/publish
+# linux-x64 RID ("linux64"): architecture-pinned publish — the same RID the
+# integration stand (docker/integration) and CI run under via --platform linux/amd64.
+RUN dotnet publish BGPLite/BGPLite.csproj -c Release -r linux-x64 --self-contained false -o /app/publish
 
 FROM mcr.microsoft.com/dotnet/runtime:10.0 AS runtime
 WORKDIR /app

--- a/appsettings.Example.yml
+++ b/appsettings.Example.yml
@@ -3,6 +3,10 @@ Bgp:
   RouterId: 1.2.3.4
   KeepAlive: 60
   HoldTime: 180
+  # Optional: the global IPv6 next hop advertised to MP-BGP IPv6/Unicast peers (#14 phase 4,
+  # RFC 2545 §3). Unset = IPv6 routes are never advertised (suppressed with a warning);
+  # set = each MP-IPv6-negotiated session announces IPv6 routes with this next hop.
+  # NextHopIpv6: "2001:db8::1"
   # Listener hardening (#115) — connect-to-OPEN timeout (Slowloris defense) and per-source-IP
   # accept throttle. Both have secure, generous defaults; set to 0 to disable either.
   # OpenTimeoutSeconds: 30                 # drop a peer that connects but never sends OPEN (default 30, 0 = off)

--- a/docker/integration/Dockerfile.bird
+++ b/docker/integration/Dockerfile.bird
@@ -1,0 +1,12 @@
+FROM debian:bookworm-slim
+
+# bird2 ships both the daemon and birdc (the control CLI the test runner uses).
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends bird2 \
+ && rm -rf /var/lib/apt/lists/* \
+ && mkdir -p /run/bird
+
+COPY bird.conf /etc/bird/bird.conf
+
+# Foreground: PID 1 must stay attached for `docker compose up`/health checks.
+CMD ["bird", "-f", "-c", "/etc/bird/bird.conf"]

--- a/docker/integration/Dockerfile.capture
+++ b/docker/integration/Dockerfile.capture
@@ -1,0 +1,6 @@
+FROM alpine:3.20
+RUN apk add --no-cache tcpdump
+# tcpdump runs in the SERVER's network namespace (network_mode: "service:server"),
+# so it sees every BGP segment on both transports; frames land in a pcap for
+# Wireshark/tshark analysis.
+ENTRYPOINT ["tcpdump"]

--- a/docker/integration/README.md
+++ b/docker/integration/README.md
@@ -52,6 +52,11 @@ Requirements: `docker` with the compose v2 plugin (daemon running), `curl`,
 polls until assertions pass, and always tears the stand down
 (`docker compose down -v`). Exit code is the test verdict.
 
+API assertions go through an in-network `probe` sidecar (curlimages/curl) —
+no host port publishing is required. For interactive poking, `exec` into the
+probe: `docker compose -f docker/integration/docker-compose.yml exec probe
+curl http://server:5001/api/server`.
+
 **Traffic capture (`--capture`)**: a tcpdump sidecar joins the server's network
 namespace and records everything on port 179 (both transports) to
 `docker/integration/captures/bgp.pcap` — open it in Wireshark (filter `bgp`)

--- a/docker/integration/README.md
+++ b/docker/integration/README.md
@@ -1,0 +1,73 @@
+# Integration tests: BGPLite × BIRD2 (docker compose, linux64)
+
+End-to-end BGP tests against REAL speaker processes — no mocks. A BGPLite route
+server container and a [BIRD2](https://bird.network.cz/) peer container exchange
+routes over **both** transport families, and a shell script asserts the result
+through BGPLite's management API and `birdc`.
+
+BIRD2 was chosen over alternatives (e.g. MikroTik CHR) because it is a small
+deterministic container, starts in milliseconds, needs no license/bootstrap, and
+its `birdc` CLI gives precise per-protocol assertions.
+
+## Topology
+
+```
+           net bgp4  172.30.100.0/24        net bgp6  fd00:b00b::/64
+  server   172.30.100.10                    fd00:b00b::10        (BGPLite :179, API 5001)
+  bird     172.30.100.20                    fd00:b00b::20        (BIRD2, AS65002)
+```
+
+Server AS65001. Two BGP sessions: `bgplite4` (IPv4 transport) and `bgplite6`
+(IPv6 transport — this one exercises the dual-mode listener from #14 phase 4a).
+Both images are pinned to `platform: linux/amd64`; the server is published with
+the `linux-x64` RID, so the stand is identical on an arm64 Mac (Rosetta) and the
+amd64 CI runner.
+
+## What is asserted
+
+1. The management API answers (`GET /api/server`).
+2. `POST /api/peers` registers the BIRD peer with the `openai` subscription
+   (an HTTP prefix source fed from [ruhex/prefix-lists](https://github.com/ruhex/prefix-lists)
+   raw data — the full HTTP-fetch pipeline runs against real-world lists) plus a
+   custom prefix `192.0.2.0/24`.
+3. Both sessions reach `Established` (checked from BIRD's view, `birdc`, and the
+   server reports `active >= 2`).
+4. BIRD → server propagation: BIRD's 3 static announcements (2× IPv4 NLRI, 1×
+   IPv6 NLRI via MP_REACH) appear in the server's route table (`GET /api/routes`
+   — the untagged `default` community group must hold exactly 3).
+5. Server → BIRD propagation: the custom prefix (192.0.2.0/24) plus >= 100
+   routes from the `openai` HTTP source on the IPv4 session, and the seed
+   prefixes `10.100.0.0/16`, `10.200.0.0/16` (file source, `test-nets.txt`)
+   riding as classic IPv4 NLRI over the IPv6-transport session.
+
+## Run it
+
+```bash
+docker/integration/run-tests.sh              # core suite
+docker/integration/run-tests.sh --capture    # + packet capture for analysis
+```
+
+Requirements: `docker` with the compose v2 plugin (daemon running), `curl`,
+`tcpdump` on the host for `--capture` verification. The script builds, starts,
+polls until assertions pass, and always tears the stand down
+(`docker compose down -v`). Exit code is the test verdict.
+
+**Traffic capture (`--capture`)**: a tcpdump sidecar joins the server's network
+namespace and records everything on port 179 (both transports) to
+`docker/integration/captures/bgp.pcap` — open it in Wireshark (filter `bgp`)
+to inspect OPEN/UPDATE/KEEPALIVE exchange. The runner verifies the pcap holds
+a real BGP conversation before passing.
+
+The same script runs in CI: `.github/workflows/integration.yml` (push to
+`main`/`dev` + manual `workflow_dispatch`).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `docker-compose.yml` | The stand: two networks, fixed addresses, linux/amd64 |
+| `server-appsettings.yml` | Offline server config (file prefix source, short timers) |
+| `test-nets.txt` | Seed prefixes the server originates |
+| `bird.conf` | BIRD2 config: two BGP protocols + static announcements |
+| `Dockerfile.bird` | BIRD2 image (Debian bookworm package) |
+| `run-tests.sh` | The test runner |

--- a/docker/integration/README.md
+++ b/docker/integration/README.md
@@ -12,9 +12,9 @@ its `birdc` CLI gives precise per-protocol assertions.
 ## Topology
 
 ```
-           net bgp4  172.30.100.0/24        net bgp6  fd00:b00b::/64
-  server   172.30.100.10                    fd00:b00b::10        (BGPLite :179, API 5001)
-  bird     172.30.100.20                    fd00:b00b::20        (BIRD2, AS65002)
+           net bgp4  172.30.100.0/24        net bgp6  2001:db8:cccc::/64
+  server   172.30.100.10                    2001:db8:cccc::10    (BGPLite :179, API 5001)
+  bird     172.30.100.20                    2001:db8:cccc::20    (BIRD2, AS65002)
 ```
 
 Server AS65001. Two BGP sessions: `bgplite4` (IPv4 transport) and `bgplite6`

--- a/docker/integration/bird.conf
+++ b/docker/integration/bird.conf
@@ -1,0 +1,54 @@
+# BIRD2 peer for the BGPLite integration stand (see docker/integration/README.md).
+# Announces static test prefixes over TWO sessions: IPv4 transport (172.30.100.x)
+# and IPv6 transport (fd00:b00b::x) — the latter exercises BGPLite's dual-mode
+# listener (#14 phase 4a).
+
+router id 172.30.100.20;
+
+log stderr all;
+
+protocol device { scan time 5; }
+
+protocol static announce4 {
+    ipv4 { import all; };
+    route 203.0.113.0/24 blackhole;
+    route 198.51.100.0/24 blackhole;
+}
+
+protocol static announce6 {
+    ipv6 { import all; };
+    route 2001:db8:ffff::/48 blackhole;
+}
+
+protocol bgp bgplite4 {
+    description "IPv4 transport";
+    local as 65002;
+    neighbor 172.30.100.10 as 65001;
+    hold time 15;
+    keepalive time 5;
+    ipv4 {
+        import all;
+        export where source = RTS_STATIC;
+        next hop self;
+    };
+}
+
+protocol bgp bgplite6 {
+    description "IPv6 transport";
+    local as 65002;
+    neighbor fd00:b00b::10 as 65001;
+    hold time 15;
+    keepalive time 5;
+    # The server (until epic phase 4b) sends its IPv4 seed prefixes as classic
+    # IPv4 NLRI on EVERY session, including this one — accept them here so the
+    # session is not torn down for unexpected NLRI; never export v4 back.
+    ipv4 {
+        import all;
+        export none;
+    };
+    ipv6 {
+        import all;
+        export where source = RTS_STATIC;
+        next hop self;
+    };
+}

--- a/docker/integration/bird.conf
+++ b/docker/integration/bird.conf
@@ -1,6 +1,6 @@
 # BIRD2 peer for the BGPLite integration stand (see docker/integration/README.md).
 # Announces static test prefixes over TWO sessions: IPv4 transport (172.30.100.x)
-# and IPv6 transport (fd00:b00b::x) — the latter exercises BGPLite's dual-mode
+# and IPv6 transport (2001:db8:cccc::x) — the latter exercises BGPLite's dual-mode
 # listener (#14 phase 4a).
 
 router id 172.30.100.20;
@@ -36,12 +36,12 @@ protocol bgp bgplite4 {
 protocol bgp bgplite6 {
     description "IPv6 transport";
     local as 65002;
-    neighbor fd00:b00b::10 as 65001;
+    neighbor 2001:db8:cccc::10 as 65001;
     hold time 15;
     keepalive time 5;
-    # The server (until epic phase 4b) sends its IPv4 seed prefixes as classic
-    # IPv4 NLRI on EVERY session, including this one — accept them here so the
-    # session is not torn down for unexpected NLRI; never export v4 back.
+    # The server sends its IPv4 seed prefixes as classic IPv4 NLRI on EVERY session,
+    # including this one — accept them here so the session is not torn down for
+    # unexpected NLRI; never export v4 back.
     ipv4 {
         import all;
         export none;

--- a/docker/integration/docker-compose.yml
+++ b/docker/integration/docker-compose.yml
@@ -1,0 +1,74 @@
+# Integration-test stand: BGPLite route server + BIRD2 peer over BOTH transport
+# families. Fixed addressing (no dynamic discovery) so BIRD's neighbor statements
+# and the server's peer registration agree.
+#
+#   net bgp4  172.30.100.0/24   server .10   bird .20
+#   net bgp6  fd00:b00b::/64    server ::10  bird ::20
+#
+# Everything is forced to linux/amd64 ("linux64"): the server image publishes with
+# the linux-x64 RID and both services pin the platform, so the stand behaves the
+# same on an arm64 developer Mac (via Rosetta) and on the amd64 CI runner.
+name: bgplite-integration
+
+services:
+  server:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    platform: linux/amd64
+    container_name: bgplite-it-server
+    networks:
+      bgp4:
+        ipv4_address: 172.30.100.10
+      bgp6:
+        ipv6_address: fd00:b00b::10
+    volumes:
+      - ./server-appsettings.yml:/app/appsettings.yml:ro
+      - ./test-nets.txt:/app/test-nets.txt:ro
+    ports:
+      - "15001:5001"
+    environment:
+      # Debug logs for the session pipeline — this stand exists to diagnose it.
+      - Logging__LogLevel__BGPLite=Debug
+
+  bird:
+    build:
+      context: .
+      dockerfile: Dockerfile.bird
+    platform: linux/amd64
+    container_name: bgplite-it-bird
+    networks:
+      bgp4:
+        ipv4_address: 172.30.100.20
+      bgp6:
+        ipv6_address: fd00:b00b::20
+
+  # Opt-in packet capture of the BGP traffic INSIDE the server's network namespace
+  # (both transports, one pcap). Start the stand with:
+  #   docker compose --profile capture up -d
+  # or run the tests with:  ./run-tests.sh --capture
+  # The pcap lands in ./captures/ for Wireshark/tshark analysis.
+  capture:
+    build:
+      context: .
+      dockerfile: Dockerfile.capture
+    platform: linux/amd64
+    container_name: bgplite-it-capture
+    profiles: ["capture"]
+    network_mode: "service:server"
+    volumes:
+      - ./captures:/captures
+    command: ["-i", "any", "-U", "-w", "/captures/bgp.pcap", "port 179"]
+
+networks:
+  bgp4:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.30.100.0/24
+  bgp6:
+    driver: bridge
+    enable_ipv6: true
+    ipam:
+      config:
+        - subnet: fd00:b00b::/64

--- a/docker/integration/docker-compose.yml
+++ b/docker/integration/docker-compose.yml
@@ -60,6 +60,17 @@ services:
       - ./captures:/captures
     command: ["-i", "any", "-U", "-w", "/captures/bgp.pcap", "port 179"]
 
+  # In-network API probe: the runner talks to the server through this sidecar, so the
+  # tests never depend on host-loopback port publishing (unreachable under some CI
+  # docker configurations — userland-proxy/iptables variance).
+  probe:
+    image: curlimages/curl:8.11.0
+    platform: linux/amd64
+    container_name: bgplite-it-probe
+    networks:
+      bgp4:
+    entrypoint: ["sleep", "infinity"]
+
 networks:
   bgp4:
     driver: bridge

--- a/docker/integration/docker-compose.yml
+++ b/docker/integration/docker-compose.yml
@@ -25,8 +25,6 @@ services:
     volumes:
       - ./server-appsettings.yml:/app/appsettings.yml:ro
       - ./test-nets.txt:/app/test-nets.txt:ro
-    ports:
-      - "15001:5001"
     environment:
       # Debug logs for the session pipeline — this stand exists to diagnose it.
       - Logging__LogLevel__BGPLite=Debug

--- a/docker/integration/docker-compose.yml
+++ b/docker/integration/docker-compose.yml
@@ -3,7 +3,7 @@
 # and the server's peer registration agree.
 #
 #   net bgp4  172.30.100.0/24   server .10   bird .20
-#   net bgp6  fd00:b00b::/64    server ::10  bird ::20
+#   net bgp6  2001:db8:cccc::/64 server ::10  bird ::20 (doc prefix, RFC 3849)
 #
 # Everything is forced to linux/amd64 ("linux64"): the server image publishes with
 # the linux-x64 RID and both services pin the platform, so the stand behaves the
@@ -21,7 +21,7 @@ services:
       bgp4:
         ipv4_address: 172.30.100.10
       bgp6:
-        ipv6_address: fd00:b00b::10
+        ipv6_address: 2001:db8:cccc::10
     volumes:
       - ./server-appsettings.yml:/app/appsettings.yml:ro
       - ./test-nets.txt:/app/test-nets.txt:ro
@@ -41,7 +41,7 @@ services:
       bgp4:
         ipv4_address: 172.30.100.20
       bgp6:
-        ipv6_address: fd00:b00b::20
+        ipv6_address: 2001:db8:cccc::20
 
   # Opt-in packet capture of the BGP traffic INSIDE the server's network namespace
   # (both transports, one pcap). Start the stand with:
@@ -82,4 +82,4 @@ networks:
     enable_ipv6: true
     ipam:
       config:
-        - subnet: fd00:b00b::/64
+        - subnet: 2001:db8:cccc::/64

--- a/docker/integration/run-tests.sh
+++ b/docker/integration/run-tests.sh
@@ -5,7 +5,7 @@
 #   1. API plane is reachable (/api/server).
 #   2. A configured peer (registered via POST /api/peers) establishes over IPv4 transport.
 #   3. An UNconfigured peer establishes over IPv6 transport — proves the dual-mode
-#      listener (#14 phase 4a): fd00:b00b::20 -> fd00:b00b::10 port 179.
+#      listener (#14 phase 4a): 2001:db8:cccc::20 -> 2001:db8:cccc::10 port 179.
 #   4. Route exchange, server <- BIRD: BIRD's static prefixes (203.0.113.0/24,
 #      198.51.100.0/24 via IPv4 session, 2001:db8:ffff::/48 via MP_REACH over the
 #      IPv6 session) land in the server's route table (the "default" community group
@@ -38,13 +38,16 @@ api_post() { $COMPOSE exec -T probe curl -s --max-time 10 -o - -w '\n%{http_code
 say "build (linux/amd64)"
 $COMPOSE build --pull
 
-say "up"
-$COMPOSE up -d
+say "up (server first — BIRD joins only after the peer is registered, see step 2)"
+$COMPOSE up -d server probe
 cleanup() {
   # Evidence before teardown: the first thing a CI failure needs is the server's
-  # own account of why the API/session assertions never succeeded.
-  say "server log (tail, pre-teardown)"
-  $COMPOSE logs --no-color --tail 120 server bird 2>&1 | tail -120 || true
+  # own account of why the API/session assertions never succeeded. Filtered to the
+  # route-pipeline lines — raw keepalive/debug noise would push them out of a tail.
+  say "server pipeline log (pre-teardown)"
+  $COMPOSE logs --no-color server 2>&1 \
+    | grep -E "Unconfigured|Sending |UpdateSent|Suppress|SessionEstablished|Route refresh|Withdrawn|registering" \
+    | tail -60 || true
   $COMPOSE ps -a || true
   $COMPOSE down -v --remove-orphans
 }
@@ -72,7 +75,7 @@ wait_for() {
 say "1. API reachable"
 wait_for 'api_get $API/api/server >/dev/null' 60
 
-# --- 2. register the IPv4 peer --------------------------------------------------
+# --- 2. register the IPv4 peer, THEN connect BIRD --------------------------------
 say "2. register peer 172.30.100.20 (AS65002, custom prefix 192.0.2.0/24)"
 PEER_BODY='{"ip":"172.30.100.20","asn":65002,"description":"integration-bird","lists":["openai"],"customPrefixes":["192.0.2.0/24"]}'
 CREATE_RESP=$(api_post "$API/api/peers" "$PEER_BODY") || fail "POST /api/peers curl error"
@@ -82,14 +85,12 @@ echo "$CREATE_RESP" | sed '$d' > "$TMP/create-peer.json"
 grep -q '"error"' "$TMP/create-peer.json" && fail "POST /api/peers rejected: $(cat "$TMP/create-peer.json")"
 echo "created: $(cat "$TMP/create-peer.json")"
 
+$COMPOSE up -d bird
+
 # --- 3. both sessions Established ----------------------------------------------
-# BIRD connects the moment the stand is up, which races the peer registration in
-# step 2 (the session's initial dump would run against a not-yet-created peer row
-# and take the unconfigured path). Restarting the protocols forces a fresh dump
-# that sees the registered peer — deterministic, no sleep-based hope.
-say "3. restart BIRD sessions, then Established (IPv4 + IPv6 transport)"
-birdc "restart bgplite4" >/dev/null 2>&1
-birdc "restart bgplite6" >/dev/null 2>&1
+# BIRD is started AFTER the registration, so its very first dump already sees the
+# configured peer — no restart race, no sleep-based hope.
+say "3. BGP sessions Established (IPv4 + IPv6 transport)"
 wait_for 'birdc "show protocols all bgplite4" 2>/dev/null | grep -q "BGP state:.*Established"' 90
 wait_for 'birdc "show protocols all bgplite6" 2>/dev/null | grep -q "BGP state:.*Established"' 90
 
@@ -105,7 +106,7 @@ say "4. BIRD announcements reach the server route table"
 wait_for 'api_get $API/api/routes | grep -q "\"default\":3"' 60
 ROUTES=$(api_get $API/api/routes)
 echo "$ROUTES"
-echo "$ROUTES" | grep -q '"65001:100":2' || fail "seed source group (65001:100) should hold 2: $ROUTES"
+echo "$ROUTES" | grep -q '"65001:100":3' || fail "seed source group (65001:100) should hold 3 (2 IPv4 + 1 IPv6 seed): $ROUTES"
 # The openai HTTP-source group must hold a healthy bulk (the live list has ~300;
 # aggregation may merge some, lists may evolve — assert a conservative floor).
 HTTP_ROUTES=$(echo "$ROUTES" | grep -oE '"65001:110":[0-9]+' | grep -oE '[0-9]+$')
@@ -115,8 +116,9 @@ HTTP_ROUTES=$(echo "$ROUTES" | grep -oE '"65001:110":[0-9]+' | grep -oE '[0-9]+$
 # --- 5. server -> BIRD route propagation ----------------------------------------
 say "5. server advertisements reach BIRD"
 # The REGISTERED IPv4 peer gets its custom prefix (the configured-peer pipeline:
-# custom prefixes + subscriptions, no RU defaults).
-wait_for 'birdc "show route protocol bgplite4" 2>/dev/null | grep -q "192.0.2.0/24"' 60
+# custom prefixes + subscriptions, no RU defaults). Point lookup — stable regardless
+# of how the full table listing renders.
+wait_for 'birdc "show route 192.0.2.0/24" 2>/dev/null | grep -q "bgplite4"' 90
 birdc "show route protocol bgplite4" || true
 
 # The peer also subscribes to the "openai" HTTP source (ruhex/prefix-lists): the full
@@ -129,10 +131,12 @@ ROUTES4=$(birdc "show route protocol bgplite4 count" 2>/dev/null | tail -n +2 | 
 printf 'bgplite4 carries %s routes (custom + HTTP-source subscription)\n' "$ROUTES4"
 
 # The UNREGISTERED IPv6-transport peer gets the RU defaults (= the file seed source).
-# They ride as classic IPv4 NLRI over the IPv6 transport, imported by bgplite6's
-# IPv4 channel.
-wait_for 'birdc "show route protocol bgplite6" 2>/dev/null | grep -q "10.100.0.0/16"' 60
-wait_for 'birdc "show route protocol bgplite6" 2>/dev/null | grep -q "10.200.0.0/16"' 60
+# The IPv4 seeds ride as classic IPv4 NLRI over the IPv6 transport, imported by
+# bgplite6's IPv4 channel — and the IPv6 seed rides MP_REACH_NLRI (#14 phase 4b):
+# BIRD's IPv6 channel must import 2001:db8:cccc::/64 from the server.
+wait_for 'birdc "show route protocol bgplite6" 2>/dev/null | grep -q "10.100.0.0/16"' 90
+wait_for 'birdc "show route protocol bgplite6" 2>/dev/null | grep -q "10.200.0.0/16"' 90
+wait_for 'birdc "show route protocol bgplite6" 2>/dev/null | grep -q "2001:db8:cccc::/64"' 90
 birdc "show route protocol bgplite6" || true
 
 # --- 6. traffic capture (opt-in: --capture) --------------------------------------

--- a/docker/integration/run-tests.sh
+++ b/docker/integration/run-tests.sh
@@ -85,6 +85,12 @@ echo "$CREATE_RESP" | sed '$d' > "$TMP/create-peer.json"
 grep -q '"error"' "$TMP/create-peer.json" && fail "POST /api/peers rejected: $(cat "$TMP/create-peer.json")"
 echo "created: $(cat "$TMP/create-peer.json")"
 
+# The IPv6-transport peer is registered too — the API accepts IPv6 peers (#14 phase 5).
+V6_BODY='{"ip":"2001:db8:cccc::20","asn":65002,"description":"integration-bird-v6"}'
+V6_STATUS=$(api_post "$API/api/peers" "$V6_BODY" | tail -1)
+[ "$V6_STATUS" = "200" ] || fail "IPv6 peer registration returned $V6_STATUS"
+echo "v6 peer registered: $V6_STATUS"
+
 $COMPOSE up -d bird
 
 # --- 3. both sessions Established ----------------------------------------------

--- a/docker/integration/run-tests.sh
+++ b/docker/integration/run-tests.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# BGPLite × BIRD2 integration tests (docker compose, linux/amd64).
+#
+# What is proven against REAL BGP speaker processes (no mocks):
+#   1. API plane is reachable (/api/server).
+#   2. A configured peer (registered via POST /api/peers) establishes over IPv4 transport.
+#   3. An UNconfigured peer establishes over IPv6 transport — proves the dual-mode
+#      listener (#14 phase 4a): fd00:b00b::20 -> fd00:b00b::10 port 179.
+#   4. Route exchange, server <- BIRD: BIRD's static prefixes (203.0.113.0/24,
+#      198.51.100.0/24 via IPv4 session, 2001:db8:ffff::/48 via MP_REACH over the
+#      IPv6 session) land in the server's route table (the "default" community group
+#      in /api/routes grows by 3 — announced prefixes carry no community).
+#   5. Route exchange, server -> BIRD: the seed prefixes from the file source
+#      (10.100.0.0/16, 10.200.0.0/16) appear in BIRD's import for the IPv4 session.
+#
+# Requirements: docker + docker compose (v2), curl. The runner itself may be any OS.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+API="http://localhost:15001"
+API_PORT_HOST=15001
+CAPTURE=0
+[ "${1:-}" = "--capture" ] && CAPTURE=1
+PROFILES=""
+[ "$CAPTURE" = 1 ] && PROFILES="--profile capture"
+COMPOSE="docker compose $PROFILES -f docker-compose.yml"
+
+say() { printf '\n=== %s ===\n' "$1"; }
+fail() { printf 'FAILED: %s\n' "$1" >&2; exit 1; }
+
+# --- bring the stand up -------------------------------------------------------
+say "build (linux/amd64)"
+$COMPOSE build --pull
+
+say "up"
+$COMPOSE up -d
+cleanup() { $COMPOSE down -v --remove-orphans; }
+trap cleanup EXIT
+
+# --- helpers ------------------------------------------------------------------
+api_get() { curl -sf --max-time 5 "$API$1"; }
+TMP=$(mktemp -d)
+birdc() { $COMPOSE exec -T bird birdc "$@"; }
+
+# Wait until `bash -c "$1"` succeeds; $2 = deadline in seconds.
+wait_for() {
+  local what="$1" deadline="$2" i=0
+  while ! eval "$what"; do
+    i=$((i + 1))
+    [ "$i" -gt "$deadline" ] && fail "timeout after ${deadline}s waiting for: $what"
+    sleep 1
+  done
+  printf 'ok (%ss): %s\n' "$i" "$what"
+}
+
+# --- 1. API plane --------------------------------------------------------------
+say "1. API reachable"
+wait_for 'api_get /api/server >/dev/null' 60
+
+# --- 2. register the IPv4 peer --------------------------------------------------
+say "2. register peer 172.30.100.20 (AS65002, custom prefix 192.0.2.0/24)"
+PEER_BODY='{"ip":"172.30.100.20","asn":65002,"description":"integration-bird","lists":["openai"],"customPrefixes":["192.0.2.0/24"]}'
+CREATE_STATUS=$(curl -s --max-time 10 -o "$TMP/create-peer.json" -w '%{http_code}' \
+  -X POST -H 'Content-Type: application/json' -d "$PEER_BODY" "$API/api/peers") \
+  || fail "POST /api/peers curl error"
+[ "$CREATE_STATUS" = "200" ] || fail "POST /api/peers returned $CREATE_STATUS: $(cat "$TMP/create-peer.json")"
+grep -q '"error"' "$TMP/create-peer.json" && fail "POST /api/peers rejected: $(cat "$TMP/create-peer.json")"
+echo "created: $(cat "$TMP/create-peer.json")"
+
+# --- 3. both sessions Established ----------------------------------------------
+# BIRD connects the moment the stand is up, which races the peer registration in
+# step 2 (the session's initial dump would run against a not-yet-created peer row
+# and take the unconfigured path). Restarting the protocols forces a fresh dump
+# that sees the registered peer — deterministic, no sleep-based hope.
+say "3. restart BIRD sessions, then Established (IPv4 + IPv6 transport)"
+birdc "restart bgplite4" >/dev/null 2>&1
+birdc "restart bgplite6" >/dev/null 2>&1
+wait_for 'birdc "show protocols all bgplite4" 2>/dev/null | grep -q "BGP state:.*Established"' 90
+wait_for 'birdc "show protocols all bgplite6" 2>/dev/null | grep -q "BGP state:.*Established"' 90
+
+ACTIVE=$(api_get /api/sessions | grep -o '"active":[0-9]*' | cut -d: -f2)
+[ -n "$ACTIVE" ] && [ "$ACTIVE" -ge 2 ] || fail "server reports active=$ACTIVE, want >=2 (both transports)"
+printf 'server reports %s active sessions\n' "$ACTIVE"
+
+# --- 4. BIRD -> server route propagation ----------------------------------------
+say "4. BIRD announcements reach the server route table"
+# Seed prefixes carry community 65001:100; BIRD's are untagged -> the "default"
+# group must grow to exactly the 3 announced prefixes (2x IPv4 NLRI + 1x MP_REACH v6).
+wait_for 'api_get /api/routes | grep -q "\"default\":3"' 60
+ROUTES=$(api_get /api/routes)
+echo "$ROUTES"
+echo "$ROUTES" | grep -q '"65001:100":2' || fail "seed source group (65001:100) should hold 2: $ROUTES"
+# The openai HTTP-source group must hold a healthy bulk (the live list has ~300;
+# aggregation may merge some, lists may evolve — assert a conservative floor).
+HTTP_ROUTES=$(echo "$ROUTES" | grep -oE '"65001:110":[0-9]+' | grep -oE '[0-9]+$')
+[ -n "$HTTP_ROUTES" ] && [ "$HTTP_ROUTES" -ge 100 ] \
+  || fail "openai HTTP-source group should hold >=100 routes, got: $HTTP_ROUTES"
+
+# --- 5. server -> BIRD route propagation ----------------------------------------
+say "5. server advertisements reach BIRD"
+# The REGISTERED IPv4 peer gets its custom prefix (the configured-peer pipeline:
+# custom prefixes + subscriptions, no RU defaults).
+wait_for 'birdc "show route protocol bgplite4" 2>/dev/null | grep -q "192.0.2.0/24"' 60
+birdc "show route protocol bgplite4" || true
+
+# The peer also subscribes to the "openai" HTTP source (ruhex/prefix-lists): the full
+# HTTP-fetch pipeline must deliver its ~300 real-world prefixes to BIRD. Assert a
+# conservative floor (>= 100 routes) — aggregation may merge some, lists may evolve.
+# (tail -n +2 skips the "BIRD 2.0.12 ready" banner — its digits would break the parse.)
+ROUTES4=$(birdc "show route protocol bgplite4 count" 2>/dev/null | tail -n +2 | grep -oE "[0-9]+" | head -1)
+[ -n "$ROUTES4" ] && [ "$ROUTES4" -ge 100 ] \
+  || fail "expected >=100 routes from the openai HTTP source on bgplite4, got: $ROUTES4"
+printf 'bgplite4 carries %s routes (custom + HTTP-source subscription)\n' "$ROUTES4"
+
+# The UNREGISTERED IPv6-transport peer gets the RU defaults (= the file seed source).
+# They ride as classic IPv4 NLRI over the IPv6 transport, imported by bgplite6's
+# IPv4 channel.
+wait_for 'birdc "show route protocol bgplite6" 2>/dev/null | grep -q "10.100.0.0/16"' 60
+wait_for 'birdc "show route protocol bgplite6" 2>/dev/null | grep -q "10.200.0.0/16"' 60
+birdc "show route protocol bgplite6" || true
+
+# --- 6. traffic capture (opt-in: --capture) --------------------------------------
+if [ "$CAPTURE" = 1 ]; then
+  say "6. packet capture (--capture)"
+  $COMPOSE stop capture
+  PCAP=$(ls -S captures/*.pcap 2>/dev/null | head -1)
+  [ -n "$PCAP" ] && [ -s "$PCAP" ] || fail "capture produced no pcap in captures/"
+  BGP_PKTS=$(tcpdump -r "$PCAP" 2>/dev/null | grep -c "BGP" || true)
+  [ -n "$BGP_PKTS" ] && [ "$BGP_PKTS" -ge 10 ] \
+    || fail "pcap holds $BGP_PKTS BGP packets, expected >= 10: $PCAP"
+  printf '%s: %s BGP packets captured (open in Wireshark for analysis)\n' "$PCAP" "$BGP_PKTS"
+fi
+
+say "ALL INTEGRATION TESTS PASSED"

--- a/docker/integration/run-tests.sh
+++ b/docker/integration/run-tests.sh
@@ -86,6 +86,8 @@ grep -q '"error"' "$TMP/create-peer.json" && fail "POST /api/peers rejected: $(c
 echo "created: $(cat "$TMP/create-peer.json")"
 
 # The IPv6-transport peer is registered too — the API accepts IPv6 peers (#14 phase 5).
+# It is registered with NO lists/custom prefixes, so it exercises the "configured peer with
+# zero resolved prefixes falls back to the RU/default source" branch of the assembler.
 V6_BODY='{"ip":"2001:db8:cccc::20","asn":65002,"description":"integration-bird-v6"}'
 V6_STATUS=$(api_post "$API/api/peers" "$V6_BODY" | tail -1)
 [ "$V6_STATUS" = "200" ] || fail "IPv6 peer registration returned $V6_STATUS"

--- a/docker/integration/run-tests.sh
+++ b/docker/integration/run-tests.sh
@@ -17,8 +17,11 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
-API="http://localhost:15001"
-API_PORT_HOST=15001
+# The API is reached THROUGH the probe sidecar (compose network, by service name):
+# host-loopback port publishing is unavailable under some CI docker configurations
+# (userland-proxy/iptables variance) — this way the tests depend only on the
+# compose network itself.
+API="http://server:5001"
 CAPTURE=0
 [ "${1:-}" = "--capture" ] && CAPTURE=1
 PROFILES=""
@@ -28,17 +31,26 @@ COMPOSE="docker compose $PROFILES -f docker-compose.yml"
 say() { printf '\n=== %s ===\n' "$1"; }
 fail() { printf 'FAILED: %s\n' "$1" >&2; exit 1; }
 
+api_get() { $COMPOSE exec -T probe curl -sf --max-time 5 "$1"; }
+api_post() { $COMPOSE exec -T probe curl -s --max-time 10 -o - -w '\n%{http_code}' -X POST -H 'Content-Type: application/json' -d "$2" "$1"; }
+
 # --- bring the stand up -------------------------------------------------------
 say "build (linux/amd64)"
 $COMPOSE build --pull
 
 say "up"
 $COMPOSE up -d
-cleanup() { $COMPOSE down -v --remove-orphans; }
+cleanup() {
+  # Evidence before teardown: the first thing a CI failure needs is the server's
+  # own account of why the API/session assertions never succeeded.
+  say "server log (tail, pre-teardown)"
+  $COMPOSE logs --no-color --tail 120 server bird 2>&1 | tail -120 || true
+  $COMPOSE ps -a || true
+  $COMPOSE down -v --remove-orphans
+}
 trap cleanup EXIT
 
 # --- helpers ------------------------------------------------------------------
-api_get() { curl -sf --max-time 5 "$API$1"; }
 TMP=$(mktemp -d)
 birdc() { $COMPOSE exec -T bird birdc "$@"; }
 
@@ -47,7 +59,10 @@ wait_for() {
   local what="$1" deadline="$2" i=0
   while ! eval "$what"; do
     i=$((i + 1))
-    [ "$i" -gt "$deadline" ] && fail "timeout after ${deadline}s waiting for: $what"
+    if [ "$i" -gt "$deadline" ]; then
+      $COMPOSE ps -a || true
+      fail "timeout after ${deadline}s waiting for: $what"
+    fi
     sleep 1
   done
   printf 'ok (%ss): %s\n' "$i" "$what"
@@ -55,14 +70,14 @@ wait_for() {
 
 # --- 1. API plane --------------------------------------------------------------
 say "1. API reachable"
-wait_for 'api_get /api/server >/dev/null' 60
+wait_for 'api_get $API/api/server >/dev/null' 60
 
 # --- 2. register the IPv4 peer --------------------------------------------------
 say "2. register peer 172.30.100.20 (AS65002, custom prefix 192.0.2.0/24)"
 PEER_BODY='{"ip":"172.30.100.20","asn":65002,"description":"integration-bird","lists":["openai"],"customPrefixes":["192.0.2.0/24"]}'
-CREATE_STATUS=$(curl -s --max-time 10 -o "$TMP/create-peer.json" -w '%{http_code}' \
-  -X POST -H 'Content-Type: application/json' -d "$PEER_BODY" "$API/api/peers") \
-  || fail "POST /api/peers curl error"
+CREATE_RESP=$(api_post "$API/api/peers" "$PEER_BODY") || fail "POST /api/peers curl error"
+CREATE_STATUS=$(echo "$CREATE_RESP" | tail -1)
+echo "$CREATE_RESP" | sed '$d' > "$TMP/create-peer.json"
 [ "$CREATE_STATUS" = "200" ] || fail "POST /api/peers returned $CREATE_STATUS: $(cat "$TMP/create-peer.json")"
 grep -q '"error"' "$TMP/create-peer.json" && fail "POST /api/peers rejected: $(cat "$TMP/create-peer.json")"
 echo "created: $(cat "$TMP/create-peer.json")"
@@ -78,16 +93,17 @@ birdc "restart bgplite6" >/dev/null 2>&1
 wait_for 'birdc "show protocols all bgplite4" 2>/dev/null | grep -q "BGP state:.*Established"' 90
 wait_for 'birdc "show protocols all bgplite6" 2>/dev/null | grep -q "BGP state:.*Established"' 90
 
-ACTIVE=$(api_get /api/sessions | grep -o '"active":[0-9]*' | cut -d: -f2)
-[ -n "$ACTIVE" ] && [ "$ACTIVE" -ge 2 ] || fail "server reports active=$ACTIVE, want >=2 (both transports)"
-printf 'server reports %s active sessions\n' "$ACTIVE"
+# Poll instead of a one-shot pipe: under `set -o pipefail` a single curl/grep hiccup
+# here would silently kill the script (set -e) before any diagnostic is printed.
+wait_for 'api_get $API/api/sessions | grep -q "\"active\":[2-9]"' 60
+printf 'server reports both transports active\n'
 
 # --- 4. BIRD -> server route propagation ----------------------------------------
 say "4. BIRD announcements reach the server route table"
 # Seed prefixes carry community 65001:100; BIRD's are untagged -> the "default"
 # group must grow to exactly the 3 announced prefixes (2x IPv4 NLRI + 1x MP_REACH v6).
-wait_for 'api_get /api/routes | grep -q "\"default\":3"' 60
-ROUTES=$(api_get /api/routes)
+wait_for 'api_get $API/api/routes | grep -q "\"default\":3"' 60
+ROUTES=$(api_get $API/api/routes)
 echo "$ROUTES"
 echo "$ROUTES" | grep -q '"65001:100":2' || fail "seed source group (65001:100) should hold 2: $ROUTES"
 # The openai HTTP-source group must hold a healthy bulk (the live list has ~300;

--- a/docker/integration/run-tests.sh
+++ b/docker/integration/run-tests.sh
@@ -138,7 +138,9 @@ ROUTES4=$(birdc "show route protocol bgplite4 count" 2>/dev/null | tail -n +2 | 
   || fail "expected >=100 routes from the openai HTTP source on bgplite4, got: $ROUTES4"
 printf 'bgplite4 carries %s routes (custom + HTTP-source subscription)\n' "$ROUTES4"
 
-# The UNREGISTERED IPv6-transport peer gets the RU defaults (= the file seed source).
+# The IPv6-transport peer is REGISTERED but configures no lists/custom prefixes, so the
+# assembler's zero-resolved-prefixes branch falls back to the RU defaults (= the file seed
+# source) for it — same source the unconfigured case would get.
 # The IPv4 seeds ride as classic IPv4 NLRI over the IPv6 transport, imported by
 # bgplite6's IPv4 channel — and the IPv6 seed rides MP_REACH_NLRI (#14 phase 4b):
 # BIRD's IPv6 channel must import 2001:db8:cccc::/64 from the server.

--- a/docker/integration/server-appsettings.yml
+++ b/docker/integration/server-appsettings.yml
@@ -7,6 +7,8 @@ Bgp:
   # Short timers: a dead session must be noticed in seconds, not minutes.
   KeepAlive: 5
   HoldTime: 15
+  # Phase 4b: enables IPv6 advertisements via MP_REACH to MP-IPv6-negotiated peers.
+  NextHopIpv6: "2001:db8:cccc::10"
 
 # Reachable from the test runner via the published port (compose: 15001 -> 5001).
 # Loopback (the production default, #90/#181) would be invisible outside the container.

--- a/docker/integration/server-appsettings.yml
+++ b/docker/integration/server-appsettings.yml
@@ -1,0 +1,37 @@
+# Integration-test configuration: minimal, fully offline (no RIPEstat fetches).
+# The file source below is the "RU/default" set served to unconfigured peers —
+# so BGP exchange works without internet access.
+Bgp:
+  Asn: 65001
+  RouterId: 172.30.100.10
+  # Short timers: a dead session must be noticed in seconds, not minutes.
+  KeepAlive: 5
+  HoldTime: 15
+
+# Reachable from the test runner via the published port (compose: 15001 -> 5001).
+# Loopback (the production default, #90/#181) would be invisible outside the container.
+ApiListen: "0.0.0.0"
+ApiPort: 5001
+
+DefaultPrefixSource: test4
+
+PrefixSources:
+  - Kind: file
+    Name: test4
+    Description: "Integration-test seed prefixes (IPv4)"
+    Path: "/app/test-nets.txt"
+    Community: "65001:100"
+
+  # Real-world data through the full HTTP fetch path (SSRF validator, response cap,
+  # parser, cache). Small list (~300 prefixes) from the operator's own repo, so the
+  # subscription pipeline is exercised against live internet content.
+  - Kind: http
+    Name: openai
+    Description: "OpenAI prefixes from ruhex/prefix-lists (integration test data)"
+    Url: "https://raw.githubusercontent.com/ruhex/prefix-lists/main/openai_prefixes.txt"
+    Timeout: 30
+    Community: "65001:110"
+
+RipeStat:
+  TimeoutSeconds: 5
+  RetryAttempts: 0

--- a/docker/integration/test-nets.txt
+++ b/docker/integration/test-nets.txt
@@ -1,0 +1,3 @@
+# Seed prefixes the server originates toward every peer (DefaultPrefixSource).
+10.100.0.0/16
+10.200.0.0/16

--- a/docker/integration/test-nets.txt
+++ b/docker/integration/test-nets.txt
@@ -1,3 +1,4 @@
 # Seed prefixes the server originates toward every peer (DefaultPrefixSource).
 10.100.0.0/16
 10.200.0.0/16
+2001:db8:cccc::/64

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -228,6 +228,23 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
   routes flowing; such routes now stop at the filter (visible via the existing send logs).
 - **Tracker:** #389.
 
+### D22. IPv6 outbound advertisement is gated on negotiation AND a configured global next hop
+- **Decision:** IPv6 routes are advertised to a peer only when BOTH hold: the peer negotiated
+  MP IPv6/Unicast in OPEN, and `Bgp.NextHopIpv6` is configured (validated at startup as a global
+  unicast address, 2000::/3). Otherwise IPv6 routes are suppressed for that send with a warning —
+  never silently, and never encoded as classic IPv4 NLRI (which would corrupt the peer's table).
+  v6 UPDATEs carry no classic NEXT_HOP (RFC 4760 §5 — the next hop rides in MP_REACH_NLRI,
+  RFC 2545 §3 global form); IPv6 withdrawals ride MP_UNREACH_NLRI (RFC 4760 §7).
+- **Context:** after the phase-2 codec (#15) and #407 fix the session could RECEIVE IPv6 routes
+  but had no outbound path — sources were IPv4-only and the send path had no family split.
+  Advertising IPv6 with the IPv4 router-id as next hop (or without the peer's negotiation) would
+  be a route leak/blackhole, so the gate is deliberately double-sided and fail-visible.
+- **Consequence:** IPv4-only deployments need no config change (no `NextHopIpv6` = no IPv6
+  advertisements, one Warning per send that actually had v6 routes); MP-IPv6 deployments add one
+  config line. The MP_REACH attribute is appended per batch (it embeds the batch's NLRI bytes) and
+  goes last — attribute ordering is an implementation choice (D15).
+- **Tracker:** #14 (phase 4b), #407.
+
 ### D21. IPv6 dual-stack address model (ADR 0001)
 - **Decision:** `IpPrefix` is family-aware over `UInt128` — IPv4 in the low 32 bits with an
   explicit `IsIpv4` flag, IPv6 as the full 128 bits; the constructor masks host bits (canonical

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -62,7 +62,9 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
   End-of-RIB) is not implemented, and advertising the `<AFI=1, SAFI=1, F>` tuple promised behavior
   the code does not have. The sending-side conveniences gated on the `GracefulRestart` config are
   unchanged: an End-of-RIB marker after the initial route dump, and the GR-aware silent close on
-  server shutdown (`StopAsync`).
+  server shutdown (`StopAsync`). #14 phase 5 made the factory/parser per-family (IPv4/Unicast AND
+  IPv6/Unicast tuples) and added the IPv6-family End-of-RIB (empty MP_UNREACH, RFC 4724 §2) for
+  MP-IPv6-negotiated peers; the advertisement itself remains off until retention exists.
 - **Context:** the capability was previously advertised by default while routes of a
   silently-disconnecting peer were flushed immediately (`RemoveAllOwnedBy`, #314) — a wire promise
   the code did not honor. RFC 4724 §4.2's MUST binds a speaker to the procedures it engages;

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -232,7 +232,9 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
 - **Decision:** `IpPrefix` is family-aware over `UInt128` — IPv4 in the low 32 bits with an
   explicit `IsIpv4` flag, IPv6 as the full 128 bits; the constructor masks host bits (canonical
   keys); `Route.Key`/`RouteTable` keys carry the family; the aggregator partitions by family.
-  Full ADR: `docs/adr/0001-ipv6-address-model.md` (#15 phase 1).
+  Full ADR: `docs/adr/0001-ipv6-address-model.md` (#15 phase 1). The family partition and
+  128-bit interval math in `ExactUnionPrefixAggregator`, plus the `RouteTable`
+  longest-prefix-match lookup, landed with #14 phase 3.
 - **Tracker:** #15, #14.
 
 ## Management API

--- a/docs/adr/0001-ipv6-address-model.md
+++ b/docs/adr/0001-ipv6-address-model.md
@@ -33,16 +33,18 @@ files and the whole test suite, so the representation choice is expensive to rev
    IPv4-only router-id / next-hop paths.
 6. **Aggregation**: `ExactUnionPrefixAggregator` groups by (communities, IsIpv4) — IPv4 and IPv6
    prefixes are never merged into one summary even with identical tags. Interval math is
-   generalized to UInt128. (Full 128-bit LPM and IPv6 aggregation policy remain Phase 3.)
+   generalized to UInt128. (Delivered as planned in #14 phase 3, together with the
+   longest-prefix-match lookup on `RouteTable`.)
 
 ## Consequences
 
 - `uint` → `UInt128` widening is implicit, so IPv4 construction sites (`Route { Prefix = 0xC0A80000u }`)
   keep compiling unchanged; narrowing reads cast explicitly.
-- Phase 2 delivered IPv6 NLRI via MP_REACH/MP_UNREACH; the aggregator's `length > 32` skip
-  means IPv6 routes arriving via MP_REACH are defensively dropped until Phase 3 generalizes the
-  aggregator.
-- `Route.NextHop` stays IPv4 `uint` until Phase 2 (MP_REACH next-hop, RFC 2545).
+- Phase 2 delivered IPv6 NLRI via MP_REACH/MP_UNREACH; until then the aggregator's `length > 32`
+  skip defensively dropped inbound IPv6 routes. #14 phase 3 closed the interim gap: the aggregator
+  is now fully 128-bit and family-partitioned, and `RouteTable` gained a longest-prefix-match
+  lookup.
+- `Route.NextHop` stayed IPv4 `uint` until Phase 2 delivered the MP_REACH next-hop (RFC 2545).
 - Each later phase builds on this model without re-breaking it; the epic's phased checklist
   (#14 phases 2–5) tracks the remaining work.
 


### PR DESCRIPTION
Closes #14
Closes #407

Batched integration of everything accumulated on `dev` since the last integration (#403, phases 1+2):

## Per-change summary

| PR | What / why | Verification |
|---|---|---|
| #405 — phase 3 (routing) | `ExactUnionPrefixAggregator` generalized to UInt128, family-partitioned groups (IPv4/IPv6 never merge); `RouteTable.GetLongestPrefixMatch` family-scoped LPM. Red/green proven: IPv6 prefixes with length > 32 were dropped by the old 32-bit aggregator | 9 IPv6 aggregator tests (8 red pre-fix); 9 LPM tests |
| #406 — phase 4a (transport) | Dual-mode `[::]:179` listener; IPv4-mapped address normalization; TCP-MD5 keys stored in kernel wire form on v6 sockets — **fixed TcpMd5 writing Winsock AF_INET6 (23) instead of kernel 10**, caught by a new kernel-level dual-mode handshake test | 976→977 tests; macOS behavior verified unchanged |
| #408 — fix #407 | MP_REACH/MP_UNREACH-only UPDATEs were dropped by the `Nlri.Count > 0` gate (the normal IPv6 announcement shape, RFC 4760 §5/§7) — found by the new integration stand; red/green session-level tests | 979/979 |
| #409 + #410 — integration stand | Docker compose BGPLite × BIRD2 over IPv4 AND IPv6 transport (linux/amd64, server published with linux-x64 RID): session establishment through the dual-mode listener, route exchange both directions, IPv6 peer registration via the API, live HTTP prefix source (ruhex/prefix-lists), opt-in tcpdump capture. Runs in CI on every push to main/dev | ALL INTEGRATION TESTS PASSED (local + CI) |
| #411 — phase 4b (providers + outbound) | Dual-stack prefix pipeline end-to-end (RIPEstat `v6.originating`, IPv6 in PrefixListParser/PrefixCidr, family-tagged `IPrefixService`); send path family split: IPv6 advertised via MP_REACH (RFC 4760 §5, RFC 2545 §3 global next hop) gated on MP-IPv6 negotiation AND `Bgp.NextHopIpv6` (global unicast 2000::/3); withdrawals via MP_UNREACH. IPv4 wire behavior byte-identical | 7 wire-level session tests; 995/995; stand advertises a real IPv6 seed to BIRD2 |
| #412 — phase 5 (api/protocol) | IPv6 peer-setup templates (Cisco address-family ipv6 unicast / BIRD ipv6 {} / MikroTik afi=ip6); Graceful Restart per-AFI tuples (RFC 4724 §2) + IPv6 End-of-RIB (empty MP_UNREACH, AFI=2/SAFI=1) — capability advertisement itself stays off per D6; `NormalizePeerIp` accepts IPv6 peers | 1007/1007; stand registers its IPv6 peer via the API |

## Notes
- `docs/DESIGN_DECISIONS.md` carries two new entries (D21 IPv6 model, D22 IPv6 outbound gating) and an updated D6 (GR stays unadvertised; per-AFI plumbing delivered).
- The BIRD2 stand is now a CI gate (`integration` workflow) — it already proved its worth by catching #407.
- Known deferred item: MikroTik CHR as an opt-in stand profile (official image is a QEMU VM — serial-console provisioning; deliberately not a CI gate).

## Verification
- `dotnet test BGPLite.sln` — **1007/1007** on the merged dev tip
- `dotnet build` 0 warnings; `dotnet format` clean
- integration workflow green on dev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dual-stack IPv4/IPv6 BGP support for announcements, withdrawals, next-hop configuration, aggregation, and longest-prefix matching.
  * Added IPv6 peer setup guidance and management API output.
  * Added end-to-end integration testing with real BIRD2 peers over IPv4 and IPv6, including optional packet capture.

* **Bug Fixes**
  * Improved address normalization and TCP-MD5 compatibility across IPv4 and IPv6.
  * Corrected graceful-restart capability validation and IPv6 forwarding-state handling.

* **Documentation**
  * Updated configuration examples, integration instructions, and design documentation for IPv6 behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->