### PR TITLE
fix(api,server): NULL-Asn peer delete terminates its sessions by IP (#422)

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -1107,9 +1107,29 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         _logger.LogInformation("Updated peer {Id}", SanitizeForLog(peerId));
 
-        _ = _sessionManager.RefreshPeerAsync(peer.Ip, peer.Asn ?? 0);
+        RequestPeerRefresh(peerId, peer);
 
         return await HandleGetPeer(peerId);
+    }
+
+    /// <summary>
+    /// Fire-and-forget per-peer refresh after a config change. A NULL-Asn row (legacy Ip-only era)
+    /// cannot match any live session by (Ip, Asn) — no session ever has RemoteAsn 0 (#300) — so
+    /// the refresh is skipped with a warning instead of the confusing "no session for {Ip} AS0"
+    /// the old <c>asn ?? 0</c> produced (#422).
+    /// </summary>
+    private void RequestPeerRefresh(string peerId, Peer peer)
+    {
+        if (peer.Asn.HasValue)
+        {
+            _ = _sessionManager.RefreshPeerAsync(peer.Ip, peer.Asn.Value);
+        }
+        else
+        {
+            _logger.LogWarning(
+                "Peer row {Id} at {Ip} has NULL Asn — refresh skipped (no (Ip, Asn) session match is possible)",
+                SanitizeForLog(peerId), peer.Ip);
+        }
     }
 
     internal async Task<ApiResponse> HandleDeletePeer(string peerId)
@@ -1126,7 +1146,21 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // send-timeout backstop) from pinning the DELETE request; the session is disposed even
         // when the Cease send is cancelled.
         using var bound = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        await _sessionManager.TerminatePeerAsync(peer.Ip, peer.Asn ?? 0, bound.Token);
+        if (peer.Asn.HasValue)
+        {
+            await _sessionManager.TerminatePeerAsync(peer.Ip, peer.Asn.Value, bound.Token);
+        }
+        else
+        {
+            // #422: a NULL-Asn row (legacy Ip-only era) cannot be matched by (Ip, Asn) — no live
+            // session ever has RemoteAsn 0 (AS 0 OPENs are rejected, #300) — so the pre-#422
+            // `asn ?? 0` teardown was a SILENT no-op and the session kept advertising a deleted
+            // peer. Terminate by IP instead, and say so in the log.
+            _logger.LogWarning(
+                "Deleting peer row {Id} at {Ip} with NULL Asn — terminating ALL its sessions by IP",
+                SanitizeForLog(peerId), peer.Ip);
+            await _sessionManager.TerminatePeerByIpAsync(peer.Ip, bound.Token);
+        }
 
         await _store.DeletePeerAsync(peerId);
 
@@ -1211,7 +1245,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         // Trigger refresh so the peer receives the new source's prefixes immediately —
         // same pattern as CreatePeer/UpdatePeer. Pass ASN so shared-IP peers aren't refreshed (#200).
-        _ = _sessionManager.RefreshPeerAsync(peer.Ip, peer.Asn ?? 0);
+        RequestPeerRefresh(peerId, peer);
 
         _logger.LogInformation("Added source '{Name}' ({Url}) to peer {PeerId}",
             SanitizeForLog(data.Name), SanitizeForLog(data.Url), SanitizeForLog(peerId));
@@ -1228,7 +1262,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
             return ApiResponse.Error($"Source '{sourceId}' not found", 404);
 
         // Trigger refresh so the source's prefixes are withdrawn immediately (#200: ASN-scoped).
-        _ = _sessionManager.RefreshPeerAsync(peer.Ip, peer.Asn ?? 0);
+        RequestPeerRefresh(peerId, peer);
 
         _logger.LogInformation("Deleted source {SourceId} from peer {PeerId}", SanitizeForLog(sourceId), SanitizeForLog(peerId));
         return ApiResponse.Ok(new { id = sourceId, deleted = true });
@@ -1251,7 +1285,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
             return ApiResponse.Error($"Source '{sourceId}' not found", 404);
 
         // Trigger refresh so toggling active/inactive takes effect immediately (#200: ASN-scoped).
