### PR TITLE
fix(providers): fetch peer-supplied user sources on a breaker-free pipeline (#425)

### DIFF
--- a/BGPLite.Providers/HttpPrefixProvider.cs
+++ b/BGPLite.Providers/HttpPrefixProvider.cs
@@ -22,10 +22,19 @@ namespace BGPLite.Providers;
 public sealed class HttpPrefixProvider(
     IHttpClientFactory httpFactory,
     ILogger<HttpPrefixProvider> logger,
-    int defaultFetchTimeoutSeconds = 30) // mirrors DefaultFetchTimeoutSeconds (a ctor default cannot reference the member const)
+    int defaultFetchTimeoutSeconds = 30, // mirrors DefaultFetchTimeoutSeconds (a ctor default cannot reference the member const)
+    string? clientName = null) // #425: selects the resilience pipeline — see UserSourceClientName
     : IPrefixSourceProvider
 {
     public const string ClientName = "http";
+
+    /// <summary>
+    /// #425: the peer-supplied user-source path uses this named client — a retry WITHOUT a circuit
+    /// breaker. The shared breaker coupled peer-controlled failure rates to operator sources: a few
+    /// blackholed user URLs opened the shared breaker and suppressed every operator source fetch
+    /// for 30s windows. SSRF handler and body cap are identical for both pipelines.
+    /// </summary>
+    public const string UserSourceClientName = "http-user-source";
 
     /// <summary>Maximum response body size (10 MB) — defends against OOM from huge/malicious files (#144).</summary>
     internal const int MaxResponseBytes = 10 * 1024 * 1024;
@@ -53,7 +62,7 @@ public sealed class HttpPrefixProvider(
         if (string.IsNullOrWhiteSpace(source.Url))
             throw new InvalidOperationException($"Prefix source '{source.Name}': Kind=http requires a Url.");
 
-        var http = httpFactory.CreateClient(ClientName);
+        var http = httpFactory.CreateClient(clientName ?? ClientName);
 
         // Per-source timeout: link the caller's token with a CancelAfter so a slow source can't pin
         // the fetch past its budget — now ALWAYS armed (#324): a configured Timeout wins, otherwise

--- a/BGPLite.Providers/PrefixService.cs
+++ b/BGPLite.Providers/PrefixService.cs
@@ -21,13 +21,14 @@ public sealed class PrefixService : IPrefixService
     private readonly ILogger<PrefixService>? _logger;
     private readonly TimeProvider _timeProvider;
     private readonly UserSourceCache _userSourceCache;
+    private readonly IPrefixSourceProvider _userSourceHttpProvider;
     // #229: gate serializing the RU/default-prefix cache-miss fetch path. The RU set is a single
     // shared cache (unlike the per-ASN _cache), so a single SemaphoreSlim is enough — it prevents a
     // thundering herd of N concurrent sessions from all re-fetching the ~11k-prefix default list
     // when the TTL elapses. Mirrors the per-ASN gate pattern in GetPrefixesAsync.
     private readonly SemaphoreSlim _ruGate = new(1, 1);
 
-    public PrefixService(AppConfig config, RipeStatPrefixCache ripeStatCache, IPrefixSourceService prefixSources, HttpPrefixProvider httpProvider, TimeSpan? ruCacheTtl = null, ILogger<PrefixService>? logger = null, TimeProvider? timeProvider = null, int? userSourceTimeoutSeconds = null, Func<string, Task>? onSourceChanged = null)
+    public PrefixService(AppConfig config, RipeStatPrefixCache ripeStatCache, IPrefixSourceService prefixSources, HttpPrefixProvider httpProvider, TimeSpan? ruCacheTtl = null, ILogger<PrefixService>? logger = null, TimeProvider? timeProvider = null, int? userSourceTimeoutSeconds = null, Func<string, Task>? onSourceChanged = null, IPrefixSourceProvider? userSourceHttpProvider = null)
     {
         _config = config;
         _ripeStatCache = ripeStatCache;
@@ -44,6 +45,10 @@ public sealed class PrefixService : IPrefixService
         // #416: convergence push for default-source changes detected on the RU path. Fired AFTER
         // _ruGate.Release() in GetRuPrefixesAsync — never while the gate is held.
         _onSourceChanged = onSourceChanged;
+        // #425: the peer-supplied user-source path uses its OWN http provider (the retry-only
+        // pipeline) so peer-controlled failures cannot open the breaker gating operator sources;
+        // falls back to the operator provider when not wired (tests).
+        _userSourceHttpProvider = userSourceHttpProvider ?? httpProvider;
     }
 
     /// <summary>Default per-fetch budget for peer-supplied URL sources (#320).</summary>
@@ -80,7 +85,7 @@ public sealed class PrefixService : IPrefixService
         };
         var prefixes = await _userSourceCache.GetOrLoadAsync(url, name, async ct =>
         {
-            var result = await _httpProvider.LoadAsync(source, ct: ct);
+            var result = await _userSourceHttpProvider.LoadAsync(source, ct: ct);
             return result.Prefixes;   // provider-native IpPrefix list
         }, ct);
         return ToContract(prefixes);

--- a/BGPLite.Tests/HttpPrefixProviderTests.cs
+++ b/BGPLite.Tests/HttpPrefixProviderTests.cs
@@ -21,6 +21,8 @@ public class HttpPrefixProviderTests
             _body = body;
         }
 
