### PR TITLE
fix(server): record the send mirror only after a batch reaches the wire (#430)

### DIFF
--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -1301,21 +1301,26 @@ public sealed class BgpSession : IDisposable
         var attrCache = UpdateCodec.CreateUpdateAttributeCache();
         var v6AttrCache = UpdateCodec.CreateV6UpdateAttributeCache();
 
+        // #430: build-then-commit — a batch's prefixes are recorded in _advertisedPrefixes only
+        // AFTER its UPDATE serialized and hit the wire. A send that throws (e.g. a composed
+        // UPDATE over the 4096-byte maximum) leaves the mirror exactly matching reality: a later
+        // WithdrawAllAsync no longer sends withdrawals for prefixes that were never announced.
         foreach (var route in v4Routes)
         {
             batch.Add(route);
-            _advertisedPrefixes.Add(new IpPrefix(route.Prefix, route.PrefixLength, route.IsIpv4));
-            if (batch.Count >= maxNlriPerUpdate)
-            {
-                await SendRouteBatchAsync(nextHop, batch, attrCache);
-                sent += batch.Count;
-                batch.Clear();
-            }
+            if (batch.Count < maxNlriPerUpdate) continue;
+            await SendRouteBatchAsync(nextHop, batch, attrCache);
+            foreach (var sent_route in batch)
+                _advertisedPrefixes.Add(new IpPrefix(sent_route.Prefix, sent_route.PrefixLength, sent_route.IsIpv4));
+            sent += batch.Count;
+            batch.Clear();
         }
 
         if (batch.Count > 0)
         {
             await SendRouteBatchAsync(nextHop, batch, attrCache);
+            foreach (var sent_route in batch)
+                _advertisedPrefixes.Add(new IpPrefix(sent_route.Prefix, sent_route.PrefixLength, sent_route.IsIpv4));
             sent += batch.Count;
         }
 
@@ -1324,18 +1329,19 @@ public sealed class BgpSession : IDisposable
         foreach (var route in v6Routes)
         {
             batch.Add(route);
-            _advertisedPrefixes.Add(new IpPrefix(route.Prefix, route.PrefixLength, route.IsIpv4));
-            if (batch.Count >= maxNlriPerUpdate)
-            {
-                await SendV6RouteBatchAsync(v6NextHop, batch, v6AttrCache);
-                sent += batch.Count;
-                batch.Clear();
-            }
+            if (batch.Count < maxNlriPerUpdate) continue;
+            await SendV6RouteBatchAsync(v6NextHop, batch, v6AttrCache);
+            foreach (var sent_route in batch)
+                _advertisedPrefixes.Add(new IpPrefix(sent_route.Prefix, sent_route.PrefixLength, sent_route.IsIpv4));
+            sent += batch.Count;
+            batch.Clear();
         }
 
         if (batch.Count > 0)
         {
             await SendV6RouteBatchAsync(v6NextHop, batch, v6AttrCache);
+            foreach (var sent_route in batch)
+                _advertisedPrefixes.Add(new IpPrefix(sent_route.Prefix, sent_route.PrefixLength, sent_route.IsIpv4));
             sent += batch.Count;
         }
 

--- a/BGPLite.Tests/BgpSessionPhantomWithdrawalTests.cs
+++ b/BGPLite.Tests/BgpSessionPhantomWithdrawalTests.cs
@@ -1,0 +1,119 @@
+using BGPLite.Configuration;
+using BGPLite.Contracts;
+using BGPLite.Protocol;
+using BGPLite.Routing;
+using BGPLite.Server;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #430: the send mirror (<c>_advertisedPrefixes</c>) recorded a batch BEFORE its UPDATE was
+/// serialized. A batch whose composed UPDATE exceeded the 4096-byte maximum (constructible from
+/// a peer-supplied route carrying ~1200 communities) threw out of the writer AFTER the mirror
+/// already claimed the routes — so the NEXT refresh sent WITHDRAWALS for prefixes that were never
+/// announced. Build-then-commit keeps the mirror equal to what is actually on the wire.
+/// </summary>
+public sealed class BgpSessionPhantomWithdrawalTests
+{
+    private static Route PoisonRoute() => new()
+    {
+        Prefix = 0x0A010000,        // 10.1.0.0/16
+        PrefixLength = 16,
+        NextHop = 1,
+        // 1200 communities → a COMMUNITY attribute of ~4800 bytes → the composed UPDATE (NLRI +
+        // ORIGIN + AS_PATH + NEXT_HOP + COMMUNITY) exceeds MaxMessageSize and the writer refuses it.
+        Communities = Enumerable.Range(0, 1200).Select(i => (uint)i).ToArray()
+    };
+
+    private static async Task<(BgpSession Session, Task Run, ScriptedConnection Conn)> EstablishAsync(RouteTable routeTable)
+    {
+        var conn = new ScriptedConnection();
+        var session = new BgpSession(
+            conn,
+            new PeerConfig { Address = "127.0.0.1" },
+            new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 },
+            routeTable,
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            NullLogger<BgpSession>.Instance);
+
+        var run = session.RunAsync();
+        conn.EnqueueMessage(new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = 0,
+            RouterId = 0x0A000002,
+            Capabilities = [BgpCapabilityInfo.FourOctetAsn(65002)]
+        });
+        conn.EnqueueMessage(BgpKeepaliveMessage.Instance);
+
+        for (var i = 0; i < 200 && !session.IsEstablished; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        Assert.True(session.IsEstablished, "session must reach Established");
+        return (session, run, conn);
+    }
+
+    private static int CountUpdates(ScriptedConnection conn) =>
+        conn.Sent.Select(f => BgpMessageReader.ReadMessage(f)).OfType<BgpUpdateMessage>().Count();
+
+    [Fact]
+    public async Task FailedOversizeSend_DoesNotLeavePhantomMirrorEntries()
+    {
+        var routeTable = new RouteTable();
+        routeTable.AddOrUpdate(new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 1 }); // healthy seed
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        // Healthy refresh #1: the /8 is advertised normally.
+        await session.RefreshRoutesAsync();
+
+        // Inject the poison route and refresh: the composed UPDATE exceeds MaxMessageSize, the
+        // writer throws mid-send, and RefreshCycleAsync contains the failure (session stays up).
+        routeTable.AddOrUpdate(PoisonRoute());
+        await session.RefreshRoutesAsync();
+
+        var updatesBefore = CountUpdates(conn);
+
+        // Healthy refresh #2: WithdrawAllAsync must withdraw ONLY what is actually on the wire —
+        // pre-#430 the mirror also held the POISON route (recorded before the failed send), so
+        // this refresh put a PHANTOM withdrawal for 10.1.0.0/16 on the wire. The healthy /8's
+        // withdraw+re-announce may legitimately appear again.
+        await session.RefreshRoutesAsync();
+        await Task.Delay(TimeSpan.FromMilliseconds(100));
+
+        Assert.True(session.IsEstablished, "the oversize send is contained — the session stays up");
+        var updatesAfter = conn.Sent
+            .Skip(updatesBefore)
+            .Select(f => BgpMessageReader.ReadMessage(f))
+            .OfType<BgpUpdateMessage>()
+            .ToList();
+        Assert.DoesNotContain(updatesAfter,
+            u => u.WithdrawnRoutes.Any(p => p.Address == 0x0A010000 && p.Length == 16));
+
+        session.Dispose();
+        try { await run.WaitAsync(TimeSpan.FromSeconds(2)); } catch (TimeoutException) { }
+    }
+
+    [Fact]
+    public async Task HealthySend_MirrorMatchesTheWire()
+    {
+        // Control: on a normal send the mirror (observable via a later withdrawal) still matches
+        // the wire — the reorder must not break the withdraw-what-we-advertised contract.
+        var routeTable = new RouteTable();
+        routeTable.AddOrUpdate(new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 1 });
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        await session.RefreshRoutesAsync();                       // advertises the /8
+        routeTable.Remove(0x0A000000, 8);                         // source disappears
+        await session.RefreshRoutesAsync();                       // withdraws the /8
+
+        var updates = conn.Sent.Select(f => BgpMessageReader.ReadMessage(f)).OfType<BgpUpdateMessage>().ToList();
+        Assert.Contains(updates, u => u.Nlri.Any(p => p.Address == 0x0A000000 && p.Length == 8));
+        var withdrawal = updates.LastOrDefault(u => u.WithdrawnRoutes.Any(p => p.Address == 0x0A000000));
+        Assert.NotNull(withdrawal);
+
+        session.Dispose();
+        try { await run.WaitAsync(TimeSpan.FromSeconds(2)); } catch (TimeoutException) { }
+    }
+}


