### PR TITLE
fix(api): evict idle rate-limiter partitions instead of growing forever (#423)

### DIFF
--- a/BGPLite.Api/ClientIpRateLimiter.cs
+++ b/BGPLite.Api/ClientIpRateLimiter.cs
@@ -1,0 +1,135 @@
+using System.Collections.Concurrent;
+using System.Threading.RateLimiting;
+using BGPLite.Configuration;
+
+namespace BGPLite.Api;
+
+/// <summary>
+/// Per-client-IP token-bucket rate limiter with IDLE-PARTITION EVICTION (#423).
+/// <para>
+/// System.Threading.RateLimiting's <c>PartitionedRateLimiter</c> has no idle eviction: every
+/// client IP ever seen held its bucket (and its AutoReplenishment timer) for the process lifetime —
+/// unbounded growth on a long-lived deployment, and with <c>Api.TrustXRealIp</c> the partition key
+/// is client-controlled (rotating <c>X-Real-IP</c> minted fresh buckets per request, both defeating
+/// the limit and growing the partition table). This registry keeps one
+/// <see cref="TokenBucketRateLimiter"/> per IP, stamps last-access on every acquire, and —
+/// amortized, every <see cref="SweepEvery"/> acquires — removes and disposes partitions idle for
+/// longer than the threshold (default: 20 replenishment periods, floor 5 minutes).
+/// </para>
+/// <para>
+/// A request racing a sweep's dispose gets a fresh bucket (the acquire retries once) — a rare
+/// request loses its refill state, never correctness. 429/deny semantics, queue-free, are
+/// identical to the <c>PartitionedRateLimiter</c> this replaces (#116).
+/// </para>
+/// </summary>
+internal sealed class ClientIpRateLimiter : IDisposable, IAsyncDisposable
+{
+    internal const int DefaultSweepEvery = 64;
+    private static readonly TimeSpan MinIdleThreshold = TimeSpan.FromMinutes(5);
+
+    private readonly ConcurrentDictionary<string, (TokenBucketRateLimiter Limiter, long LastAccessTicks)> _partitions = new();
+    private readonly TokenBucketRateLimiterOptions _options;
+    private readonly TimeProvider _timeProvider;
+    private readonly TimeSpan _idleThreshold;
+    private readonly int _sweepEvery;
+    private int _acquiresSinceSweep;
+
+    public ClientIpRateLimiter(
+        ApiRateLimitConfig cfg,
+        TimeProvider? timeProvider = null,
+        TimeSpan? idleThreshold = null,
+        int? sweepEvery = null)
+    {
+        _options = new TokenBucketRateLimiterOptions
+        {
+            TokenLimit = Math.Max(1, cfg.TokenLimit),
+            TokensPerPeriod = Math.Max(1, cfg.TokensPerPeriod),
+            ReplenishmentPeriod = TimeSpan.FromSeconds(Math.Max(1, cfg.PeriodSeconds)),
+            QueueLimit = 0,         // deny immediately (429) when no tokens — never queue
+            AutoReplenishment = true
+        };
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _idleThreshold = idleThreshold ?? TimeSpan.FromTicks(Math.Max(MinIdleThreshold.Ticks, 20 * _options.ReplenishmentPeriod.Ticks));
+        _sweepEvery = sweepEvery ?? DefaultSweepEvery;
+    }
+
+    /// <summary>Partitions currently tracked (test/observability — eviction coverage).</summary>
+    internal int TrackedCount => _partitions.Count;
+
+    public ValueTask<RateLimitLease> AcquireAsync(string clientIp)
+    {
+        // #423: amortized idle-partition eviction — see the class doc.
+        if (Interlocked.Increment(ref _acquiresSinceSweep) >= _sweepEvery)
+        {
+            Volatile.Write(ref _acquiresSinceSweep, 0);
+            SweepIdle();
+        }
+
+        var limiter = GetOrAdd(clientIp);
+        RateLimitLease lease;
+        try
+        {
+            lease = limiter.AttemptAcquire();
+        }
+        catch (ObjectDisposedException)
+        {
+            // Lost a race with the eviction sweep's Dispose: mint a fresh bucket and retry once.
+            // Narrow and benign — the request sees an unfilled bucket instead of failing.
+            limiter = new TokenBucketRateLimiter(_options);
+            _partitions[clientIp] = (limiter, Stamp());
+            lease = limiter.AttemptAcquire();
+        }
+
+        return ValueTask.FromResult(lease);
+    }
+
+    private TokenBucketRateLimiter GetOrAdd(string clientIp)
+    {
+        var now = Stamp();
+        while (true)
+        {
+            if (_partitions.TryGetValue(clientIp, out var existing))
+            {
+                // Touch last-access; the limiter reference is unchanged, so the tuple write is
+                // safe even against a concurrent sweep (compare-remove either wins before the
+                // touch — the request retries on a fresh bucket — or loses and the touch keeps
+                // the partition alive).
+                _partitions[clientIp] = (existing.Limiter, now);
+                return existing.Limiter;
+            }
+
+            var created = new TokenBucketRateLimiter(_options);
+            if (_partitions.TryAdd(clientIp, (created, now)))
+                return created;
+            created.Dispose(); // lost the first-insert race — dispose the spare (no timer leak)
+        }
+    }
+
+    private void SweepIdle()
+    {
+        var now = Stamp();
+        foreach (var (key, entry) in _partitions)
+        {
+            if (now - entry.LastAccessTicks < _idleThreshold.Ticks) continue;
+            // Compare-remove: an entry touched since the snapshot is kept (the pair no longer
+            // matches), so an active partition is never disposed mid-request.
+            if (_partitions.TryRemove(new KeyValuePair<string, (TokenBucketRateLimiter, long)>(key, entry)))
+                entry.Limiter.Dispose();
+        }
+    }
+
+    private long Stamp() => _timeProvider.GetUtcNow().UtcDateTime.Ticks;
+
+    public void Dispose()
+    {
+        foreach (var (_, entry) in _partitions)
+            entry.Limiter.Dispose();
+        _partitions.Clear();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Dispose();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -24,7 +24,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
     // them into locals (Volatile.Read) so a reload mid-request cannot observe a half-swapped set.
     private AppConfig _config;
     private IReadOnlyList<IPNetwork> _trustedProxyNetworks;
-    private PartitionedRateLimiter<string>? _rateLimiter;
+    private ClientIpRateLimiter? _rateLimiter;
     private ConcurrencyLimiter? _concurrencyLimiter;
     // #330: limiters swapped out by ApplyConfig, disposed in StopAsync/Dispose after in-flight
     // requests have drained — a retired TokenBucketRateLimiter with AutoReplenishment roots a
@@ -1748,22 +1748,15 @@ public sealed class ManagementApi : IHostedService, IDisposable
     /// <summary>
     /// Builds the per-client-IP token-bucket rate limiter for the management API (#116). Each distinct
     /// resolved client IP (see <see cref="GetClientIp"/>) gets its own token bucket; a request is
-    /// rejected with 429 once its bucket is exhausted. Tunable via <see cref="ApiRateLimitConfig"/>; the
+    /// rejected with 429 once the resolved client's token bucket is drained. Tunable via <see cref="ApiRateLimitConfig"/>; the
     /// limiter is only created when the operator opts in (ApiRateLimit section present + Enabled).
-    /// Extracted as a pure factory for unit tests.
+    /// Extracted as a pure factory for unit tests. #423: the registry evicts idle IP partitions —
+    /// <see cref="PartitionedRateLimiter"/> kept every IP ever seen (and its replenishment timer)
+    /// for the process lifetime.
     /// </summary>
-    internal static PartitionedRateLimiter<string> CreateRateLimiter(ApiRateLimitConfig cfg)
+    internal static ClientIpRateLimiter CreateRateLimiter(ApiRateLimitConfig cfg)
     {
-        var options = new TokenBucketRateLimiterOptions
-        {
-            TokenLimit = Math.Max(1, cfg.TokenLimit),
-            TokensPerPeriod = Math.Max(1, cfg.TokensPerPeriod),
-            ReplenishmentPeriod = TimeSpan.FromSeconds(Math.Max(1, cfg.PeriodSeconds)),
-            QueueLimit = 0,         // deny immediately (429) when no tokens — never queue
-            AutoReplenishment = true
-        };
-        return PartitionedRateLimiter.Create<string, string>(
-            ip => RateLimitPartition.GetTokenBucketLimiter(ip, _ => options));
+        return new ClientIpRateLimiter(cfg);
     }
 
     /// <summary>

--- a/BGPLite.Tests/ApiRateLimiterTests.cs
+++ b/BGPLite.Tests/ApiRateLimiterTests.cs
@@ -17,7 +17,7 @@ public class ApiRateLimiterTests
         PeriodSeconds = periodSeconds
     };
 
-    private static async Task<bool> TryAcquire(PartitionedRateLimiter<string> limiter, string ip)
+    private static async Task<bool> TryAcquire(ClientIpRateLimiter limiter, string ip)
     {
         using var lease = await limiter.AcquireAsync(ip); // RateLimitLease is IDisposable, not IAsyncDisposable
         return lease.IsAcquired;
@@ -39,5 +39,42 @@ public class ApiRateLimiterTests
         Assert.True(await TryAcquire(limiter, "198.51.100.1"));
         Assert.True(await TryAcquire(limiter, "198.51.100.2")); // separate bucket — still allowed
         Assert.False(await TryAcquire(limiter, "198.51.100.1")); // first IP's bucket exhausted
+    }
+
+    [Fact]
+    public async Task IdlePartitions_AreEvicted_ByTheAmortizedSweep()
+    {
+        // #423: PartitionedRateLimiter kept every IP ever seen (and its replenishment timer) for
+        // the process lifetime — with TrustXRealIp the key is client-controlled, so rotating the
+        // header minted fresh buckets without bound. Idle partitions must be evicted.
+        var time = new Microsoft.Extensions.Time.Testing.FakeTimeProvider();
+        await using var limiter = new ClientIpRateLimiter(
+            Cfg(10, 10, 60), timeProvider: time, idleThreshold: TimeSpan.FromSeconds(30), sweepEvery: 1);
+
+        await TryAcquire(limiter, "198.51.100.1");
+        await TryAcquire(limiter, "198.51.100.2");
+        Assert.Equal(2, limiter.TrackedCount);
+
+        time.Advance(TimeSpan.FromSeconds(31));    // both idle past the threshold
+        await TryAcquire(limiter, "198.51.100.3"); // the sweep evicts .1/.2, then mints .3
+
+        Assert.Equal(1, limiter.TrackedCount);
+    }
+
+    [Fact]
+    public async Task ActivePartition_SurvivesTheSweep()
+    {
+        var time = new Microsoft.Extensions.Time.Testing.FakeTimeProvider();
+        await using var limiter = new ClientIpRateLimiter(
+            Cfg(10, 10, 60), timeProvider: time, idleThreshold: TimeSpan.FromSeconds(30), sweepEvery: 1);
+
+        await TryAcquire(limiter, "198.51.100.1");
+        for (var i = 0; i < 5; i++)
+        {
+            time.Advance(TimeSpan.FromSeconds(10)); // under the idle threshold at every touch
+            await TryAcquire(limiter, "198.51.100.1");
+        }
+
+        Assert.Equal(1, limiter.TrackedCount);
     }
 }


### PR DESCRIPTION
Closes #423

## Problem
`CreateRateLimiter` built a `PartitionedRateLimiter` with a lazily-created `TokenBucketRateLimiter` per distinct client IP. System.Threading.RateLimiting has no idle-partition eviction: every IP ever seen (even one rejected request) held its partition and its AutoReplenishment timer for the process lifetime — unbounded growth on a long-lived deployment. Sharper: with `Api.TrustXRealIp` and a pass-through proxy, the partition key comes from the attacker-supplied `X-Real-IP` header — rotating the header per request both defeats the rate limit entirely (fresh bucket each time) and grows the partition table without bound.

## Fix
New `ClientIpRateLimiter` (replaces the `PartitionedRateLimiter`): one `TokenBucketRateLimiter` per IP with last-access stamps; an amortized sweep (every 64th acquire) removes and **disposes** partitions idle past a threshold (default: 20 replenishment periods, floor 5 min). Races handled by construction: compare-remove keeps a touched partition alive, and a request that raced a dispose retries once on a fresh bucket (loses refill state, never correctness). Bucket options, 429/no-queue semantics, opt-in gating, hot-reload parking, and the `HandleAsync` acquire flow are unchanged.

## Regression Test
`ApiRateLimiterTests` (FakeTimeProvider, injectable threshold/sweep):
- `IdlePartitions_AreEvicted_ByTheAmortizedSweep` — two stale partitions gone after the threshold, the fresh one kept.
- `ActivePartition_SurvivesTheSweep` — a partition touched every 10s of a 30s threshold is never evicted.
- The two original #116 tests (burst-then-429, per-IP independence) pass unchanged against the new registry.

## Verification
- dotnet format / dotnet build (0 errors) / dotnet test — full suite green (delta +2 tests).

## RFC
- none.

## Behavior Change
- Idle IPs lose their bucket state after the idle threshold — a returning IP starts from a refilled bucket. That is the correct semantic for a per-IP limiter (a minute-silent client is not the same threat as a continuous one); continuous abusers are unaffected.

## Deviation from Issue Proposal
- None (the issue's "registry with last-seen stamps + sweep, reusing the retired-limiter drain machinery" option).