+        public StubHandler() : this(HttpStatusCode.OK, "10.0.0.0/8\n") { }
+
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
         {
             LastRequestUri = request.RequestUri;
@@ -33,6 +35,7 @@ public class HttpPrefixProviderTests
         private readonly HttpMessageHandler _handler;
         private readonly string? _defaultUserAgent;
         public HttpClient? LastClient { get; private set; }
+        public string LastName { get; private set; } = "";
         public StubFactory(HttpMessageHandler handler, string? defaultUserAgent = null)
         {
             _handler = handler;
@@ -40,6 +43,7 @@ public class HttpPrefixProviderTests
         }
         public HttpClient CreateClient(string name)
         {
+            LastName = name;
             LastClient = new HttpClient(_handler, disposeHandler: false);
             if (_defaultUserAgent is not null)
                 LastClient.DefaultRequestHeaders.UserAgent.ParseAdd(_defaultUserAgent);
@@ -78,6 +82,31 @@ public class HttpPrefixProviderTests
         var provider = Provider(new StubHandler(HttpStatusCode.OK, "1.2.3.0/24\n5.6.0.0/16\n"));
         var result = await provider.LoadAsync(HttpSource("https://raw.githubusercontent.com/o/r/main/x.txt"));
         Assert.Equal(2, result.Prefixes.Count);
+    }
+
+    [Fact]
+    public async Task LoadAsync_UsesTheClientNameFromTheCtor()
+    {
+        // #425: the user-source instance must draw its HttpClient from the retry-only named
+        // pipeline, never from the shared breaker pipeline the operator sources use.
+        var factory = new StubFactory(new StubHandler());
+        var provider = new HttpPrefixProvider(
+            factory, NullLogger<HttpPrefixProvider>.Instance, clientName: HttpPrefixProvider.UserSourceClientName);
+
+        await provider.LoadAsync(HttpSource("https://example.com/u.txt"));
+
+        Assert.Equal(HttpPrefixProvider.UserSourceClientName, factory.LastName);
+    }
+
+    [Fact]
+    public async Task LoadAsync_DefaultsToTheOperatorClientName()
+    {
+        var factory = new StubFactory(new StubHandler());
+        var provider = new HttpPrefixProvider(factory, NullLogger<HttpPrefixProvider>.Instance);
+
+        await provider.LoadAsync(HttpSource("https://example.com/o.txt"));
+
+        Assert.Equal(HttpPrefixProvider.ClientName, factory.LastName);
     }
 
     [Fact]

--- a/BGPLite.Tests/PrefixServiceTests.cs
+++ b/BGPLite.Tests/PrefixServiceTests.cs
@@ -635,6 +635,46 @@ public class PrefixServiceTests
         Assert.Equal(1, handler.Calls);
     }
 
