### PR TITLE
fix(api): map SQLite constraint classes by extended code, not a 409 catch-all (#431)

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -518,18 +518,24 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (ex is JsonException)
             return ("Malformed JSON body", 400);
 
-        // EF Core constraint violation. #266 item 8: distinguish the two SQLite constraint codes —
-        // 2067 (SQLITE_CONSTRAINT_UNIQUE, a concurrent duplicate insert) is a genuine 409, while
-        // 19 (SQLITE_CONSTRAINT, in practice an FK violation after a concurrent DELETE removed the
-        // parent peer row) must not answer "already exists" for a resource that is GONE.
+        // EF Core constraint violation. #266 item 8 + #377 review + #431: classify by the SQLite
+        // EXTENDED code — 787 (SQLITE_CONSTRAINT_FOREIGNKEY) is the concurrent-DELETE case (the
+        // resource is GONE, not duplicated), 2067 (SQLITE_CONSTRAINT_UNIQUE) is a genuine conflict,
+        // and everything else — NOT NULL (1299), CHECK (275), other constraint classes, or a
+        // non-SQLite DbUpdateException — is a server-side data/schema problem that must not be
+        // mislabeled "already exists" to the client (pre-#431 the whole remaining bucket was 409).
         if (ex is Microsoft.EntityFrameworkCore.DbUpdateException)
         {
-            // #377 review: BOTH constraint classes report primary code 19 in SqliteErrorCode;
-            // the discriminator is the EXTENDED code — 787 (SQLITE_CONSTRAINT_FOREIGNKEY) is the
-            // concurrent-DELETE case, anything else (2067 unique, 19 bare) is a genuine conflict.
-            if (ex.InnerException is Microsoft.Data.Sqlite.SqliteException sqlite && sqlite.SqliteExtendedErrorCode == 787)
-                return ("The peer was removed while the change was being applied", 404);
-            return ("The resource already exists or conflicts with the current state", 409);
+            if (ex.InnerException is Microsoft.Data.Sqlite.SqliteException sqlite)
+            {
+                return sqlite.SqliteExtendedErrorCode switch
+                {
+                    787 => ("The peer was removed while the change was being applied", 404),
+                    2067 => ("The resource already exists or conflicts with the current state", 409),
+                    _ => ("Internal server error", 500),
+                };
+            }
+            return ("Internal server error", 500);
         }
 
         // Anything else: generic message, full detail logged server-side.

--- a/BGPLite.Tests/ExceptionMappingTests.cs
+++ b/BGPLite.Tests/ExceptionMappingTests.cs
@@ -26,17 +26,18 @@ public class ExceptionMappingTests
     }
 
     [Fact]
