### PR TITLE
docs(integration): fix stale comment on the v6 route assertions

### DIFF
--- a/BGPLite.Contracts/TcpMd5.cs
+++ b/BGPLite.Contracts/TcpMd5.cs
@@ -100,28 +100,39 @@ public static class TcpMd5
 
     /// <summary>Writes a sockaddr_storage-shaped sockaddr_in/inn6 for the peer, port 0 = "any port".
     /// <para>
-    /// The address family constants are the KERNEL's, not .NET's <see cref="AddressFamily"/> values
-    /// (which follow Winsock: InterNetworkV6 = 23). Linux wants AF_INET6 = 10, Darwin 28 — writing
-    /// 23 makes the kernel's md5 parse path reject the entry with EINVAL
-    /// (<c>sin6_family != AF_INET6</c>), which no v4 test could catch because AF_INET = 2 happens
-    /// to agree everywhere. The accepted-socket runtime checks are the OS guard: TCP-MD5 is only
-    /// ever applied on Linux/macOS.
+    /// Two per-OS differences live here:
+    /// <list type="bullet">
+    /// <item><b>Address family constants are the KERNEL's</b>, not .NET's <see cref="AddressFamily"/>
+    /// values (which follow Winsock: InterNetworkV6 = 23). Linux wants AF_INET6 = 10, Darwin 28 —
+    /// writing 23 makes Linux's md5 parse path reject the entry with EINVAL
+    /// (<c>sin6_family != AF_INET6</c>).</item>
+    /// <item><b>Darwin sockaddr_in/in6 carry a length byte first</b> (<c>sin_len</c>/<c>sin6_len</c>),
+    /// with the family in byte 1; Linux has no length byte and keeps the family in bytes 0-1.
+    /// Darwin's own tcpmd5sig path reads that length field, so omitting it (or writing the family
+    /// into byte 0) breaks key lookup there.</item>
+    /// </list>
     /// </para>
     /// </summary>
     internal static void WriteSockaddr(IPEndPoint peer, Span<byte> destination)
     {
         destination.Clear();
         var port = (ushort)peer.Port;
-        if (peer.Address.AddressFamily == AddressFamily.InterNetwork)
+        var isV4 = peer.Address.AddressFamily == AddressFamily.InterNetwork;
+        var darwin = OperatingSystem.IsMacOS();
+        if (isV4)
         {
-            destination[0] = AfInet;                                  // AF_INET: 2 on Linux and Darwin
+            var af = AfInet;
+            if (darwin) { destination[0] = 16; destination[1] = af; } // sin_len, sin_family
+            else { destination[0] = af; }                             // Linux: family, host order
             destination[2] = (byte)(port >> 8);                       // port, network byte order
             destination[3] = (byte)port;
             peer.Address.TryWriteBytes(destination.Slice(4, 4), out _);
         }
         else
         {
-            destination[0] = AfInet6;                                 // AF_INET6: 10 (Linux) / 28 (Darwin)
+            var af = AfInet6;
+            if (darwin) { destination[0] = 28; destination[1] = af; } // sin6_len, sin6_family
+            else { destination[0] = af; }
             destination[2] = (byte)(port >> 8);
             destination[3] = (byte)port;
             peer.Address.TryWriteBytes(destination.Slice(8, 16), out _);

--- a/BGPLite.Protocol/BgpCapabilityInfo.cs
+++ b/BGPLite.Protocol/BgpCapabilityInfo.cs
@@ -68,6 +68,9 @@ public sealed class BgpCapabilityInfo
     public static (bool RestartState, ushort RestartTime, bool Ipv4UnicastForwarding, bool Ipv6UnicastForwarding)? TryParseGracefulRestart(ReadOnlySpan<byte> data)
     {
         if (data.Length < 2) return null;
+        // RFC 4724 §2: the value is the 2-byte header followed by COMPLETE 4-byte <AFI, SAFI, F>
+        // tuples — a trailing partial tuple means a malformed capability, not "ignore the tail".
+        if ((data.Length - 2) % 4 != 0) return null;
         var restartState = (data[0] & BgpConstants.GracefulRestartFlag.RestartState) != 0;
         var restartTime = (ushort)(((data[0] & 0x0F) << 8) | data[1]);
         var ipv4UnicastForwarding = false;

--- a/BGPLite.Server/BgpServer.cs
+++ b/BGPLite.Server/BgpServer.cs
@@ -60,19 +60,32 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        // #14 phase 4: a dual-mode IPv6 listener accepts both IPv6 peers and IPv4 peers — the
-        // kernel surfaces the latter as IPv4-mapped addresses, normalized in AcceptLoopAsync.
-        // DualMode must be set before Bind.
-        _listener = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
-        _listener.DualMode = true;
-        _listener.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
-        _listener.Bind(new IPEndPoint(IPAddress.IPv6Any, BgpConstants.BgpPort));
+        // #14 phase 4: prefer the dual-mode IPv6 listener — it accepts both IPv6 peers and IPv4
+        // peers (the kernel surfaces the latter as IPv4-mapped addresses, normalized in
+        // AcceptLoopAsync). DualMode must be set before Bind. On hosts with IPv6 disabled we fall
+        // back to the pre-phase-4 IPv4 listener instead of refusing to start: serving IPv4-only
+        // beats not serving at all, and the capability difference is announced loudly.
+        var useDualMode = Socket.OSSupportsIPv6;
+        if (useDualMode)
+        {
+            _listener = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
+            _listener.DualMode = true;
+            _listener.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+            _listener.Bind(new IPEndPoint(IPAddress.IPv6Any, BgpConstants.BgpPort));
+        }
+        else
+        {
+            _listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            _listener.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+            _listener.Bind(new IPEndPoint(IPAddress.Any, BgpConstants.BgpPort));
+            _logger.LogWarning("IPv6 is not available on this host — serving IPv4 peers only");
+        }
         // #344: after a restart every peer reconnects at once; backlog 16 dropped SYNs and pushed
         // peers into their own retry backoff, stretching reconvergence for no benefit. A few
         // hundred pending accepts costs nothing on a route-server host.
         _listener.Listen(512);
 
-        _logger.LogInformation("BGP server listening on [::]:{Port} (dual-mode IPv6+IPv4)", BgpConstants.BgpPort);
+        _logger.LogInformation("BGP server listening on {Address}:{Port}", useDualMode ? "[::]" : "0.0.0.0", BgpConstants.BgpPort);
         _logger.LogInformation("Local ASN={Asn}, RouterId={RouterId}", _config.Bgp.Asn, _config.Bgp.RouterId);
 
         _acceptTask = AcceptLoopAsync(_cts.Token);

--- a/BGPLite.Tests/GracefulRestartTests.cs
+++ b/BGPLite.Tests/GracefulRestartTests.cs
@@ -58,6 +58,10 @@ public class GracefulRestartTests
     {
         Assert.Null(BgpCapabilityInfo.TryParseGracefulRestart([]));
         Assert.Null(BgpCapabilityInfo.TryParseGracefulRestart(new byte[] { 0x80 })); // only 1 byte
+        // RFC 4724 §2: the value is a 2-byte header plus COMPLETE 4-byte tuples — a trailing
+        // partial tuple is malformed, not a tail to ignore.
+        Assert.Null(BgpCapabilityInfo.TryParseGracefulRestart(new byte[] { 0x80, 0x3C, 0x00, 0x01, 0x01 }));
+        Assert.Null(BgpCapabilityInfo.TryParseGracefulRestart(new byte[] { 0x80, 0x3C, 0x00 }));
     }
 
     [Fact]

--- a/BGPLite.Tests/TcpMd5Tests.cs
+++ b/BGPLite.Tests/TcpMd5Tests.cs
@@ -35,15 +35,46 @@ public class TcpMd5Tests
     [Fact]
     public void WriteSockaddr_V6Peer_CarriesKernelAddressFamily()
     {
+        // TCP-MD5 is only ever applied on Linux/macOS; other platforms have no defined layout.
+        if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS()) return;
+
         Span<byte> buffer = stackalloc byte[128];
         TcpMd5.WriteSockaddr(new IPEndPoint(IPAddress.Parse("2001:db8::1"), 0), buffer);
 
-        var expectedFamily = OperatingSystem.IsLinux() ? 10 : OperatingSystem.IsMacOS() ? (byte)28 : 23;
+        var expectedFamily = OperatingSystem.IsLinux() ? 10 : 28;
         Assert.Equal(expectedFamily, buffer[0]);
-        Assert.Equal(0, buffer[1]);
+        // Linux keeps byte 1 zero (family is 2 bytes little-endian); Darwin's byte 1 is the family.
+        Assert.Equal(OperatingSystem.IsLinux() ? 0 : 28, buffer[1]);
 
         TcpMd5.WriteSockaddr(new IPEndPoint(IPAddress.Loopback, 0), buffer);
-        Assert.Equal(2, buffer[0]); // AF_INET = 2 on every supported platform
+        // v4 layout per OS: Linux = family in byte 0; Darwin = sin_len first, family in byte 1.
+        if (OperatingSystem.IsLinux())
+        {
+            Assert.Equal(2, buffer[0]);
+            Assert.Equal(0, buffer[1]);
+        }
+        else
+        {
+            Assert.Equal(16, buffer[0]); // sin_len
+            Assert.Equal(2, buffer[1]);  // sin_family
+        }
+    }
+
+    [Fact]
+    public void WriteSockaddr_Darwin_CarriesSinLenFirst()
+    {
+        // BSD sockaddr_in/in6 start with a LENGTH byte; the family follows in byte 1. Asserted
+        // only on Darwin, where the layout applies (the Linux expectations live above).
+        if (!OperatingSystem.IsMacOS()) return;
+
+        var buffer = new byte[128];
+        TcpMd5.WriteSockaddr(new IPEndPoint(IPAddress.Loopback, 0), buffer);
+        Assert.Equal(16, buffer[0]); // sin_len
+        Assert.Equal(2, buffer[1]);  // sin_family
+
+        TcpMd5.WriteSockaddr(new IPEndPoint(IPAddress.Parse("2001:db8::1"), 0), buffer);
+        Assert.Equal(28, buffer[0]); // sin6_len
+        Assert.Equal(28, buffer[1]); // sin6_family
     }
 
     [Fact]

--- a/docker/integration/README.md
+++ b/docker/integration/README.md
@@ -52,6 +52,11 @@ Requirements: `docker` with the compose v2 plugin (daemon running), `curl`,
 polls until assertions pass, and always tears the stand down
 (`docker compose down -v`). Exit code is the test verdict.
 
+API assertions go through an in-network `probe` sidecar (curlimages/curl) —
+no host port publishing is required. For interactive poking, `exec` into the
+probe: `docker compose -f docker/integration/docker-compose.yml exec probe
+curl http://server:5001/api/server`.
+
 **Traffic capture (`--capture`)**: a tcpdump sidecar joins the server's network
 namespace and records everything on port 179 (both transports) to
 `docker/integration/captures/bgp.pcap` — open it in Wireshark (filter `bgp`)

--- a/docker/integration/docker-compose.yml
+++ b/docker/integration/docker-compose.yml
@@ -25,8 +25,6 @@ services:
     volumes:
       - ./server-appsettings.yml:/app/appsettings.yml:ro
       - ./test-nets.txt:/app/test-nets.txt:ro
-    ports:
-      - "15001:5001"
     environment:
       # Debug logs for the session pipeline — this stand exists to diagnose it.
       - Logging__LogLevel__BGPLite=Debug

--- a/docker/integration/run-tests.sh
+++ b/docker/integration/run-tests.sh
@@ -86,6 +86,8 @@ grep -q '"error"' "$TMP/create-peer.json" && fail "POST /api/peers rejected: $(c
 echo "created: $(cat "$TMP/create-peer.json")"
 
 # The IPv6-transport peer is registered too — the API accepts IPv6 peers (#14 phase 5).
+# It is registered with NO lists/custom prefixes, so it exercises the "configured peer with
+# zero resolved prefixes falls back to the RU/default source" branch of the assembler.
 V6_BODY='{"ip":"2001:db8:cccc::20","asn":65002,"description":"integration-bird-v6"}'
 V6_STATUS=$(api_post "$API/api/peers" "$V6_BODY" | tail -1)
 [ "$V6_STATUS" = "200" ] || fail "IPv6 peer registration returned $V6_STATUS"

--- a/docker/integration/run-tests.sh
+++ b/docker/integration/run-tests.sh
@@ -138,7 +138,9 @@ ROUTES4=$(birdc "show route protocol bgplite4 count" 2>/dev/null | tail -n +2 | 
   || fail "expected >=100 routes from the openai HTTP source on bgplite4, got: $ROUTES4"
 printf 'bgplite4 carries %s routes (custom + HTTP-source subscription)\n' "$ROUTES4"
 
-# The UNREGISTERED IPv6-transport peer gets the RU defaults (= the file seed source).
+# The IPv6-transport peer is REGISTERED but configures no lists/custom prefixes, so the
+# assembler's zero-resolved-prefixes branch falls back to the RU defaults (= the file seed
+# source) for it — same source the unconfigured case would get.
 # The IPv4 seeds ride as classic IPv4 NLRI over the IPv6 transport, imported by
 # bgplite6's IPv4 channel — and the IPv6 seed rides MP_REACH_NLRI (#14 phase 4b):
 # BIRD's IPv6 channel must import 2001:db8:cccc::/64 from the server.


### PR DESCRIPTION
Follow-up to the #413 CodeRabbit re-review: the comment before the bgplite6 route assertions still said 'UNREGISTERED IPv6-transport peer' — the peer is registered (it exercises the zero-resolved-prefixes RU-defaults fallback). Comment-only change; functional part of the finding was already confirmed as not applying.