+    [Fact]
+    public async Task GetUserSourcePrefixesAsync_FetchesThroughTheUserSourceProvider()
+    {
+        // #425: the peer-supplied URL path must fetch through the user-source provider (the
+        // retry-only pipeline), never through the operator provider whose breaker it could open.
+        var operatorProvider = new StubHttpSourceProvider();
+        var userSource = new StubHttpSourceProvider();
+        var service = new PrefixService(
+            new AppConfig(),
+            null!, // RipeStatPrefixCache is not on the user-source path
+            null!, // IPrefixSourceService is not on the user-source path
+            new HttpPrefixProvider(new ThrowingOperatorFactory(), NullLogger<HttpPrefixProvider>.Instance),
+            userSourceHttpProvider: userSource);
+
+        var prefixes = await service.GetUserSourcePrefixesAsync("u", "https://example.com/u.txt", null);
+
+        Assert.NotEmpty(prefixes);
+        Assert.Equal(1, userSource.Calls);
+    }
+
+    private sealed class StubHttpSourceProvider : IPrefixSourceProvider
+    {
+        public string Kind => "http";
+        public bool SupportsConditionalRequests => false;
+        public int Calls { get; private set; }
+
+        public Task<SourceLoadResult> LoadAsync(PrefixSourceConfig source, string? etag = null, DateTimeOffset? lastModified = null, CancellationToken ct = default)
+        {
+            Calls++;
+            return Task.FromResult(SourceLoadResult.Ok(new List<IpPrefix> { new(0x0A000000u, 8) }));
+        }
+    }
+
+    /// <summary>Any touch of the operator pipeline fails the test loudly (#425).</summary>
+    private sealed class ThrowingOperatorFactory : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => throw new NotSupportedException(
+            "the user-source path must not touch the operator client pipeline");
+    }
+
     /// <summary>
     /// #324: a config source that hangs must not wedge sequential seeding — LoadAllAsync awaits
     /// sources one by one, so before the default budget one dripping source stalled every later

--- a/BGPLite/Program.cs
+++ b/BGPLite/Program.cs
@@ -95,14 +95,7 @@ builder.Services.AddSingleton(new BgpMetrics());
 // Prefix sources (file / HTTP / ...) resolved by Kind via a provider factory,
 // with an in-memory TTL cache. Add a new loader by implementing IPrefixSourceProvider
 // and registering it here.
