### PR TITLE
fix(server): honor ROUTE_REFRESH for AFI=2 on MP-IPv6 sessions (#420)

### DIFF
--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -815,9 +815,19 @@ public sealed class BgpSession : IDisposable
                         _logger.LogWarning("RouteRefresh received from {Peer} without negotiated capability, ignoring", _peer);
                         break;
                     }
-                    if (refresh.Afi != BgpConstants.Afi.IPv4 || refresh.Safi != BgpConstants.Safi.Unicast)
+                    // RFC 2918 §2: the receiving speaker re-sends Adj-RIB-Out for the REQUESTED
+                    // AFI/SAFI. Both families BGPLite advertises are honored (#420): IPv4/Unicast
+                    // always, IPv6/Unicast for MP-IPv6-negotiated sessions (#14). The re-announcement
+                    // dump is family-unified (withdraw-all + re-send), so the same debounced refresh
+                    // serves either request.
+                    var isSupportedFamily = refresh.Safi == BgpConstants.Safi.Unicast &&
+                        (refresh.Afi == BgpConstants.Afi.IPv4 ||
+                         (refresh.Afi == BgpConstants.Afi.IPv6 && _peerMpIpv6Unicast));
+                    if (!isSupportedFamily)
                     {
-                        _logger.LogDebug("RouteRefresh ignored: unsupported AFI/SAFI from {Peer}", _peer);
+                        _logger.LogDebug(
+                            "RouteRefresh ignored: unsupported AFI/SAFI {Afi}/{Safi} from {Peer} (MP IPv6 negotiated: {MpV6})",
+                            refresh.Afi, refresh.Safi, _peer, _peerMpIpv6Unicast);
                         break;
                     }
                     // Debounce: ignore ROUTE_REFRESH floods. Atomic check-and-set so a burst of N

