### PR TITLE
fix(providers): block the RFC 8215 NAT64 local-use prefix in the SSRF filter (#419)

### DIFF
--- a/BGPLite.Providers/PrefixSourceUrlValidator.cs
+++ b/BGPLite.Providers/PrefixSourceUrlValidator.cs
@@ -38,7 +38,7 @@ public static class PrefixSourceUrlValidator
         IPNetwork.Parse("::ffff:0:0/96"),       // IPv4-mapped (also caught by IsIPv4MappedToIPv6, defense in depth)
         IPNetwork.Parse("::/96"),               // IPv4-compatible (deprecated ::a.b.c.d form)
         IPNetwork.Parse("64:ff9b::/96"),        // NAT64 well-known — a DNS64 name can embed any IPv4 here (#321)
-        IPNetwork.Parse("64:ff8:1::/96"),       // NAT64 well-known, local scope (RFC 6052 §2.1 alternate)
+        IPNetwork.Parse("64:ff9b:1::/48"),      // NAT64 local-use (RFC 8215) — same IPv4-embedding hazard as the well-known prefix (#419)
     ];
 
     /// <summary>Per-address connect budget so one blackholed candidate can't consume the whole

--- a/BGPLite.Tests/PrefixSourceUrlValidatorTests.cs
+++ b/BGPLite.Tests/PrefixSourceUrlValidatorTests.cs
@@ -141,7 +141,7 @@ public class PrefixSourceUrlValidatorTests
     [InlineData("::192.168.1.1")]       // IPv4-compatible (deprecated ::a.b.c.d form)
     [InlineData("::ffff:10.0.0.1")]     // IPv4-mapped private (also caught by normalize, defense in depth)
     [InlineData("64:ff9b::0a00:0001")]  // NAT64 well-known embedding 10.0.0.1 (#321)
-    [InlineData("64:ff8:1::c0a8:0101")] // NAT64 local-scope embedding 192.168.1.1 (#321)
+    [InlineData("64:ff9b:1::a9fe:c9fe")] // NAT64 local-use 64:ff9b:1::/48 (RFC 8215) — cloud-metadata embedding (#419)
     public void IsBlockedAddress_Rejects_IPv4EmbeddingForms(string ip)
     {
         // Without the #158 ranges, an attacker controlling DNS returns one of these IPv6 addresses


### PR DESCRIPTION
Closes #419

## Problem
The SSRF blocklist entry intended for the NAT64 **local-use** translation prefix was wrong twice: `64:ff8:1::/96` instead of `64:ff9b:1::/48`. A peer-supplied source URL resolving to an address under `64:ff9b:1::/48` (e.g. embedding cloud metadata `169.254.169.254`) passed `IsBlockedAddress` at BOTH defense layers — save-time `ValidateUrlAsync` and the fetch-time `ConnectCallback` — and could reach the embedded internal IPv4 target on any network that routes NAT64 local-use prefixes. That is exactly the IPv4-embedding class lines 34-40 of the blocklist exist to close (#158).

## Root Cause
Typo'd literal (`ff8` vs `ff9b`) and wrong length (`/96` vs `/48`), plus a misplaced citation: the local-use prefix is reserved by **RFC 8215**, not RFC 6052 §2.1 (which defines only the well-known `64:ff9b::/96` — correctly and separately blocked already).

## Fix
One line: `IPNetwork.Parse("64:ff8:1::/96")` → `IPNetwork.Parse("64:ff9b:1::/48")`, comment corrected to cite RFC 8215.

## Regression Test
`IsBlockedAddress_Rejects_IPv4EmbeddingForms`: the old bogus-literal InlineData (`64:ff8:1::c0a8:0101` — only "blocked" because the typo'd entry matched it) is replaced with `64:ff9b:1::a9fe:c9fe`. **Red/green proven**: the new case FAILS against the pre-fix blocklist (address not blocked), passes after the literal fix.

## Verification
- dotnet format / dotnet build BGPLite.sln (0 errors) / dotnet test BGPLite.sln — **1016/1016 passed**.
- Literal verified against the RFC texts (well-known 64:ff9b::/96 = RFC 6052 §2.1; local-use 64:ff9b:1::/48 = RFC 8215).

## RFC
- RFC 6052 §2.1 (well-known prefix), RFC 8215 (local-use prefix 64:ff9b:1::/48).

## Behavior Change
- Peer-supplied URLs resolving into `64:ff9b:1::/48` are now rejected at save time and blocked at connect time. That is the intended control finally working, not a regression.

## Deviation from Issue Proposal
- None.