-builder.Services.AddHttpClient(HttpPrefixProvider.ClientName, c =>
-{
-    // HttpClient.Timeout MUST be InfiniteTimeSpan when a Polly resilience pipeline is attached —
-    // otherwise the client's own timeout fires prematurely across retries and cancels the whole
-    // pipeline (CodeRabbit #177). The per-attempt timeout is enforced by the pipeline's AddTimeout.
-    c.Timeout = Timeout.InfiniteTimeSpan;
-    c.DefaultRequestHeaders.UserAgent.ParseAdd("BGPLite/1.0");
-})
+builder.Services.AddHttpClient(HttpPrefixProvider.ClientName, ConfigureHttpSourceClient)
 .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
 {
     // SSRF defense (#144): validate DNS resolution at the socket level — no TOCTOU race (every
@@ -118,6 +111,41 @@ builder.Services.AddHttpClient(HttpPrefixProvider.ClientName, c =>
 // with exponential backoff + jitter, plus a circuit breaker. A transient blip on a prefix-source
 // fetch previously returned 0 prefixes for that source until the next refresh; now it is retried.
 .AddResilienceHandler("http-prefix-source", ConfigureDefaultHttpResilience);
+
+// #425: peer-supplied user-source URLs get their OWN named client — retry WITHOUT a circuit
+// breaker. The shared breaker coupled peer-controlled failure rates to operator sources: a few
+// blackholed user URLs opened the shared breaker and suppressed every operator source fetch for
+// 30s windows. Handler, SSRF gate and body cap are identical to the operator client.
+builder.Services.AddHttpClient(HttpPrefixProvider.UserSourceClientName, ConfigureHttpSourceClient)
+.ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
+{
+    ConnectCallback = PrefixSourceUrlValidator.CreateValidatedConnectionAsync,
+    AllowAutoRedirect = false
+})
+.AddResilienceHandler("http-user-source", pipelineBuilder => pipelineBuilder.AddRetry(new HttpRetryStrategyOptions
+{
+    MaxRetryAttempts = 2,
+    Delay = TimeSpan.FromMilliseconds(500),
+    MaxDelay = TimeSpan.FromSeconds(2),
+}));
+
+// #425: the user-source provider instance wired with the retry-only client, keyed so the
+// operator registrations above are untouched.
+builder.Services.AddKeyedSingleton<IPrefixSourceProvider>(HttpPrefixProvider.UserSourceClientName,
+    (sp, _) => new HttpPrefixProvider(
+        sp.GetRequiredService<IHttpClientFactory>(),
+        sp.GetRequiredService<ILogger<HttpPrefixProvider>>(),
+        clientName: HttpPrefixProvider.UserSourceClientName));
+
+static void ConfigureHttpSourceClient(HttpClient c)
+{
+    // HttpClient.Timeout MUST be InfiniteTimeSpan when a Polly resilience pipeline is attached —
+    // otherwise the client's own timeout fires prematurely across retries and cancels the whole
+    // pipeline (CodeRabbit #177). Per-attempt/per-source budgets are enforced downstream (#324).
+    c.Timeout = Timeout.InfiniteTimeSpan;
+    c.DefaultRequestHeaders.UserAgent.ParseAdd("BGPLite/1.0");
+}
+
 builder.Services.AddSingleton<HttpPrefixProvider>();
 builder.Services.AddSingleton<FilePrefixProvider>();
 builder.Services.AddSingleton<IPrefixSourceProvider>(sp => sp.GetRequiredService<HttpPrefixProvider>());
@@ -191,7 +219,10 @@ builder.Services.AddSingleton<IPrefixService>(sp =>
         onSourceChanged: async name =>
         {
             await sp.GetRequiredService<ISessionManager>().RefreshAllEstablishedAsync();
-        });
+        },
+        // #425: the peer-supplied user-source path uses the retry-only client so its failures
+        // cannot open the circuit breaker gating operator sources.
+        userSourceHttpProvider: sp.GetRequiredKeyedService<IPrefixSourceProvider>(HttpPrefixProvider.UserSourceClientName));
 });
 
 // #263: the BGP send path's dependencies are registered explicitly and resolved with


### PR DESCRIPTION
Closes #425

## Problem
A single resilience pipeline (retry + circuit breaker: 10 failures / 0.5 ratio / 30s open) sat on the shared `"http"` named client serving BOTH operator-configured `PrefixSources` and peer-supplied user URLs. A handful of peers pointing user sources at blackholed IPs generated repeated failures; the shared breaker opened and every operator source fetch failed fast with `BrokenCircuitException` for 30s windows — fleet-wide suppression of source updates driven entirely by peer-controlled input.

## Fix
- New named client `http-user-source` with a **retry-only** pipeline (same retry shape as the operator pipeline, no breaker); the SSRF `ConnectCallback` handler, no-redirect policy, 10MB body cap and per-fetch budget are identical.
- `HttpPrefixProvider` gains an optional `clientName`; the composition root registers a keyed user-source instance.
- `PrefixService` gains an optional `userSourceHttpProvider` and routes `GetUserSourcePrefixesAsync` through it (operator provider untouched, falls back for tests).

## Regression Test
- `HttpPrefixProviderTests`: client-name routing — user-source instance uses `http-user-source`, default stays `http` (name recorded by the stub factory).
- `PrefixServiceTests.GetUserSourcePrefixesAsync_FetchesThroughTheUserSourceProvider` — the user-source path fetches through the injected provider while the operator pipeline is a **throwing** factory (any wrong touch fails the test).

## Verification
- dotnet format / dotnet build (0 errors) / dotnet test — full suite green (delta +3 tests).

## RFC
- none.

## Behavior Change
- Peer-URL failures can no longer suppress operator source fetches via the shared breaker (the point of the fix). Operator sources keep retry+breaker; user sources retry without a breaker — bounded instead by the per-fetch budget (#320) and negative caching.

## Deviation from Issue Proposal
- None (the issue's "separate named clients" option).