### PR TITLE
fix(api): bound cold-cache external-fetch GETs with a wall-clock budget (#424)

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -60,6 +60,14 @@ public sealed class ManagementApi : IHostedService, IDisposable
     /// </summary>
     private const int DefaultInflightCap = 64;
     private readonly SemaphoreSlim _inflightCap = new(DefaultInflightCap);
+    /// <summary>
+    /// #424: wall-clock budget for the GET endpoints that can trigger external fetches
+    /// (<c>/api/asn-lists</c>, <c>/api/peers/&#123;id&#125;/prefixes</c>). A cold RIPEstat fetch is
+    /// minutes-scale per ASN (180s timeout × retries), so N such GETs used to monopolize the
+    /// global in-flight cap and starve every other route for minutes. On expiry the handlers serve
+    /// their PARTIAL result with a warning; shutdown still propagates. internal settable for tests.
+    /// </summary>
+    internal TimeSpan ExternalFetchBudget { get; set; } = TimeSpan.FromSeconds(30);
     // #258: in-flight tracking is a COUNT plus an idle Task (completed whenever the count is 0),
     // not a List<Task> — the #248 design appended every handler and never removed it, so each
     // completed request leaked its Task (and its exception, if faulted) for the process lifetime
@@ -1307,7 +1315,22 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (peer is null)
             return ApiResponse.Error("Peer not found", 404);
 
-        var prefixes = await CollectPeerPrefixes(peerId, _shutdownCts.Token);
+        // #424: same wall-clock budget as /api/asn-lists — cold subscription fetches are
+        // minutes-scale and must not pin the request (and its in-flight slot) indefinitely.
+        using var budget = CancellationTokenSource.CreateLinkedTokenSource(_shutdownCts.Token);
+        budget.CancelAfter(ExternalFetchBudget);
+        List<string> prefixes;
+        try
+        {
+            prefixes = await CollectPeerPrefixes(peerId, budget.Token);
+        }
+        catch (OperationCanceledException) when (!_shutdownCts.IsCancellationRequested)
+        {
+            _logger.LogWarning(
+                "GET /api/peers/{Id}/prefixes exceeded the {Seconds:0}s external-fetch budget — serving a partial list",
+                SanitizeForLog(peerId), ExternalFetchBudget.TotalSeconds);
+            prefixes = [];
+        }
 
         var format = ctx.Request.QueryString["format"] ?? "txt";
         if (format == "json")
@@ -1339,7 +1362,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
                 foreach (var p in fetched)
                     prefixes.Add(new IpPrefix(p.Prefix, p.Length, p.IsIpv4).ToString());
             }
-            catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#337: only shutdown cancellation — a provider-timeout OCE (live token) is a fetch failure below
+            catch (OperationCanceledException) when (_shutdownCts.IsCancellationRequested) { throw; }  // #114/#337/#424: only SHUTDOWN propagates — budget expiry degrades to the partial list
             catch (Exception ex) { _logger.LogWarning(ex, "CollectPeerPrefixes: ASN fetch failed"); }
         }
 
@@ -1352,7 +1375,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
                 foreach (var p in ruPrefixes)
                     prefixes.Add(new IpPrefix(p.Prefix, p.Length, p.IsIpv4).ToString());
             }
-            catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#337: only shutdown cancellation — a provider-timeout OCE (live token) is a fetch failure below
+            catch (OperationCanceledException) when (_shutdownCts.IsCancellationRequested) { throw; }  // #114/#337/#424: see above
             catch (Exception ex) { _logger.LogWarning(ex, "CollectPeerPrefixes: RU prefix fetch failed"); }
         }
 
