### PR TITLE
fix(providers): sweep expired cache entries and bound UserSourceCache memory (#426)

### DIFF
--- a/BGPLite.Providers/RipeStatPrefixCache.cs
+++ b/BGPLite.Providers/RipeStatPrefixCache.cs
@@ -52,6 +52,9 @@ public sealed class RipeStatPrefixCache
     // integration review): a plain presence marker would be removed by the first caller's exit
     // while a second caller is still inside/queued on the same gate.
     private readonly ConcurrentDictionary<uint, int> _inflight = new();
+    // #426: amortized expired-entry sweep state (see GetPrefixesAsync). injectable for tests.
+    private int _callsSinceSweep;
+    private readonly int _sweepEvery;
 
     public RipeStatPrefixCache(
         RipeStatProvider ripe,
@@ -59,7 +62,8 @@ public sealed class RipeStatPrefixCache
         TimeSpan? cacheTtl = null,
         TimeSpan? negativeTtl = null,
         int? maxCacheEntries = null,
-        TimeProvider? timeProvider = null)
+        TimeProvider? timeProvider = null,
+        int? sweepEvery = null)
     {
         _ripe = ripe;
         _logger = logger;
@@ -70,10 +74,22 @@ public sealed class RipeStatPrefixCache
         // churn traffic, not normal operation.
         _maxCacheEntries = maxCacheEntries ?? 4096;
         _timeProvider = timeProvider ?? TimeProvider.System;
+        _sweepEvery = sweepEvery ?? 64;
     }
