### PR TITLE
fix(providers): never cache a failed default-source load as an empty RU set (#417)

### DIFF
--- a/BGPLite.Providers/IPrefixSourceService.cs
+++ b/BGPLite.Providers/IPrefixSourceService.cs
@@ -16,17 +16,21 @@ public interface IPrefixSourceService
     /// <summary>One source by name (cache-through). Empty list if missing or failed.</summary>
     Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default);
 
-    /// <summary>The source named by <c>AppConfig.DefaultPrefixSource</c>. Empty list if unset/missing.</summary>
-    Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default);
-
     /// <summary>
-    /// #416: callback-free counterpart of <see cref="GetDefaultAsync"/> — loads the default source
-    /// and reports whether the content actually changed, but NEVER fires the
+    /// #416: lock-free convergence load of the source named by <c>AppConfig.DefaultPrefixSource</c> —
+    /// returns the prefix list plus whether the content actually changed, and NEVER fires the
     /// <c>onSourceChanged</c> convergence callback. Callers that invoke it while holding a lock
     /// (the RU gate in <c>PrefixService.GetRuPrefixesAsync</c>) must own the push themselves and
     /// fire it only AFTER releasing the lock: an inline callback that re-enters the RU path from
     /// another session's build deadlocked on the caller-held gate (the gate holder awaited the
     /// push, the push awaited the gate).
+    /// <para>
+    /// #417: failures PROPAGATE rather than collapsing to <c>[]</c> — including a fresh negative
+    /// (failure-backoff) cache entry, which throws instead of returning an empty list. The RU
+    /// caller's stale-on-failure handling needs the real failure; a swallowed one would cache an
+    /// empty set positively for the full RU TTL, dropping every unconfigured peer's routes off a
+    /// single transient outage.
+    /// </para>
     /// </summary>
     Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default);
 

--- a/BGPLite.Providers/PrefixSourceService.cs
+++ b/BGPLite.Providers/PrefixSourceService.cs
@@ -78,26 +78,11 @@ public sealed class PrefixSourceService : IPrefixSourceService
         }
     }
 
-    public async Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default)
-    {
-        // Deliberately swallowing: GetDefaultAsync is the "best-effort" shape (empty on unset
-        // source, missing source, or fetch failure). #416 split the callback-free, propagating
-        // variant into LoadDefaultAsync for the RU path, whose caller has stale-on-failure
-        // handling a swallowed exception would defeat.
-        try { return (await LoadDefaultAsync(ct)).Prefixes; }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #324: only CALLER cancellation — the #324 default fetch budget fires as a foreign-token OCE (live ct) and must stay a per-source failure below
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to load default prefix source '{Name}'.", _config.DefaultPrefixSource);
-            return [];
-        }
-    }
-
     /// <inheritdoc cref="IPrefixSourceService.LoadDefaultAsync" />
     /// <remarks>
-    /// Same load as <see cref="GetDefaultAsync"/> minus two things, both deliberate (#416):
-    /// the <c>onSourceChanged</c> callback is NOT fired (the caller owns the push, off its own
-    /// locks), and failures PROPAGATE instead of collapsing to <c>[]</c> — the RU caller
+    /// Deliberately different from <see cref="GetAsync"/> in two ways (#416/#417): the
+    /// <c>onSourceChanged</c> callback is NOT fired (the caller owns the push, off its own locks),
+    /// and failures PROPAGATE instead of collapsing to <c>[]</c> — the RU caller
     /// (<c>PrefixService.GetRuPrefixesAsync</c>) has stale-on-failure handling that a swallowed
     /// exception would defeat (a failed cold load must not be cached as a positive empty set).
     /// </remarks>
@@ -113,7 +98,21 @@ public sealed class PrefixSourceService : IPrefixSourceService
             return ([], false);
         }
 
-        return await LoadCachedAsync(source, ct, triggerCallback: false);
+        var (prefixes, changed) = await LoadCachedAsync(source, ct, triggerCallback: false);
+
+        // #417: an empty result served from a fresh NEGATIVE entry is failure backoff, not
+        // content. The negative entry is only ever written by the failure path above, so a
+        // negative hit means "the last real load failed" — surface it as a failure so the RU
+        // caller stale-serves (or throws) instead of positively caching an empty set for the full
+        // RU TTL. A legitimately empty source writes a NON-negative entry and passes through.
+        if (prefixes.Count == 0 && _cache.TryGetValue(source.Name, out var entry) &&
+            entry.Negative && _timeProvider.GetUtcNow().UtcDateTime - entry.CachedAt < _negativeTtl)
+        {
+            throw new InvalidOperationException(
+                $"Default prefix source '{defaultName}' is in failure backoff — the last load failed within the last {_negativeTtl.TotalSeconds:0}s.");
+        }
+
+        return (prefixes, changed);
     }
 
     public async Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default)