@@ -1369,7 +1392,12 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
     private async Task<ApiResponse> HandleGetAsnListsAsync()
     {
-        var ct = _shutdownCts.Token;
+        // #424: bound the whole handler — see ExternalFetchBudget. Shutdown still propagates;
+        // budget expiry degrades to the partial counts collected so far (each later fetch fails
+        // fast against the cancelled token) instead of pinning the request for minutes.
+        using var budget = CancellationTokenSource.CreateLinkedTokenSource(_shutdownCts.Token);
+        budget.CancelAfter(ExternalFetchBudget);
+        var ct = budget.Token;
         var lists = _config.RipeStat?.AsnLists ?? [];
         var result = new List<object>();
 
@@ -1381,14 +1409,14 @@ public sealed class ManagementApi : IHostedService, IDisposable
                 foreach (var asn in l.Asns)
                 {
                     try { prefixCount += await _prefixService.GetPrefixCountAsync(asn, ct); }
-                    catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#337: only shutdown cancellation — a provider-timeout OCE (live token) is a fetch failure below
+                    catch (OperationCanceledException) when (_shutdownCts.IsCancellationRequested) { throw; }  // #114/#337/#424: only SHUTDOWN propagates — the #424 fetch budget fires as OCE on a live shutdown token and degrades below
                     catch (Exception ex) { _logger.LogWarning(ex, "Failed to get prefix count for AS{Asn}", asn); }
                 }
             }
             else if (l.Country is not null)
             {
                 try { prefixCount = (await _prefixService.GetRuPrefixesAsync(ct)).Count; }
-                catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#337: only shutdown cancellation — a provider-timeout OCE (live token) is a fetch failure below
+                catch (OperationCanceledException) when (_shutdownCts.IsCancellationRequested) { throw; }  // #114/#337/#424: see above
                 catch (Exception ex) { _logger.LogWarning(ex, "Failed to get RU prefix count"); }
             }
 
@@ -1421,6 +1449,11 @@ public sealed class ManagementApi : IHostedService, IDisposable
                 type = source.Kind == "asn" ? "asn" : "list"
             });
         }
+
+        if (ct.IsCancellationRequested && !_shutdownCts.IsCancellationRequested)
+            _logger.LogWarning(
+                "GET /api/asn-lists exceeded the {Seconds:0}s external-fetch budget — serving partial prefix counts",
+                ExternalFetchBudget.TotalSeconds);
 
         return ApiResponse.Ok(result);
     }

--- a/BGPLite.Tests/ManagementApiShutdownTests.cs
+++ b/BGPLite.Tests/ManagementApiShutdownTests.cs
@@ -104,6 +104,111 @@ public sealed class ManagementApiShutdownTests : IDisposable
     }
 
     [Fact]