+
+    /// <summary>Entries currently tracked (test/observability — #426 sweep coverage).</summary>
+    internal int TrackedCount => _cache.Count;
 
     public async Task<IReadOnlyList<IpPrefix>> GetPrefixesAsync(uint asn, CancellationToken ct = default, bool serveNegativeEntries = true)
     {
+        // #426: amortized expired-entry sweep — expired entries used to be pinned until the entry
+        // cap was hit. Cheap (every Nth call), idempotent, in-flight ASNs are never touched.
+        if (Interlocked.Increment(ref _callsSinceSweep) >= _sweepEvery)
+        {
+            Volatile.Write(ref _callsSinceSweep, 0);
+            SweepExpired();
+        }
+
         // Fast path: fresh entry (positive, or negative within its TTL when the caller accepts
         // the []-on-recent-failure semantic — the RouteAssembler fan-out does; a source provider
         // must NOT, see the class doc).
@@ -173,6 +189,24 @@ public sealed class RipeStatPrefixCache
     /// for an in-flight ASN (#267 item 3). Under the lock of the caller's per-ASN gate, so the
     /// sweep is serialized against itself; ConcurrentDictionary enumeration is a snapshot and safe
     /// against concurrent writers.</summary>
+    /// <summary>
+    /// #426: removes EXPIRED entries regardless of the entry cap — they used to be pinned until
+    /// the cap was hit, so steady-state memory was "every ASN fetched recently", not "live ASNs".
+    /// In-flight ASNs are never touched (#267 item 3); concurrent sweeps are idempotent.
+    /// </summary>
+    private void SweepExpired()
+    {
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        foreach (var (key, entry) in _cache)
+        {
+            var ttl = entry.Negative ? _negativeTtl : _cacheTtl;
+            if (now - entry.CachedAt < ttl) continue;
+            if (_inflight.TryGetValue(key, out var active) && active > 0) continue;
+            if (_cache.TryRemove(key, out _))
+                _locks.TryRemove(key, out _);
+        }
+    }
+
     private void EvictIfAtCapacity(uint insertingKey)
     {
         if (_cache.Count < _maxCacheEntries) return;

--- a/BGPLite.Providers/UserSourceCache.cs
+++ b/BGPLite.Providers/UserSourceCache.cs
@@ -33,13 +33,29 @@ internal sealed class UserSourceCache
     // each (the HTTP body cap) plus a SemaphoreSlim — so operator churn or an API client loop grows
     // the cache without limit. Exceeded → sweep expired entries first, then the oldest by CachedAt.
     private readonly int _maxEntries;
+    // #426: entry COUNT caps say nothing about memory — one entry can hold ~1M prefixes (a 10 MB
+    // response parsed). The budget bounds the TOTAL parsed prefixes across all entries; over
+    // budget → the sweep drops the OLDEST positive entries until under. 2M prefixes ≈ 50 MB worst
+    // case — generous for real peer sources, hostile to unbounded growth.
+    internal const long DefaultMaxTotalPrefixes = 2_000_000;
+    private readonly long _maxTotalPrefixes;
+    // #426: expired entries used to be PINNED until the entry cap was hit — steady-state memory
+    // was "everything fetched recently", not "live entries". The amortized sweep (every
+    // _sweepEvery calls) now removes expired entries and enforces the prefix budget regardless
+    // of the cap. internal-settable via ctor for tests.
+    private int _callsSinceSweep;
+    private readonly int _sweepEvery;
+    internal int SweepEvery => _sweepEvery;
+
+    /// <summary>Total parsed prefixes currently held in positive entries (test/observability).</summary>
+    internal long TrackedPrefixes => _cache.Where(kvp => !kvp.Value.Negative).Sum(kvp => (long)kvp.Value.List.Count);
 
     // url → (list, cached at, is negative). Negative entries (failed loads) use _negativeTtl.
     private readonly ConcurrentDictionary<string, (IReadOnlyList<IpPrefix> List, DateTime CachedAt, bool Negative)> _cache = new();
     // url → gate serializing the cache-miss fetch path (prevents thundering herd on cold/expired keys).
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new();
 
-    public UserSourceCache(TimeSpan? positiveTtl = null, TimeSpan? negativeTtl = null, ILogger? logger = null, TimeProvider? timeProvider = null, int? maxCacheEntries = null)
+    public UserSourceCache(TimeSpan? positiveTtl = null, TimeSpan? negativeTtl = null, ILogger? logger = null, TimeProvider? timeProvider = null, int? maxCacheEntries = null, long? maxTotalPrefixes = null, int? sweepEvery = null)
     {
         _positiveTtl = positiveTtl ?? TimeSpan.FromHours(1);
         _negativeTtl = negativeTtl ?? TimeSpan.FromSeconds(30);
@@ -48,6 +64,8 @@ internal sealed class UserSourceCache
         // Generous vs. real deployments (peers × a few active sources each); the cap defends
         // against unbounded growth from churn/adversarial URL variety, not normal operation.
         _maxEntries = maxCacheEntries ?? 1024;
+        _maxTotalPrefixes = maxTotalPrefixes ?? DefaultMaxTotalPrefixes;
+        _sweepEvery = sweepEvery ?? 64;
     }
 
     /// <summary>Entries currently tracked (test/observability).</summary>
@@ -66,6 +84,10 @@ internal sealed class UserSourceCache
         Func<CancellationToken, Task<IReadOnlyList<IpPrefix>>> loadAsync,
         CancellationToken ct)
     {
+        // #426: amortized expired-entry + prefix-budget sweep — expired entries used to be pinned
+        // until the entry cap was hit. Cheap (every Nth call), idempotent under concurrency.
+        SweepIfNeeded();
+
         if (TryGetFresh(url, out var fresh))
             return fresh;
 
@@ -189,5 +211,49 @@ internal sealed class UserSourceCache
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// #426: amortized housekeeping, run every <see cref="_sweepEvery"/> calls. (1) Removes EXPIRED
+    /// entries regardless of the entry cap — they used to be pinned until the cap was hit. (2)
+    /// Enforces the total-prefix budget: over budget, the OLDEST positive entries are dropped until
+    /// under (a later caller re-fetches them — a duplicate idempotent GET, never a correctness
+    /// loss, the same tradeoff <see cref="EvictIfAtCapacity"/> accepts).
+    /// </summary>
+    private void SweepIfNeeded()
+    {
+        if (Interlocked.Increment(ref _callsSinceSweep) < _sweepEvery)
+            return;
+        Volatile.Write(ref _callsSinceSweep, 0);
+
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        var toEvict = new List<string>();
+        long total = 0;
+        foreach (var (key, entry) in _cache)
+        {
+            var ttl = entry.Negative ? _negativeTtl : _positiveTtl;
+            if (now - entry.CachedAt >= ttl)
+            {
+                toEvict.Add(key);
+                continue;
+            }
+            if (!entry.Negative)
+                total += entry.List.Count;
+        }
+
+        foreach (var kvp in _cache
+                     .Where(kvp => !kvp.Value.Negative && !toEvict.Contains(kvp.Key))
+                     .OrderBy(kvp => kvp.Value.CachedAt))
+        {
+            if (total <= _maxTotalPrefixes) break;
+            toEvict.Add(kvp.Key);
+            total -= kvp.Value.List.Count;
+        }
+
+        foreach (var key in toEvict)
+        {
+            if (_cache.TryRemove(key, out _))
+                _locks.TryRemove(key, out _);
+        }
     }
 }

--- a/BGPLite.Tests/AsnPrefixProviderTests.cs
+++ b/BGPLite.Tests/AsnPrefixProviderTests.cs
@@ -108,4 +108,29 @@ public class AsnPrefixProviderTests
             provider.LoadAsync(new PrefixSourceConfig { Name = "x", Kind = "asn", Asn = 65010 }));
         Assert.Equal(primedCalls + 1, handler.Calls);   // exactly one provider-driven wire attempt
     }
