### PR TITLE
fix(api): reject non-unicast peer IPs at the management API (#421)

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -1555,8 +1555,11 @@ public sealed class ManagementApi : IHostedService, IDisposable
     /// <c>ToString()</c> collapses all of them onto the form the BGP path will look for.
     /// </para>
     /// <para>
-    /// IPv6 is rejected rather than mapped: BGPLite is IPv4-unicast only (#14 tracks the rest), so
-    /// <c>::ffff:1.2.3.4</c> would produce a peer no session can match.
+    /// Both families are accepted (#14 phase 5): a peer may be an IPv6 host. Addresses no BGP
+    /// session can ever originate from — unspecified, loopback, multicast, and the IPv4 broadcast
+    /// address — are rejected (#421), the API-side parity of the YAML path's fail-loud validation
+    /// (#390): such rows can never match a session, and a multicast row would even arm a kernel
+    /// TCP-MD5 entry.
     /// </para>
     /// </summary>
     internal static string? NormalizePeerIp(string? ip)
@@ -1567,9 +1570,29 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // plain IPv4 form so the row matches the address form the dual-mode listener reports.
         if (address.IsIPv4MappedToIPv6)
             address = address.MapToIPv4();
-        // Both families are accepted (#14 phase 5): a peer may be an IPv6 host; the canonical
-        // ToString form matches what the accept loop stores.
+        if (IsNonPeerAddress(address))
+            return null;
+        // The canonical ToString form matches what the accept loop stores.
         return address.ToString();
+    }
+
+    /// <summary>
+    /// The unspecified, loopback, multicast and (IPv4) broadcast addresses — unusable as a peer
+    /// identity. internal static for unit tests.
+    /// </summary>
+    internal static bool IsNonPeerAddress(IPAddress address)
+    {
+        if (address.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork)
+        {
+            var b = address.GetAddressBytes();
+            return b[0] == 0                                                 // 0.0.0.0/8 — unspecified / current-network
+                || b[0] == 127                                               // 127/8 — loopback
+                || (b[0] & 0xF0) == 0xE0                                     // 224/4 — multicast
+                || (b[0] == 255 && b[1] == 255 && b[2] == 255 && b[3] == 255); // broadcast
+        }
+        return IPAddress.IPv6Any.Equals(address)
+            || IPAddress.IPv6Loopback.Equals(address)
+            || address.IsIPv6Multicast;
     }
 
     /// <summary>

--- a/BGPLite.Tests/PeerInputValidationTests.cs
+++ b/BGPLite.Tests/PeerInputValidationTests.cs
@@ -36,8 +36,9 @@ public class PeerInputValidationTests
 
     /// <summary>
     /// Rejected outright: unparseable input, absent input (which reached the store as null and
-    /// surfaced as a 500 from a NOT NULL violation), and IPv6 — BGPLite is IPv4-unicast only, so an
-    /// IPv6 peer row could never match a session either.
+    /// surfaced as a 500 from a NOT NULL violation), and — #421 — addresses no BGP session can
+    /// ever originate from (unspecified / loopback / multicast / broadcast; parity with the YAML
+    /// path's #390 validation, which already rejects 0.0.0.0).
     /// </summary>
     [Theory]
     [InlineData(null)]
@@ -47,6 +48,15 @@ public class PeerInputValidationTests
     [InlineData(" 1.2.3.4")]
     [InlineData("banana")]
     [InlineData("1.2.3.4.5")]
+    [InlineData("0.0.0.0")]              // #421: unspecified (the YAML path rejects it too, #390)
+    [InlineData("0.1.2.3")]              // #421: 0.0.0.0/8
+    [InlineData("127.0.0.1")]            // #421: loopback
+    [InlineData("224.0.0.1")]            // #421: multicast
+    [InlineData("255.255.255.255")]      // #421: broadcast
+    [InlineData("::")]                   // #421: IPv6 unspecified
+    [InlineData("::1")]                  // #421: IPv6 loopback
+    [InlineData("ff02::1")]              // #421: IPv6 multicast
+    [InlineData("::ffff:224.0.0.1")]     // #421: multicast hidden behind the mapped form
     public void NormalizePeerIp_RejectsUnusableInput(string? input)
     {
         Assert.Null(ManagementApi.NormalizePeerIp(input));

--- a/BGPLite.Tests/PeerSetupTemplateTests.cs
+++ b/BGPLite.Tests/PeerSetupTemplateTests.cs
@@ -56,7 +56,9 @@ public class PeerSetupTemplateTests
     public void NormalizePeerIp_Ipv6_AcceptedAndCanonical()
     {
         Assert.Equal("2001:db8:cccc::20", ManagementApi.NormalizePeerIp("2001:db8:cccc:0:0:0:0:20"));
-        Assert.Equal("::1", ManagementApi.NormalizePeerIp("::1"));
+        // #421: ::1 (loopback) is no longer accepted as a peer address — the compressed-form
+        // canonicalization this test pins is covered by a non-special address instead.
+        Assert.Equal("2001:db8:cccc::21", ManagementApi.NormalizePeerIp("2001:0db8:cccc:0000:0000:0000:0000:0021"));
     }
 
     [Fact]


### PR DESCRIPTION
Closes #421

## Problem
`NormalizePeerIp` accepted anything `IPAddress.TryParse` took: `0.0.0.0`, `127.0.0.1`, multicast, broadcast (both families) all became peer rows that can never establish a session — and a multicast row would even arm a kernel TCP-MD5 entry via `SetPeerMd5Key`. Server validation disagreed with itself: the YAML path rejects `0.0.0.0` (#390), the API path accepted it.

## Fix
A shared `IsNonPeerAddress` gate inside `NormalizePeerIp` (after mapped-form normalization, so `::ffff:224.0.0.1` is caught): unspecified / loopback / multicast / broadcast → null → the handlers' existing 400 path. The stale "IPv6 is rejected" doc comment (pre-phase-5) is corrected — both families remain accepted for real peers.

## Regression Test
`PeerInputValidationTests.NormalizePeerIp_RejectsUnusableInput` extended with 9 address classes (0.0.0.0/8, 127/8, 224/4, broadcast, ::, ::1, ff02::1, mapped multicast). **Red/green proven**: all 9 fail against the pre-fix code, pass after. Canonicalization and storage-form tests untouched.

## Verification
- dotnet format / dotnet build (0 errors) / dotnet test — full suite green.

## RFC
- none — management plane validation (address-class semantics per the IANA special-purpose registries).

## Behavior Change
- POST/PATCH peer IPs in the rejected classes now return 400 instead of creating unusable rows.

## Deviation from Issue Proposal
- None.