### PR TITLE
fix(server): an OPEN received in Established is an FSM error (#427)

### DIFF
--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -729,6 +729,22 @@ public sealed class BgpSession : IDisposable
                 LogPeerClosedEstablished(ex);
                 return;
             }
+            catch (BgpParseException ex) when (ex.ErrorCode == BgpConstants.Error.OpenMessageError)
+            {
+                // #427 (RFC 4271 §8.2.2): an OPEN received in Established is an FSM error
+                // regardless of body validity — Established accepts only UPDATE, KEEPALIVE,
+                // NOTIFICATION and ROUTE_REFRESH, and a conformant speaker never parses the body.
+                // The body-error filter below must NOT keep the session up for this message class
+                // (that treatment is UPDATE-specific, D17). Same teardown as the FSM-error default
+                // case: exactly one NOTIFICATION 5/0 (CAS-latched), then Idle.
+                _logger.LogWarning("OPEN received from {Peer} in Established — FSM error (RFC 4271 §8.2.2)", _peer);
+                if (Interlocked.CompareExchange(ref _teardownReason, (int)TeardownReason.LocalCease, (int)TeardownReason.None) == (int)TeardownReason.None)
+                {
+                    try { await SendNotificationAsync(BgpConstants.Error.FiniteStateMachineError, BgpConstants.SubError.Unspecific); }
+                    catch { /* best-effort — partial write counts, see RFC 4271 §8.1 */ }
+                }
+                return;
+            }
             catch (BgpParseException ex) when (ex.ErrorCode is not null)
             {
                 // #222: a malformed message BODY (truncated path attribute, out-of-range NLRI length,

--- a/BGPLite.Tests/MalformedUpdateResilienceTests.cs
+++ b/BGPLite.Tests/MalformedUpdateResilienceTests.cs
@@ -161,6 +161,86 @@ public class MalformedUpdateResilienceTests
     }
 
     [Fact]