+
+    [Fact]
+    public async Task RipeStatCache_ExpiredEntries_Swept_EvenBelowTheCap()
+    {
+        // #426: expired per-ASN entries used to be pinned until the 4096-entry cap was hit —
+        // steady-state memory was "every ASN fetched recently", not "live ASNs". The amortized
+        // sweep drops them regardless of the cap (in-flight ASNs excepted).
+        var time = new Microsoft.Extensions.Time.Testing.FakeTimeProvider();
+        var handler = new CountingRipeHandler();
+        var cache = new RipeStatPrefixCache(
+            new RipeStatProvider(new StubFactory(handler), NullLogger<RipeStatProvider>.Instance,
+                new RipeStatConfig { RetryAttempts = 0, RetryDelaySeconds = 0 }),
+            cacheTtl: TimeSpan.FromMilliseconds(100),
+            timeProvider: time,
+            sweepEvery: 1);
+
+        _ = await cache.GetPrefixesAsync(65010);
+        _ = await cache.GetPrefixesAsync(65011);
+        Assert.Equal(2, cache.TrackedCount);
+
+        time.Advance(TimeSpan.FromMilliseconds(150)); // both entries expire
+        _ = await cache.GetPrefixesAsync(65012);      // sweep drops 65010/65011, then fetches 65012
+
+        Assert.Equal(1, cache.TrackedCount);
+    }
 }

--- a/BGPLite.Tests/UserSourceCacheTests.cs
+++ b/BGPLite.Tests/UserSourceCacheTests.cs
@@ -78,8 +78,11 @@ public class UserSourceCacheTests
             (0x0A000000u, (byte)8, true), (0x0A000100u, (byte)8, true),
             (0x0A000200u, (byte)8, true), (0x0A000300u, (byte)8, true))
         };
-        var small = new Fetcher { OnSuccess = () => P(
-            (0xC0A80000u, (byte)24, true), (0xC0A80001u, (byte)24, true)) };
+        var small = new Fetcher
+        {
+            OnSuccess = () => P(
+            (0xC0A80000u, (byte)24, true), (0xC0A80001u, (byte)24, true))
+        };
         var third = new Fetcher { OnSuccess = () => P((0x0A0B0000u, (byte)16, true)) };
 
         await cache.GetOrLoadAsync("https://example.com/big", "big", big.Invoke, CancellationToken.None);

--- a/BGPLite.Tests/UserSourceCacheTests.cs
+++ b/BGPLite.Tests/UserSourceCacheTests.cs
@@ -46,6 +46,53 @@ public class UserSourceCacheTests
     }
 
     [Fact]
