### PR TITLE
fix(providers): fire the RU convergence push off the _ruGate holder's stack (#416)

### DIFF
--- a/BGPLite.Providers/IPrefixSourceService.cs
+++ b/BGPLite.Providers/IPrefixSourceService.cs
@@ -19,6 +19,17 @@ public interface IPrefixSourceService
     /// <summary>The source named by <c>AppConfig.DefaultPrefixSource</c>. Empty list if unset/missing.</summary>
     Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default);
 
+    /// <summary>
+    /// #416: callback-free counterpart of <see cref="GetDefaultAsync"/> — loads the default source
+    /// and reports whether the content actually changed, but NEVER fires the
+    /// <c>onSourceChanged</c> convergence callback. Callers that invoke it while holding a lock
+    /// (the RU gate in <c>PrefixService.GetRuPrefixesAsync</c>) must own the push themselves and
+    /// fire it only AFTER releasing the lock: an inline callback that re-enters the RU path from
+    /// another session's build deadlocked on the caller-held gate (the gate holder awaited the
+    /// push, the push awaited the gate).
+    /// </summary>
+    Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default);
+
     /// <summary>Prime the in-memory cache for all sources.</summary>
     Task WarmUpAsync(CancellationToken ct = default);
 

--- a/BGPLite.Providers/PrefixService.cs
+++ b/BGPLite.Providers/PrefixService.cs
@@ -27,7 +27,7 @@ public sealed class PrefixService : IPrefixService
     // when the TTL elapses. Mirrors the per-ASN gate pattern in GetPrefixesAsync.
     private readonly SemaphoreSlim _ruGate = new(1, 1);
 
-    public PrefixService(AppConfig config, RipeStatPrefixCache ripeStatCache, IPrefixSourceService prefixSources, HttpPrefixProvider httpProvider, TimeSpan? ruCacheTtl = null, ILogger<PrefixService>? logger = null, TimeProvider? timeProvider = null, int? userSourceTimeoutSeconds = null)
+    public PrefixService(AppConfig config, RipeStatPrefixCache ripeStatCache, IPrefixSourceService prefixSources, HttpPrefixProvider httpProvider, TimeSpan? ruCacheTtl = null, ILogger<PrefixService>? logger = null, TimeProvider? timeProvider = null, int? userSourceTimeoutSeconds = null, Func<string, Task>? onSourceChanged = null)
     {
         _config = config;
         _ripeStatCache = ripeStatCache;
@@ -41,6 +41,9 @@ public sealed class PrefixService : IPrefixService
         // stall the route dump behind the per-URL gate.
         _userSourceTimeoutSeconds = userSourceTimeoutSeconds ?? DefaultUserSourceTimeoutSeconds;
         _userSourceCache = new UserSourceCache(logger: logger, timeProvider: _timeProvider);
+        // #416: convergence push for default-source changes detected on the RU path. Fired AFTER
+        // _ruGate.Release() in GetRuPrefixesAsync — never while the gate is held.
+        _onSourceChanged = onSourceChanged;
     }
 
     /// <summary>Default per-fetch budget for peer-supplied URL sources (#320).</summary>
@@ -178,9 +181,18 @@ public sealed class PrefixService : IPrefixService
     /// fetch so concurrent callers share one default-source load (thundering-herd defense), and
     /// stale-on-failure serves the last good copy on a transient fetch error (#163 parity).
     /// </para>
+    /// <para>
+    /// #416: the convergence push for a detected content change fires AFTER <c>_ruGate.Release()</c>
+    /// — the load itself runs callback-free (<see cref="IPrefixSourceService.LoadDefaultAsync"/>).
+    /// Firing it while the gate was held deadlocked the fleet refresh: the push re-enters this
+    /// method from other sessions' builds, which blocked on the gate the triggering frame still
+    /// held, while that frame awaited the push (Task.WhenAll over every session) — a permanent
+    /// circular wait with sessions staying Established and nothing in the logs.
+    /// </para>
     /// </summary>
     private sealed record RuCacheEntry(List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)> Projected, long CachedAtTicks);
     private RuCacheEntry? _ruCache;