--- a/BGPLite.Tests/ApiHandlerBehaviorTests.cs
+++ b/BGPLite.Tests/ApiHandlerBehaviorTests.cs
@@ -277,7 +277,6 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
     {
         public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
-        public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default) => Task.FromResult<(IReadOnlyList<IpPrefix>, bool)>(([], false));
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);

--- a/BGPLite.Tests/ConfigHotReloadTests.cs
+++ b/BGPLite.Tests/ConfigHotReloadTests.cs
@@ -373,8 +373,6 @@ public class ConfigHotReloadTests
             => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default)
             => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
-        public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default)
             => Task.FromResult<(IReadOnlyList<IpPrefix>, bool)>(([], false));
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;

--- a/BGPLite.Tests/ManagementApiShutdownTests.cs
+++ b/BGPLite.Tests/ManagementApiShutdownTests.cs
@@ -232,8 +232,6 @@ public sealed class ManagementApiShutdownTests : IDisposable
             => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default)
             => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
-        public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default)
             => Task.FromResult<(IReadOnlyList<IpPrefix>, bool)>(([], false));
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;

--- a/BGPLite.Tests/PeerDeleteTeardownTests.cs
+++ b/BGPLite.Tests/PeerDeleteTeardownTests.cs
@@ -266,8 +266,6 @@ public sealed class PeerDeleteTeardownTests
             => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default)
             => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
-        public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default)
             => Task.FromResult<(IReadOnlyList<IpPrefix>, bool)>(([], false));
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;

--- a/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
+++ b/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
@@ -40,7 +40,6 @@ public class PrefixAutoRefreshServiceTests
         public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
             => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
-        public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default) => Task.FromResult<(IReadOnlyList<IpPrefix>, bool)>(([], false));
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
     }