-        _ = _sessionManager.RefreshPeerAsync(peer.Ip, peer.Asn ?? 0);
+        RequestPeerRefresh(peerId, peer);
 
         _logger.LogInformation("Source {SourceId} active={Active}", SanitizeForLog(sourceId), data.Active.Value);
         return ApiResponse.Ok(new { id = sourceId, active = data.Active.Value });

--- a/BGPLite.Contracts/ISessionManager.cs
+++ b/BGPLite.Contracts/ISessionManager.cs
@@ -26,6 +26,15 @@ public interface ISessionManager
     Task TerminatePeerAsync(string peerIp, uint asn, CancellationToken ct = default);
 
     /// <summary>
+    /// Terminates all live BGP sessions arriving from ONE source IP, regardless of their ASN
+    /// (#422). The IP-only counterpart of <see cref="TerminatePeerAsync"/>: a deleted peer row
+    /// with a NULL Asn (legacy Ip-only era rows) cannot be matched by (Ip, Asn) — no live session
+    /// ever has RemoteAsn 0 — so without this the teardown was a silent no-op and the session kept
+    /// advertising a deleted peer. Same Cease + dispose semantics as <see cref="TerminatePeerAsync"/>.
+    /// </summary>
+    Task TerminatePeerByIpAsync(string peerIp, CancellationToken ct = default);
+
+    /// <summary>
     /// Sets or clears the TCP-MD5 (RFC 2385) shared key for a peer's source IP (#36). A password
     /// enables enforcement on the listening socket (unsigned segments from that peer are dropped
     /// by the kernel); null/empty disables it. Passwords are never logged.

--- a/BGPLite.Server/BgpServer.cs
+++ b/BGPLite.Server/BgpServer.cs
@@ -472,6 +472,28 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
         await TerminateSessionsAsync(sessions, ct);
     }
 
+    /// <inheritdoc cref="ISessionManager.TerminatePeerByIpAsync" />
+    public async Task TerminatePeerByIpAsync(string peerIp, CancellationToken ct = default)
+    {
+        if (!IPAddress.TryParse(peerIp, out var ip))
+        {
+            _logger.LogWarning("TerminatePeerByIp: invalid IP {Ip}", peerIp);
+            return;
+        }
+
+        var sessions = _sessions
+            .Where(kvp => kvp.Key.Address.Equals(ip))
+            .Select(kvp => kvp.Value)
+            .ToList();
+
+        if (sessions.Count == 0)
+            return;
+
+        _logger.LogInformation("Terminating {Count} session(s) from {Ip} (IP-only match — the deleted peer row carries no ASN)",
+            sessions.Count, peerIp);
+        await TerminateSessionsAsync(sessions, ct);
+    }
+
     /// <summary>
     /// The #323 teardown core, split out so tests can drive real sessions without a live BgpServer
     /// (sessions enter <see cref="_sessions"/> only through the accept loop, which binds port 179).

--- a/BGPLite.Tests/ApiHandlerBehaviorTests.cs
+++ b/BGPLite.Tests/ApiHandlerBehaviorTests.cs
@@ -288,6 +288,7 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
         public Task RefreshPeerAsync(string peerIp, uint asn) => Task.CompletedTask;
         public List<string> GetActivePeerIps() => [];
         public Task TerminatePeerAsync(string peerIp, uint asn, CancellationToken ct = default) => Task.CompletedTask;
+        public Task TerminatePeerByIpAsync(string peerIp, CancellationToken ct = default) => Task.CompletedTask;
         public void SetPeerMd5Key(string peerIp, string? password) { }
         public int GetAdvertisedPrefixCount(string peerIp, uint asn) => 0;
         public Task RefreshAllEstablishedAsync() => Task.CompletedTask;

--- a/BGPLite.Tests/ConfigHotReloadTests.cs
+++ b/BGPLite.Tests/ConfigHotReloadTests.cs
@@ -388,6 +388,7 @@ public class ConfigHotReloadTests
         public int GetAdvertisedPrefixCount(string peerIp, uint asn) => 0;
         public Task RefreshAllEstablishedAsync() => Task.CompletedTask;
         public Task TerminatePeerAsync(string peerIp, uint asn, CancellationToken ct = default) => Task.CompletedTask;