### PR DESCRIPTION
Closes #430

## Problem
`SendRoutesAsync` appended each batch's prefixes to `_advertisedPrefixes` **before** serializing the batch. A composed UPDATE exceeding `MaxMessageSize` (a peer-supplied route carrying ~1200 communities reaches it) threw out of `BgpMessageWriter` **after** the mirror had claimed the routes — a later `WithdrawAllAsync` then put PHANTOM withdrawal frames for never-announced prefixes on the wire, and `AdvertisedPrefixCount` diverged from reality.

## Root Cause
Commit ordering: the mirror was mutated before the send could fail, with no rollback on the failure path.

## Fix
Build-then-commit: each 100-NLRI batch (and the tail batch, v4 and v6 loops alike) is recorded into `_advertisedPrefixes` only after `SendRouteBatchAsync`/`SendV6RouteBatchAsync` completed. A failed send leaves the mirror exactly matching the wire; healthy batches sent before the failure are still recorded.

## Correctness
- The withdraw-what-we-advertised contract is preserved and pinned (control test: advertise → withdraw round-trip unchanged).
- Batches are ≤100 NLRI ≈ ≤500 bytes of NLRI plus attributes, so splitting never triggers the writer guard for normal traffic — the guard now only fires on genuinely oversized community sets, where failing loudly (into RefreshCycleAsync's contained catch) is the intended behavior.

## Regression Test
`BgpSessionPhantomWithdrawalTests` (real session, SharedTableRouteAssembler, scripted wire):
- `FailedOversizeSend_DoesNotLeavePhantomMirrorEntries` — a 1200-community poison route fails the send; the NEXT refresh puts **no phantom withdrawal for 10.1.0.0/16** on the wire. **Red/green proven**: reverting the mirror order fails the test (phantom withdrawal observed).
- `HealthySend_MirrorMatchesTheWire` — the advertise → withdraw contract still holds through the reorder.

## Verification
- dotnet format / dotnet build (0 errors) / dotnet test — full suite green (delta +2 tests).

## RFC
- none — internal mirror/wire consistency (RFC 4271 §9.2 adjacency semantics respected).

## Behavior Change
- After a failed oversize send, subsequent refreshes no longer emit withdrawals for routes that never reached the wire.

## Deviation from Issue Proposal
- None (build-then-commit, the issue's fix shape).