+    private readonly Func<string, Task>? _onSourceChanged;
 
     public async Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
     {
@@ -192,6 +204,8 @@ public sealed class PrefixService : IPrefixService
 
         // Serialize the cache-miss fetch so concurrent callers share one default-source fetch
         // (thundering-herd defense — #229). Mirrors the per-ASN gate in GetPrefixesAsync.
+        List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)> projected;
+        var changed = false;
         await _ruGate.WaitAsync(ct);
         try
         {
@@ -200,11 +214,14 @@ public sealed class PrefixService : IPrefixService
             if (cached is not null && _timeProvider.GetUtcNow().UtcDateTime.Ticks - cached.CachedAtTicks < _ruCacheTtl.Ticks)
                 return cached.Projected;
 
-            List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)> projected;
             try
             {
-                var prefixes = await _prefixSources.GetDefaultAsync(ct);
+                // Callback-free load (#416): no onSourceChanged can fire while this frame holds
+                // the gate. Failures propagate so the stale-on-failure branch below stays live —
+                // a failed cold load must not be cached as a positive empty set.
+                var (prefixes, loadChanged) = await _prefixSources.LoadDefaultAsync(ct);
                 projected = prefixes.Select(p => (p.Address, p.Length, p.IsIpv4, 0u)).ToList();
+                changed = loadChanged;
             }
             catch (OperationCanceledException) { throw; }
             catch (Exception ex)
@@ -226,12 +243,25 @@ public sealed class PrefixService : IPrefixService
             // Swap the whole entry atomically — projection and timestamp move together, so a reader
             // can never observe a mismatched (new projection, old timestamp) pair.
             Interlocked.Exchange(ref _ruCache, new RuCacheEntry(projected, _timeProvider.GetUtcNow().UtcDateTime.Ticks));
-            return projected;
         }
         finally
         {
             _ruGate.Release();
         }
+
+        // #416: the push runs AFTER the gate is released — a re-entrant GetRuPrefixesAsync (another
+        // session's build) takes the fast path against the just-written cache instead of blocking
+        // on this frame. A failure is logged, never propagated into the caller's route dump.
+        if (changed && _onSourceChanged is not null)
+        {
+            try { await _onSourceChanged(_config.DefaultPrefixSource ?? string.Empty); }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "OnSourceChanged callback failed for the default prefix source.");
+            }
+        }
+
+        return projected;
     }
 
     /// <summary>Prefixes of a configured source by name (cache-through).</summary>

--- a/BGPLite.Providers/PrefixSourceService.cs
+++ b/BGPLite.Providers/PrefixSourceService.cs
@@ -80,23 +80,40 @@ public sealed class PrefixSourceService : IPrefixSourceService
 
     public async Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default)
     {
+        // Deliberately swallowing: GetDefaultAsync is the "best-effort" shape (empty on unset
+        // source, missing source, or fetch failure). #416 split the callback-free, propagating
+        // variant into LoadDefaultAsync for the RU path, whose caller has stale-on-failure
+        // handling a swallowed exception would defeat.
+        try { return (await LoadDefaultAsync(ct)).Prefixes; }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #324: only CALLER cancellation — the #324 default fetch budget fires as a foreign-token OCE (live ct) and must stay a per-source failure below
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to load default prefix source '{Name}'.", _config.DefaultPrefixSource);
+            return [];
+        }
+    }
+
+    /// <inheritdoc cref="IPrefixSourceService.LoadDefaultAsync" />
+    /// <remarks>
+    /// Same load as <see cref="GetDefaultAsync"/> minus two things, both deliberate (#416):
+    /// the <c>onSourceChanged</c> callback is NOT fired (the caller owns the push, off its own
+    /// locks), and failures PROPAGATE instead of collapsing to <c>[]</c> — the RU caller
+    /// (<c>PrefixService.GetRuPrefixesAsync</c>) has stale-on-failure handling that a swallowed
+    /// exception would defeat (a failed cold load must not be cached as a positive empty set).
+    /// </remarks>
+    public async Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default)
+    {
         var defaultName = _config.DefaultPrefixSource;
         if (string.IsNullOrWhiteSpace(defaultName))
-            return [];
+            return ([], false);
 
         if (!_sourcesByName.TryGetValue(defaultName, out var source))
         {
             _logger.LogWarning("DefaultPrefixSource '{Name}' does not match any configured source.", defaultName);
-            return [];
+            return ([], false);
         }
 
-        try { return (await LoadCachedAsync(source, ct)).Prefixes; }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #324: only CALLER cancellation — the #324 default fetch budget fires as a foreign-token OCE (live ct) and must stay a per-source failure below
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to load default prefix source '{Name}'.", defaultName);
-            return [];
-        }
+        return await LoadCachedAsync(source, ct, triggerCallback: false);
     }
 
     public async Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default)