--- a/BGPLite.Tests/PrefixCacheFailureTests.cs
+++ b/BGPLite.Tests/PrefixCacheFailureTests.cs
@@ -1,0 +1,138 @@
+using BGPLite.Configuration;
+using BGPLite.Providers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using BGPLite.Protocol;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// Regression coverage for #417: a failed load of the default prefix source used to reach the RU
+/// cache as a "successful" empty result — either directly (the old GetDefaultAsync swallowed
+/// exceptions) or, after #416's propagation, via the 30s NEGATIVE backoff entry that a retry
+/// within the window hits. In both shapes the empty list was cached POSITIVELY for the full RU
+/// TTL (1h), so a single transient outage dropped every unconfigured peer's routes for up to an
+/// hour. The failure must surface as a failure on every call inside the backoff window; recovery
+/// happens on the first real load after the backoff expires.
+/// </summary>
+public class PrefixCacheFailureTests
+{
+    private sealed class SwitchableProvider : IPrefixSourceProvider
+    {
+        public string Kind => "stub";
+        public bool SupportsConditionalRequests => true;
+        public int Calls { get; private set; }
+        public bool FailNext { get; set; }
+
+        public Task<SourceLoadResult> LoadAsync(PrefixSourceConfig source, string? etag = null, DateTimeOffset? lastModified = null, CancellationToken ct = default)
+        {
+            Calls++;
+            if (FailNext) throw new InvalidOperationException("simulated source outage");
+            return Task.FromResult(SourceLoadResult.Ok(new List<IpPrefix> { new(0x0A000000u, 8) }));
+        }
+    }
+
+    private static (PrefixService Service, SwitchableProvider Provider, FakeTimeProvider Time) Build(TimeSpan? ruTtl = null)
+    {
+        var yaml = "Bgp:\n  Asn: 65444\n  RouterId: 10.0.0.1\n" +
+                   "PrefixSources:\n  - Name: ru\n    Kind: stub\nDefaultPrefixSource: ru\n";
+        var config = ConfigLoader.LoadFromText(yaml);
+        var provider = new SwitchableProvider();
+        var time = new FakeTimeProvider();
+        var sources = new PrefixSourceService(
+            config,
+            new PrefixSourceProviderFactory([provider]),
+            NullLogger<PrefixSourceService>.Instance,
+            timeProvider: time);
+        var service = new PrefixService(
+            config,
+            null!, // RipeStatPrefixCache — not on the GetRuPrefixesAsync path
+            sources,
+            null!, // HttpPrefixProvider — not on the GetRuPrefixesAsync path
+            ruCacheTtl: ruTtl ?? TimeSpan.FromHours(1),
+            logger: NullLogger<PrefixService>.Instance,
+            timeProvider: time);
+        return (service, provider, time);
+    }
+
+    [Fact]
+    public async Task GetRuPrefixesAsync_FailedColdLoad_DoesNotPoisonTheCache()
+    {
+        var (service, provider, time) = Build();
+
+        // 1. Cold failure propagates — nothing stale to serve.
+        provider.FailNext = true;
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetRuPrefixesAsync());
+
+        // 2/3. Retries inside the 30s negative-backoff window surface as failures too — they must
+        // NOT arrive as a successful empty list (pre-#417 they did, and the empty set was cached
+        // positively for the full RU TTL).
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetRuPrefixesAsync());
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetRuPrefixesAsync());
+
+        // 4. Recovery: past the backoff window the next call performs a REAL fetch and serves the
+        // actual content — never a cached empty set.
+        provider.FailNext = false;
+        time.Advance(TimeSpan.FromSeconds(31));
+        var routes = await service.GetRuPrefixesAsync();
+        Assert.Single(routes);
+        Assert.Equal(2, provider.Calls); // exactly two real fetches happened (fail + recover)
+    }
+
+    [Fact]
+    public async Task GetRuPrefixesAsync_FailureWithStaleCopy_ServesStale_NotEmpty()
+    {
+        var (service, provider, time) = Build();
+
+        // A good copy first.
+        var first = await service.GetRuPrefixesAsync();
+        Assert.Single(first);
+
+        // The source dies; after the RU TTL the re-fetch fails — the stale copy is served
+        // (stale-on-failure, #163 parity), never an empty set (#417).
+        provider.FailNext = true;
+        time.Advance(TimeSpan.FromHours(2));
+        var stale = await service.GetRuPrefixesAsync();
+        Assert.Equal(first, stale);
+
+        // And after another full RU TTL the failure path repeats — still stale, still never empty.
+        time.Advance(TimeSpan.FromHours(2));
+        var staleAgain = await service.GetRuPrefixesAsync();
+        Assert.Equal(first, staleAgain);
+    }
+
+    [Fact]
+    public async Task LoadDefaultAsync_LegitimatelyEmptySource_IsNotBackoff()
+    {
+        // A source that SUCCEEDS with zero prefixes is real content ("the operator emptied the
+        // list"), not failure backoff — it must pass through and cache normally, not throw.
+        var yaml = "Bgp:\n  Asn: 65444\n  RouterId: 10.0.0.1\n" +
+                   "PrefixSources:\n  - Name: ru\n    Kind: stub\nDefaultPrefixSource: ru\n";
+        var config = ConfigLoader.LoadFromText(yaml);
+        var time = new FakeTimeProvider();
+        var provider = new EmptyOkProvider();
+        var sources = new PrefixSourceService(
+            config, new PrefixSourceProviderFactory([provider]),
+            NullLogger<PrefixSourceService>.Instance, timeProvider: time);
+        var service = new PrefixService(
+            config, null!, sources, null!,
+            logger: NullLogger<PrefixService>.Instance, timeProvider: time);
+
+        var routes = await service.GetRuPrefixesAsync();
+        Assert.Empty(routes); // legitimately empty — cached as such, no exception
+
+        // Reload past the RU TTL: the empty CONTENT entry is non-negative, so the reload is a
+        // real (successful-empty) load — still no throw, never misread as failure backoff.
+        time.Advance(TimeSpan.FromHours(2));
+        routes = await service.GetRuPrefixesAsync();
+        Assert.Empty(routes);
+    }
+
+    private sealed class EmptyOkProvider : IPrefixSourceProvider
+    {
+        public string Kind => "stub";
+        public bool SupportsConditionalRequests => true;
+        public Task<SourceLoadResult> LoadAsync(PrefixSourceConfig source, string? etag = null, DateTimeOffset? lastModified = null, CancellationToken ct = default)
+            => Task.FromResult(SourceLoadResult.Ok(new List<IpPrefix>()));
+    }
+}

--- a/BGPLite.Tests/PrefixSourceServiceTests.cs
+++ b/BGPLite.Tests/PrefixSourceServiceTests.cs
@@ -65,7 +65,7 @@ public class PrefixSourceServiceTests
     }
 
     [Fact]
-    public async Task GetDefaultAsync_ResolvesByName()
+    public async Task LoadDefaultAsync_ResolvesByName_AndReportsFirstLoadAsChanged()
     {
         var provider = new CountingProvider([new IpPrefix(1u, 24), new IpPrefix(2u, 16)]);
         var yaml = "Bgp:\n  Asn: 65444\n  RouterId: 10.0.0.1\n" +
@@ -75,19 +75,22 @@ public class PrefixSourceServiceTests
             new PrefixSourceProviderFactory([provider]),
             NullLogger<PrefixSourceService>.Instance);
 