+    public async Task AsnListsGet_ExternalFetchBudget_BoundsColdRequests()
+    {
+        // #424: a cold /api/asn-lists fetches RIPEstat per ASN (minutes-scale per ASN); N such GETs
+        // used to monopolize the global in-flight cap and starve every other route. The handler's
+        // wall-clock budget (default 30s, shrunk here) bounds the request: the parked provider is
+        // cancelled, the partial counts are served, status stays 200 — never a hang.
+        var provider = new BlockingRuPrefixService();
+        for (var attempt = 0; ; attempt++)
+        {
+            var port = FreeTcpPort();
+            var config = new AppConfig
+            {
+                ApiListen = "127.0.0.1",
+                ApiPort = port,
+                Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" },
+                RipeStat = new RipeStatConfig { AsnLists = [new AsnList { Name = "ru", Country = "RU" }] }
+            };
+            _api = new ManagementApi(
+                new PeerStore(new StaticOptionsFactory(new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(_connection).Options)),
+                new RouteTable(),
+                config,
+                new BgpMetrics(),
+                NullLogger<ManagementApi>.Instance,
+                provider,
+                new InertPrefixSourceService(),
+                new InertSessionManager());
+            _api.ExternalFetchBudget = TimeSpan.FromMilliseconds(250);
+            try
+            {
+                await _api.StartAsync(CancellationToken.None);
+                _port = port;
+                break;
+            }
+            catch (HttpListenerException) when (attempt < 2)
+            {
+                _api.Dispose();
+                _api = null;
+            }
+        }
+        _client = new HttpClient();
+
+        var watch = System.Diagnostics.Stopwatch.StartNew();
+        var response = await _client.GetAsync($"http://127.0.0.1:{_port}/api/asn-lists");
+        watch.Stop();
+
+        await provider.Entered.Task.WaitAsync(TimeSpan.FromSeconds(5)); // the fetch really started
+        Assert.True(watch.Elapsed < TimeSpan.FromSeconds(5),
+            $"the fetch budget must bound the request, took {watch.Elapsed}");
+        Assert.True(response.IsSuccessStatusCode, "budget expiry must degrade to a partial 200, not an error");
+    }
+
+    [Fact]
+    public async Task ExportPrefixesGet_ExternalFetchBudget_BoundsColdRequests()
+    {
+        // #424: /api/peers/{id}/prefixes has the same cold-fetch shape (subscription ASN/RU pulls).
+        var store = new PeerStore(new StaticOptionsFactory(new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(_connection).Options));
+        var peerId = await store.CreatePeerAsync("203.0.113.42", 65002, null);
+        await store.SetSubscriptionsAsync(peerId, ["ru"]);
+
+        var provider = new BlockingRuPrefixService();
+        for (var attempt = 0; ; attempt++)
+        {
+            var port = FreeTcpPort();
+            var config = new AppConfig
+            {
+                ApiListen = "127.0.0.1",
+                ApiPort = port,
+                Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" },
+                RipeStat = new RipeStatConfig { AsnLists = [new AsnList { Name = "ru", Country = "RU" }] }
+            };
+            _api = new ManagementApi(
+                store,
+                new RouteTable(),
+                config,
+                new BgpMetrics(),
+                NullLogger<ManagementApi>.Instance,
+                provider,
+                new InertPrefixSourceService(),
+                new InertSessionManager());
+            _api.ExternalFetchBudget = TimeSpan.FromMilliseconds(250);
+            try
+            {
+                await _api.StartAsync(CancellationToken.None);
+                _port = port;
+                break;
+            }
+            catch (HttpListenerException) when (attempt < 2)
+            {
+                _api.Dispose();
+                _api = null;
+            }
+        }
+        _client = new HttpClient();
+
+        var watch = System.Diagnostics.Stopwatch.StartNew();
+        var response = await _client.GetAsync($"http://127.0.0.1:{_port}/api/peers/{peerId}/prefixes");
+        watch.Stop();
+
+        await provider.Entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(watch.Elapsed < TimeSpan.FromSeconds(5),
+            $"the fetch budget must bound the request, took {watch.Elapsed}");
+        Assert.True(response.IsSuccessStatusCode, "budget expiry must degrade to a partial 200, not an error");
+    }
+
+    [Fact]
     public async Task StartAsync_Retries_WhenThePortIsTaken()
     {
         // FreeTcpPort has an inherent TOCTOU window — a concurrent bind between the probe and


### PR DESCRIPTION
Closes #424

## Problem
`GET /api/asn-lists` (sequential `GetPrefixCountAsync` per ASN per list) and `GET /api/peers/{id}/prefixes` (subscription ASN/RU pulls) perform external fetches that are minutes-scale cold (RIPEstat: 180s per-attempt timeout × retries). They were bounded only by the shutdown token; with the per-IP rate limiter and the concurrency limiter both opt-in (off by default), N such GETs occupied the entire global in-flight cap (64) and starved `/api/me` and every mutating route for minutes.

## Fix
Both handlers run under a `CancellationTokenSource` budget — default **30s**, linked to the shutdown token (shutdown still propagates, and is still observable mid-handler). On expiry the handler serves its **partial result** with a server-side warning; per-section fetches fail fast against the cancelled token. The per-fetch OCE filters now distinguish shutdown (propagates) from budget expiry (degrades) — the pre-#424 filters re-threw both.

## Correctness
- Shutdown semantics unchanged (the existing shutdown-drain test passes unmodified).
- Response shapes unchanged (list / text export) — partial data, never an error status, so UIs degrade gracefully.
- `ExternalFetchBudget` is internal-settable for tests.

## Regression Test
`ManagementApiShutdownTests` (real listener + a provider that parks until its token fires):
- `AsnListsGet_ExternalFetchBudget_BoundsColdRequests` and `ExportPrefixesGet_ExternalFetchBudget_BoundsColdRequests` — with a 250ms budget both requests return a 200 partial response well under 5s; the parked provider is provably entered and cancelled. **Red/green by construction**: pre-fix both hang until shutdown (the existing shutdown test demonstrates exactly that shape).

## Verification
- dotnet format / dotnet build (0 errors) / dotnet test — full suite green (delta +2 tests).

## RFC
- none.

## Behavior Change
- Cold fetch-bearing GETs now cap at ~30s and may return partial prefix counts/lists (with a warning in the server log) instead of hanging for minutes.

## Deviation from Issue Proposal
- The issue offered "per-request wall-clock bound" or "dedicated fetch semaphore"; implemented the bound (simplest, per-request semantics), leaving the semaphore option recorded here if fleet-refresh patterns ever need it.