--- a/BGPLite.Tests/ApiHandlerBehaviorTests.cs
+++ b/BGPLite.Tests/ApiHandlerBehaviorTests.cs
@@ -278,6 +278,7 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
         public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
+        public Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default) => Task.FromResult<(IReadOnlyList<IpPrefix>, bool)>(([], false));
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);
         public bool SourceSupportsConditional(string sourceName) => false;

--- a/BGPLite.Tests/ConfigHotReloadTests.cs
+++ b/BGPLite.Tests/ConfigHotReloadTests.cs
@@ -375,6 +375,8 @@ public class ConfigHotReloadTests
             => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default)
             => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
+        public Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default)
+            => Task.FromResult<(IReadOnlyList<IpPrefix>, bool)>(([], false));
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);
         public bool SourceSupportsConditional(string sourceName) => false;

--- a/BGPLite.Tests/ManagementApiShutdownTests.cs
+++ b/BGPLite.Tests/ManagementApiShutdownTests.cs
@@ -234,6 +234,8 @@ public sealed class ManagementApiShutdownTests : IDisposable
             => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default)
             => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
+        public Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default)
+            => Task.FromResult<(IReadOnlyList<IpPrefix>, bool)>(([], false));
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);
         public bool SourceSupportsConditional(string sourceName) => false;

--- a/BGPLite.Tests/PeerDeleteTeardownTests.cs
+++ b/BGPLite.Tests/PeerDeleteTeardownTests.cs
@@ -268,6 +268,8 @@ public sealed class PeerDeleteTeardownTests
             => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default)
             => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
+        public Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default)
+            => Task.FromResult<(IReadOnlyList<IpPrefix>, bool)>(([], false));
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);
         public bool SourceSupportsConditional(string sourceName) => false;

--- a/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
+++ b/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
@@ -41,6 +41,7 @@ public class PrefixAutoRefreshServiceTests
             => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
+        public Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default) => Task.FromResult<(IReadOnlyList<IpPrefix>, bool)>(([], false));
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
     }
 

--- a/BGPLite.Tests/PrefixCacheRaceTests.cs
+++ b/BGPLite.Tests/PrefixCacheRaceTests.cs
@@ -28,7 +28,7 @@ public class PrefixCacheRaceTests
         var tasks = Enumerable.Range(0, 10).Select(_ => service.GetRuPrefixesAsync()).ToArray();
         var results = await Task.WhenAll(tasks);
 
-        Assert.Equal(1, source.DefaultCalls); // single fetch, shared across all 10
+        Assert.Equal(1, source.LoadCalls); // single fetch, shared across all 10
         // All callers get the same projected list.
         Assert.All(results, r => Assert.Equal(results[0], r));
         Assert.True(results[0].Count > 0);
@@ -48,7 +48,7 @@ public class PrefixCacheRaceTests
 
         // First call: populates the cache.
         await service.GetRuPrefixesAsync();
-        Assert.Equal(1, source.DefaultCalls);
+        Assert.Equal(1, source.LoadCalls);
 
         // Advance past the TTL.
         fakeTime.Advance(TimeSpan.FromMilliseconds(150));
@@ -56,7 +56,7 @@ public class PrefixCacheRaceTests
         // 10 concurrent callers on the now-expired cache.
         await Task.WhenAll(Enumerable.Range(0, 10).Select(_ => service.GetRuPrefixesAsync()));
 
-        Assert.Equal(2, source.DefaultCalls); // exactly one more fetch, not ten
+        Assert.Equal(2, source.LoadCalls); // exactly one more fetch, not ten
     }
 
     /// <summary>
@@ -77,7 +77,7 @@ public class PrefixCacheRaceTests
 
         // Populate a good copy.
         var first = await service.GetRuPrefixesAsync();
-        Assert.Equal(1, source.DefaultCalls);
+        Assert.Equal(1, source.LoadCalls);
         Assert.True(first.Count > 0);
 
         // Advance past the TTL so the next call must re-fetch, then make the source fail.