+    public async Task MalformedOpen_InEstablished_IsFsmError_SessionResets()
+    {
+        // #427 (RFC 4271 §8.2.2): an OPEN received in Established is an FSM error REGARDLESS of
+        // body validity — Established accepts only UPDATE/KEEPALIVE/NOTIFICATION/ROUTE_REFRESH
+        // and a conformant speaker never parses the body. Pre-fix the body-error filter applied
+        // the UPDATE treatment (D17): the session stayed up with a warning and no NOTIFICATION.
+        var (server, client) = ConnectedPair();
+        using var clientSock = client;
+        var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
+        var metrics = new BgpMetrics();
+        using var session = new BgpSession(
+            new SocketBgpConnection(server),
+            new PeerConfig { Address = "127.0.0.1" },
+            bgpConfig,
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            metrics,
+            new NopLogger<BgpSession>());
+
+        var runTask = await EstablishSessionAsync(session, client, bgpConfig);
+
+        // Well-framed OPEN, body-invalid: the 10-byte minimum payload declares optParamsLen=5,
+        // which cannot fit — ParseOpen throws Open Message Error before the FSM switch saw the type.
+        var payload = new byte[10];
+        payload[0] = 4;                       // version
+        payload[1] = 0xFD; payload[2] = 0xE8; // My AS 65002
+        payload[9] = 5;                       // optional-parameters length: mismatches the 0 present
+        var open = BuildMessage(BgpMessageType.Open, payload);
+        client.Send(open, 0, open.Length, SocketFlags.None);
+
+        var sent = await DrainAsync(client, TimeSpan.FromSeconds(2));
+        var notification = Assert.Single(sent.OfType<BgpNotificationMessage>());
+        Assert.Equal(BgpConstants.Error.FiniteStateMachineError, notification.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.Unspecific, notification.SubErrorCode);
+        Assert.False(session.IsEstablished, "an OPEN in Established must reset the session (RFC 4271 §8.2.2)");
+
+        await runTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task WellFormedOpen_InEstablished_IsFsmError_Too()
+    {
+        // Control for #427: both OPEN classes in Established — well-formed and malformed — take
+        // the same FSM-error teardown; only the parse-failure path changed.
+        var (server, client) = ConnectedPair();
+        using var clientSock = client;
+        var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
+        var metrics = new BgpMetrics();
+        using var session = new BgpSession(
+            new SocketBgpConnection(server),
+            new PeerConfig { Address = "127.0.0.1" },
+            bgpConfig,
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            metrics,
+            new NopLogger<BgpSession>());
+
+        var runTask = await EstablishSessionAsync(session, client, bgpConfig);
+
+        var open = new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = 0,
+            RouterId = 0x0A000002,
+            Capabilities = [BgpCapabilityInfo.FourOctetAsn(65002)]
+        };
+        var buffer = new byte[BgpMessageWriter.GetBufferSize(open)];
+        var written = BgpMessageWriter.WriteMessage(open, buffer);
+        client.Send(buffer, 0, written, SocketFlags.None);
+
+        var sent = await DrainAsync(client, TimeSpan.FromSeconds(2));
+        Assert.Equal(BgpConstants.Error.FiniteStateMachineError,
+            Assert.Single(sent.OfType<BgpNotificationMessage>()).ErrorCode);
+        Assert.False(session.IsEstablished);
+
+        await runTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
     public async Task DuplicateNextHop_OnWire_InstallsTheFirstOccurrence()
     {
         // #287 / RFC 7606 §3: a duplicated attribute is not an error — all occurrences after the

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -194,7 +194,10 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
   adversarial UPDATE (#94, #222, #284 lineage). No NOTIFICATION is sent because RFC 4271 §6.3
   requires its receiver to tear down, defeating the purpose. Withdrawal semantics: class (b)
   withdraws the peer's own NLRI (RFC 7606's "treat" half, #288); class (a) cannot — the NLRI is
-  unrecoverable — and discards only (D2).
+  unrecoverable — and discards only (D2). Scope: **UPDATE only**. A malformed OPEN received in
+  Established is an FSM error (NOTIFICATION 5/0, #427) — RFC 4271 §8.2.2 makes ANY OPEN in
+  Established an FSM input regardless of body validity, so there is nothing to "keep alive" for
+  that message class.
 - **Consequence:** a peer sending structurally valid but semantically rejected UPDATEs gets them
   silently dropped (log Warning + `UpdatesRejected` metric) instead of a session reset; operators
   comparing against RFC-strict speakers will see BGPLite retain sessions others would close.


### PR DESCRIPTION
Closes #427

## Problem
A well-formed OPEN in Established correctly hit the FSM-error default (NOTIFICATION 5/0 + Idle). A MALFORMED OPEN did not: `ParseOpen` threw `BgpParseException(OpenMessageError)` before the message-type switch, and the read loop's body-error filter (D17, `when ErrorCode is not null`) treated it as per-message content — session stayed up with a Warning. Per RFC 4271 §8.2.2 an OPEN in Established is an FSM error regardless of body validity; the divergence was an accident of dispatch order, not a recorded decision (D17 is UPDATE-scoped).

## Root Cause
Dispatch order: body parsing happens before the FSM switch, and the UPDATE-oriented body-error filter caught OPEN-body failures too.

## Fix
A dedicated catch in `ReadLoopAsync` for `OpenMessageError` parse failures, placed before the generic body-error filter: logs the FSM violation, CAS-latches the teardown, sends exactly one NOTIFICATION 5/0, and returns to Idle — byte-for-byte the well-formed-OPEN path. `docs/DESIGN_DECISIONS.md` D17 gains an explicit scope note (UPDATE-only; OPEN in Established is always an FSM error per §8.2.2).

## Correctness
- Well-formed-OPEN handling unchanged (pinned by control test).
- Teardown latching keeps the exactly-one-NOTIFICATION invariant (the finally-block Cease cannot double-emit).
- UPDATE body errors still keep the session up (D17 untouched; full suite green).

## Regression Test
`MalformedUpdateResilienceTests` (real-socket session harness):
- `MalformedOpen_InEstablished_IsFsmError_SessionResets` — well-framed, body-invalid OPEN (optParamsLen mismatch) → NOTIFICATION 5/0 + Idle. **Red/green proven**: disabling the new catch fails the test (session survives, no NOTIFICATION).
- `WellFormedOpen_InEstablished_IsFsmError_Too` — control pinning both OPEN classes to the same teardown.

## Verification
- dotnet format / dotnet build (0 errors) / dotnet test — full suite green (delta +2 tests).

## RFC
- RFC 4271 §8.2.2 (FSM: legal inputs in Established; OpenSent events), §6.2 (Open Message Error).

## Behavior Change
- A malformed OPEN in Established now resets the session with NOTIFICATION 5/0 instead of being silently dropped. This aligns the malformed case with the well-formed case and with RFC-strict speakers.

## Deviation from Issue Proposal
- None (option (a) of the issue: route to FSM error; plus the D-catalog scope note the issue suggested for option (b), recorded for clarity).