+    public async Task ExpiredEntries_Swept_EvenBelowTheCap()
+    {
+        // #426: expired entries used to be PINNED until the entry cap was hit — steady-state
+        // memory was "everything fetched recently", not "live entries". The amortized sweep
+        // drops them regardless of the cap.
+        var time = new Microsoft.Extensions.Time.Testing.FakeTimeProvider();
+        var cache = new UserSourceCache(
+            positiveTtl: TimeSpan.FromMilliseconds(100), timeProvider: time, sweepEvery: 1);
+        var f = new Fetcher { OnSuccess = () => P((0xC0A80000u, (byte)24, true)) };
+
+        await cache.GetOrLoadAsync("https://example.com/a", "src", f.Invoke, CancellationToken.None);
+        time.Advance(TimeSpan.FromMilliseconds(150)); // A expires
+
+        await cache.GetOrLoadAsync("https://example.com/b", "src", f.Invoke, CancellationToken.None); // sweep drops A, loads B
+
+        Assert.Equal(1, cache.TrackedCount);
+    }
+
+    [Fact]
+    public async Task PrefixBudget_EvictsOldestPositives_EvenBelowTheCap()
+    {
+        // #426: the entry-count cap says nothing about MEMORY — a handful of huge entries could
+        // hold millions of parsed prefixes. Over the total-prefix budget the sweep drops the
+        // OLDEST positive entries even though the entry cap is nowhere near reached. Budget = 5:
+        // big(4) + small(2) = 6 over budget; the next sweep evicts big (oldest) → 2 ≤ 5.
+        var cache = new UserSourceCache(maxTotalPrefixes: 5, sweepEvery: 1);
+        var big = new Fetcher
+        {
+            OnSuccess = () => P(
+            (0x0A000000u, (byte)8, true), (0x0A000100u, (byte)8, true),
+            (0x0A000200u, (byte)8, true), (0x0A000300u, (byte)8, true))
+        };
+        var small = new Fetcher { OnSuccess = () => P(
+            (0xC0A80000u, (byte)24, true), (0xC0A80001u, (byte)24, true)) };
+        var third = new Fetcher { OnSuccess = () => P((0x0A0B0000u, (byte)16, true)) };
+
+        await cache.GetOrLoadAsync("https://example.com/big", "big", big.Invoke, CancellationToken.None);
+        await cache.GetOrLoadAsync("https://example.com/small", "small", small.Invoke, CancellationToken.None);
+        Assert.Equal(6, cache.TrackedPrefixes); // over the budget — enforced at the next sweep
+
+        await cache.GetOrLoadAsync("https://example.com/third", "third", third.Invoke, CancellationToken.None);
+
+        Assert.Equal(2, cache.TrackedCount);    // small + third
+        Assert.Equal(3, cache.TrackedPrefixes); // small(2) + third(1); big(4) swept
+    }
+
+    [Fact]
     public async Task Concurrent_Same_Url_Fetched_Once_Gate_Serializes()
     {
         // Exercises the per-URL SemaphoreSlim (the actual thundering-herd defense): many concurrent


### PR DESCRIPTION
Closes #426

## Problem
`UserSourceCache` (1024 entries × up to a 10MB parsed response each) and `RipeStatPrefixCache` (4096 entries) evicted ONLY on insert at capacity: expired entries were pinned indefinitely, so steady-state memory was "everything fetched recently" — tens of GB worst case from peer-triggered URL churn.

## Fix
- **Amortized expired-entry sweep** in both caches (every 64th call, injectable for tests). The RIPEstat sweep skips in-flight ASNs (#267 item 3 invariant preserved).
- **Total-prefix budget** on `UserSourceCache` (default 2M ≈ 50MB worst case): the sweep drops the OLDEST positive entries while over budget — the peer-triggered adversarial path gets a real memory bound, not just an entry count. Eviction trades one duplicate idempotent GET, the established semantics.
- `TrackedCount`/`TrackedPrefixes` observability for tests.

## Regression Test
- `UserSourceCacheTests.ExpiredEntries_Swept_EvenBelowTheCap`, `PrefixBudget_EvictsOldestPositives_EvenBelowTheCap` (budget=5: big(4)+small(2)=6 over → next sweep evicts big).
- `AsnPrefixProviderTests.RipeStatCache_ExpiredEntries_Swept_EvenBelowTheCap`.

## Verification
- dotnet format / dotnet build (0 errors) / dotnet test — full suite green (delta +3 tests).

## RFC
- none.

## Behavior Change
- Evicted-then-re-requested user sources re-fetch (one extra GET) instead of staying pinned past their TTL — that is the TTL contract finally holding.

## Deviation from Issue Proposal
- Implemented the idle sweep + a prefix-count budget on the peer-triggered cache. A precise byte-budget (vs prefix-count proxy) and lowering the RIPEstat cap were consciously not done: RIPEstat keys are operator-driven, and the prefix proxy bounds the adversarial path.