@@ -87,7 +87,7 @@ public class PrefixCacheRaceTests
         // The re-fetch fails, but the stale cached copy is served (NOT thrown) — #163 parity.
         var stale = await service.GetRuPrefixesAsync();
         Assert.Equal(first, stale);                  // same projection as the original good copy
-        Assert.Equal(2, source.DefaultCalls);        // the failed fetch DID happen (expired cache)
+        Assert.Equal(2, source.LoadCalls);        // the failed fetch DID happen (expired cache)
     }
 
     /// <summary>
@@ -105,9 +105,88 @@ public class PrefixCacheRaceTests
         await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetRuPrefixesAsync());
     }
 
+    /// <summary>
+    /// #416: a changed default-source load must not deadlock when the convergence push re-enters
+    /// the RU path. Pre-fix, <see cref="PrefixService.GetRuPrefixesAsync"/> held <c>_ruGate</c>
+    /// across the default-source load and a changed load fired <c>onSourceChanged</c> INLINE on
+    /// that stack; the push (<c>RefreshAllEstablishedAsync</c> in production — a second RU consumer
+    /// here) blocked on the gate the outer frame still held, while that frame awaited the push —
+    /// a permanent circular wait with sessions staying Established and nothing in the logs.
+    /// Post-fix the load runs callback-free (<c>LoadDefaultAsync</c>) and the push fires AFTER
+    /// <c>_ruGate.Release()</c>, so the re-entrant caller takes the fast path against the
+    /// just-written cache. The pre-fix deadlock is structural (both waits unconditional), so the
+    /// bounded <see cref="Task.WaitAsync(TimeSpan)"/> makes this test FAIL against the pre-fix
+    /// implementation (TimeoutException) and pass after it — no timing dependence in the green
+    /// direction.
+    /// </summary>
+    [Fact]
+    public async Task GetRuPrefixesAsync_ChangedLoad_PushReenteringTheRuPath_DoesNotDeadlock()
+    {
+        var source = new CountingPrefixSource { ChangedOnNextLoad = true };
+        PrefixService service = null!;
+        Task reentrant = Task.CompletedTask;
+        var pushStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        service = Service(source, onSourceChanged: async _ =>
+        {
+            pushStarted.TrySetResult();
+            // The production push (RefreshAllEstablishedAsync) rebuilds every established session's
+            // route set; a RU-consuming session's build re-enters GetRuPrefixesAsync right here.
+            reentrant = service.GetRuPrefixesAsync();
+            await reentrant;
+        });
+
+        var main = service.GetRuPrefixesAsync();
+
+        // The changed load must trigger the push…
+        await pushStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        // …and both the triggering call and the re-entrant consumer must complete.
+        await main.WaitAsync(TimeSpan.FromSeconds(10));       // pre-fix: TimeoutException (deadlock)
+        await reentrant.WaitAsync(TimeSpan.FromSeconds(10));  // pre-fix: never completes (gate held)
+
+        Assert.Equal(1, source.LoadCalls); // the re-entry hit the fresh cache — no second fetch
+    }
+
+    /// <summary>
+    /// #416: the RU push fires exactly when the load reports a content change — not on the fresh
+    /// fast path, not on an unchanged reload. The name passed through is the configured default
+    /// source name (empty string when none is configured).
+    /// </summary>
+    [Fact]
+    public async Task GetRuPrefixesAsync_PushFiresOnlyOnChange()
+    {
+        var source = new CountingPrefixSource();
+        var fakeTime = new Microsoft.Extensions.Time.Testing.FakeTimeProvider();
+        var pushes = new List<string>();
+        var service = Service(
+            source, cacheTtl: TimeSpan.FromMilliseconds(100), timeProvider: fakeTime,
+            onSourceChanged: name => { lock (pushes) pushes.Add(name); return Task.CompletedTask; });
+
+        // Cold load reporting changed → push #1.
+        source.ChangedOnNextLoad = true;
+        await service.GetRuPrefixesAsync();
+        Assert.Single(pushes);
+        Assert.Equal(string.Empty, pushes[0]); // no DefaultPrefixSource configured in this fixture
+
+        // Fresh fast path → no push.
+        await service.GetRuPrefixesAsync();
+        Assert.Single(pushes);
+
+        // Expired reload, unchanged content → no push.
+        fakeTime.Advance(TimeSpan.FromMilliseconds(150));
+        await service.GetRuPrefixesAsync();
+        Assert.Single(pushes);
+
+        // Expired reload, changed content → push #2.
+        fakeTime.Advance(TimeSpan.FromMilliseconds(150));
+        source.ChangedOnNextLoad = true;
+        await service.GetRuPrefixesAsync();
+        Assert.Equal(2, pushes.Count);
+    }
+
     // ---- helpers ----
 