-    public void DbUpdateException_MapsTo_409_Conflict()
+    public void DbUpdateException_WithoutSqliteInner_MapsTo_500()
     {
-        // A unique-constraint violation (concurrent duplicate CreatePeer/UpsertPeer) is a 409, not
-        // a 500. EF Core wraps SQLite's "UNIQUE constraint failed" in DbUpdateException.
+        // #431: a DbUpdateException WITHOUT a SqliteException inner (an EF-level failure, e.g. a
+        // value conversion) is a server-side problem — the pre-#431 mapping answered 409 "already
+        // exists" for it, misleading every client debugging the conflict.
         var inner = new InvalidOperationException("UNIQUE constraint failed: Peers.Ip, Peers.Asn");
         var ex = new DbUpdateException("An error occurred while saving the entity changes.", inner);
 
         var (message, status) = ManagementApi.MapExceptionToResponse(ex);
 
-        Assert.Equal(409, status);
-        Assert.Equal("The resource already exists or conflicts with the current state", message);
+        Assert.Equal(500, status);
+        Assert.Equal("Internal server error", message);
         // The raw constraint text must NOT appear in the client-facing message.
         Assert.DoesNotContain("UNIQUE constraint", message);
         Assert.DoesNotContain("Peers.Ip", message);
@@ -113,5 +114,34 @@ public class ExceptionMappingTests
 
         Assert.Equal(409, status);
         Assert.Contains("exists", message);
+    }
+
+    [Fact]
+    public void DbUpdateException_WithoutSqliteInner_MapsTo_500()
+    {
+        // #431: a DbUpdateException WITHOUT a SqliteException inner (an EF-level failure, e.g. a
+        // value conversion) is a server-side problem — the pre-#431 mapping answered 409 "already
+        // exists" for it, misleading every client debugging the conflict.
+        var ex = new DbUpdateException("An error occurred while saving.", new InvalidOperationException("value conversion failed"));
+
+        var (message, status) = ManagementApi.MapExceptionToResponse(ex);
+
+        Assert.Equal(500, status);
+        Assert.Equal("Internal server error", message);
+    }
+
+    [Theory]
+    [InlineData(1299)] // SQLITE_CONSTRAINT_NOTNULL — a schema/data bug, not a client conflict
+    [InlineData(275)]  // SQLITE_CONSTRAINT_CHECK
+    public void DbUpdateException_NonConflictConstraint_MapsTo_500(int extendedCode)
+    {
+        // #431: the pre-#431 catch-all labeled every non-FK constraint 409 "already exists" —
+        // including NOT NULL / CHECK violations, which are server-side bugs. Only UNIQUE (2067)
+        // is a conflict.
+        var ex = new DbUpdateException("constraint failed", new SqliteException("constraint failed", 19, extendedCode));
+        var (message, status) = ManagementApi.MapExceptionToResponse(ex);
+
+        Assert.Equal(500, status);
+        Assert.Equal("Internal server error", message);
     }
 }

--- a/BGPLite.Tests/ExceptionMappingTests.cs
+++ b/BGPLite.Tests/ExceptionMappingTests.cs
@@ -116,20 +116,6 @@ public class ExceptionMappingTests
         Assert.Contains("exists", message);
     }
 
-    [Fact]
-    public void DbUpdateException_WithoutSqliteInner_MapsTo_500()
-    {
-        // #431: a DbUpdateException WITHOUT a SqliteException inner (an EF-level failure, e.g. a
-        // value conversion) is a server-side problem — the pre-#431 mapping answered 409 "already
-        // exists" for it, misleading every client debugging the conflict.
-        var ex = new DbUpdateException("An error occurred while saving.", new InvalidOperationException("value conversion failed"));
-
-        var (message, status) = ManagementApi.MapExceptionToResponse(ex);
-
-        Assert.Equal(500, status);
-        Assert.Equal("Internal server error", message);
-    }
-
     [Theory]
     [InlineData(1299)] // SQLITE_CONSTRAINT_NOTNULL — a schema/data bug, not a client conflict
     [InlineData(275)]  // SQLITE_CONSTRAINT_CHECK


### PR DESCRIPTION
Closes #431

## Problem
`MapExceptionToResponse` answered **409 The resource already exists** for every `DbUpdateException` whose extended SQLite code was not 787 — including NOT NULL (1299) and CHECK (275) violations and non-SQLite EF failures. Those are server-side data/schema bugs, not client conflicts; clients debugging an impossible-to-conflict create/update were misled, with the real cause only in the server log.

## Fix
Classify by extended code: 787 → 404 (unchanged), 2067 → 409 (unchanged), anything else → 500 with the generic non-revealing message (unchanged #157 discipline — detail stays server-side).

## Regression Test
`ExceptionMappingTests`: the old no-Sqlite-inner case now pins **500** (was 409); new NOT NULL (1299) and CHECK (275) cases pin **500**. Red/green: all three fail against the pre-fix catch-all.

## Verification
- dotnet format / dotnet build (0 errors) / dotnet test — full suite green.

## RFC
- none — API error mapping only.

## Behavior Change
- Server-side constraint/EF failures now surface as 500 instead of a misleading 409. The 404 (FK race) and 409 (unique conflict) contracts are unchanged.

## Deviation from Issue Proposal
- None.