--- a/BGPLite.Tests/BgpSessionV6AdvertiseTests.cs
+++ b/BGPLite.Tests/BgpSessionV6AdvertiseTests.cs
@@ -36,7 +36,7 @@ public class BgpSessionV6AdvertiseTests
     };
 
     private static async Task<(BgpSession Session, Task Run, ScriptedConnection Conn)> EstablishAsync(
-        RouteTable routeTable, BgpConfig? config = null, bool negotiateMpV6 = true)
+        RouteTable routeTable, BgpConfig? config = null, bool negotiateMpV6 = true, bool routeRefresh = false)
     {
         var conn = new ScriptedConnection();
         var session = new BgpSession(
@@ -52,6 +52,8 @@ public class BgpSessionV6AdvertiseTests
         var capabilities = new List<BgpCapabilityInfo> { BgpCapabilityInfo.FourOctetAsn(65002) };
         if (negotiateMpV6)
             capabilities.Add(BgpCapabilityInfo.MultiprotocolIpv6Unicast());
+        if (routeRefresh)
+            capabilities.Add(BgpCapabilityInfo.RouteRefresh());
         conn.EnqueueMessage(new BgpOpenMessage
         {
             Version = BgpConstants.BgpVersion,
@@ -67,6 +69,74 @@ public class BgpSessionV6AdvertiseTests
         Assert.True(session.IsEstablished, "session must reach Established");
         return (session, run, conn);
     }
+
+    [Fact]
+    public async Task RouteRefresh_Afi2_RereadvertisesV6Routes()
+    {
+        // #420 (RFC 2918 §2): a refresh request names the AFI/SAFI to re-send. An MP-IPv6-
+        // negotiated peer's AFI=2/SAFI=1 request was silently ignored — the only way to get the
+        // routes re-advertised was bouncing the session. It must trigger the same debounced
+        // re-announcement dump the AFI=1 request does.
+        var routeTable = new RouteTable();
+        routeTable.AddOrUpdate(V6Route());
+        var (session, run, conn) = await EstablishAsync(routeTable, routeRefresh: true);
+
+        // Wait for the initial dump's single MP_REACH frame before asking for a refresh.
+        var initial = 0;
+        for (var i = 0; i < 300 && (initial = CountMpReach(conn)) == 0; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        Assert.Equal(1, initial);
+
+        conn.EnqueueMessage(new BgpRouteRefreshMessage { Afi = BgpConstants.Afi.IPv6, Reserved = 0, Safi = BgpConstants.Safi.Unicast });
+        for (var i = 0; i < 300 && CountMpReach(conn) <= initial; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+
+        Assert.True(CountMpReach(conn) > initial, "AFI=2 ROUTE_REFRESH must re-advertise the v6 routes");
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task RouteRefresh_Afi2_WithoutNegotiation_Ignored()
+    {
+        var routeTable = new RouteTable();
+        routeTable.AddOrUpdate(V6Route());
+        var (session, run, conn) = await EstablishAsync(routeTable, negotiateMpV6: false, routeRefresh: true);
+
+        conn.EnqueueMessage(new BgpRouteRefreshMessage { Afi = BgpConstants.Afi.IPv6, Reserved = 0, Safi = BgpConstants.Safi.Unicast });
+        await Task.Delay(TimeSpan.FromMilliseconds(300));
+
+        // Without MP-IPv6 negotiation no v6 advertisement exists to refresh — the request is a no-op.
+        Assert.Equal(0, CountMpReach(conn));
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task RouteRefresh_Afi1_StillRereadvertises()
+    {
+        // Control for the #420 gate refactor: the IPv4/Unicast refresh path is unchanged.
+        var routeTable = new RouteTable();
+        routeTable.AddOrUpdate(new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 1 });
+        var (session, run, conn) = await EstablishAsync(routeTable, routeRefresh: true);
+
+        var initial = CountUpdates(conn);
+        Assert.True(initial > 0);
+
+        conn.EnqueueMessage(new BgpRouteRefreshMessage { Afi = BgpConstants.Afi.IPv4, Reserved = 0, Safi = BgpConstants.Safi.Unicast });
+        for (var i = 0; i < 300 && CountUpdates(conn) <= initial; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+
+        Assert.True(CountUpdates(conn) > initial, "AFI=1 ROUTE_REFRESH must re-advertise");
+
+        await TeardownAsync(session, run);
+    }
+
+    private static int CountUpdates(ScriptedConnection conn) =>
+        conn.Sent.Select(f => BgpMessageReader.ReadMessage(f)).OfType<BgpUpdateMessage>().Count();
+
+    private static int CountMpReach(ScriptedConnection conn) =>
+        conn.Sent.Select(f => BgpMessageReader.ReadMessage(f)).OfType<BgpUpdateMessage>().Count(u => u.MpReachV6 is not null);
 
     private static async Task TeardownAsync(BgpSession session, Task run)
     {


### PR DESCRIPTION
Closes #420

## Problem
The read loop accepted ROUTE_REFRESH only for AFI=1/SAFI=1 and dropped every other AFI/SAFI with a Debug log. BGPLite advertises MP IPv6/Unicast (RFC 4760 §8), so a conformant peer MAY send ROUTE_REFRESH with AFI=2 (RFC 2918 §2 — the receiving speaker re-sends Adj-RIB-Out for the requested AFI/SAFI). Such a request was silently ignored: an IPv6 peer that lost our routes could never get them re-advertised without bouncing the session.

## Root Cause
The family gate predated the MP-IPv6 advertisement work (epic #14) and was never widened.

## Fix
The gate now honors IPv6/Unicast for MP-IPv6-negotiated sessions; the re-announcement dump is family-unified (withdraw-all + re-send both families), so the same debounced refresh serves either request. Unsupported AFI/SAFI stays ignored, with the diagnostic now naming the negotiated MP-IPv6 state.

## Correctness
- Debounce (`MinRouteRefreshInterval`, CAS) and the #253 off-read-loop execution are untouched — an AFI=2 refresh cannot bypass the flood control.
- AFI=2 without negotiated capability → ignored (nothing exists to refresh).
- Non-unicast SAFI or unknown AFI → ignored as before.

## Regression Test
`BgpSessionV6AdvertiseTests` (real session over `ScriptedConnection`):
- `RouteRefresh_Afi2_RereadvertisesV6Routes` — negotiated peer sends ROUTE_REFRESH(2/1) → a second MP_REACH dump lands on the wire. **Red/green proven**: fails against the AFI=1-only gate, passes after.
- `RouteRefresh_Afi2_WithoutNegotiation_Ignored` — stays a no-op (no MP_REACH ever).
- `RouteRefresh_Afi1_StillRereadvertises` — control pinning the v4 path through the refactor.

## Verification
- dotnet format / dotnet build (0 errors) / dotnet test — full suite green (delta +3 tests).

## RFC
- RFC 2918 §2 (receiving-speaker refresh semantics per AFI/SAFI); RFC 4760 §8 (MP capability advertisement).

## Behavior Change
- MP-IPv6 peers can now trigger a re-announcement via ROUTE_REFRESH(2/1); previously ignored.

## Deviation from Issue Proposal
- None.