-    private static PrefixService Service(CountingPrefixSource source, TimeSpan? cacheTtl = null, TimeProvider? timeProvider = null) =>
+    private static PrefixService Service(CountingPrefixSource source, TimeSpan? cacheTtl = null, TimeProvider? timeProvider = null, Func<string, Task>? onSourceChanged = null) =>
         new(new AppConfig(),
             // #263 made both required in production; neither is on the GetRuPrefixesAsync path this
             // fixture exercises, so the fake composition states that explicitly rather than relying
@@ -117,18 +196,22 @@ public class PrefixCacheRaceTests
             httpProvider: null!,
             ruCacheTtl: cacheTtl ?? TimeSpan.FromHours(1),
             logger: NullLogger<PrefixService>.Instance,
-            timeProvider: timeProvider);
+            timeProvider: timeProvider,
+            onSourceChanged: onSourceChanged);
 
     /// <summary>
-    /// Fake IPrefixSourceService that counts GetDefaultAsync calls and can be made to fail. Only
-    /// GetDefaultAsync is exercised by GetRuPrefixesAsync; the other members throw NotImplemented
+    /// Fake IPrefixSourceService that counts LoadDefaultAsync calls, can be made to fail, and can
+    /// report a content change. Only LoadDefaultAsync is exercised by GetRuPrefixesAsync (#416 —
+    /// the RU path no longer goes through GetDefaultAsync); the other members throw NotImplemented
     /// to catch accidental reliance.
     /// </summary>
     private sealed class CountingPrefixSource : IPrefixSourceService
     {
-        private int _defaultCalls;
-        public int DefaultCalls => Volatile.Read(ref _defaultCalls);
+        private int _loadCalls;
+        public int LoadCalls => Volatile.Read(ref _loadCalls);
         public bool FailNext { get; set; }
+        /// <summary>Whether the next completed load reports a content change (#416 push trigger).</summary>
+        public bool ChangedOnNextLoad { get; set; }
 
         public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default) =>
             throw new NotImplementedException();
@@ -136,19 +219,24 @@ public class PrefixCacheRaceTests
         public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default) =>
             throw new NotImplementedException();
 
-        public async Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default)
+        public async Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default)
         {
-            Interlocked.Increment(ref _defaultCalls);
+            Interlocked.Increment(ref _loadCalls);
             // Simulate real I/O latency so concurrent callers actually overlap inside the gate.
             await Task.Delay(20, ct);
             if (FailNext) throw new InvalidOperationException("simulated default-source failure");
-            return new List<IpPrefix>
+            var changed = ChangedOnNextLoad;
+            ChangedOnNextLoad = false;
+            IReadOnlyList<IpPrefix> prefixes = new List<IpPrefix>
             {
                 new(0x0A000000u, 8),
                 new(0xC0A80000u, 16),
             };
+            return (prefixes, changed);
         }
 
+        public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default) =>
+            throw new NotImplementedException();
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);
         public bool SourceSupportsConditional(string sourceName) => false;

--- a/BGPLite.Tests/RouteSeedingServiceTests.cs
+++ b/BGPLite.Tests/RouteSeedingServiceTests.cs
@@ -51,6 +51,7 @@ public class RouteSeedingServiceTests
             Task.FromResult(_sources);
         public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
+        public Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default) => Task.FromResult<(IReadOnlyList<IpPrefix>, bool)>(([], false));
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);
         public bool SourceSupportsConditional(string sourceName) => false;

--- a/BGPLite/Program.cs
+++ b/BGPLite/Program.cs
@@ -184,7 +184,14 @@ builder.Services.AddSingleton<IPrefixService>(sp =>
         sp.GetRequiredService<RipeStatPrefixCache>(),
         sources,
         sp.GetRequiredService<HttpPrefixProvider>(),
-        logger: sp.GetRequiredService<ILogger<PrefixService>>());
+        logger: sp.GetRequiredService<ILogger<PrefixService>>(),
+        // #416: the RU path now owns its convergence push — GetRuPrefixesAsync fires it AFTER
+        // releasing _ruGate (the load itself is callback-free via LoadDefaultAsync), so a changed
+        // default source can no longer deadlock the fleet refresh it triggers.
+        onSourceChanged: async name =>
+        {
+            await sp.GetRequiredService<ISessionManager>().RefreshAllEstablishedAsync();
+        });
 });
 
 // #263: the BGP send path's dependencies are registered explicitly and resolved with