+        public Task TerminatePeerByIpAsync(string peerIp, CancellationToken ct = default) => Task.CompletedTask;
         public void SetPeerMd5Key(string peerIp, string? password) { }
     }
 

--- a/BGPLite.Tests/ManagementApiShutdownTests.cs
+++ b/BGPLite.Tests/ManagementApiShutdownTests.cs
@@ -247,6 +247,7 @@ public sealed class ManagementApiShutdownTests : IDisposable
         public int GetAdvertisedPrefixCount(string peerIp, uint asn) => 0;
         public Task RefreshAllEstablishedAsync() => Task.CompletedTask;
         public Task TerminatePeerAsync(string peerIp, uint asn, CancellationToken ct = default) => Task.CompletedTask;
+        public Task TerminatePeerByIpAsync(string peerIp, CancellationToken ct = default) => Task.CompletedTask;
         public void SetPeerMd5Key(string peerIp, string? password) { }
     }
 

--- a/BGPLite.Tests/PeerDeleteTeardownTests.cs
+++ b/BGPLite.Tests/PeerDeleteTeardownTests.cs
@@ -53,6 +53,42 @@ public sealed class PeerDeleteTeardownTests
         Assert.Empty(manager.Terminated);
     }
 
+    [Fact]
+    public async Task DeletePeer_NullAsn_TerminatesByIp_NotSilentNoOp()
+    {
+        // #422: a legacy NULL-Asn row cannot match a live session by (Ip, Asn) — no session ever
+        // has RemoteAsn 0 (AS 0 OPENs are rejected, #300) — so the pre-#422 `asn ?? 0` teardown
+        // was a SILENT no-op: the row was deleted while its session kept advertising. The delete
+        // must terminate by IP instead.
+        using var connection = NewOpenConnection();
+        var store = NewStore(connection);
+        InsertLegacyNullAsnRow(connection, "203.0.113.9");
+        var row = (await store.GetPeersByIpAsync("203.0.113.9")).Single();
+        var manager = new RecordingSessionManager();
+        using var api = NewApi(store, manager);
+
+        var response = await api.HandleDeletePeer(row.Id);
+
+        Assert.Equal(200, response.StatusCode);
+        Assert.Empty(manager.Terminated); // the (Ip, Asn=0) match is gone — it never matched anything
+        Assert.Equal("203.0.113.9", Assert.Single(manager.TerminatedByIp));
+        Assert.Null(await store.GetDbPeerByIdAsync(row.Id));
+    }
+
+    /// <summary>A row from the Ip-only era: no Asn column value (#19 pre-#422 legacy shape).</summary>
+    private static void InsertLegacyNullAsnRow(SqliteConnection connection, string ip)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText =
+            "INSERT INTO Peers (Id, Ip, Asn, Description, Status, CreatedAt, LastSessionAt) " +
+            "VALUES ('legacy-row', @ip, NULL, NULL, 'inactive', '2026-01-01T00:00:00.0000000Z', NULL)";
+        var p = cmd.CreateParameter();
+        p.ParameterName = "@ip";
+        p.Value = ip;
+        cmd.Parameters.Add(p);
+        cmd.ExecuteNonQuery();
+    }
+
     // ---- management API: TCP-MD5 key re-arm on delete (#418) ----
 
     [Fact]
@@ -283,6 +319,7 @@ public sealed class PeerDeleteTeardownTests
     private sealed class RecordingSessionManager(Func<string, uint, Task>? onTerminate = null) : ISessionManager
     {
         public List<(string Ip, uint Asn)> Terminated { get; } = [];
+        public List<string> TerminatedByIp { get; } = [];
         public List<(string Ip, string? Password)> Md5Keys { get; } = [];
 
         public Task RefreshPeerAsync(string peerIp, uint asn) => Task.CompletedTask;
@@ -294,6 +331,11 @@ public sealed class PeerDeleteTeardownTests
         {
             Terminated.Add((peerIp, asn));
             if (onTerminate is not null) await onTerminate(peerIp, asn);
+        }
+        public Task TerminatePeerByIpAsync(string peerIp, CancellationToken ct = default)
+        {
+            TerminatedByIp.Add(peerIp);
+            return Task.CompletedTask;
         }
         public void SetPeerMd5Key(string peerIp, string? password) => Md5Keys.Add((peerIp, password));
     }

