### PR TITLE
fix(api,server): re-arm the per-IP TCP-MD5 key from surviving sibling rows (#418)

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -241,20 +241,48 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // before this runs is the only unprotected moment (documented in #36).
         var md5Bootstrapped = 0;
         // TCP keys by source IP: if two peer rows share an IP with DIFFERENT keys, the last one
-        // would win non-deterministically — sort for determinism and warn (values never logged).
+        // would win non-deterministically — the shared resolver sorts for determinism and warns
+        // (values never logged). #418: the same resolver re-arms the key on delete/PATCH so the
+        // runtime behavior cannot drift from this bootstrap.
         foreach (var group in (await _store.GetPeerMd5CredentialsAsync(cancellationToken))
                      .GroupBy(c => c.Ip).OrderBy(g => g.Key, StringComparer.Ordinal))
         {
-            var creds = group.OrderBy(c => c.Md5Password, StringComparer.Ordinal).ToList();
-            if (creds.Select(c => c.Md5Password).Distinct().Count() > 1)
-                _logger.LogWarning(
-                    "TCP-MD5: {Count} peer rows on source IP {Ip} configure DIFFERENT keys — TCP-MD5 keys by IP, so one key applies to all of them (peers: {Peers})",
-                    creds.Count, group.Key, string.Join(", ", creds.Select(c => c.Ip)));
-            _sessionManager.SetPeerMd5Key(group.Key, creds[0].Md5Password);
+            var key = ResolveSharedIpKey(group.Key, [.. group]);
+            if (key is null) continue;
+            _sessionManager.SetPeerMd5Key(group.Key, key);
             md5Bootstrapped++;
         }
         if (md5Bootstrapped > 0)
             _logger.LogInformation("TCP-MD5 armed for {Count} peer(s)", md5Bootstrapped);
+    }
+
+    /// <summary>
+    /// Resolves the ONE TCP-MD5 key a source IP's surviving peer rows must share (#36 — TCP keys
+    /// by address, not by (IP, ASN)). Deterministic ordinal pick among the rows, with the same
+    /// warning the startup bootstrap emits when siblings declare DIFFERENT keys; null when no
+    /// surviving row carries a key (#418).
+    /// </summary>
+    private string? ResolveSharedIpKey(string ip, IReadOnlyList<(string Ip, string Md5Password)> rows)
+    {
+        if (rows.Count == 0) return null;
+        var creds = rows.OrderBy(c => c.Md5Password, StringComparer.Ordinal).ToList();
+        if (creds.Select(c => c.Md5Password).Distinct().Count() > 1)
+            _logger.LogWarning(
+                "TCP-MD5: {Count} peer rows on source IP {Ip} configure DIFFERENT keys — TCP-MD5 keys by IP, so one key applies to all of them (peers: {Peers})",
+                creds.Count, ip, string.Join(", ", creds.Select(c => c.Ip)));
+        return creds[0].Md5Password;
+    }
+
+    /// <summary>
+    /// Re-arms the per-IP TCP-MD5 key from the SURVIVING peer rows (#418): deleting a peer or
+    /// clearing its password must fall back to a sibling's key on the same source IP, and setting
+    /// a new one must leave the whole-IP state consistent with the store. The pre-#418 behavior
+    /// armed/unarmed from the single edited row, silently disarming (or overriding) siblings.
+    /// </summary>
+    internal async Task RearmPeerIpMd5KeyAsync(string ip)
+    {
+        var remaining = await _store.GetPeerMd5CredentialsForIpAsync(ip);
+        _sessionManager.SetPeerMd5Key(ip, ResolveSharedIpKey(ip, remaining));
     }
 
     public async Task StopAsync(CancellationToken cancellationToken)
@@ -1070,10 +1098,11 @@ public sealed class ManagementApi : IHostedService, IDisposable
             md5Password: data.Md5Password);
         if (data.Md5Password is not null)
         {
-            // The peer row carries the source IP the key is attached to.
+            // #418: re-arm from ALL surviving rows for this IP — clearing this peer's key must
+            // fall back to a sibling's, not silently disarm the address for every peer on it.
             var md5Peer = await _store.GetDbPeerByIdAsync(peerId);
             if (md5Peer is not null)
-                _sessionManager.SetPeerMd5Key(md5Peer.Ip, md5Peer.Md5Password);
+                await RearmPeerIpMd5KeyAsync(md5Peer.Ip);
         }
 
         _logger.LogInformation("Updated peer {Id}", SanitizeForLog(peerId));
@@ -1101,9 +1130,10 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         await _store.DeletePeerAsync(peerId);
 
-        // #36: disarm the deleted peer's TCP-MD5 key. Uses the row loaded BEFORE the delete —
-        // a post-delete re-read always returned null (CodeRabbit on #398).
-        _sessionManager.SetPeerMd5Key(peer.Ip, null);
+        // #36 + #418: re-arm the IP's TCP-MD5 key from the SURVIVING rows — deleting one sibling
+        // must not disarm TCP-MD5 for the other peers sharing the source IP (pre-#418 this was an
+        // unconditional SetPeerMd5Key(ip, null)). No key left on the IP resolves to null (disarm).
+        await RearmPeerIpMd5KeyAsync(peer.Ip);
         _logger.LogInformation("Deleted peer {Id} ({Ip})", SanitizeForLog(peerId), peer.Ip);
         return ApiResponse.Ok(new { id = peerId, deleted = true });
     }

