### PR TITLE
fix(server): bound the accept-loop retry rate on persistent accept failures (#428)

### DIFF
--- a/BGPLite.Server/BgpServer.cs
+++ b/BGPLite.Server/BgpServer.cs
@@ -37,6 +37,8 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
     private Task? _acceptTask;
     private PeriodicTimer? _statusTimer;
     private Task? _statusTask;
+    // #428: pause before retrying after a failed accept — see the catch in AcceptLoopAsync.
+    private static readonly TimeSpan AcceptFailureBackoff = TimeSpan.FromMilliseconds(500);
 
     public BgpMetrics Metrics => _metrics;
     public RouteTable Routes => _routeTable;
@@ -365,6 +367,12 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
                 if (Volatile.Read(ref _acceptingConnections) == 0)
                     break;
                 _logger.LogError(ex, "Error accepting connection");
+                // #428: a persistent accept failure (fd exhaustion/EMFILE is the classic) used to
+                // spin this loop at full speed — log + immediate retry thousands of times a
+                // second, exactly when the host is already out of resources. Bound the retry
+                // rate; the shutdown token breaks the wait so shutdown latency is unaffected.
+                try { await Task.Delay(AcceptFailureBackoff, cancellationToken); }
+                catch (OperationCanceledException) { break; }
             }
         }
     }


### PR DESCRIPTION
Closes #428

## Problem
`AcceptLoopAsync` caught accept failures and continued immediately: a persistent `AcceptAsync` failure (fd exhaustion/EMFILE is the classic) spun the loop at full speed — log Error + immediate retry thousands of times per second, exactly when the host was already out of resources. The shutdown check only breaks the loop during shutdown, not on listener faults.

## Fix
A 500ms cancellable pause after every non-cancellation accept failure (shutdown token breaks the wait — shutdown latency unaffected).

## Regression Test
Not technically reachable: deterministically forcing a persistent accept failure requires the real listener bound to port 179 plus host resource manipulation, neither available to the test harness. Documented per the fix protocol; the change is a bounded delay on an existing catch path, and the full suite is green.

## Verification
- dotnet format / dotnet build (0 errors) / dotnet test — full suite green.

## RFC
- none.

## Behavior Change
- Accept retries after failures are rate-limited to 2/s; a re-accept storm after a transient listener error now recovers in half-second steps instead of a hot spin.

## Deviation from Issue Proposal
- None (the issue proposed exactly this backoff; the listener-recreation escalation was left out as unnecessary complexity without evidence).