--- a/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
+++ b/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
@@ -53,6 +53,7 @@ public class PrefixAutoRefreshServiceTests
         public int GetAdvertisedPrefixCount(string peerIp, uint asn) => 0;
         public Task RefreshAllEstablishedAsync() { RefreshAllCalls++; return Task.CompletedTask; }
         public Task TerminatePeerAsync(string peerIp, uint asn, CancellationToken ct = default) => Task.CompletedTask;
+        public Task TerminatePeerByIpAsync(string peerIp, CancellationToken ct = default) => Task.CompletedTask;
         public void SetPeerMd5Key(string peerIp, string? password) { }
     }
 

--- a/BGPLite.Tests/RouteSeedingServiceTests.cs
+++ b/BGPLite.Tests/RouteSeedingServiceTests.cs
@@ -64,6 +64,7 @@ public class RouteSeedingServiceTests
         public int GetAdvertisedPrefixCount(string peerIp, uint asn) => 0;
         public Task RefreshAllEstablishedAsync() { RefreshAllCalls++; return Task.CompletedTask; }
         public Task TerminatePeerAsync(string peerIp, uint asn, CancellationToken ct = default) => Task.CompletedTask;
+        public Task TerminatePeerByIpAsync(string peerIp, CancellationToken ct = default) => Task.CompletedTask;
         public void SetPeerMd5Key(string peerIp, string? password) { }
     }
 


### PR DESCRIPTION
Closes #422

## Problem
Deleting a peer row with a NULL Asn (legacy Ip-only era data) resolved the session identity as `asn ?? 0`. No live session ever has `RemoteAsn == 0` (AS 0 OPENs are rejected, #300), so `TerminatePeerAsync(ip, 0)` matched nothing: the row was deleted while its established session kept advertising — the exact outcome #323 exists to prevent — and the follow-up refresh logged a confusing `no session for {Ip} AS0`. Fully silent.

## Root Cause
`peer.Asn ?? 0` conflated "no ASN on the row" with "ASN 0 session" — a key that can never exist.

## Fix
- New `ISessionManager.TerminatePeerByIpAsync(ip)` (Contracts) with the BgpServer IP-only match implementation; same Cease + dispose semantics as the (ip, asn) path, same 10s delete-time budget.
- `HandleDeletePeer`: keyed rows take the exact (Ip, Asn) path as before; NULL-Asn rows log a warning naming the legacy shape and terminate by IP.
- The four config-change refresh call sites (PATCH, add/delete source, toggle source) go through a shared `RequestPeerRefresh` helper: keyed rows unchanged; NULL-Asn rows skip the doomed (Ip, Asn) refresh with a warning instead of the AS0 log.

## Correctness
- Keyed-row deletes are byte-for-byte unchanged (existing #323 test passes unchanged).
- IP-only termination deliberately matches ALL sessions from that IP — for a legacy NULL-Asn row there is no narrower identity; the warning makes the scope explicit. Sibling peers on the same IP with their own keyed rows are not affected by keyed deletes (#200 semantics preserved).

## Regression Test
`PeerDeleteTeardownTests.DeletePeer_NullAsn_TerminatesByIp_NotSilentNoOp` — legacy row inserted via raw SQL (true legacy shape), delete records the IP-only termination and removes the row. **Red/green proven**: with the pre-fix `asn ?? 0` dispatch the test fails (nothing recorded). `RecordingSessionManager` now records both termination forms.

## Verification
- dotnet format / dotnet build (0 errors) / dotnet test — full suite green (delta +1 test; 6 test fakes extended for the new interface member).

## RFC
- none — management plane only.

## Behavior Change
- Deleting a NULL-Asn peer now actually stops its sessions (by IP, with a warning) instead of silently leaving them alive.

## Deviation from Issue Proposal
- Implemented the strongest of the issue's three options (IP-only termination + warning) rather than the warning-only fallback.