-        var result = await svc.GetDefaultAsync();
-        Assert.Equal(2, result.Count);
+        var (prefixes, changed) = await svc.LoadDefaultAsync();
+        Assert.Equal(2, prefixes.Count);
+        Assert.True(changed); // first-ever load counts as a content change (#214)
     }
 
     [Fact]
-    public async Task GetDefaultAsync_UnsetReturnsEmpty()
+    public async Task LoadDefaultAsync_UnsetReturnsEmptyNoChange()
     {
         var svc = new PrefixSourceService(
             ConfigWith("ru"),
             new PrefixSourceProviderFactory([new CountingProvider([new(1u, 24)])]),
             NullLogger<PrefixSourceService>.Instance);
 
-        Assert.Empty(await svc.GetDefaultAsync());
+        var (prefixes, changed) = await svc.LoadDefaultAsync();
+        Assert.Empty(prefixes);
+        Assert.False(changed);
     }
 
     [Fact]

--- a/BGPLite.Tests/RouteSeedingServiceTests.cs
+++ b/BGPLite.Tests/RouteSeedingServiceTests.cs
@@ -50,7 +50,6 @@ public class RouteSeedingServiceTests
         public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default) =>
             Task.FromResult(_sources);
         public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
-        public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default) => Task.FromResult<(IReadOnlyList<IpPrefix>, bool)>(([], false));
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);


### PR DESCRIPTION
Closes #417

## Problem
A single transient failure of the default prefix source poisoned the RU cache with an empty set for the full 1h TTL — every unconfigured/unknown peer received zero routes. #416 closed the direct shape (RU path now propagates failures), but the poisoning survived through the back door: `PrefixSourceService`'s 30s NEGATIVE backoff entry (written after a failed load) is served by a retry inside the window as a **successful empty list**, which `GetRuPrefixesAsync` then cached POSITIVELY for 1h.

## Root Cause
Two layers conflated "fetch failed" with "source is legitimately empty": the swallowed exception (pre-#416) and the negative-backoff entry — both surfaced to the RU layer as `([], changed: false)`, which the RU cache treats as real content.

## Fix
- `PrefixSourceService.LoadDefaultAsync`: an empty result served from a **fresh negative entry** throws (failure backoff), so the RU caller stale-serves or throws — never caches empty. A legitimately empty source writes a NON-negative entry and passes through untouched.
- Removed `GetDefaultAsync` from `IPrefixSourceService`/implementation/fakes: production-unused since #416, and its swallow-to-empty contract is the exact trap the issue describes. Its two behavioral tests are retargeted to `LoadDefaultAsync` (pinning first-load `changed: true`, the #416 push trigger).

## Correctness
- Negative entries are only ever written by the failure path, so "negative + fresh + empty" is precisely "last load failed" — no false positives.
- Stale-on-failure (#163 parity) is now reachable in production: with a good cached copy, failures serve the stale set instead of dropping routes.
- Recovery: after the 30s backoff expires, the next call performs a real fetch and repopulates.

## Regression Test
New `PrefixCacheFailureTests` (real `PrefixService` + real `PrefixSourceService` + switchable stub provider + `FakeTimeProvider`):
- `FailedColdLoad_DoesNotPoisonTheCache` — cold failure + two backoff-window retries all throw; recovery after backoff serves real content (2 real fetches total). **Red/green proven**: with the negative check removed the test fails at attempt 2 ("No exception was thrown" — the empty success).
- `FailureWithStaleCopy_ServesStale_NotEmpty` — stale-on-failure serves the good copy across repeated failures.
- `LegitimatelyEmptySource_IsNotBackoff` — a successful empty source caches normally and never throws on reload.

## Verification
- dotnet format / dotnet build BGPLite.sln (0 errors) / dotnet test BGPLite.sln — **1013/1013 passed** (baseline full-suite green; delta = +3 tests, 0 failures).

## RFC
- none — no protocol surface.

## Behavior Change
- Inside a 30s outage backoff, RU consumers now see a failure (stale copy served if one exists; otherwise the caller's existing per-source failure path) instead of an hour of silently empty advertisements.
- `IPrefixSourceService.GetDefaultAsync` removed (production-unused since #416).

## Deviation from Issue Proposal
- The issue proposed making `GetDefaultAsync` rethrow; instead the propagating `LoadDefaultAsync` (from #416) is kept as the only default-source surface, the negative-backoff hole it exposed is closed, and the unused swallowing member is deleted rather than kept as a trap.