--- a/BGPLite.Api/PeerStore.cs
+++ b/BGPLite.Api/PeerStore.cs
@@ -197,6 +197,21 @@ public sealed class PeerStore : IPeerStore
     }
 
     /// <summary>
+    /// Returns (Ip, Md5Password) for every peer row at ONE source IP that carries a TCP-MD5 key.
+    /// Used to re-arm the per-IP key after a delete/PATCH (#418): TCP keys by address (#36), so
+    /// deleting or clearing one sibling must fall back to a surviving row's key instead of
+    /// silently disarming every peer sharing the IP.
+    /// </summary>
+    public async Task<IReadOnlyList<(string Ip, string Md5Password)>> GetPeerMd5CredentialsForIpAsync(string ip, CancellationToken ct = default)
+    {
+        using var db = _dbFactory.CreateDbContext();
+        return await db.Peers.AsNoTracking()
+            .Where(p => p.Ip == ip && p.Md5Password != null && p.Md5Password != "")
+            .Select(p => new ValueTuple<string, string>(p.Ip, p.Md5Password!))
+            .ToListAsync(ct);
+    }
+
+    /// <summary>
     /// Single-roundtrip replacement for the <c>GetPeer</c> + <c>UpdateSessionStatus</c> +
     /// <c>GetSubscriptions</c> + <c>GetCustomPrefixes</c> + <c>GetCustomAsns</c> sequence the BGP
     /// send path used to issue as FIVE separate <c>DbContext</c>s (issue #84). Loads the peer by

--- a/BGPLite.Tests/PeerDeleteTeardownTests.cs
+++ b/BGPLite.Tests/PeerDeleteTeardownTests.cs
@@ -53,6 +53,66 @@ public sealed class PeerDeleteTeardownTests
         Assert.Empty(manager.Terminated);
     }
 
+    // ---- management API: TCP-MD5 key re-arm on delete (#418) ----
+
+    [Fact]
+    public async Task DeletePeer_RearmsIpKey_FromSurvivingSibling()
+    {
+        using var connection = NewOpenConnection();
+        var store = NewStore(connection);
+        var idA = await store.CreatePeerAsync("203.0.113.7", 65001, null);
+        var idB = await store.CreatePeerAsync("203.0.113.7", 65002, null);
+        await store.UpdatePeerConfigurationAsync(idA, null, asnListNames: null, customPrefixes: null, customAsns: null, maxPrefix: null, md5Password: "key-a");
+        await store.UpdatePeerConfigurationAsync(idB, null, asnListNames: null, customPrefixes: null, customAsns: null, maxPrefix: null, md5Password: "key-b");
+        var manager = new RecordingSessionManager();
+        using var api = NewApi(store, manager);
+
+        var response = await api.HandleDeletePeer(idB);
+
+        Assert.Equal(200, response.StatusCode);
+        // Pre-#418 the delete armed null — silently disarming TCP-MD5 for the surviving sibling.
+        var armed = Assert.Single(manager.Md5Keys);
+        Assert.Equal("203.0.113.7", armed.Ip);
+        Assert.Equal("key-a", armed.Password);
+    }
+
+    [Fact]
+    public async Task DeletePeer_LastKeyedPeerOnIp_ClearsIpKey()
+    {
+        using var connection = NewOpenConnection();
+        var store = NewStore(connection);
+        var id = await store.CreatePeerAsync("203.0.113.8", 65001, null);
+        await store.UpdatePeerConfigurationAsync(id, null, asnListNames: null, customPrefixes: null, customAsns: null, maxPrefix: null, md5Password: "solo-key");
+        var manager = new RecordingSessionManager();
+        using var api = NewApi(store, manager);
+
+        await api.HandleDeletePeer(id);
+
+        var armed = Assert.Single(manager.Md5Keys);
+        Assert.Equal("203.0.113.8", armed.Ip);
+        Assert.Null(armed.Password); // nothing survives on the IP — a genuine disarm
+    }
+
+    [Fact]
+    public async Task RearmPeerIpMd5Key_ClearingSiblingPassword_FallsBackToSurvivingKey()
+    {
+        using var connection = NewOpenConnection();
+        var store = NewStore(connection);
+        var idA = await store.CreatePeerAsync("203.0.113.7", 65001, null);
+        var idB = await store.CreatePeerAsync("203.0.113.7", 65002, null);
+        await store.UpdatePeerConfigurationAsync(idA, null, asnListNames: null, customPrefixes: null, customAsns: null, maxPrefix: null, md5Password: "key-a");
+        await store.UpdatePeerConfigurationAsync(idB, null, asnListNames: null, customPrefixes: null, customAsns: null, maxPrefix: null, md5Password: "key-b");
+        var manager = new RecordingSessionManager();
+        using var api = NewApi(store, manager);
+
+        // The PATCH path clears idB's password (store already updated), then re-arms the IP.
+        await store.UpdatePeerConfigurationAsync(idB, null, asnListNames: null, customPrefixes: null, customAsns: null, maxPrefix: null, md5Password: "");
+        await api.RearmPeerIpMd5KeyAsync("203.0.113.7");
+
+        var armed = Assert.Single(manager.Md5Keys);
+        Assert.Equal("key-a", armed.Password); // the sibling's enforcement survives the clear
+    }
+
     // ---- server: the teardown core over real scripted sessions ----
 
     [Fact]