### PR DESCRIPTION
Closes #416

## Problem
A changed default-source load detected inside `PrefixService.GetRuPrefixesAsync` fired the `onSourceChanged` convergence callback **inline on the gate-holder's stack**: `_ruGate` was held across `_prefixSources.GetDefaultAsync(ct)`, and `PrefixSourceService.LoadCachedAsync` awaits the callback (wired in Program.cs to `RefreshAllEstablishedAsync`) right after releasing only its own per-source gate. The push rebuilds every established session's route set; any second RU-consuming session's build re-enters `GetRuPrefixesAsync` and blocks on `_ruGate` — which the triggering frame still holds, while that frame awaits the push (`Task.WhenAll` over all sessions). Permanent circular wait: RU consumers stall forever, sessions stay Established (KEEPALIVEs feed the hold timer), nothing is logged. Recovery = process restart.

## Root Cause
A lock (`_ruGate`) held across an await whose completion path synchronously invokes a callback that needs that same lock (directly or transitively). Only the RU/default path has this shape — the per-source path releases its gate before the callback.

## Fix
- New `IPrefixSourceService.LoadDefaultAsync`: the default-source load **without** the callback, returning `(Prefixes, Changed)`; failures propagate (the RU caller has stale-on-failure handling a swallow would defeat).
- `PrefixSourceService.GetDefaultAsync` delegates to it and keeps its best-effort swallow-to-empty contract.
- `PrefixService.GetRuPrefixesAsync`: loads via `LoadDefaultAsync` under `_ruGate`, then fires the push **after `_ruGate.Release()`**, with the failure logged, not propagated into the caller's route dump.
- Program.cs wires the same `RefreshAllEstablishedAsync` lambda into `PrefixService`'s `onSourceChanged`.

## Correctness
- Fresh fast path, thundering-herd gate, stale-on-failure, and no-cache-throw semantics unchanged; the push fires exactly on a detected content change (not on fresh/unchanged/stale/failure paths).
- No new deadlock shape: the gate is never held across the push; two overlapping pushes are coalesced by each session's existing `_refreshRunning` debounce.
- Deviation from the issue's proposed shape ("GetDefaultAsync returns (prefixes, changed)"): implemented as a separate callback-free method instead, so the best-effort `GetDefaultAsync` contract is untouched and no caller-held lock can ever observe the callback again.

## Regression Test
`PrefixCacheRaceTests.GetRuPrefixesAsync_ChangedLoad_PushReenteringTheRuPath_DoesNotDeadlock` — a changed load whose push re-enters `GetRuPrefixesAsync` (simulating another session's build) must complete; bounded by `WaitAsync(10s)`. **Red/green proven**: against the pre-fix shape (push fired before the cache write, under the gate) the test fails with `TimeoutException`; with the fix it passes. The green direction has no timing dependence — the pre-fix deadlock is structural. Plus `GetRuPrefixesAsync_PushFiresOnlyOnChange` pinning push semantics (changed-only, name passthrough).

## Verification
- dotnet format / dotnet build BGPLite.sln (0 errors) / dotnet test BGPLite.sln — **1010/1010 passed** (baseline: full suite green before the change; delta = +2 tests, 0 failures).
- Behavioral note (intentional): on the RU path a failed cold load now propagates to the existing stale-on-failure branch instead of being cached as a positive empty set — this closes #417's poisoning scenario for this call site; #417 remains open for the `GetDefaultAsync` surface itself.

## RFC
- none — no protocol surface (providers layer).

## Behavior Change
- RU cold-load failure now serves stale or throws instead of caching an empty set for 1h (documented; completes the #163 parity the old code claimed but the production wiring made unreachable).

## Deviation from Issue Proposal
- Separate `LoadDefaultAsync` member instead of changing `GetDefaultAsync`'s return type — keeps the best-effort contract intact and fixes the deadlock class (any caller-held lock) rather than only the RU gate.