@@ -219,10 +279,11 @@ public sealed class PeerDeleteTeardownTests
             NullLogger<RouteAssembler>.Instance);
     }
 
-    /// <summary>Records TerminatePeerAsync calls; the optional hook runs at call time (row-state assertions).</summary>
+    /// <summary>Records TerminatePeerAsync and SetPeerMd5Key calls; the optional hook runs at terminate time (row-state assertions).</summary>
     private sealed class RecordingSessionManager(Func<string, uint, Task>? onTerminate = null) : ISessionManager
     {
         public List<(string Ip, uint Asn)> Terminated { get; } = [];
+        public List<(string Ip, string? Password)> Md5Keys { get; } = [];
 
         public Task RefreshPeerAsync(string peerIp, uint asn) => Task.CompletedTask;
         public List<string> GetActivePeerIps() => [];
@@ -234,7 +295,7 @@ public sealed class PeerDeleteTeardownTests
             Terminated.Add((peerIp, asn));
             if (onTerminate is not null) await onTerminate(peerIp, asn);
         }
-        public void SetPeerMd5Key(string peerIp, string? password) { }
+        public void SetPeerMd5Key(string peerIp, string? password) => Md5Keys.Add((peerIp, password));
     }
 
     private sealed class StaticOptionsFactory(DbContextOptions<BgpDbContext> options) : IDbContextFactory<BgpDbContext>


### PR DESCRIPTION
Closes #418

## Problem
TCP-MD5 keys live in a per-source-IP table (#36), but peer deletion and PATCH armed/disarmed the whole-IP key from the SINGLE edited row. Deleting one of two peers sharing an IP called `SetPeerMd5Key(ip, null)` — silently disarming RFC 2385 enforcement for the surviving sibling until a process restart re-ran the startup bootstrap. PATCH had the same shape: clearing one sibling's password dropped the address's key; setting a new one overwrote the sibling's (last-writer-wins, no warning at mutation time).

## Root Cause
The mutation paths resolved the key from one row while the enforcement scope is the whole IP; the store had no per-IP credential read to do better.

## Fix
- `PeerStore.GetPeerMd5CredentialsForIpAsync(ip)` — all surviving rows on one IP that carry a key.
- `ManagementApi.ResolveSharedIpKey(ip, rows)` — the deterministic ordinal pick + multi-key DIFFERENT-keys warning, extracted verbatim from the startup bootstrap (which now uses the same helper, so runtime and bootstrap cannot drift).
- `ManagementApi.RearmPeerIpMd5KeyAsync(ip)` — queries surviving rows and arms the resolved key (null = genuine disarm). Called from DELETE (after the row is gone) and from PATCH's MD5 branch (after the store update, so the edited row's new/cleared state is included).

## Correctness
- Delete of the LAST keyed peer on an IP still disarms (empty survivor set → null) — the old legitimate behavior is preserved exactly.
- Startup bootstrap semantics unchanged (same helper, same ordering, same warning).
- Create path (`POST /api/peers`) unchanged: the operator just set the key, last-writer-wins is the intent there.

## Regression Test
`PeerDeleteTeardownTests` (`RecordingSessionManager` now records `SetPeerMd5Key` calls):
- `DeletePeer_RearmsIpKey_FromSurvivingSibling` — deleting sibling B keeps A's key armed. **Red/green proven**: against the pre-fix unconditional disarm the test fails (expected `key-a`, got `null`).
- `DeletePeer_LastKeyedPeerOnIp_ClearsIpKey` — no survivors → genuine disarm (pins the preserved behavior).
- `RearmPeerIpMd5Key_ClearingSiblingPassword_FallsBackToSurvivingKey` — PATCH-shaped clear falls back to the sibling.

## Verification
- dotnet format / dotnet build BGPLite.sln (0 errors) / dotnet test BGPLite.sln — **1016/1016 passed** (baseline full-suite green; delta = +3 tests, 0 failures).

## RFC
- RFC 2385 (TCP-MD5 signature option) surface — no wire-format change; enforcement consistency only.

## Behavior Change
- Deleting/clearing a peer now re-arms the per-IP key from surviving siblings instead of silently disarming the address. Operators who RELIED on the disarm side effect (delete sibling → whole IP unprotected) must delete every keyed row on the IP — that reliance contradicted the configured intent.

## Deviation from Issue Proposal
- None of substance: the issue proposed re-arming from remaining rows; implemented via a shared resolver so the startup warning semantics (multiple DIFFERENT keys on one IP) apply at mutation time too.