### PR TITLE
chore: integrate dev — external audit fixes #416–#431 (16 issues)

### DIFF
--- a/BGPLite.Api/ClientIpRateLimiter.cs
+++ b/BGPLite.Api/ClientIpRateLimiter.cs
@@ -1,0 +1,135 @@
+using System.Collections.Concurrent;
+using System.Threading.RateLimiting;
+using BGPLite.Configuration;
+
+namespace BGPLite.Api;
+
+/// <summary>
+/// Per-client-IP token-bucket rate limiter with IDLE-PARTITION EVICTION (#423).
+/// <para>
+/// System.Threading.RateLimiting's <c>PartitionedRateLimiter</c> has no idle eviction: every
+/// client IP ever seen held its bucket (and its AutoReplenishment timer) for the process lifetime —
+/// unbounded growth on a long-lived deployment, and with <c>Api.TrustXRealIp</c> the partition key
+/// is client-controlled (rotating <c>X-Real-IP</c> minted fresh buckets per request, both defeating
+/// the limit and growing the partition table). This registry keeps one
+/// <see cref="TokenBucketRateLimiter"/> per IP, stamps last-access on every acquire, and —
+/// amortized, every <see cref="SweepEvery"/> acquires — removes and disposes partitions idle for
+/// longer than the threshold (default: 20 replenishment periods, floor 5 minutes).
+/// </para>
+/// <para>
+/// A request racing a sweep's dispose gets a fresh bucket (the acquire retries once) — a rare
+/// request loses its refill state, never correctness. 429/deny semantics, queue-free, are
+/// identical to the <c>PartitionedRateLimiter</c> this replaces (#116).
+/// </para>
+/// </summary>
+internal sealed class ClientIpRateLimiter : IDisposable, IAsyncDisposable
+{
+    internal const int DefaultSweepEvery = 64;
+    private static readonly TimeSpan MinIdleThreshold = TimeSpan.FromMinutes(5);
+
+    private readonly ConcurrentDictionary<string, (TokenBucketRateLimiter Limiter, long LastAccessTicks)> _partitions = new();
+    private readonly TokenBucketRateLimiterOptions _options;
+    private readonly TimeProvider _timeProvider;
+    private readonly TimeSpan _idleThreshold;
+    private readonly int _sweepEvery;
+    private int _acquiresSinceSweep;
+
+    public ClientIpRateLimiter(
+        ApiRateLimitConfig cfg,
+        TimeProvider? timeProvider = null,
+        TimeSpan? idleThreshold = null,
+        int? sweepEvery = null)
+    {
+        _options = new TokenBucketRateLimiterOptions
+        {
+            TokenLimit = Math.Max(1, cfg.TokenLimit),
+            TokensPerPeriod = Math.Max(1, cfg.TokensPerPeriod),
+            ReplenishmentPeriod = TimeSpan.FromSeconds(Math.Max(1, cfg.PeriodSeconds)),
+            QueueLimit = 0,         // deny immediately (429) when no tokens — never queue
+            AutoReplenishment = true
+        };
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _idleThreshold = idleThreshold ?? TimeSpan.FromTicks(Math.Max(MinIdleThreshold.Ticks, 20 * _options.ReplenishmentPeriod.Ticks));
+        _sweepEvery = sweepEvery ?? DefaultSweepEvery;
+    }
+
+    /// <summary>Partitions currently tracked (test/observability — eviction coverage).</summary>
+    internal int TrackedCount => _partitions.Count;
+
+    public ValueTask<RateLimitLease> AcquireAsync(string clientIp)
+    {
+        // #423: amortized idle-partition eviction — see the class doc.
+        if (Interlocked.Increment(ref _acquiresSinceSweep) >= _sweepEvery)
+        {
+            Volatile.Write(ref _acquiresSinceSweep, 0);
+            SweepIdle();
+        }
+
+        var limiter = GetOrAdd(clientIp);
+        RateLimitLease lease;
+        try
+        {
+            lease = limiter.AttemptAcquire();
+        }
+        catch (ObjectDisposedException)
+        {
+            // Lost a race with the eviction sweep's Dispose: mint a fresh bucket and retry once.
+            // Narrow and benign — the request sees an unfilled bucket instead of failing.
+            limiter = new TokenBucketRateLimiter(_options);
+            _partitions[clientIp] = (limiter, Stamp());
+            lease = limiter.AttemptAcquire();
+        }
+
+        return ValueTask.FromResult(lease);
+    }
+
+    private TokenBucketRateLimiter GetOrAdd(string clientIp)
+    {
+        var now = Stamp();
+        while (true)
+        {
+            if (_partitions.TryGetValue(clientIp, out var existing))
+            {
+                // Touch last-access; the limiter reference is unchanged, so the tuple write is
+                // safe even against a concurrent sweep (compare-remove either wins before the
+                // touch — the request retries on a fresh bucket — or loses and the touch keeps
+                // the partition alive).
+                _partitions[clientIp] = (existing.Limiter, now);
+                return existing.Limiter;
+            }
+
+            var created = new TokenBucketRateLimiter(_options);
+            if (_partitions.TryAdd(clientIp, (created, now)))
+                return created;
+            created.Dispose(); // lost the first-insert race — dispose the spare (no timer leak)
+        }
+    }
+
+    private void SweepIdle()
+    {
+        var now = Stamp();
+        foreach (var (key, entry) in _partitions)
+        {
+            if (now - entry.LastAccessTicks < _idleThreshold.Ticks) continue;
+            // Compare-remove: an entry touched since the snapshot is kept (the pair no longer
+            // matches), so an active partition is never disposed mid-request.
+            if (_partitions.TryRemove(new KeyValuePair<string, (TokenBucketRateLimiter, long)>(key, entry)))
+                entry.Limiter.Dispose();
+        }
+    }
+
+    private long Stamp() => _timeProvider.GetUtcNow().UtcDateTime.Ticks;
+
+    public void Dispose()
+    {
+        foreach (var (_, entry) in _partitions)
+            entry.Limiter.Dispose();
+        _partitions.Clear();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Dispose();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/BGPLite.Api/ClientIpRateLimiter.cs
+++ b/BGPLite.Api/ClientIpRateLimiter.cs
@@ -73,10 +73,10 @@ internal sealed class ClientIpRateLimiter : IDisposable, IAsyncDisposable
         }
         catch (ObjectDisposedException)
         {
-            // Lost a race with the eviction sweep's Dispose: mint a fresh bucket and retry once.
-            // Narrow and benign — the request sees an unfilled bucket instead of failing.
-            limiter = new TokenBucketRateLimiter(_options);
-            _partitions[clientIp] = (limiter, Stamp());
+            // Lost a race with the eviction sweep's Dispose (CodeRabbit on #450): the sweep
+            // removed the dead partition, so re-read via GetOrAdd — this mints a fresh bucket
+            // WITHOUT blindly overwriting whatever a concurrent request may have installed.
+            limiter = GetOrAdd(clientIp);
             lease = limiter.AttemptAcquire();
         }
 
@@ -90,12 +90,13 @@ internal sealed class ClientIpRateLimiter : IDisposable, IAsyncDisposable
         {
             if (_partitions.TryGetValue(clientIp, out var existing))
             {
-                // Touch last-access; the limiter reference is unchanged, so the tuple write is
-                // safe even against a concurrent sweep (compare-remove either wins before the
-                // touch — the request retries on a fresh bucket — or loses and the touch keeps
-                // the partition alive).
-                _partitions[clientIp] = (existing.Limiter, now);
-                return existing.Limiter;
+                // Touch last-access CONDITIONALLY (CodeRabbit on #450): a sweep may have removed
+                // and disposed this partition between the read and the write — a blind indexer
+                // write would resurrect the disposed limiter. TryUpdate succeeds only against
+                // the exact tuple read; on failure the loop re-reads (or mints a fresh bucket).
+                if (_partitions.TryUpdate(clientIp, (existing.Limiter, now), existing))
+                    return existing.Limiter;
+                continue;
             }
 
             var created = new TokenBucketRateLimiter(_options);

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -1555,8 +1555,11 @@ public sealed class ManagementApi : IHostedService, IDisposable
     /// <c>ToString()</c> collapses all of them onto the form the BGP path will look for.
     /// </para>
     /// <para>
-    /// IPv6 is rejected rather than mapped: BGPLite is IPv4-unicast only (#14 tracks the rest), so
-    /// <c>::ffff:1.2.3.4</c> would produce a peer no session can match.
+    /// Both families are accepted (#14 phase 5): a peer may be an IPv6 host. Addresses no BGP
+    /// session can ever originate from — unspecified, loopback, multicast, and the IPv4 broadcast
+    /// address — are rejected (#421), the API-side parity of the YAML path's fail-loud validation
+    /// (#390): such rows can never match a session, and a multicast row would even arm a kernel
+    /// TCP-MD5 entry.
     /// </para>
     /// </summary>
     internal static string? NormalizePeerIp(string? ip)
@@ -1567,9 +1570,29 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // plain IPv4 form so the row matches the address form the dual-mode listener reports.
         if (address.IsIPv4MappedToIPv6)
             address = address.MapToIPv4();
-        // Both families are accepted (#14 phase 5): a peer may be an IPv6 host; the canonical
-        // ToString form matches what the accept loop stores.
+        if (IsNonPeerAddress(address))
+            return null;
+        // The canonical ToString form matches what the accept loop stores.
         return address.ToString();
+    }
+
+    /// <summary>
+    /// The unspecified, loopback, multicast and (IPv4) broadcast addresses — unusable as a peer
+    /// identity. internal static for unit tests.
+    /// </summary>
+    internal static bool IsNonPeerAddress(IPAddress address)
+    {
+        if (address.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork)
+        {
+            var b = address.GetAddressBytes();
+            return b[0] == 0                                                 // 0.0.0.0/8 — unspecified / current-network
+                || b[0] == 127                                               // 127/8 — loopback
+                || (b[0] & 0xF0) == 0xE0                                     // 224/4 — multicast
+                || (b[0] == 255 && b[1] == 255 && b[2] == 255 && b[3] == 255); // broadcast
+        }
+        return IPAddress.IPv6Any.Equals(address)
+            || IPAddress.IPv6Loopback.Equals(address)
+            || address.IsIPv6Multicast;
     }
 
     /// <summary>

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -1107,9 +1107,29 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         _logger.LogInformation("Updated peer {Id}", SanitizeForLog(peerId));
 
-        _ = _sessionManager.RefreshPeerAsync(peer.Ip, peer.Asn ?? 0);
+        RequestPeerRefresh(peerId, peer);
 
         return await HandleGetPeer(peerId);
+    }
+
+    /// <summary>
+    /// Fire-and-forget per-peer refresh after a config change. A NULL-Asn row (legacy Ip-only era)
+    /// cannot match any live session by (Ip, Asn) — no session ever has RemoteAsn 0 (#300) — so
+    /// the refresh is skipped with a warning instead of the confusing "no session for {Ip} AS0"
+    /// the old <c>asn ?? 0</c> produced (#422).
+    /// </summary>
+    private void RequestPeerRefresh(string peerId, Peer peer)
+    {
+        if (peer.Asn.HasValue)
+        {
+            _ = _sessionManager.RefreshPeerAsync(peer.Ip, peer.Asn.Value);
+        }
+        else
+        {
+            _logger.LogWarning(
+                "Peer row {Id} at {Ip} has NULL Asn — refresh skipped (no (Ip, Asn) session match is possible)",
+                SanitizeForLog(peerId), peer.Ip);
+        }
     }
 
     internal async Task<ApiResponse> HandleDeletePeer(string peerId)
@@ -1126,7 +1146,21 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // send-timeout backstop) from pinning the DELETE request; the session is disposed even
         // when the Cease send is cancelled.
         using var bound = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        await _sessionManager.TerminatePeerAsync(peer.Ip, peer.Asn ?? 0, bound.Token);
+        if (peer.Asn.HasValue)
+        {
+            await _sessionManager.TerminatePeerAsync(peer.Ip, peer.Asn.Value, bound.Token);
+        }
+        else
+        {
+            // #422: a NULL-Asn row (legacy Ip-only era) cannot be matched by (Ip, Asn) — no live
+            // session ever has RemoteAsn 0 (AS 0 OPENs are rejected, #300) — so the pre-#422
+            // `asn ?? 0` teardown was a SILENT no-op and the session kept advertising a deleted
+            // peer. Terminate by IP instead, and say so in the log.
+            _logger.LogWarning(
+                "Deleting peer row {Id} at {Ip} with NULL Asn — terminating ALL its sessions by IP",
+                SanitizeForLog(peerId), peer.Ip);
+            await _sessionManager.TerminatePeerByIpAsync(peer.Ip, bound.Token);
+        }
 
         await _store.DeletePeerAsync(peerId);
 
@@ -1211,7 +1245,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         // Trigger refresh so the peer receives the new source's prefixes immediately —
         // same pattern as CreatePeer/UpdatePeer. Pass ASN so shared-IP peers aren't refreshed (#200).
-        _ = _sessionManager.RefreshPeerAsync(peer.Ip, peer.Asn ?? 0);
+        RequestPeerRefresh(peerId, peer);
 
         _logger.LogInformation("Added source '{Name}' ({Url}) to peer {PeerId}",
             SanitizeForLog(data.Name), SanitizeForLog(data.Url), SanitizeForLog(peerId));
@@ -1228,7 +1262,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
             return ApiResponse.Error($"Source '{sourceId}' not found", 404);
 
         // Trigger refresh so the source's prefixes are withdrawn immediately (#200: ASN-scoped).
-        _ = _sessionManager.RefreshPeerAsync(peer.Ip, peer.Asn ?? 0);
+        RequestPeerRefresh(peerId, peer);
 
         _logger.LogInformation("Deleted source {SourceId} from peer {PeerId}", SanitizeForLog(sourceId), SanitizeForLog(peerId));
         return ApiResponse.Ok(new { id = sourceId, deleted = true });
@@ -1251,7 +1285,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
             return ApiResponse.Error($"Source '{sourceId}' not found", 404);
 
         // Trigger refresh so toggling active/inactive takes effect immediately (#200: ASN-scoped).
-        _ = _sessionManager.RefreshPeerAsync(peer.Ip, peer.Asn ?? 0);
+        RequestPeerRefresh(peerId, peer);
 
         _logger.LogInformation("Source {SourceId} active={Active}", SanitizeForLog(sourceId), data.Active.Value);
         return ApiResponse.Ok(new { id = sourceId, active = data.Active.Value });

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -241,20 +241,48 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // before this runs is the only unprotected moment (documented in #36).
         var md5Bootstrapped = 0;
         // TCP keys by source IP: if two peer rows share an IP with DIFFERENT keys, the last one
-        // would win non-deterministically — sort for determinism and warn (values never logged).
+        // would win non-deterministically — the shared resolver sorts for determinism and warns
+        // (values never logged). #418: the same resolver re-arms the key on delete/PATCH so the
+        // runtime behavior cannot drift from this bootstrap.
         foreach (var group in (await _store.GetPeerMd5CredentialsAsync(cancellationToken))
                      .GroupBy(c => c.Ip).OrderBy(g => g.Key, StringComparer.Ordinal))
         {
-            var creds = group.OrderBy(c => c.Md5Password, StringComparer.Ordinal).ToList();
-            if (creds.Select(c => c.Md5Password).Distinct().Count() > 1)
-                _logger.LogWarning(
-                    "TCP-MD5: {Count} peer rows on source IP {Ip} configure DIFFERENT keys — TCP-MD5 keys by IP, so one key applies to all of them (peers: {Peers})",
-                    creds.Count, group.Key, string.Join(", ", creds.Select(c => c.Ip)));
-            _sessionManager.SetPeerMd5Key(group.Key, creds[0].Md5Password);
+            var key = ResolveSharedIpKey(group.Key, [.. group]);
+            if (key is null) continue;
+            _sessionManager.SetPeerMd5Key(group.Key, key);
             md5Bootstrapped++;
         }
         if (md5Bootstrapped > 0)
             _logger.LogInformation("TCP-MD5 armed for {Count} peer(s)", md5Bootstrapped);
+    }
+
+    /// <summary>
+    /// Resolves the ONE TCP-MD5 key a source IP's surviving peer rows must share (#36 — TCP keys
+    /// by address, not by (IP, ASN)). Deterministic ordinal pick among the rows, with the same
+    /// warning the startup bootstrap emits when siblings declare DIFFERENT keys; null when no
+    /// surviving row carries a key (#418).
+    /// </summary>
+    private string? ResolveSharedIpKey(string ip, IReadOnlyList<(string Ip, string Md5Password)> rows)
+    {
+        if (rows.Count == 0) return null;
+        var creds = rows.OrderBy(c => c.Md5Password, StringComparer.Ordinal).ToList();
+        if (creds.Select(c => c.Md5Password).Distinct().Count() > 1)
+            _logger.LogWarning(
+                "TCP-MD5: {Count} peer rows on source IP {Ip} configure DIFFERENT keys — TCP-MD5 keys by IP, so one key applies to all of them (peers: {Peers})",
+                creds.Count, ip, string.Join(", ", creds.Select(c => c.Ip)));
+        return creds[0].Md5Password;
+    }
+
+    /// <summary>
+    /// Re-arms the per-IP TCP-MD5 key from the SURVIVING peer rows (#418): deleting a peer or
+    /// clearing its password must fall back to a sibling's key on the same source IP, and setting
+    /// a new one must leave the whole-IP state consistent with the store. The pre-#418 behavior
+    /// armed/unarmed from the single edited row, silently disarming (or overriding) siblings.
+    /// </summary>
+    internal async Task RearmPeerIpMd5KeyAsync(string ip)
+    {
+        var remaining = await _store.GetPeerMd5CredentialsForIpAsync(ip);
+        _sessionManager.SetPeerMd5Key(ip, ResolveSharedIpKey(ip, remaining));
     }
 
     public async Task StopAsync(CancellationToken cancellationToken)
@@ -1070,10 +1098,11 @@ public sealed class ManagementApi : IHostedService, IDisposable
             md5Password: data.Md5Password);
         if (data.Md5Password is not null)
         {
-            // The peer row carries the source IP the key is attached to.
+            // #418: re-arm from ALL surviving rows for this IP — clearing this peer's key must
+            // fall back to a sibling's, not silently disarm the address for every peer on it.
             var md5Peer = await _store.GetDbPeerByIdAsync(peerId);
             if (md5Peer is not null)
-                _sessionManager.SetPeerMd5Key(md5Peer.Ip, md5Peer.Md5Password);
+                await RearmPeerIpMd5KeyAsync(md5Peer.Ip);
         }
 
         _logger.LogInformation("Updated peer {Id}", SanitizeForLog(peerId));
@@ -1101,9 +1130,10 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         await _store.DeletePeerAsync(peerId);
 
-        // #36: disarm the deleted peer's TCP-MD5 key. Uses the row loaded BEFORE the delete —
-        // a post-delete re-read always returned null (CodeRabbit on #398).
-        _sessionManager.SetPeerMd5Key(peer.Ip, null);
+        // #36 + #418: re-arm the IP's TCP-MD5 key from the SURVIVING rows — deleting one sibling
+        // must not disarm TCP-MD5 for the other peers sharing the source IP (pre-#418 this was an
+        // unconditional SetPeerMd5Key(ip, null)). No key left on the IP resolves to null (disarm).
+        await RearmPeerIpMd5KeyAsync(peer.Ip);
         _logger.LogInformation("Deleted peer {Id} ({Ip})", SanitizeForLog(peerId), peer.Ip);
         return ApiResponse.Ok(new { id = peerId, deleted = true });
     }

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -518,18 +518,24 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (ex is JsonException)
             return ("Malformed JSON body", 400);
 
-        // EF Core constraint violation. #266 item 8: distinguish the two SQLite constraint codes —
-        // 2067 (SQLITE_CONSTRAINT_UNIQUE, a concurrent duplicate insert) is a genuine 409, while
-        // 19 (SQLITE_CONSTRAINT, in practice an FK violation after a concurrent DELETE removed the
-        // parent peer row) must not answer "already exists" for a resource that is GONE.
+        // EF Core constraint violation. #266 item 8 + #377 review + #431: classify by the SQLite
+        // EXTENDED code — 787 (SQLITE_CONSTRAINT_FOREIGNKEY) is the concurrent-DELETE case (the
+        // resource is GONE, not duplicated), 2067 (SQLITE_CONSTRAINT_UNIQUE) is a genuine conflict,
+        // and everything else — NOT NULL (1299), CHECK (275), other constraint classes, or a
+        // non-SQLite DbUpdateException — is a server-side data/schema problem that must not be
+        // mislabeled "already exists" to the client (pre-#431 the whole remaining bucket was 409).
         if (ex is Microsoft.EntityFrameworkCore.DbUpdateException)
         {
-            // #377 review: BOTH constraint classes report primary code 19 in SqliteErrorCode;
-            // the discriminator is the EXTENDED code — 787 (SQLITE_CONSTRAINT_FOREIGNKEY) is the
-            // concurrent-DELETE case, anything else (2067 unique, 19 bare) is a genuine conflict.
-            if (ex.InnerException is Microsoft.Data.Sqlite.SqliteException sqlite && sqlite.SqliteExtendedErrorCode == 787)
-                return ("The peer was removed while the change was being applied", 404);
-            return ("The resource already exists or conflicts with the current state", 409);
+            if (ex.InnerException is Microsoft.Data.Sqlite.SqliteException sqlite)
+            {
+                return sqlite.SqliteExtendedErrorCode switch
+                {
+                    787 => ("The peer was removed while the change was being applied", 404),
+                    2067 => ("The resource already exists or conflicts with the current state", 409),
+                    _ => ("Internal server error", 500),
+                };
+            }
+            return ("Internal server error", 500);
         }
 
         // Anything else: generic message, full detail logged server-side.

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -24,7 +24,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
     // them into locals (Volatile.Read) so a reload mid-request cannot observe a half-swapped set.
     private AppConfig _config;
     private IReadOnlyList<IPNetwork> _trustedProxyNetworks;
-    private PartitionedRateLimiter<string>? _rateLimiter;
+    private ClientIpRateLimiter? _rateLimiter;
     private ConcurrencyLimiter? _concurrencyLimiter;
     // #330: limiters swapped out by ApplyConfig, disposed in StopAsync/Dispose after in-flight
     // requests have drained — a retired TokenBucketRateLimiter with AutoReplenishment roots a
@@ -1748,22 +1748,15 @@ public sealed class ManagementApi : IHostedService, IDisposable
     /// <summary>
     /// Builds the per-client-IP token-bucket rate limiter for the management API (#116). Each distinct
     /// resolved client IP (see <see cref="GetClientIp"/>) gets its own token bucket; a request is
-    /// rejected with 429 once its bucket is exhausted. Tunable via <see cref="ApiRateLimitConfig"/>; the
+    /// rejected with 429 once the resolved client's token bucket is drained. Tunable via <see cref="ApiRateLimitConfig"/>; the
     /// limiter is only created when the operator opts in (ApiRateLimit section present + Enabled).
-    /// Extracted as a pure factory for unit tests.
+    /// Extracted as a pure factory for unit tests. #423: the registry evicts idle IP partitions —
+    /// <see cref="PartitionedRateLimiter"/> kept every IP ever seen (and its replenishment timer)
+    /// for the process lifetime.
     /// </summary>
-    internal static PartitionedRateLimiter<string> CreateRateLimiter(ApiRateLimitConfig cfg)
+    internal static ClientIpRateLimiter CreateRateLimiter(ApiRateLimitConfig cfg)
     {
-        var options = new TokenBucketRateLimiterOptions
-        {
-            TokenLimit = Math.Max(1, cfg.TokenLimit),
-            TokensPerPeriod = Math.Max(1, cfg.TokensPerPeriod),
-            ReplenishmentPeriod = TimeSpan.FromSeconds(Math.Max(1, cfg.PeriodSeconds)),
-            QueueLimit = 0,         // deny immediately (429) when no tokens — never queue
-            AutoReplenishment = true
-        };
-        return PartitionedRateLimiter.Create<string, string>(
-            ip => RateLimitPartition.GetTokenBucketLimiter(ip, _ => options));
+        return new ClientIpRateLimiter(cfg);
     }
 
     /// <summary>

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -60,6 +60,14 @@ public sealed class ManagementApi : IHostedService, IDisposable
     /// </summary>
     private const int DefaultInflightCap = 64;
     private readonly SemaphoreSlim _inflightCap = new(DefaultInflightCap);
+    /// <summary>
+    /// #424: wall-clock budget for the GET endpoints that can trigger external fetches
+    /// (<c>/api/asn-lists</c>, <c>/api/peers/&#123;id&#125;/prefixes</c>). A cold RIPEstat fetch is
+    /// minutes-scale per ASN (180s timeout × retries), so N such GETs used to monopolize the
+    /// global in-flight cap and starve every other route for minutes. On expiry the handlers serve
+    /// their PARTIAL result with a warning; shutdown still propagates. internal settable for tests.
+    /// </summary>
+    internal TimeSpan ExternalFetchBudget { get; set; } = TimeSpan.FromSeconds(30);
     // #258: in-flight tracking is a COUNT plus an idle Task (completed whenever the count is 0),
     // not a List<Task> — the #248 design appended every handler and never removed it, so each
     // completed request leaked its Task (and its exception, if faulted) for the process lifetime
@@ -1307,7 +1315,22 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (peer is null)
             return ApiResponse.Error("Peer not found", 404);
 
-        var prefixes = await CollectPeerPrefixes(peerId, _shutdownCts.Token);
+        // #424: same wall-clock budget as /api/asn-lists — cold subscription fetches are
+        // minutes-scale and must not pin the request (and its in-flight slot) indefinitely.
+        using var budget = CancellationTokenSource.CreateLinkedTokenSource(_shutdownCts.Token);
+        budget.CancelAfter(ExternalFetchBudget);
+        List<string> prefixes;
+        try
+        {
+            prefixes = await CollectPeerPrefixes(peerId, budget.Token);
+        }
+        catch (OperationCanceledException) when (!_shutdownCts.IsCancellationRequested)
+        {
+            _logger.LogWarning(
+                "GET /api/peers/{Id}/prefixes exceeded the {Seconds:0}s external-fetch budget — serving a partial list",
+                SanitizeForLog(peerId), ExternalFetchBudget.TotalSeconds);
+            prefixes = [];
+        }
 
         var format = ctx.Request.QueryString["format"] ?? "txt";
         if (format == "json")
@@ -1339,7 +1362,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
                 foreach (var p in fetched)
                     prefixes.Add(new IpPrefix(p.Prefix, p.Length, p.IsIpv4).ToString());
             }
-            catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#337: only shutdown cancellation — a provider-timeout OCE (live token) is a fetch failure below
+            catch (OperationCanceledException) when (_shutdownCts.IsCancellationRequested) { throw; }  // #114/#337/#424: only SHUTDOWN propagates — budget expiry degrades to the partial list
             catch (Exception ex) { _logger.LogWarning(ex, "CollectPeerPrefixes: ASN fetch failed"); }
         }
 
@@ -1352,7 +1375,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
                 foreach (var p in ruPrefixes)
                     prefixes.Add(new IpPrefix(p.Prefix, p.Length, p.IsIpv4).ToString());
             }
-            catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#337: only shutdown cancellation — a provider-timeout OCE (live token) is a fetch failure below
+            catch (OperationCanceledException) when (_shutdownCts.IsCancellationRequested) { throw; }  // #114/#337/#424: see above
             catch (Exception ex) { _logger.LogWarning(ex, "CollectPeerPrefixes: RU prefix fetch failed"); }
         }
 
@@ -1369,7 +1392,12 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
     private async Task<ApiResponse> HandleGetAsnListsAsync()
     {
-        var ct = _shutdownCts.Token;
+        // #424: bound the whole handler — see ExternalFetchBudget. Shutdown still propagates;
+        // budget expiry degrades to the partial counts collected so far (each later fetch fails
+        // fast against the cancelled token) instead of pinning the request for minutes.
+        using var budget = CancellationTokenSource.CreateLinkedTokenSource(_shutdownCts.Token);
+        budget.CancelAfter(ExternalFetchBudget);
+        var ct = budget.Token;
         var lists = _config.RipeStat?.AsnLists ?? [];
         var result = new List<object>();
 
@@ -1381,14 +1409,14 @@ public sealed class ManagementApi : IHostedService, IDisposable
                 foreach (var asn in l.Asns)
                 {
                     try { prefixCount += await _prefixService.GetPrefixCountAsync(asn, ct); }
-                    catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#337: only shutdown cancellation — a provider-timeout OCE (live token) is a fetch failure below
+                    catch (OperationCanceledException) when (_shutdownCts.IsCancellationRequested) { throw; }  // #114/#337/#424: only SHUTDOWN propagates — the #424 fetch budget fires as OCE on a live shutdown token and degrades below
                     catch (Exception ex) { _logger.LogWarning(ex, "Failed to get prefix count for AS{Asn}", asn); }
                 }
             }
             else if (l.Country is not null)
             {
                 try { prefixCount = (await _prefixService.GetRuPrefixesAsync(ct)).Count; }
-                catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#337: only shutdown cancellation — a provider-timeout OCE (live token) is a fetch failure below
+                catch (OperationCanceledException) when (_shutdownCts.IsCancellationRequested) { throw; }  // #114/#337/#424: see above
                 catch (Exception ex) { _logger.LogWarning(ex, "Failed to get RU prefix count"); }
             }
 
@@ -1421,6 +1449,11 @@ public sealed class ManagementApi : IHostedService, IDisposable
                 type = source.Kind == "asn" ? "asn" : "list"
             });
         }
+
+        if (ct.IsCancellationRequested && !_shutdownCts.IsCancellationRequested)
+            _logger.LogWarning(
+                "GET /api/asn-lists exceeded the {Seconds:0}s external-fetch budget — serving partial prefix counts",
+                ExternalFetchBudget.TotalSeconds);
 
         return ApiResponse.Ok(result);
     }

--- a/BGPLite.Api/PeerStore.cs
+++ b/BGPLite.Api/PeerStore.cs
@@ -197,6 +197,21 @@ public sealed class PeerStore : IPeerStore
     }
 
     /// <summary>
+    /// Returns (Ip, Md5Password) for every peer row at ONE source IP that carries a TCP-MD5 key.
+    /// Used to re-arm the per-IP key after a delete/PATCH (#418): TCP keys by address (#36), so
+    /// deleting or clearing one sibling must fall back to a surviving row's key instead of
+    /// silently disarming every peer sharing the IP.
+    /// </summary>
+    public async Task<IReadOnlyList<(string Ip, string Md5Password)>> GetPeerMd5CredentialsForIpAsync(string ip, CancellationToken ct = default)
+    {
+        using var db = _dbFactory.CreateDbContext();
+        return await db.Peers.AsNoTracking()
+            .Where(p => p.Ip == ip && p.Md5Password != null && p.Md5Password != "")
+            .Select(p => new ValueTuple<string, string>(p.Ip, p.Md5Password!))
+            .ToListAsync(ct);
+    }
+
+    /// <summary>
     /// Single-roundtrip replacement for the <c>GetPeer</c> + <c>UpdateSessionStatus</c> +
     /// <c>GetSubscriptions</c> + <c>GetCustomPrefixes</c> + <c>GetCustomAsns</c> sequence the BGP
     /// send path used to issue as FIVE separate <c>DbContext</c>s (issue #84). Loads the peer by

--- a/BGPLite.Contracts/ISessionManager.cs
+++ b/BGPLite.Contracts/ISessionManager.cs
@@ -26,6 +26,15 @@ public interface ISessionManager
     Task TerminatePeerAsync(string peerIp, uint asn, CancellationToken ct = default);
 
     /// <summary>
+    /// Terminates all live BGP sessions arriving from ONE source IP, regardless of their ASN
+    /// (#422). The IP-only counterpart of <see cref="TerminatePeerAsync"/>: a deleted peer row
+    /// with a NULL Asn (legacy Ip-only era rows) cannot be matched by (Ip, Asn) — no live session
+    /// ever has RemoteAsn 0 — so without this the teardown was a silent no-op and the session kept
+    /// advertising a deleted peer. Same Cease + dispose semantics as <see cref="TerminatePeerAsync"/>.
+    /// </summary>
+    Task TerminatePeerByIpAsync(string peerIp, CancellationToken ct = default);
+
+    /// <summary>
     /// Sets or clears the TCP-MD5 (RFC 2385) shared key for a peer's source IP (#36). A password
     /// enables enforcement on the listening socket (unsigned segments from that peer are dropped
     /// by the kernel); null/empty disables it. Passwords are never logged.

--- a/BGPLite.Providers/HttpPrefixProvider.cs
+++ b/BGPLite.Providers/HttpPrefixProvider.cs
@@ -22,10 +22,19 @@ namespace BGPLite.Providers;
 public sealed class HttpPrefixProvider(
     IHttpClientFactory httpFactory,
     ILogger<HttpPrefixProvider> logger,
-    int defaultFetchTimeoutSeconds = 30) // mirrors DefaultFetchTimeoutSeconds (a ctor default cannot reference the member const)
+    int defaultFetchTimeoutSeconds = 30, // mirrors DefaultFetchTimeoutSeconds (a ctor default cannot reference the member const)
+    string? clientName = null) // #425: selects the resilience pipeline — see UserSourceClientName
     : IPrefixSourceProvider
 {
     public const string ClientName = "http";
+
+    /// <summary>
+    /// #425: the peer-supplied user-source path uses this named client — a retry WITHOUT a circuit
+    /// breaker. The shared breaker coupled peer-controlled failure rates to operator sources: a few
+    /// blackholed user URLs opened the shared breaker and suppressed every operator source fetch
+    /// for 30s windows. SSRF handler and body cap are identical for both pipelines.
+    /// </summary>
+    public const string UserSourceClientName = "http-user-source";
 
     /// <summary>Maximum response body size (10 MB) — defends against OOM from huge/malicious files (#144).</summary>
     internal const int MaxResponseBytes = 10 * 1024 * 1024;
@@ -53,7 +62,7 @@ public sealed class HttpPrefixProvider(
         if (string.IsNullOrWhiteSpace(source.Url))
             throw new InvalidOperationException($"Prefix source '{source.Name}': Kind=http requires a Url.");
 
-        var http = httpFactory.CreateClient(ClientName);
+        var http = httpFactory.CreateClient(clientName ?? ClientName);
 
         // Per-source timeout: link the caller's token with a CancelAfter so a slow source can't pin
         // the fetch past its budget — now ALWAYS armed (#324): a configured Timeout wins, otherwise

--- a/BGPLite.Providers/IPrefixSourceService.cs
+++ b/BGPLite.Providers/IPrefixSourceService.cs
@@ -19,6 +19,17 @@ public interface IPrefixSourceService
     /// <summary>The source named by <c>AppConfig.DefaultPrefixSource</c>. Empty list if unset/missing.</summary>
     Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default);
 
+    /// <summary>
+    /// #416: callback-free counterpart of <see cref="GetDefaultAsync"/> — loads the default source
+    /// and reports whether the content actually changed, but NEVER fires the
+    /// <c>onSourceChanged</c> convergence callback. Callers that invoke it while holding a lock
+    /// (the RU gate in <c>PrefixService.GetRuPrefixesAsync</c>) must own the push themselves and
+    /// fire it only AFTER releasing the lock: an inline callback that re-enters the RU path from
+    /// another session's build deadlocked on the caller-held gate (the gate holder awaited the
+    /// push, the push awaited the gate).
+    /// </summary>
+    Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default);
+
     /// <summary>Prime the in-memory cache for all sources.</summary>
     Task WarmUpAsync(CancellationToken ct = default);
 

--- a/BGPLite.Providers/IPrefixSourceService.cs
+++ b/BGPLite.Providers/IPrefixSourceService.cs
@@ -16,17 +16,21 @@ public interface IPrefixSourceService
     /// <summary>One source by name (cache-through). Empty list if missing or failed.</summary>
     Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default);
 
-    /// <summary>The source named by <c>AppConfig.DefaultPrefixSource</c>. Empty list if unset/missing.</summary>
-    Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default);
-
     /// <summary>
-    /// #416: callback-free counterpart of <see cref="GetDefaultAsync"/> — loads the default source
-    /// and reports whether the content actually changed, but NEVER fires the
+    /// #416: lock-free convergence load of the source named by <c>AppConfig.DefaultPrefixSource</c> —
+    /// returns the prefix list plus whether the content actually changed, and NEVER fires the
     /// <c>onSourceChanged</c> convergence callback. Callers that invoke it while holding a lock
     /// (the RU gate in <c>PrefixService.GetRuPrefixesAsync</c>) must own the push themselves and
     /// fire it only AFTER releasing the lock: an inline callback that re-enters the RU path from
     /// another session's build deadlocked on the caller-held gate (the gate holder awaited the
     /// push, the push awaited the gate).
+    /// <para>
+    /// #417: failures PROPAGATE rather than collapsing to <c>[]</c> — including a fresh negative
+    /// (failure-backoff) cache entry, which throws instead of returning an empty list. The RU
+    /// caller's stale-on-failure handling needs the real failure; a swallowed one would cache an
+    /// empty set positively for the full RU TTL, dropping every unconfigured peer's routes off a
+    /// single transient outage.
+    /// </para>
     /// </summary>
     Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default);
 

--- a/BGPLite.Providers/PrefixService.cs
+++ b/BGPLite.Providers/PrefixService.cs
@@ -27,7 +27,7 @@ public sealed class PrefixService : IPrefixService
     // when the TTL elapses. Mirrors the per-ASN gate pattern in GetPrefixesAsync.
     private readonly SemaphoreSlim _ruGate = new(1, 1);
 
-    public PrefixService(AppConfig config, RipeStatPrefixCache ripeStatCache, IPrefixSourceService prefixSources, HttpPrefixProvider httpProvider, TimeSpan? ruCacheTtl = null, ILogger<PrefixService>? logger = null, TimeProvider? timeProvider = null, int? userSourceTimeoutSeconds = null)
+    public PrefixService(AppConfig config, RipeStatPrefixCache ripeStatCache, IPrefixSourceService prefixSources, HttpPrefixProvider httpProvider, TimeSpan? ruCacheTtl = null, ILogger<PrefixService>? logger = null, TimeProvider? timeProvider = null, int? userSourceTimeoutSeconds = null, Func<string, Task>? onSourceChanged = null)
     {
         _config = config;
         _ripeStatCache = ripeStatCache;
@@ -41,6 +41,9 @@ public sealed class PrefixService : IPrefixService
         // stall the route dump behind the per-URL gate.
         _userSourceTimeoutSeconds = userSourceTimeoutSeconds ?? DefaultUserSourceTimeoutSeconds;
         _userSourceCache = new UserSourceCache(logger: logger, timeProvider: _timeProvider);
+        // #416: convergence push for default-source changes detected on the RU path. Fired AFTER
+        // _ruGate.Release() in GetRuPrefixesAsync — never while the gate is held.
+        _onSourceChanged = onSourceChanged;
     }
 
     /// <summary>Default per-fetch budget for peer-supplied URL sources (#320).</summary>
@@ -178,9 +181,18 @@ public sealed class PrefixService : IPrefixService
     /// fetch so concurrent callers share one default-source load (thundering-herd defense), and
     /// stale-on-failure serves the last good copy on a transient fetch error (#163 parity).
     /// </para>
+    /// <para>
+    /// #416: the convergence push for a detected content change fires AFTER <c>_ruGate.Release()</c>
+    /// — the load itself runs callback-free (<see cref="IPrefixSourceService.LoadDefaultAsync"/>).
+    /// Firing it while the gate was held deadlocked the fleet refresh: the push re-enters this
+    /// method from other sessions' builds, which blocked on the gate the triggering frame still
+    /// held, while that frame awaited the push (Task.WhenAll over every session) — a permanent
+    /// circular wait with sessions staying Established and nothing in the logs.
+    /// </para>
     /// </summary>
     private sealed record RuCacheEntry(List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)> Projected, long CachedAtTicks);
     private RuCacheEntry? _ruCache;
+    private readonly Func<string, Task>? _onSourceChanged;
 
     public async Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
     {
@@ -192,6 +204,8 @@ public sealed class PrefixService : IPrefixService
 
         // Serialize the cache-miss fetch so concurrent callers share one default-source fetch
         // (thundering-herd defense — #229). Mirrors the per-ASN gate in GetPrefixesAsync.
+        List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)> projected;
+        var changed = false;
         await _ruGate.WaitAsync(ct);
         try
         {
@@ -200,11 +214,14 @@ public sealed class PrefixService : IPrefixService
             if (cached is not null && _timeProvider.GetUtcNow().UtcDateTime.Ticks - cached.CachedAtTicks < _ruCacheTtl.Ticks)
                 return cached.Projected;
 
-            List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)> projected;
             try
             {
-                var prefixes = await _prefixSources.GetDefaultAsync(ct);
+                // Callback-free load (#416): no onSourceChanged can fire while this frame holds
+                // the gate. Failures propagate so the stale-on-failure branch below stays live —
+                // a failed cold load must not be cached as a positive empty set.
+                var (prefixes, loadChanged) = await _prefixSources.LoadDefaultAsync(ct);
                 projected = prefixes.Select(p => (p.Address, p.Length, p.IsIpv4, 0u)).ToList();
+                changed = loadChanged;
             }
             catch (OperationCanceledException) { throw; }
             catch (Exception ex)
@@ -226,12 +243,25 @@ public sealed class PrefixService : IPrefixService
             // Swap the whole entry atomically — projection and timestamp move together, so a reader
             // can never observe a mismatched (new projection, old timestamp) pair.
             Interlocked.Exchange(ref _ruCache, new RuCacheEntry(projected, _timeProvider.GetUtcNow().UtcDateTime.Ticks));
-            return projected;
         }
         finally
         {
             _ruGate.Release();
         }
+
+        // #416: the push runs AFTER the gate is released — a re-entrant GetRuPrefixesAsync (another
+        // session's build) takes the fast path against the just-written cache instead of blocking
+        // on this frame. A failure is logged, never propagated into the caller's route dump.
+        if (changed && _onSourceChanged is not null)
+        {
+            try { await _onSourceChanged(_config.DefaultPrefixSource ?? string.Empty); }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "OnSourceChanged callback failed for the default prefix source.");
+            }
+        }
+
+        return projected;
     }
 
     /// <summary>Prefixes of a configured source by name (cache-through).</summary>

--- a/BGPLite.Providers/PrefixService.cs
+++ b/BGPLite.Providers/PrefixService.cs
@@ -273,10 +273,22 @@ public sealed class PrefixService : IPrefixService
     public async Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default) =>
         ToContract(await _prefixSources.GetAsync(name, ct));
 
-    /// <summary>Provider-native <see cref="IpPrefix"/> values mapped onto the Contracts tuple
-    /// layout (Contracts is a dependency-free leaf and cannot see the Protocol type).</summary>
+    /// <summary>
+    /// Provider-native <see cref="IpPrefix"/> values mapped onto the Contracts tuple layout
+    /// (Contracts is a dependency-free leaf and cannot see the Protocol type).
+    /// <para>
+    /// #429: the projection is memoized by the NATIVE list instance (ConditionalWeakTable — freed
+    /// with it, no eviction needed). All three cache layers return the SAME list instance until
+    /// their next reload, so every warm call was re-projecting an 11k-entry list per peer per
+    /// refresh; now the tuple list is built once per load and shared read-only.
+    /// </para>
+    /// </summary>
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable
+        <IReadOnlyList<IpPrefix>, IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> ContractMemo = new();
+
     private static IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)> ToContract(IReadOnlyList<IpPrefix> prefixes) =>
-        prefixes.Select(p => (p.Address, p.Length, p.IsIpv4)).ToList();
+        ContractMemo.GetValue(prefixes, p =>
+            (IReadOnlyList<(UInt128, byte, bool)>)p.Select(x => (x.Address, x.Length, x.IsIpv4)).ToList());
 
     public async Task WarmUpAsync(CancellationToken ct = default)
     {

--- a/BGPLite.Providers/PrefixService.cs
+++ b/BGPLite.Providers/PrefixService.cs
@@ -21,13 +21,14 @@ public sealed class PrefixService : IPrefixService
     private readonly ILogger<PrefixService>? _logger;
     private readonly TimeProvider _timeProvider;
     private readonly UserSourceCache _userSourceCache;
+    private readonly IPrefixSourceProvider _userSourceHttpProvider;
     // #229: gate serializing the RU/default-prefix cache-miss fetch path. The RU set is a single
     // shared cache (unlike the per-ASN _cache), so a single SemaphoreSlim is enough — it prevents a
     // thundering herd of N concurrent sessions from all re-fetching the ~11k-prefix default list
     // when the TTL elapses. Mirrors the per-ASN gate pattern in GetPrefixesAsync.
     private readonly SemaphoreSlim _ruGate = new(1, 1);
 
-    public PrefixService(AppConfig config, RipeStatPrefixCache ripeStatCache, IPrefixSourceService prefixSources, HttpPrefixProvider httpProvider, TimeSpan? ruCacheTtl = null, ILogger<PrefixService>? logger = null, TimeProvider? timeProvider = null, int? userSourceTimeoutSeconds = null, Func<string, Task>? onSourceChanged = null)
+    public PrefixService(AppConfig config, RipeStatPrefixCache ripeStatCache, IPrefixSourceService prefixSources, HttpPrefixProvider httpProvider, TimeSpan? ruCacheTtl = null, ILogger<PrefixService>? logger = null, TimeProvider? timeProvider = null, int? userSourceTimeoutSeconds = null, Func<string, Task>? onSourceChanged = null, IPrefixSourceProvider? userSourceHttpProvider = null)
     {
         _config = config;
         _ripeStatCache = ripeStatCache;
@@ -44,6 +45,10 @@ public sealed class PrefixService : IPrefixService
         // #416: convergence push for default-source changes detected on the RU path. Fired AFTER
         // _ruGate.Release() in GetRuPrefixesAsync — never while the gate is held.
         _onSourceChanged = onSourceChanged;
+        // #425: the peer-supplied user-source path uses its OWN http provider (the retry-only
+        // pipeline) so peer-controlled failures cannot open the breaker gating operator sources;
+        // falls back to the operator provider when not wired (tests).
+        _userSourceHttpProvider = userSourceHttpProvider ?? httpProvider;
     }
 
     /// <summary>Default per-fetch budget for peer-supplied URL sources (#320).</summary>
@@ -80,7 +85,7 @@ public sealed class PrefixService : IPrefixService
         };
         var prefixes = await _userSourceCache.GetOrLoadAsync(url, name, async ct =>
         {
-            var result = await _httpProvider.LoadAsync(source, ct: ct);
+            var result = await _userSourceHttpProvider.LoadAsync(source, ct: ct);
             return result.Prefixes;   // provider-native IpPrefix list
         }, ct);
         return ToContract(prefixes);

--- a/BGPLite.Providers/PrefixSourceService.cs
+++ b/BGPLite.Providers/PrefixSourceService.cs
@@ -80,23 +80,40 @@ public sealed class PrefixSourceService : IPrefixSourceService
 
     public async Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default)
     {
+        // Deliberately swallowing: GetDefaultAsync is the "best-effort" shape (empty on unset
+        // source, missing source, or fetch failure). #416 split the callback-free, propagating
+        // variant into LoadDefaultAsync for the RU path, whose caller has stale-on-failure
+        // handling a swallowed exception would defeat.
+        try { return (await LoadDefaultAsync(ct)).Prefixes; }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #324: only CALLER cancellation — the #324 default fetch budget fires as a foreign-token OCE (live ct) and must stay a per-source failure below
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to load default prefix source '{Name}'.", _config.DefaultPrefixSource);
+            return [];
+        }
+    }
+
+    /// <inheritdoc cref="IPrefixSourceService.LoadDefaultAsync" />
+    /// <remarks>
+    /// Same load as <see cref="GetDefaultAsync"/> minus two things, both deliberate (#416):
+    /// the <c>onSourceChanged</c> callback is NOT fired (the caller owns the push, off its own
+    /// locks), and failures PROPAGATE instead of collapsing to <c>[]</c> — the RU caller
+    /// (<c>PrefixService.GetRuPrefixesAsync</c>) has stale-on-failure handling that a swallowed
+    /// exception would defeat (a failed cold load must not be cached as a positive empty set).
+    /// </remarks>
+    public async Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default)
+    {
         var defaultName = _config.DefaultPrefixSource;
         if (string.IsNullOrWhiteSpace(defaultName))
-            return [];
+            return ([], false);
 
         if (!_sourcesByName.TryGetValue(defaultName, out var source))
         {
             _logger.LogWarning("DefaultPrefixSource '{Name}' does not match any configured source.", defaultName);
-            return [];
+            return ([], false);
         }
 
-        try { return (await LoadCachedAsync(source, ct)).Prefixes; }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #324: only CALLER cancellation — the #324 default fetch budget fires as a foreign-token OCE (live ct) and must stay a per-source failure below
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to load default prefix source '{Name}'.", defaultName);
-            return [];
-        }
+        return await LoadCachedAsync(source, ct, triggerCallback: false);
     }
 
     public async Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default)

--- a/BGPLite.Providers/PrefixSourceService.cs
+++ b/BGPLite.Providers/PrefixSourceService.cs
@@ -78,26 +78,11 @@ public sealed class PrefixSourceService : IPrefixSourceService
         }
     }
 
-    public async Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default)
-    {
-        // Deliberately swallowing: GetDefaultAsync is the "best-effort" shape (empty on unset
-        // source, missing source, or fetch failure). #416 split the callback-free, propagating
-        // variant into LoadDefaultAsync for the RU path, whose caller has stale-on-failure
-        // handling a swallowed exception would defeat.
-        try { return (await LoadDefaultAsync(ct)).Prefixes; }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #324: only CALLER cancellation — the #324 default fetch budget fires as a foreign-token OCE (live ct) and must stay a per-source failure below
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to load default prefix source '{Name}'.", _config.DefaultPrefixSource);
-            return [];
-        }
-    }
-
     /// <inheritdoc cref="IPrefixSourceService.LoadDefaultAsync" />
     /// <remarks>
-    /// Same load as <see cref="GetDefaultAsync"/> minus two things, both deliberate (#416):
-    /// the <c>onSourceChanged</c> callback is NOT fired (the caller owns the push, off its own
-    /// locks), and failures PROPAGATE instead of collapsing to <c>[]</c> — the RU caller
+    /// Deliberately different from <see cref="GetAsync"/> in two ways (#416/#417): the
+    /// <c>onSourceChanged</c> callback is NOT fired (the caller owns the push, off its own locks),
+    /// and failures PROPAGATE instead of collapsing to <c>[]</c> — the RU caller
     /// (<c>PrefixService.GetRuPrefixesAsync</c>) has stale-on-failure handling that a swallowed
     /// exception would defeat (a failed cold load must not be cached as a positive empty set).
     /// </remarks>
@@ -113,7 +98,21 @@ public sealed class PrefixSourceService : IPrefixSourceService
             return ([], false);
         }
 
-        return await LoadCachedAsync(source, ct, triggerCallback: false);
+        var (prefixes, changed) = await LoadCachedAsync(source, ct, triggerCallback: false);
+
+        // #417: an empty result served from a fresh NEGATIVE entry is failure backoff, not
+        // content. The negative entry is only ever written by the failure path above, so a
+        // negative hit means "the last real load failed" — surface it as a failure so the RU
+        // caller stale-serves (or throws) instead of positively caching an empty set for the full
+        // RU TTL. A legitimately empty source writes a NON-negative entry and passes through.
+        if (prefixes.Count == 0 && _cache.TryGetValue(source.Name, out var entry) &&
+            entry.Negative && _timeProvider.GetUtcNow().UtcDateTime - entry.CachedAt < _negativeTtl)
+        {
+            throw new InvalidOperationException(
+                $"Default prefix source '{defaultName}' is in failure backoff — the last load failed within the last {_negativeTtl.TotalSeconds:0}s.");
+        }
+
+        return (prefixes, changed);
     }
 
     public async Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default)

--- a/BGPLite.Providers/PrefixSourceUrlValidator.cs
+++ b/BGPLite.Providers/PrefixSourceUrlValidator.cs
@@ -38,7 +38,7 @@ public static class PrefixSourceUrlValidator
         IPNetwork.Parse("::ffff:0:0/96"),       // IPv4-mapped (also caught by IsIPv4MappedToIPv6, defense in depth)
         IPNetwork.Parse("::/96"),               // IPv4-compatible (deprecated ::a.b.c.d form)
         IPNetwork.Parse("64:ff9b::/96"),        // NAT64 well-known — a DNS64 name can embed any IPv4 here (#321)
-        IPNetwork.Parse("64:ff8:1::/96"),       // NAT64 well-known, local scope (RFC 6052 §2.1 alternate)
+        IPNetwork.Parse("64:ff9b:1::/48"),      // NAT64 local-use (RFC 8215) — same IPv4-embedding hazard as the well-known prefix (#419)
     ];
 
     /// <summary>Per-address connect budget so one blackholed candidate can't consume the whole

--- a/BGPLite.Providers/RipeStatPrefixCache.cs
+++ b/BGPLite.Providers/RipeStatPrefixCache.cs
@@ -52,6 +52,9 @@ public sealed class RipeStatPrefixCache
     // integration review): a plain presence marker would be removed by the first caller's exit
     // while a second caller is still inside/queued on the same gate.
     private readonly ConcurrentDictionary<uint, int> _inflight = new();
+    // #426: amortized expired-entry sweep state (see GetPrefixesAsync). injectable for tests.
+    private int _callsSinceSweep;
+    private readonly int _sweepEvery;
 
     public RipeStatPrefixCache(
         RipeStatProvider ripe,
@@ -59,7 +62,8 @@ public sealed class RipeStatPrefixCache
         TimeSpan? cacheTtl = null,
         TimeSpan? negativeTtl = null,
         int? maxCacheEntries = null,
-        TimeProvider? timeProvider = null)
+        TimeProvider? timeProvider = null,
+        int? sweepEvery = null)
     {
         _ripe = ripe;
         _logger = logger;
@@ -70,10 +74,22 @@ public sealed class RipeStatPrefixCache
         // churn traffic, not normal operation.
         _maxCacheEntries = maxCacheEntries ?? 4096;
         _timeProvider = timeProvider ?? TimeProvider.System;
+        _sweepEvery = sweepEvery ?? 64;
     }
+
+    /// <summary>Entries currently tracked (test/observability — #426 sweep coverage).</summary>
+    internal int TrackedCount => _cache.Count;
 
     public async Task<IReadOnlyList<IpPrefix>> GetPrefixesAsync(uint asn, CancellationToken ct = default, bool serveNegativeEntries = true)
     {
+        // #426: amortized expired-entry sweep — expired entries used to be pinned until the entry
+        // cap was hit. Cheap (every Nth call), idempotent, in-flight ASNs are never touched.
+        if (Interlocked.Increment(ref _callsSinceSweep) >= _sweepEvery)
+        {
+            Volatile.Write(ref _callsSinceSweep, 0);
+            SweepExpired();
+        }
+
         // Fast path: fresh entry (positive, or negative within its TTL when the caller accepts
         // the []-on-recent-failure semantic — the RouteAssembler fan-out does; a source provider
         // must NOT, see the class doc).
@@ -173,6 +189,24 @@ public sealed class RipeStatPrefixCache
     /// for an in-flight ASN (#267 item 3). Under the lock of the caller's per-ASN gate, so the
     /// sweep is serialized against itself; ConcurrentDictionary enumeration is a snapshot and safe
     /// against concurrent writers.</summary>
+    /// <summary>
+    /// #426: removes EXPIRED entries regardless of the entry cap — they used to be pinned until
+    /// the cap was hit, so steady-state memory was "every ASN fetched recently", not "live ASNs".
+    /// In-flight ASNs are never touched (#267 item 3); concurrent sweeps are idempotent.
+    /// </summary>
+    private void SweepExpired()
+    {
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        foreach (var (key, entry) in _cache)
+        {
+            var ttl = entry.Negative ? _negativeTtl : _cacheTtl;
+            if (now - entry.CachedAt < ttl) continue;
+            if (_inflight.TryGetValue(key, out var active) && active > 0) continue;
+            if (_cache.TryRemove(key, out _))
+                _locks.TryRemove(key, out _);
+        }
+    }
+
     private void EvictIfAtCapacity(uint insertingKey)
     {
         if (_cache.Count < _maxCacheEntries) return;

--- a/BGPLite.Providers/UserSourceCache.cs
+++ b/BGPLite.Providers/UserSourceCache.cs
@@ -33,13 +33,29 @@ internal sealed class UserSourceCache
     // each (the HTTP body cap) plus a SemaphoreSlim — so operator churn or an API client loop grows
     // the cache without limit. Exceeded → sweep expired entries first, then the oldest by CachedAt.
     private readonly int _maxEntries;
+    // #426: entry COUNT caps say nothing about memory — one entry can hold ~1M prefixes (a 10 MB
+    // response parsed). The budget bounds the TOTAL parsed prefixes across all entries; over
+    // budget → the sweep drops the OLDEST positive entries until under. 2M prefixes ≈ 50 MB worst
+    // case — generous for real peer sources, hostile to unbounded growth.
+    internal const long DefaultMaxTotalPrefixes = 2_000_000;
+    private readonly long _maxTotalPrefixes;
+    // #426: expired entries used to be PINNED until the entry cap was hit — steady-state memory
+    // was "everything fetched recently", not "live entries". The amortized sweep (every
+    // _sweepEvery calls) now removes expired entries and enforces the prefix budget regardless
+    // of the cap. internal-settable via ctor for tests.
+    private int _callsSinceSweep;
+    private readonly int _sweepEvery;
+    internal int SweepEvery => _sweepEvery;
+
+    /// <summary>Total parsed prefixes currently held in positive entries (test/observability).</summary>
+    internal long TrackedPrefixes => _cache.Where(kvp => !kvp.Value.Negative).Sum(kvp => (long)kvp.Value.List.Count);
 
     // url → (list, cached at, is negative). Negative entries (failed loads) use _negativeTtl.
     private readonly ConcurrentDictionary<string, (IReadOnlyList<IpPrefix> List, DateTime CachedAt, bool Negative)> _cache = new();
     // url → gate serializing the cache-miss fetch path (prevents thundering herd on cold/expired keys).
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new();
 
-    public UserSourceCache(TimeSpan? positiveTtl = null, TimeSpan? negativeTtl = null, ILogger? logger = null, TimeProvider? timeProvider = null, int? maxCacheEntries = null)
+    public UserSourceCache(TimeSpan? positiveTtl = null, TimeSpan? negativeTtl = null, ILogger? logger = null, TimeProvider? timeProvider = null, int? maxCacheEntries = null, long? maxTotalPrefixes = null, int? sweepEvery = null)
     {
         _positiveTtl = positiveTtl ?? TimeSpan.FromHours(1);
         _negativeTtl = negativeTtl ?? TimeSpan.FromSeconds(30);
@@ -48,6 +64,8 @@ internal sealed class UserSourceCache
         // Generous vs. real deployments (peers × a few active sources each); the cap defends
         // against unbounded growth from churn/adversarial URL variety, not normal operation.
         _maxEntries = maxCacheEntries ?? 1024;
+        _maxTotalPrefixes = maxTotalPrefixes ?? DefaultMaxTotalPrefixes;
+        _sweepEvery = sweepEvery ?? 64;
     }
 
     /// <summary>Entries currently tracked (test/observability).</summary>
@@ -66,6 +84,10 @@ internal sealed class UserSourceCache
         Func<CancellationToken, Task<IReadOnlyList<IpPrefix>>> loadAsync,
         CancellationToken ct)
     {
+        // #426: amortized expired-entry + prefix-budget sweep — expired entries used to be pinned
+        // until the entry cap was hit. Cheap (every Nth call), idempotent under concurrency.
+        SweepIfNeeded();
+
         if (TryGetFresh(url, out var fresh))
             return fresh;
 
@@ -189,5 +211,49 @@ internal sealed class UserSourceCache
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// #426: amortized housekeeping, run every <see cref="_sweepEvery"/> calls. (1) Removes EXPIRED
+    /// entries regardless of the entry cap — they used to be pinned until the cap was hit. (2)
+    /// Enforces the total-prefix budget: over budget, the OLDEST positive entries are dropped until
+    /// under (a later caller re-fetches them — a duplicate idempotent GET, never a correctness
+    /// loss, the same tradeoff <see cref="EvictIfAtCapacity"/> accepts).
+    /// </summary>
+    private void SweepIfNeeded()
+    {
+        if (Interlocked.Increment(ref _callsSinceSweep) < _sweepEvery)
+            return;
+        Volatile.Write(ref _callsSinceSweep, 0);
+
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        var toEvict = new List<string>();
+        long total = 0;
+        foreach (var (key, entry) in _cache)
+        {
+            var ttl = entry.Negative ? _negativeTtl : _positiveTtl;
+            if (now - entry.CachedAt >= ttl)
+            {
+                toEvict.Add(key);
+                continue;
+            }
+            if (!entry.Negative)
+                total += entry.List.Count;
+        }
+
+        foreach (var kvp in _cache
+                     .Where(kvp => !kvp.Value.Negative && !toEvict.Contains(kvp.Key))
+                     .OrderBy(kvp => kvp.Value.CachedAt))
+        {
+            if (total <= _maxTotalPrefixes) break;
+            toEvict.Add(kvp.Key);
+            total -= kvp.Value.List.Count;
+        }
+
+        foreach (var key in toEvict)
+        {
+            if (_cache.TryRemove(key, out _))
+                _locks.TryRemove(key, out _);
+        }
     }
 }

--- a/BGPLite.Providers/UserSourceCache.cs
+++ b/BGPLite.Providers/UserSourceCache.cs
@@ -54,6 +54,10 @@ internal sealed class UserSourceCache
     private readonly ConcurrentDictionary<string, (IReadOnlyList<IpPrefix> List, DateTime CachedAt, bool Negative)> _cache = new();
     // url → gate serializing the cache-miss fetch path (prevents thundering herd on cold/expired keys).
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new();
+    // url → ACTIVE-loader count (#450 review): the sweeps never remove a gate whose loaders are
+    // still inside or queued — otherwise two gates coexist and two loaders race one URL, with the
+    // older response able to overwrite the newer (RipeStatPrefixCache's #267-item-3 invariant).
+    private readonly ConcurrentDictionary<string, int> _inflight = new();
 
     public UserSourceCache(TimeSpan? positiveTtl = null, TimeSpan? negativeTtl = null, ILogger? logger = null, TimeProvider? timeProvider = null, int? maxCacheEntries = null, long? maxTotalPrefixes = null, int? sweepEvery = null)
     {
@@ -94,66 +98,88 @@ internal sealed class UserSourceCache
         // Serialize per-key so concurrent callers (e.g. several peers refreshing the same URL) share
         // a single fetch — no thundering herd.
         var gate = _locks.GetOrAdd(url, _ => new SemaphoreSlim(1, 1));
+        // #450 review: register as an active loader BEFORE the gate is taken — the sweep and
+        // EvictIfAtCapacity never remove a gate that still has loaders (RipeStatPrefixCache's
+        // _inflight invariant, #267 item 3). Without this, a removed-then-recreated gate let two
+        // loaders run concurrently for one URL and the OLDER response could overwrite the newer.
+        _inflight.AddOrUpdate(url, 1, (_, c) => c + 1);
+        var entered = false;
         try
         {
-            await gate.WaitAsync(ct);
-        }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
-        {
-            // #358 review (orphan-lock hygiene for #261): a caller cancelled while queued never
-            // writes a cache entry, so its freshly-created gate would never be evicted (the sweep
-            // removes locks only for removed cache keys) — cancelled URLs accumulated semaphores.
-            // Pair-remove OUR gate instance: a concurrent waiter keeps running on its own
-            // reference, and a fresh caller GetOrAdd's a new gate — the same duplicate-fetch
-            // tradeoff the eviction sweep already accepts.
-            ((ICollection<KeyValuePair<string, SemaphoreSlim>>)_locks).Remove(new KeyValuePair<string, SemaphoreSlim>(url, gate));
-            throw;
-        }
-        try
-        {
-            if (TryGetFresh(url, out var rechecked))
-                return rechecked;
-
-            IReadOnlyList<IpPrefix> prefixes;
             try
             {
-                prefixes = await loadAsync(ct);
+                await gate.WaitAsync(ct);
+                entered = true;
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
             {
-                // #114: CALLER-initiated cancellation always propagates and is never cached — it
-                // is teardown, not a property of the source. A foreign-token OCE (e.g. the #320
-                // per-fetch budget's linked CTS firing on a live caller token) falls through to
-                // the failure handling below instead: stale-on-failure serve if possible, else a
-                // brief negative-cache so repeated refreshes do not re-pay the full budget.
+                // #358 review (orphan-lock hygiene for #261): a caller cancelled while queued never
+                // writes a cache entry, so its freshly-created gate would never be evicted (the sweep
+                // removes locks only for removed cache keys) — cancelled URLs accumulated semaphores.
+                // Pair-remove OUR gate instance: a concurrent waiter keeps running on its own
+                // reference, and a fresh caller GetOrAdd's a new gate — the same duplicate-fetch
+                // tradeoff the eviction sweep already accepts.
+                ((ICollection<KeyValuePair<string, SemaphoreSlim>>)_locks).Remove(new KeyValuePair<string, SemaphoreSlim>(url, gate));
                 throw;
             }
-            catch (Exception ex)
+            try
             {
-                // Serve the last good copy if we have one (regardless of its age).
-                if (_cache.TryGetValue(url, out var stale) && !stale.Negative)
+                if (TryGetFresh(url, out var rechecked))
+                    return rechecked;
+
+                IReadOnlyList<IpPrefix> prefixes;
+                try
                 {
-                    _logger?.LogWarning(ex, "User-source '{Name}' load failed; serving cached copy ({Count} prefixes).",
-                        logLabel, stale.List.Count);
-                    return stale.List;
+                    prefixes = await loadAsync(ct);
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    // #114: CALLER-initiated cancellation always propagates and is never cached — it
+                    // is teardown, not a property of the source. A foreign-token OCE (e.g. the #320
+                    // per-fetch budget's linked CTS firing on a live caller token) falls through to
+                    // the failure handling below instead: stale-on-failure serve if possible, else a
+                    // brief negative-cache so repeated refreshes do not re-pay the full budget.
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    // Serve the last good copy if we have one (regardless of its age).
+                    if (_cache.TryGetValue(url, out var stale) && !stale.Negative)
+                    {
+                        _logger?.LogWarning(ex, "User-source '{Name}' load failed; serving cached copy ({Count} prefixes).",
+                            logLabel, stale.List.Count);
+                        return stale.List;
+                    }
+
+                    // Otherwise remember the failure briefly so repeated calls don't hammer the fetcher.
+                    EvictIfAtCapacity(url);
+                    _cache[url] = ([], _timeProvider.GetUtcNow().UtcDateTime, Negative: true);
+                    _logger?.LogWarning(ex, "User-source '{Name}' load failed (no cached copy); negative-cached for {Seconds}s.",
+                        logLabel, (int)_negativeTtl.TotalSeconds);
+                    throw;
                 }
 
-                // Otherwise remember the failure briefly so repeated calls don't hammer the fetcher.
                 EvictIfAtCapacity(url);
-                _cache[url] = ([], _timeProvider.GetUtcNow().UtcDateTime, Negative: true);
-                _logger?.LogWarning(ex, "User-source '{Name}' load failed (no cached copy); negative-cached for {Seconds}s.",
-                    logLabel, (int)_negativeTtl.TotalSeconds);
-                throw;
+                _cache[url] = (prefixes, _timeProvider.GetUtcNow().UtcDateTime, Negative: false);
+                return prefixes;
             }
-
-            EvictIfAtCapacity(url);
-            _cache[url] = (prefixes, _timeProvider.GetUtcNow().UtcDateTime, Negative: false);
-            return prefixes;
+            finally
+            {
+                if (entered) gate.Release();
+            }
         }
         finally
         {
-            gate.Release();
+            ExitInflight(url);
         }
+    }
+
+    /// <summary>Decrements the active-loader count for <paramref name="url"/> and removes the
+    /// marker when it reaches zero, so the sweeps know the gate is removable (#450 review).</summary>
+    private void ExitInflight(string url)
+    {
+        _inflight.AddOrUpdate(url, 0, (_, c) => c - 1);
+        _inflight.TryRemove(new KeyValuePair<string, int>(url, 0));
     }
 
     /// <summary>
@@ -193,6 +219,8 @@ internal sealed class UserSourceCache
 
         foreach (var key in toEvict)
         {
+            // #450 review: a URL with active loaders keeps its gate (see SweepIfNeeded).
+            if (_inflight.TryGetValue(key, out var active) && active > 0) continue;
             if (_cache.TryRemove(key, out _))
                 _locks.TryRemove(key, out _);
         }
@@ -252,6 +280,9 @@ internal sealed class UserSourceCache
 
         foreach (var key in toEvict)
         {
+            // #450 review: a URL with active loaders keeps its gate (its loader writes the entry
+            // on its own reference) — removing the gate would mint a duplicate concurrent fetch.
+            if (_inflight.TryGetValue(key, out var active) && active > 0) continue;
             if (_cache.TryRemove(key, out _))
                 _locks.TryRemove(key, out _);
         }

--- a/BGPLite.Server/BgpServer.cs
+++ b/BGPLite.Server/BgpServer.cs
@@ -37,6 +37,8 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
     private Task? _acceptTask;
     private PeriodicTimer? _statusTimer;
     private Task? _statusTask;
+    // #428: pause before retrying after a failed accept — see the catch in AcceptLoopAsync.
+    private static readonly TimeSpan AcceptFailureBackoff = TimeSpan.FromMilliseconds(500);
 
     public BgpMetrics Metrics => _metrics;
     public RouteTable Routes => _routeTable;
@@ -365,6 +367,12 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
                 if (Volatile.Read(ref _acceptingConnections) == 0)
                     break;
                 _logger.LogError(ex, "Error accepting connection");
+                // #428: a persistent accept failure (fd exhaustion/EMFILE is the classic) used to
+                // spin this loop at full speed — log + immediate retry thousands of times a
+                // second, exactly when the host is already out of resources. Bound the retry
+                // rate; the shutdown token breaks the wait so shutdown latency is unaffected.
+                try { await Task.Delay(AcceptFailureBackoff, cancellationToken); }
+                catch (OperationCanceledException) { break; }
             }
         }
     }

--- a/BGPLite.Server/BgpServer.cs
+++ b/BGPLite.Server/BgpServer.cs
@@ -472,6 +472,28 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
         await TerminateSessionsAsync(sessions, ct);
     }
 
+    /// <inheritdoc cref="ISessionManager.TerminatePeerByIpAsync" />
+    public async Task TerminatePeerByIpAsync(string peerIp, CancellationToken ct = default)
+    {
+        if (!IPAddress.TryParse(peerIp, out var ip))
+        {
+            _logger.LogWarning("TerminatePeerByIp: invalid IP {Ip}", peerIp);
+            return;
+        }
+
+        var sessions = _sessions
+            .Where(kvp => kvp.Key.Address.Equals(ip))
+            .Select(kvp => kvp.Value)
+            .ToList();
+
+        if (sessions.Count == 0)
+            return;
+
+        _logger.LogInformation("Terminating {Count} session(s) from {Ip} (IP-only match — the deleted peer row carries no ASN)",
+            sessions.Count, peerIp);
+        await TerminateSessionsAsync(sessions, ct);
+    }
+
     /// <summary>
     /// The #323 teardown core, split out so tests can drive real sessions without a live BgpServer
     /// (sessions enter <see cref="_sessions"/> only through the accept loop, which binds port 179).

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -729,6 +729,22 @@ public sealed class BgpSession : IDisposable
                 LogPeerClosedEstablished(ex);
                 return;
             }
+            catch (BgpParseException ex) when (ex.ErrorCode == BgpConstants.Error.OpenMessageError)
+            {
+                // #427 (RFC 4271 §8.2.2): an OPEN received in Established is an FSM error
+                // regardless of body validity — Established accepts only UPDATE, KEEPALIVE,
+                // NOTIFICATION and ROUTE_REFRESH, and a conformant speaker never parses the body.
+                // The body-error filter below must NOT keep the session up for this message class
+                // (that treatment is UPDATE-specific, D17). Same teardown as the FSM-error default
+                // case: exactly one NOTIFICATION 5/0 (CAS-latched), then Idle.
+                _logger.LogWarning("OPEN received from {Peer} in Established — FSM error (RFC 4271 §8.2.2)", _peer);
+                if (Interlocked.CompareExchange(ref _teardownReason, (int)TeardownReason.LocalCease, (int)TeardownReason.None) == (int)TeardownReason.None)
+                {
+                    try { await SendNotificationAsync(BgpConstants.Error.FiniteStateMachineError, BgpConstants.SubError.Unspecific); }
+                    catch { /* best-effort — partial write counts, see RFC 4271 §8.1 */ }
+                }
+                return;
+            }
             catch (BgpParseException ex) when (ex.ErrorCode is not null)
             {
                 // #222: a malformed message BODY (truncated path attribute, out-of-range NLRI length,

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -815,9 +815,19 @@ public sealed class BgpSession : IDisposable
                         _logger.LogWarning("RouteRefresh received from {Peer} without negotiated capability, ignoring", _peer);
                         break;
                     }
-                    if (refresh.Afi != BgpConstants.Afi.IPv4 || refresh.Safi != BgpConstants.Safi.Unicast)
+                    // RFC 2918 §2: the receiving speaker re-sends Adj-RIB-Out for the REQUESTED
+                    // AFI/SAFI. Both families BGPLite advertises are honored (#420): IPv4/Unicast
+                    // always, IPv6/Unicast for MP-IPv6-negotiated sessions (#14). The re-announcement
+                    // dump is family-unified (withdraw-all + re-send), so the same debounced refresh
+                    // serves either request.
+                    var isSupportedFamily = refresh.Safi == BgpConstants.Safi.Unicast &&
+                        (refresh.Afi == BgpConstants.Afi.IPv4 ||
+                         (refresh.Afi == BgpConstants.Afi.IPv6 && _peerMpIpv6Unicast));
+                    if (!isSupportedFamily)
                     {
-                        _logger.LogDebug("RouteRefresh ignored: unsupported AFI/SAFI from {Peer}", _peer);
+                        _logger.LogDebug(
+                            "RouteRefresh ignored: unsupported AFI/SAFI {Afi}/{Safi} from {Peer} (MP IPv6 negotiated: {MpV6})",
+                            refresh.Afi, refresh.Safi, _peer, _peerMpIpv6Unicast);
                         break;
                     }
                     // Debounce: ignore ROUTE_REFRESH floods. Atomic check-and-set so a burst of N

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -1301,21 +1301,26 @@ public sealed class BgpSession : IDisposable
         var attrCache = UpdateCodec.CreateUpdateAttributeCache();
         var v6AttrCache = UpdateCodec.CreateV6UpdateAttributeCache();
 
+        // #430: build-then-commit — a batch's prefixes are recorded in _advertisedPrefixes only
+        // AFTER its UPDATE serialized and hit the wire. A send that throws (e.g. a composed
+        // UPDATE over the 4096-byte maximum) leaves the mirror exactly matching reality: a later
+        // WithdrawAllAsync no longer sends withdrawals for prefixes that were never announced.
         foreach (var route in v4Routes)
         {
             batch.Add(route);
-            _advertisedPrefixes.Add(new IpPrefix(route.Prefix, route.PrefixLength, route.IsIpv4));
-            if (batch.Count >= maxNlriPerUpdate)
-            {
-                await SendRouteBatchAsync(nextHop, batch, attrCache);
-                sent += batch.Count;
-                batch.Clear();
-            }
+            if (batch.Count < maxNlriPerUpdate) continue;
+            await SendRouteBatchAsync(nextHop, batch, attrCache);
+            foreach (var sent_route in batch)
+                _advertisedPrefixes.Add(new IpPrefix(sent_route.Prefix, sent_route.PrefixLength, sent_route.IsIpv4));
+            sent += batch.Count;
+            batch.Clear();
         }
 
         if (batch.Count > 0)
         {
             await SendRouteBatchAsync(nextHop, batch, attrCache);
+            foreach (var sent_route in batch)
+                _advertisedPrefixes.Add(new IpPrefix(sent_route.Prefix, sent_route.PrefixLength, sent_route.IsIpv4));
             sent += batch.Count;
         }
 
@@ -1324,18 +1329,19 @@ public sealed class BgpSession : IDisposable
         foreach (var route in v6Routes)
         {
             batch.Add(route);
-            _advertisedPrefixes.Add(new IpPrefix(route.Prefix, route.PrefixLength, route.IsIpv4));
-            if (batch.Count >= maxNlriPerUpdate)
-            {
-                await SendV6RouteBatchAsync(v6NextHop, batch, v6AttrCache);
-                sent += batch.Count;
-                batch.Clear();
-            }
+            if (batch.Count < maxNlriPerUpdate) continue;
+            await SendV6RouteBatchAsync(v6NextHop, batch, v6AttrCache);
+            foreach (var sent_route in batch)
+                _advertisedPrefixes.Add(new IpPrefix(sent_route.Prefix, sent_route.PrefixLength, sent_route.IsIpv4));
+            sent += batch.Count;
+            batch.Clear();
         }
 
         if (batch.Count > 0)
         {
             await SendV6RouteBatchAsync(v6NextHop, batch, v6AttrCache);
+            foreach (var sent_route in batch)
+                _advertisedPrefixes.Add(new IpPrefix(sent_route.Prefix, sent_route.PrefixLength, sent_route.IsIpv4));
             sent += batch.Count;
         }
 

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -1301,17 +1301,16 @@ public sealed class BgpSession : IDisposable
         var attrCache = UpdateCodec.CreateUpdateAttributeCache();
         var v6AttrCache = UpdateCodec.CreateV6UpdateAttributeCache();
 
-        // #430: build-then-commit — a batch's prefixes are recorded in _advertisedPrefixes only
-        // AFTER its UPDATE serialized and hit the wire. A send that throws (e.g. a composed
-        // UPDATE over the 4096-byte maximum) leaves the mirror exactly matching reality: a later
-        // WithdrawAllAsync no longer sends withdrawals for prefixes that were never announced.
+        // #430 + #450 review: build-then-commit at UPDATE granularity — each emitted UPDATE's
+        // prefixes join the mirror only after THAT frame is on the wire (a batch may emit several
+        // UPDATEs, one per community group; a group that throws — e.g. a composed UPDATE over the
+        // 4096-byte maximum — must not take earlier groups' mirror entries down with it, nor may
+        // it record its own). The healthy /8 withdraw+re-announce contract is pinned by tests.
         foreach (var route in v4Routes)
         {
             batch.Add(route);
             if (batch.Count < maxNlriPerUpdate) continue;
             await SendRouteBatchAsync(nextHop, batch, attrCache);
-            foreach (var sent_route in batch)
-                _advertisedPrefixes.Add(new IpPrefix(sent_route.Prefix, sent_route.PrefixLength, sent_route.IsIpv4));
             sent += batch.Count;
             batch.Clear();
         }
@@ -1319,8 +1318,6 @@ public sealed class BgpSession : IDisposable
         if (batch.Count > 0)
         {
             await SendRouteBatchAsync(nextHop, batch, attrCache);
-            foreach (var sent_route in batch)
-                _advertisedPrefixes.Add(new IpPrefix(sent_route.Prefix, sent_route.PrefixLength, sent_route.IsIpv4));
             sent += batch.Count;
         }
 
@@ -1331,8 +1328,6 @@ public sealed class BgpSession : IDisposable
             batch.Add(route);
             if (batch.Count < maxNlriPerUpdate) continue;
             await SendV6RouteBatchAsync(v6NextHop, batch, v6AttrCache);
-            foreach (var sent_route in batch)
-                _advertisedPrefixes.Add(new IpPrefix(sent_route.Prefix, sent_route.PrefixLength, sent_route.IsIpv4));
             sent += batch.Count;
             batch.Clear();
         }
@@ -1340,8 +1335,6 @@ public sealed class BgpSession : IDisposable
         if (batch.Count > 0)
         {
             await SendV6RouteBatchAsync(v6NextHop, batch, v6AttrCache);
-            foreach (var sent_route in batch)
-                _advertisedPrefixes.Add(new IpPrefix(sent_route.Prefix, sent_route.PrefixLength, sent_route.IsIpv4));
             sent += batch.Count;
         }
 
@@ -1447,6 +1440,20 @@ public sealed class BgpSession : IDisposable
         };
 
         await SendMessageAsync(update);
+        // #430 + #450 review: per-UPDATE mirror commit — SendRouteBatchAsync/SendV6RouteBatchAsync
+        // emit one UPDATE per community group, so a group that throws after an earlier group
+        // succeeded must not drag the earlier group's mirror entries down (they ARE on the wire)
+        // nor record its own (they are NOT).
+        if (mpReach is { } reach)
+        {
+            foreach (var p in reach.Prefixes)
+                _advertisedPrefixes.Add(p);
+        }
+        else
+        {
+            foreach (var p in nlri)
+                _advertisedPrefixes.Add(p);
+        }
         _metrics.UpdateSent();
     }
 

--- a/BGPLite.Server/RouteAssembler.cs
+++ b/BGPLite.Server/RouteAssembler.cs
@@ -310,23 +310,44 @@ public sealed class RouteAssembler : IRouteAssembler
     internal static List<Route> SuppressCoveredByCustomPrefixes(
         List<Route> routes, List<(uint Network, byte Length)> customRanges)
     {
-        // A route is covered when its length is strictly greater than the custom prefix's and its
-        // network, masked to the custom length, equals the (already host-bit-normalized) custom
-        // network — the repo's masking idiom (PrefixCidr, ExactUnionPrefixAggregator).
-        // #15 phase 1: Route.Prefix is 128-bit now. Custom prefixes are IPv4-only (PrefixCidr),
-        // so suppression applies to IPv4 routes by their low-32-bit network; an IPv6 route can
-        // never be covered by an IPv4 custom prefix and always passes.
-        // Mask is in the v4 low-32 layout; Mask(0) must be 0, not 0xFFFFFFFF << 32 (a shift-by-32
-        // is a no-op on uint, not a wipe).
+        if (customRanges.Count == 0)
+            return routes; // nothing to suppress — skip the pass entirely
+
         static UInt128 Mask(byte length) => length == 0 ? 0u : (UInt128)(0xFFFFFFFFu << (32 - length));
+
+        // #429: precompute the coverage index ONCE (exact-match set + length → custom networks)
+        // instead of scanning the custom list per route — O(routes + customs) instead of the
+        // O(routes × customs) mask+compare the per-route Where paid (11k routes × 1k customs ≈
+        // 11M compares per peer per refresh, multiplied by fleet size on a RefreshAllEstablished).
+        var exact = new HashSet<(uint Network, byte Length)>(customRanges);
+        var networksByLength = new Dictionary<byte, List<(uint Network, UInt128 Mask)>>(customRanges.Count);
+        foreach (var cr in customRanges)
+        {
+            if (!networksByLength.TryGetValue(cr.Length, out var networks))
+                networksByLength[cr.Length] = networks = [];
+            networks.Add((cr.Network, Mask(cr.Length)));
+        }
+
+        bool IsCovered(Route r)
+        {
+            foreach (var (length, networks) in networksByLength)
+            {
+                if (length >= r.PrefixLength) continue; // only a STRICTLY broader custom covers
+                var mask = Mask(length);
+                foreach (var (network, _) in networks)
+                    if (((uint)r.Prefix & mask) == network)
+                        return true;
+            }
+            return false;
+        }
+
         return routes
             .Where(r =>
                 // A configured custom prefix is never suppressed — including by a broader
                 // custom prefix of the same peer. Exact (network, length) == custom match.
-                (r.IsIpv4 && customRanges.Contains(((uint)r.Prefix, r.PrefixLength)))
+                (r.IsIpv4 && exact.Contains(((uint)r.Prefix, r.PrefixLength)))
                 || !r.IsIpv4
-                || !customRanges.Any(cr => r.PrefixLength > cr.Length
-                                           && ((uint)r.Prefix & Mask(cr.Length)) == cr.Network))
+                || !IsCovered(r))
             .ToList();
     }
 

--- a/BGPLite.Server/RouteAssembler.cs
+++ b/BGPLite.Server/RouteAssembler.cs
@@ -319,24 +319,24 @@ public sealed class RouteAssembler : IRouteAssembler
         // instead of scanning the custom list per route — O(routes + customs) instead of the
         // O(routes × customs) mask+compare the per-route Where paid (11k routes × 1k customs ≈
         // 11M compares per peer per refresh, multiplied by fleet size on a RefreshAllEstablished).
+        // #450 review: the per-length network sets are HASH sets (per-route Contains is O(1)),
+        // and the mask is stored once per length (identical for every network of that length).
         var exact = new HashSet<(uint Network, byte Length)>(customRanges);
-        var networksByLength = new Dictionary<byte, List<(uint Network, UInt128 Mask)>>(customRanges.Count);
+        var networksByLength = new Dictionary<byte, (UInt128 Mask, HashSet<UInt128> Networks)>(customRanges.Count);
         foreach (var cr in customRanges)
         {
-            if (!networksByLength.TryGetValue(cr.Length, out var networks))
-                networksByLength[cr.Length] = networks = [];
-            networks.Add((cr.Network, Mask(cr.Length)));
+            if (!networksByLength.TryGetValue(cr.Length, out var entry))
+                networksByLength[cr.Length] = entry = (Mask(cr.Length), []);
+            entry.Networks.Add(cr.Network);
         }
 
         bool IsCovered(Route r)
         {
-            foreach (var (length, networks) in networksByLength)
+            foreach (var (length, (mask, networks)) in networksByLength)
             {
                 if (length >= r.PrefixLength) continue; // only a STRICTLY broader custom covers
-                var mask = Mask(length);
-                foreach (var (network, _) in networks)
-                    if (((uint)r.Prefix & mask) == network)
-                        return true;
+                if (networks.Contains((uint)r.Prefix & mask))
+                    return true;
             }
             return false;
         }

--- a/BGPLite.Tests/ApiHandlerBehaviorTests.cs
+++ b/BGPLite.Tests/ApiHandlerBehaviorTests.cs
@@ -277,7 +277,6 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
     {
         public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
-        public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default) => Task.FromResult<(IReadOnlyList<IpPrefix>, bool)>(([], false));
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);

--- a/BGPLite.Tests/ApiHandlerBehaviorTests.cs
+++ b/BGPLite.Tests/ApiHandlerBehaviorTests.cs
@@ -278,6 +278,7 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
         public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
+        public Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default) => Task.FromResult<(IReadOnlyList<IpPrefix>, bool)>(([], false));
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);
         public bool SourceSupportsConditional(string sourceName) => false;

--- a/BGPLite.Tests/ApiHandlerBehaviorTests.cs
+++ b/BGPLite.Tests/ApiHandlerBehaviorTests.cs
@@ -288,6 +288,7 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
         public Task RefreshPeerAsync(string peerIp, uint asn) => Task.CompletedTask;
         public List<string> GetActivePeerIps() => [];
         public Task TerminatePeerAsync(string peerIp, uint asn, CancellationToken ct = default) => Task.CompletedTask;
+        public Task TerminatePeerByIpAsync(string peerIp, CancellationToken ct = default) => Task.CompletedTask;
         public void SetPeerMd5Key(string peerIp, string? password) { }
         public int GetAdvertisedPrefixCount(string peerIp, uint asn) => 0;
         public Task RefreshAllEstablishedAsync() => Task.CompletedTask;

--- a/BGPLite.Tests/ApiRateLimiterTests.cs
+++ b/BGPLite.Tests/ApiRateLimiterTests.cs
@@ -17,7 +17,7 @@ public class ApiRateLimiterTests
         PeriodSeconds = periodSeconds
     };
 
-    private static async Task<bool> TryAcquire(PartitionedRateLimiter<string> limiter, string ip)
+    private static async Task<bool> TryAcquire(ClientIpRateLimiter limiter, string ip)
     {
         using var lease = await limiter.AcquireAsync(ip); // RateLimitLease is IDisposable, not IAsyncDisposable
         return lease.IsAcquired;
@@ -39,5 +39,42 @@ public class ApiRateLimiterTests
         Assert.True(await TryAcquire(limiter, "198.51.100.1"));
         Assert.True(await TryAcquire(limiter, "198.51.100.2")); // separate bucket — still allowed
         Assert.False(await TryAcquire(limiter, "198.51.100.1")); // first IP's bucket exhausted
+    }
+
+    [Fact]
+    public async Task IdlePartitions_AreEvicted_ByTheAmortizedSweep()
+    {
+        // #423: PartitionedRateLimiter kept every IP ever seen (and its replenishment timer) for
+        // the process lifetime — with TrustXRealIp the key is client-controlled, so rotating the
+        // header minted fresh buckets without bound. Idle partitions must be evicted.
+        var time = new Microsoft.Extensions.Time.Testing.FakeTimeProvider();
+        await using var limiter = new ClientIpRateLimiter(
+            Cfg(10, 10, 60), timeProvider: time, idleThreshold: TimeSpan.FromSeconds(30), sweepEvery: 1);
+
+        await TryAcquire(limiter, "198.51.100.1");
+        await TryAcquire(limiter, "198.51.100.2");
+        Assert.Equal(2, limiter.TrackedCount);
+
+        time.Advance(TimeSpan.FromSeconds(31));    // both idle past the threshold
+        await TryAcquire(limiter, "198.51.100.3"); // the sweep evicts .1/.2, then mints .3
+
+        Assert.Equal(1, limiter.TrackedCount);
+    }
+
+    [Fact]
+    public async Task ActivePartition_SurvivesTheSweep()
+    {
+        var time = new Microsoft.Extensions.Time.Testing.FakeTimeProvider();
+        await using var limiter = new ClientIpRateLimiter(
+            Cfg(10, 10, 60), timeProvider: time, idleThreshold: TimeSpan.FromSeconds(30), sweepEvery: 1);
+
+        await TryAcquire(limiter, "198.51.100.1");
+        for (var i = 0; i < 5; i++)
+        {
+            time.Advance(TimeSpan.FromSeconds(10)); // under the idle threshold at every touch
+            await TryAcquire(limiter, "198.51.100.1");
+        }
+
+        Assert.Equal(1, limiter.TrackedCount);
     }
 }

--- a/BGPLite.Tests/AsnPrefixProviderTests.cs
+++ b/BGPLite.Tests/AsnPrefixProviderTests.cs
@@ -108,4 +108,29 @@ public class AsnPrefixProviderTests
             provider.LoadAsync(new PrefixSourceConfig { Name = "x", Kind = "asn", Asn = 65010 }));
         Assert.Equal(primedCalls + 1, handler.Calls);   // exactly one provider-driven wire attempt
     }
+
+    [Fact]
+    public async Task RipeStatCache_ExpiredEntries_Swept_EvenBelowTheCap()
+    {
+        // #426: expired per-ASN entries used to be pinned until the 4096-entry cap was hit —
+        // steady-state memory was "every ASN fetched recently", not "live ASNs". The amortized
+        // sweep drops them regardless of the cap (in-flight ASNs excepted).
+        var time = new Microsoft.Extensions.Time.Testing.FakeTimeProvider();
+        var handler = new CountingRipeHandler();
+        var cache = new RipeStatPrefixCache(
+            new RipeStatProvider(new StubFactory(handler), NullLogger<RipeStatProvider>.Instance,
+                new RipeStatConfig { RetryAttempts = 0, RetryDelaySeconds = 0 }),
+            cacheTtl: TimeSpan.FromMilliseconds(100),
+            timeProvider: time,
+            sweepEvery: 1);
+
+        _ = await cache.GetPrefixesAsync(65010);
+        _ = await cache.GetPrefixesAsync(65011);
+        Assert.Equal(2, cache.TrackedCount);
+
+        time.Advance(TimeSpan.FromMilliseconds(150)); // both entries expire
+        _ = await cache.GetPrefixesAsync(65012);      // sweep drops 65010/65011, then fetches 65012
+
+        Assert.Equal(1, cache.TrackedCount);
+    }
 }

--- a/BGPLite.Tests/BgpSessionPhantomWithdrawalTests.cs
+++ b/BGPLite.Tests/BgpSessionPhantomWithdrawalTests.cs
@@ -1,0 +1,119 @@
+using BGPLite.Configuration;
+using BGPLite.Contracts;
+using BGPLite.Protocol;
+using BGPLite.Routing;
+using BGPLite.Server;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #430: the send mirror (<c>_advertisedPrefixes</c>) recorded a batch BEFORE its UPDATE was
+/// serialized. A batch whose composed UPDATE exceeded the 4096-byte maximum (constructible from
+/// a peer-supplied route carrying ~1200 communities) threw out of the writer AFTER the mirror
+/// already claimed the routes — so the NEXT refresh sent WITHDRAWALS for prefixes that were never
+/// announced. Build-then-commit keeps the mirror equal to what is actually on the wire.
+/// </summary>
+public sealed class BgpSessionPhantomWithdrawalTests
+{
+    private static Route PoisonRoute() => new()
+    {
+        Prefix = 0x0A010000,        // 10.1.0.0/16
+        PrefixLength = 16,
+        NextHop = 1,
+        // 1200 communities → a COMMUNITY attribute of ~4800 bytes → the composed UPDATE (NLRI +
+        // ORIGIN + AS_PATH + NEXT_HOP + COMMUNITY) exceeds MaxMessageSize and the writer refuses it.
+        Communities = Enumerable.Range(0, 1200).Select(i => (uint)i).ToArray()
+    };
+
+    private static async Task<(BgpSession Session, Task Run, ScriptedConnection Conn)> EstablishAsync(RouteTable routeTable)
+    {
+        var conn = new ScriptedConnection();
+        var session = new BgpSession(
+            conn,
+            new PeerConfig { Address = "127.0.0.1" },
+            new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 },
+            routeTable,
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            NullLogger<BgpSession>.Instance);
+
+        var run = session.RunAsync();
+        conn.EnqueueMessage(new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = 0,
+            RouterId = 0x0A000002,
+            Capabilities = [BgpCapabilityInfo.FourOctetAsn(65002)]
+        });
+        conn.EnqueueMessage(BgpKeepaliveMessage.Instance);
+
+        for (var i = 0; i < 200 && !session.IsEstablished; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        Assert.True(session.IsEstablished, "session must reach Established");
+        return (session, run, conn);
+    }
+
+    private static int CountUpdates(ScriptedConnection conn) =>
+        conn.Sent.Select(f => BgpMessageReader.ReadMessage(f)).OfType<BgpUpdateMessage>().Count();
+
+    [Fact]
+    public async Task FailedOversizeSend_DoesNotLeavePhantomMirrorEntries()
+    {
+        var routeTable = new RouteTable();
+        routeTable.AddOrUpdate(new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 1 }); // healthy seed
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        // Healthy refresh #1: the /8 is advertised normally.
+        await session.RefreshRoutesAsync();
+
+        // Inject the poison route and refresh: the composed UPDATE exceeds MaxMessageSize, the
+        // writer throws mid-send, and RefreshCycleAsync contains the failure (session stays up).
+        routeTable.AddOrUpdate(PoisonRoute());
+        await session.RefreshRoutesAsync();
+
+        var updatesBefore = CountUpdates(conn);
+
+        // Healthy refresh #2: WithdrawAllAsync must withdraw ONLY what is actually on the wire —
+        // pre-#430 the mirror also held the POISON route (recorded before the failed send), so
+        // this refresh put a PHANTOM withdrawal for 10.1.0.0/16 on the wire. The healthy /8's
+        // withdraw+re-announce may legitimately appear again.
+        await session.RefreshRoutesAsync();
+        await Task.Delay(TimeSpan.FromMilliseconds(100));
+
+        Assert.True(session.IsEstablished, "the oversize send is contained — the session stays up");
+        var updatesAfter = conn.Sent
+            .Skip(updatesBefore)
+            .Select(f => BgpMessageReader.ReadMessage(f))
+            .OfType<BgpUpdateMessage>()
+            .ToList();
+        Assert.DoesNotContain(updatesAfter,
+            u => u.WithdrawnRoutes.Any(p => p.Address == 0x0A010000 && p.Length == 16));
+
+        session.Dispose();
+        try { await run.WaitAsync(TimeSpan.FromSeconds(2)); } catch (TimeoutException) { }
+    }
+
+    [Fact]
+    public async Task HealthySend_MirrorMatchesTheWire()
+    {
+        // Control: on a normal send the mirror (observable via a later withdrawal) still matches
+        // the wire — the reorder must not break the withdraw-what-we-advertised contract.
+        var routeTable = new RouteTable();
+        routeTable.AddOrUpdate(new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 1 });
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        await session.RefreshRoutesAsync();                       // advertises the /8
+        routeTable.Remove(0x0A000000, 8);                         // source disappears
+        await session.RefreshRoutesAsync();                       // withdraws the /8
+
+        var updates = conn.Sent.Select(f => BgpMessageReader.ReadMessage(f)).OfType<BgpUpdateMessage>().ToList();
+        Assert.Contains(updates, u => u.Nlri.Any(p => p.Address == 0x0A000000 && p.Length == 8));
+        var withdrawal = updates.LastOrDefault(u => u.WithdrawnRoutes.Any(p => p.Address == 0x0A000000));
+        Assert.NotNull(withdrawal);
+
+        session.Dispose();
+        try { await run.WaitAsync(TimeSpan.FromSeconds(2)); } catch (TimeoutException) { }
+    }
+}

--- a/BGPLite.Tests/BgpSessionV6AdvertiseTests.cs
+++ b/BGPLite.Tests/BgpSessionV6AdvertiseTests.cs
@@ -120,7 +120,11 @@ public class BgpSessionV6AdvertiseTests
         routeTable.AddOrUpdate(new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 1 });
         var (session, run, conn) = await EstablishAsync(routeTable, routeRefresh: true);
 
-        var initial = CountUpdates(conn);
+        // Wait for the initial dump before snapshotting (Established ≠ dump-complete,
+        // CodeRabbit on #450).
+        var initial = 0;
+        for (var i = 0; i < 300 && (initial = CountUpdates(conn)) == 0; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
         Assert.True(initial > 0);
 
         conn.EnqueueMessage(new BgpRouteRefreshMessage { Afi = BgpConstants.Afi.IPv4, Reserved = 0, Safi = BgpConstants.Safi.Unicast });

--- a/BGPLite.Tests/BgpSessionV6AdvertiseTests.cs
+++ b/BGPLite.Tests/BgpSessionV6AdvertiseTests.cs
@@ -36,7 +36,7 @@ public class BgpSessionV6AdvertiseTests
     };
 
     private static async Task<(BgpSession Session, Task Run, ScriptedConnection Conn)> EstablishAsync(
-        RouteTable routeTable, BgpConfig? config = null, bool negotiateMpV6 = true)
+        RouteTable routeTable, BgpConfig? config = null, bool negotiateMpV6 = true, bool routeRefresh = false)
     {
         var conn = new ScriptedConnection();
         var session = new BgpSession(
@@ -52,6 +52,8 @@ public class BgpSessionV6AdvertiseTests
         var capabilities = new List<BgpCapabilityInfo> { BgpCapabilityInfo.FourOctetAsn(65002) };
         if (negotiateMpV6)
             capabilities.Add(BgpCapabilityInfo.MultiprotocolIpv6Unicast());
+        if (routeRefresh)
+            capabilities.Add(BgpCapabilityInfo.RouteRefresh());
         conn.EnqueueMessage(new BgpOpenMessage
         {
             Version = BgpConstants.BgpVersion,
@@ -67,6 +69,74 @@ public class BgpSessionV6AdvertiseTests
         Assert.True(session.IsEstablished, "session must reach Established");
         return (session, run, conn);
     }
+
+    [Fact]
+    public async Task RouteRefresh_Afi2_RereadvertisesV6Routes()
+    {
+        // #420 (RFC 2918 §2): a refresh request names the AFI/SAFI to re-send. An MP-IPv6-
+        // negotiated peer's AFI=2/SAFI=1 request was silently ignored — the only way to get the
+        // routes re-advertised was bouncing the session. It must trigger the same debounced
+        // re-announcement dump the AFI=1 request does.
+        var routeTable = new RouteTable();
+        routeTable.AddOrUpdate(V6Route());
+        var (session, run, conn) = await EstablishAsync(routeTable, routeRefresh: true);
+
+        // Wait for the initial dump's single MP_REACH frame before asking for a refresh.
+        var initial = 0;
+        for (var i = 0; i < 300 && (initial = CountMpReach(conn)) == 0; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        Assert.Equal(1, initial);
+
+        conn.EnqueueMessage(new BgpRouteRefreshMessage { Afi = BgpConstants.Afi.IPv6, Reserved = 0, Safi = BgpConstants.Safi.Unicast });
+        for (var i = 0; i < 300 && CountMpReach(conn) <= initial; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+
+        Assert.True(CountMpReach(conn) > initial, "AFI=2 ROUTE_REFRESH must re-advertise the v6 routes");
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task RouteRefresh_Afi2_WithoutNegotiation_Ignored()
+    {
+        var routeTable = new RouteTable();
+        routeTable.AddOrUpdate(V6Route());
+        var (session, run, conn) = await EstablishAsync(routeTable, negotiateMpV6: false, routeRefresh: true);
+
+        conn.EnqueueMessage(new BgpRouteRefreshMessage { Afi = BgpConstants.Afi.IPv6, Reserved = 0, Safi = BgpConstants.Safi.Unicast });
+        await Task.Delay(TimeSpan.FromMilliseconds(300));
+
+        // Without MP-IPv6 negotiation no v6 advertisement exists to refresh — the request is a no-op.
+        Assert.Equal(0, CountMpReach(conn));
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task RouteRefresh_Afi1_StillRereadvertises()
+    {
+        // Control for the #420 gate refactor: the IPv4/Unicast refresh path is unchanged.
+        var routeTable = new RouteTable();
+        routeTable.AddOrUpdate(new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 1 });
+        var (session, run, conn) = await EstablishAsync(routeTable, routeRefresh: true);
+
+        var initial = CountUpdates(conn);
+        Assert.True(initial > 0);
+
+        conn.EnqueueMessage(new BgpRouteRefreshMessage { Afi = BgpConstants.Afi.IPv4, Reserved = 0, Safi = BgpConstants.Safi.Unicast });
+        for (var i = 0; i < 300 && CountUpdates(conn) <= initial; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+
+        Assert.True(CountUpdates(conn) > initial, "AFI=1 ROUTE_REFRESH must re-advertise");
+
+        await TeardownAsync(session, run);
+    }
+
+    private static int CountUpdates(ScriptedConnection conn) =>
+        conn.Sent.Select(f => BgpMessageReader.ReadMessage(f)).OfType<BgpUpdateMessage>().Count();
+
+    private static int CountMpReach(ScriptedConnection conn) =>
+        conn.Sent.Select(f => BgpMessageReader.ReadMessage(f)).OfType<BgpUpdateMessage>().Count(u => u.MpReachV6 is not null);
 
     private static async Task TeardownAsync(BgpSession session, Task run)
     {

--- a/BGPLite.Tests/ConfigHotReloadTests.cs
+++ b/BGPLite.Tests/ConfigHotReloadTests.cs
@@ -388,6 +388,7 @@ public class ConfigHotReloadTests
         public int GetAdvertisedPrefixCount(string peerIp, uint asn) => 0;
         public Task RefreshAllEstablishedAsync() => Task.CompletedTask;
         public Task TerminatePeerAsync(string peerIp, uint asn, CancellationToken ct = default) => Task.CompletedTask;
+        public Task TerminatePeerByIpAsync(string peerIp, CancellationToken ct = default) => Task.CompletedTask;
         public void SetPeerMd5Key(string peerIp, string? password) { }
     }
 

--- a/BGPLite.Tests/ConfigHotReloadTests.cs
+++ b/BGPLite.Tests/ConfigHotReloadTests.cs
@@ -373,8 +373,6 @@ public class ConfigHotReloadTests
             => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default)
             => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
-        public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default)
             => Task.FromResult<(IReadOnlyList<IpPrefix>, bool)>(([], false));
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;

--- a/BGPLite.Tests/ConfigHotReloadTests.cs
+++ b/BGPLite.Tests/ConfigHotReloadTests.cs
@@ -375,6 +375,8 @@ public class ConfigHotReloadTests
             => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default)
             => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
+        public Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default)
+            => Task.FromResult<(IReadOnlyList<IpPrefix>, bool)>(([], false));
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);
         public bool SourceSupportsConditional(string sourceName) => false;

--- a/BGPLite.Tests/ExceptionMappingTests.cs
+++ b/BGPLite.Tests/ExceptionMappingTests.cs
@@ -26,17 +26,18 @@ public class ExceptionMappingTests
     }
 
     [Fact]
-    public void DbUpdateException_MapsTo_409_Conflict()
+    public void DbUpdateException_WithoutSqliteInner_MapsTo_500()
     {
-        // A unique-constraint violation (concurrent duplicate CreatePeer/UpsertPeer) is a 409, not
-        // a 500. EF Core wraps SQLite's "UNIQUE constraint failed" in DbUpdateException.
+        // #431: a DbUpdateException WITHOUT a SqliteException inner (an EF-level failure, e.g. a
+        // value conversion) is a server-side problem — the pre-#431 mapping answered 409 "already
+        // exists" for it, misleading every client debugging the conflict.
         var inner = new InvalidOperationException("UNIQUE constraint failed: Peers.Ip, Peers.Asn");
         var ex = new DbUpdateException("An error occurred while saving the entity changes.", inner);
 
         var (message, status) = ManagementApi.MapExceptionToResponse(ex);
 
-        Assert.Equal(409, status);
-        Assert.Equal("The resource already exists or conflicts with the current state", message);
+        Assert.Equal(500, status);
+        Assert.Equal("Internal server error", message);
         // The raw constraint text must NOT appear in the client-facing message.
         Assert.DoesNotContain("UNIQUE constraint", message);
         Assert.DoesNotContain("Peers.Ip", message);
@@ -113,5 +114,20 @@ public class ExceptionMappingTests
 
         Assert.Equal(409, status);
         Assert.Contains("exists", message);
+    }
+
+    [Theory]
+    [InlineData(1299)] // SQLITE_CONSTRAINT_NOTNULL — a schema/data bug, not a client conflict
+    [InlineData(275)]  // SQLITE_CONSTRAINT_CHECK
+    public void DbUpdateException_NonConflictConstraint_MapsTo_500(int extendedCode)
+    {
+        // #431: the pre-#431 catch-all labeled every non-FK constraint 409 "already exists" —
+        // including NOT NULL / CHECK violations, which are server-side bugs. Only UNIQUE (2067)
+        // is a conflict.
+        var ex = new DbUpdateException("constraint failed", new SqliteException("constraint failed", 19, extendedCode));
+        var (message, status) = ManagementApi.MapExceptionToResponse(ex);
+
+        Assert.Equal(500, status);
+        Assert.Equal("Internal server error", message);
     }
 }

--- a/BGPLite.Tests/HttpPrefixProviderTests.cs
+++ b/BGPLite.Tests/HttpPrefixProviderTests.cs
@@ -21,6 +21,8 @@ public class HttpPrefixProviderTests
             _body = body;
         }
 
+        public StubHandler() : this(HttpStatusCode.OK, "10.0.0.0/8\n") { }
+
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
         {
             LastRequestUri = request.RequestUri;
@@ -33,6 +35,7 @@ public class HttpPrefixProviderTests
         private readonly HttpMessageHandler _handler;
         private readonly string? _defaultUserAgent;
         public HttpClient? LastClient { get; private set; }
+        public string LastName { get; private set; } = "";
         public StubFactory(HttpMessageHandler handler, string? defaultUserAgent = null)
         {
             _handler = handler;
@@ -40,6 +43,7 @@ public class HttpPrefixProviderTests
         }
         public HttpClient CreateClient(string name)
         {
+            LastName = name;
             LastClient = new HttpClient(_handler, disposeHandler: false);
             if (_defaultUserAgent is not null)
                 LastClient.DefaultRequestHeaders.UserAgent.ParseAdd(_defaultUserAgent);
@@ -78,6 +82,31 @@ public class HttpPrefixProviderTests
         var provider = Provider(new StubHandler(HttpStatusCode.OK, "1.2.3.0/24\n5.6.0.0/16\n"));
         var result = await provider.LoadAsync(HttpSource("https://raw.githubusercontent.com/o/r/main/x.txt"));
         Assert.Equal(2, result.Prefixes.Count);
+    }
+
+    [Fact]
+    public async Task LoadAsync_UsesTheClientNameFromTheCtor()
+    {
+        // #425: the user-source instance must draw its HttpClient from the retry-only named
+        // pipeline, never from the shared breaker pipeline the operator sources use.
+        var factory = new StubFactory(new StubHandler());
+        var provider = new HttpPrefixProvider(
+            factory, NullLogger<HttpPrefixProvider>.Instance, clientName: HttpPrefixProvider.UserSourceClientName);
+
+        await provider.LoadAsync(HttpSource("https://example.com/u.txt"));
+
+        Assert.Equal(HttpPrefixProvider.UserSourceClientName, factory.LastName);
+    }
+
+    [Fact]
+    public async Task LoadAsync_DefaultsToTheOperatorClientName()
+    {
+        var factory = new StubFactory(new StubHandler());
+        var provider = new HttpPrefixProvider(factory, NullLogger<HttpPrefixProvider>.Instance);
+
+        await provider.LoadAsync(HttpSource("https://example.com/o.txt"));
+
+        Assert.Equal(HttpPrefixProvider.ClientName, factory.LastName);
     }
 
     [Fact]

--- a/BGPLite.Tests/MalformedUpdateResilienceTests.cs
+++ b/BGPLite.Tests/MalformedUpdateResilienceTests.cs
@@ -161,6 +161,86 @@ public class MalformedUpdateResilienceTests
     }
 
     [Fact]
+    public async Task MalformedOpen_InEstablished_IsFsmError_SessionResets()
+    {
+        // #427 (RFC 4271 §8.2.2): an OPEN received in Established is an FSM error REGARDLESS of
+        // body validity — Established accepts only UPDATE/KEEPALIVE/NOTIFICATION/ROUTE_REFRESH
+        // and a conformant speaker never parses the body. Pre-fix the body-error filter applied
+        // the UPDATE treatment (D17): the session stayed up with a warning and no NOTIFICATION.
+        var (server, client) = ConnectedPair();
+        using var clientSock = client;
+        var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
+        var metrics = new BgpMetrics();
+        using var session = new BgpSession(
+            new SocketBgpConnection(server),
+            new PeerConfig { Address = "127.0.0.1" },
+            bgpConfig,
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            metrics,
+            new NopLogger<BgpSession>());
+
+        var runTask = await EstablishSessionAsync(session, client, bgpConfig);
+
+        // Well-framed OPEN, body-invalid: the 10-byte minimum payload declares optParamsLen=5,
+        // which cannot fit — ParseOpen throws Open Message Error before the FSM switch saw the type.
+        var payload = new byte[10];
+        payload[0] = 4;                       // version
+        payload[1] = 0xFD; payload[2] = 0xE8; // My AS 65002
+        payload[9] = 5;                       // optional-parameters length: mismatches the 0 present
+        var open = BuildMessage(BgpMessageType.Open, payload);
+        client.Send(open, 0, open.Length, SocketFlags.None);
+
+        var sent = await DrainAsync(client, TimeSpan.FromSeconds(2));
+        var notification = Assert.Single(sent.OfType<BgpNotificationMessage>());
+        Assert.Equal(BgpConstants.Error.FiniteStateMachineError, notification.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.Unspecific, notification.SubErrorCode);
+        Assert.False(session.IsEstablished, "an OPEN in Established must reset the session (RFC 4271 §8.2.2)");
+
+        await runTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task WellFormedOpen_InEstablished_IsFsmError_Too()
+    {
+        // Control for #427: both OPEN classes in Established — well-formed and malformed — take
+        // the same FSM-error teardown; only the parse-failure path changed.
+        var (server, client) = ConnectedPair();
+        using var clientSock = client;
+        var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
+        var metrics = new BgpMetrics();
+        using var session = new BgpSession(
+            new SocketBgpConnection(server),
+            new PeerConfig { Address = "127.0.0.1" },
+            bgpConfig,
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            metrics,
+            new NopLogger<BgpSession>());
+
+        var runTask = await EstablishSessionAsync(session, client, bgpConfig);
+
+        var open = new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = 0,
+            RouterId = 0x0A000002,
+            Capabilities = [BgpCapabilityInfo.FourOctetAsn(65002)]
+        };
+        var buffer = new byte[BgpMessageWriter.GetBufferSize(open)];
+        var written = BgpMessageWriter.WriteMessage(open, buffer);
+        client.Send(buffer, 0, written, SocketFlags.None);
+
+        var sent = await DrainAsync(client, TimeSpan.FromSeconds(2));
+        Assert.Equal(BgpConstants.Error.FiniteStateMachineError,
+            Assert.Single(sent.OfType<BgpNotificationMessage>()).ErrorCode);
+        Assert.False(session.IsEstablished);
+
+        await runTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
     public async Task DuplicateNextHop_OnWire_InstallsTheFirstOccurrence()
     {
         // #287 / RFC 7606 §3: a duplicated attribute is not an error — all occurrences after the

--- a/BGPLite.Tests/ManagementApiShutdownTests.cs
+++ b/BGPLite.Tests/ManagementApiShutdownTests.cs
@@ -234,6 +234,8 @@ public sealed class ManagementApiShutdownTests : IDisposable
             => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default)
             => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
+        public Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default)
+            => Task.FromResult<(IReadOnlyList<IpPrefix>, bool)>(([], false));
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);
         public bool SourceSupportsConditional(string sourceName) => false;

--- a/BGPLite.Tests/ManagementApiShutdownTests.cs
+++ b/BGPLite.Tests/ManagementApiShutdownTests.cs
@@ -104,6 +104,111 @@ public sealed class ManagementApiShutdownTests : IDisposable
     }
 
     [Fact]
+    public async Task AsnListsGet_ExternalFetchBudget_BoundsColdRequests()
+    {
+        // #424: a cold /api/asn-lists fetches RIPEstat per ASN (minutes-scale per ASN); N such GETs
+        // used to monopolize the global in-flight cap and starve every other route. The handler's
+        // wall-clock budget (default 30s, shrunk here) bounds the request: the parked provider is
+        // cancelled, the partial counts are served, status stays 200 — never a hang.
+        var provider = new BlockingRuPrefixService();
+        for (var attempt = 0; ; attempt++)
+        {
+            var port = FreeTcpPort();
+            var config = new AppConfig
+            {
+                ApiListen = "127.0.0.1",
+                ApiPort = port,
+                Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" },
+                RipeStat = new RipeStatConfig { AsnLists = [new AsnList { Name = "ru", Country = "RU" }] }
+            };
+            _api = new ManagementApi(
+                new PeerStore(new StaticOptionsFactory(new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(_connection).Options)),
+                new RouteTable(),
+                config,
+                new BgpMetrics(),
+                NullLogger<ManagementApi>.Instance,
+                provider,
+                new InertPrefixSourceService(),
+                new InertSessionManager());
+            _api.ExternalFetchBudget = TimeSpan.FromMilliseconds(250);
+            try
+            {
+                await _api.StartAsync(CancellationToken.None);
+                _port = port;
+                break;
+            }
+            catch (HttpListenerException) when (attempt < 2)
+            {
+                _api.Dispose();
+                _api = null;
+            }
+        }
+        _client = new HttpClient();
+
+        var watch = System.Diagnostics.Stopwatch.StartNew();
+        var response = await _client.GetAsync($"http://127.0.0.1:{_port}/api/asn-lists");
+        watch.Stop();
+
+        await provider.Entered.Task.WaitAsync(TimeSpan.FromSeconds(5)); // the fetch really started
+        Assert.True(watch.Elapsed < TimeSpan.FromSeconds(5),
+            $"the fetch budget must bound the request, took {watch.Elapsed}");
+        Assert.True(response.IsSuccessStatusCode, "budget expiry must degrade to a partial 200, not an error");
+    }
+
+    [Fact]
+    public async Task ExportPrefixesGet_ExternalFetchBudget_BoundsColdRequests()
+    {
+        // #424: /api/peers/{id}/prefixes has the same cold-fetch shape (subscription ASN/RU pulls).
+        var store = new PeerStore(new StaticOptionsFactory(new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(_connection).Options));
+        var peerId = await store.CreatePeerAsync("203.0.113.42", 65002, null);
+        await store.SetSubscriptionsAsync(peerId, ["ru"]);
+
+        var provider = new BlockingRuPrefixService();
+        for (var attempt = 0; ; attempt++)
+        {
+            var port = FreeTcpPort();
+            var config = new AppConfig
+            {
+                ApiListen = "127.0.0.1",
+                ApiPort = port,
+                Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" },
+                RipeStat = new RipeStatConfig { AsnLists = [new AsnList { Name = "ru", Country = "RU" }] }
+            };
+            _api = new ManagementApi(
+                store,
+                new RouteTable(),
+                config,
+                new BgpMetrics(),
+                NullLogger<ManagementApi>.Instance,
+                provider,
+                new InertPrefixSourceService(),
+                new InertSessionManager());
+            _api.ExternalFetchBudget = TimeSpan.FromMilliseconds(250);
+            try
+            {
+                await _api.StartAsync(CancellationToken.None);
+                _port = port;
+                break;
+            }
+            catch (HttpListenerException) when (attempt < 2)
+            {
+                _api.Dispose();
+                _api = null;
+            }
+        }
+        _client = new HttpClient();
+
+        var watch = System.Diagnostics.Stopwatch.StartNew();
+        var response = await _client.GetAsync($"http://127.0.0.1:{_port}/api/peers/{peerId}/prefixes");
+        watch.Stop();
+
+        await provider.Entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.True(watch.Elapsed < TimeSpan.FromSeconds(5),
+            $"the fetch budget must bound the request, took {watch.Elapsed}");
+        Assert.True(response.IsSuccessStatusCode, "budget expiry must degrade to a partial 200, not an error");
+    }
+
+    [Fact]
     public async Task StartAsync_Retries_WhenThePortIsTaken()
     {
         // FreeTcpPort has an inherent TOCTOU window — a concurrent bind between the probe and

--- a/BGPLite.Tests/ManagementApiShutdownTests.cs
+++ b/BGPLite.Tests/ManagementApiShutdownTests.cs
@@ -232,8 +232,6 @@ public sealed class ManagementApiShutdownTests : IDisposable
             => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default)
             => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
-        public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default)
             => Task.FromResult<(IReadOnlyList<IpPrefix>, bool)>(([], false));
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;

--- a/BGPLite.Tests/ManagementApiShutdownTests.cs
+++ b/BGPLite.Tests/ManagementApiShutdownTests.cs
@@ -247,6 +247,7 @@ public sealed class ManagementApiShutdownTests : IDisposable
         public int GetAdvertisedPrefixCount(string peerIp, uint asn) => 0;
         public Task RefreshAllEstablishedAsync() => Task.CompletedTask;
         public Task TerminatePeerAsync(string peerIp, uint asn, CancellationToken ct = default) => Task.CompletedTask;
+        public Task TerminatePeerByIpAsync(string peerIp, CancellationToken ct = default) => Task.CompletedTask;
         public void SetPeerMd5Key(string peerIp, string? password) { }
     }
 

--- a/BGPLite.Tests/PeerDeleteTeardownTests.cs
+++ b/BGPLite.Tests/PeerDeleteTeardownTests.cs
@@ -53,6 +53,66 @@ public sealed class PeerDeleteTeardownTests
         Assert.Empty(manager.Terminated);
     }
 
+    // ---- management API: TCP-MD5 key re-arm on delete (#418) ----
+
+    [Fact]
+    public async Task DeletePeer_RearmsIpKey_FromSurvivingSibling()
+    {
+        using var connection = NewOpenConnection();
+        var store = NewStore(connection);
+        var idA = await store.CreatePeerAsync("203.0.113.7", 65001, null);
+        var idB = await store.CreatePeerAsync("203.0.113.7", 65002, null);
+        await store.UpdatePeerConfigurationAsync(idA, null, asnListNames: null, customPrefixes: null, customAsns: null, maxPrefix: null, md5Password: "key-a");
+        await store.UpdatePeerConfigurationAsync(idB, null, asnListNames: null, customPrefixes: null, customAsns: null, maxPrefix: null, md5Password: "key-b");
+        var manager = new RecordingSessionManager();
+        using var api = NewApi(store, manager);
+
+        var response = await api.HandleDeletePeer(idB);
+
+        Assert.Equal(200, response.StatusCode);
+        // Pre-#418 the delete armed null — silently disarming TCP-MD5 for the surviving sibling.
+        var armed = Assert.Single(manager.Md5Keys);
+        Assert.Equal("203.0.113.7", armed.Ip);
+        Assert.Equal("key-a", armed.Password);
+    }
+
+    [Fact]
+    public async Task DeletePeer_LastKeyedPeerOnIp_ClearsIpKey()
+    {
+        using var connection = NewOpenConnection();
+        var store = NewStore(connection);
+        var id = await store.CreatePeerAsync("203.0.113.8", 65001, null);
+        await store.UpdatePeerConfigurationAsync(id, null, asnListNames: null, customPrefixes: null, customAsns: null, maxPrefix: null, md5Password: "solo-key");
+        var manager = new RecordingSessionManager();
+        using var api = NewApi(store, manager);
+
+        await api.HandleDeletePeer(id);
+
+        var armed = Assert.Single(manager.Md5Keys);
+        Assert.Equal("203.0.113.8", armed.Ip);
+        Assert.Null(armed.Password); // nothing survives on the IP — a genuine disarm
+    }
+
+    [Fact]
+    public async Task RearmPeerIpMd5Key_ClearingSiblingPassword_FallsBackToSurvivingKey()
+    {
+        using var connection = NewOpenConnection();
+        var store = NewStore(connection);
+        var idA = await store.CreatePeerAsync("203.0.113.7", 65001, null);
+        var idB = await store.CreatePeerAsync("203.0.113.7", 65002, null);
+        await store.UpdatePeerConfigurationAsync(idA, null, asnListNames: null, customPrefixes: null, customAsns: null, maxPrefix: null, md5Password: "key-a");
+        await store.UpdatePeerConfigurationAsync(idB, null, asnListNames: null, customPrefixes: null, customAsns: null, maxPrefix: null, md5Password: "key-b");
+        var manager = new RecordingSessionManager();
+        using var api = NewApi(store, manager);
+
+        // The PATCH path clears idB's password (store already updated), then re-arms the IP.
+        await store.UpdatePeerConfigurationAsync(idB, null, asnListNames: null, customPrefixes: null, customAsns: null, maxPrefix: null, md5Password: "");
+        await api.RearmPeerIpMd5KeyAsync("203.0.113.7");
+
+        var armed = Assert.Single(manager.Md5Keys);
+        Assert.Equal("key-a", armed.Password); // the sibling's enforcement survives the clear
+    }
+
     // ---- server: the teardown core over real scripted sessions ----
 
     [Fact]
@@ -219,10 +279,11 @@ public sealed class PeerDeleteTeardownTests
             NullLogger<RouteAssembler>.Instance);
     }
 
-    /// <summary>Records TerminatePeerAsync calls; the optional hook runs at call time (row-state assertions).</summary>
+    /// <summary>Records TerminatePeerAsync and SetPeerMd5Key calls; the optional hook runs at terminate time (row-state assertions).</summary>
     private sealed class RecordingSessionManager(Func<string, uint, Task>? onTerminate = null) : ISessionManager
     {
         public List<(string Ip, uint Asn)> Terminated { get; } = [];
+        public List<(string Ip, string? Password)> Md5Keys { get; } = [];
 
         public Task RefreshPeerAsync(string peerIp, uint asn) => Task.CompletedTask;
         public List<string> GetActivePeerIps() => [];
@@ -234,7 +295,7 @@ public sealed class PeerDeleteTeardownTests
             Terminated.Add((peerIp, asn));
             if (onTerminate is not null) await onTerminate(peerIp, asn);
         }
-        public void SetPeerMd5Key(string peerIp, string? password) { }
+        public void SetPeerMd5Key(string peerIp, string? password) => Md5Keys.Add((peerIp, password));
     }
 
     private sealed class StaticOptionsFactory(DbContextOptions<BgpDbContext> options) : IDbContextFactory<BgpDbContext>

--- a/BGPLite.Tests/PeerDeleteTeardownTests.cs
+++ b/BGPLite.Tests/PeerDeleteTeardownTests.cs
@@ -53,6 +53,42 @@ public sealed class PeerDeleteTeardownTests
         Assert.Empty(manager.Terminated);
     }
 
+    [Fact]
+    public async Task DeletePeer_NullAsn_TerminatesByIp_NotSilentNoOp()
+    {
+        // #422: a legacy NULL-Asn row cannot match a live session by (Ip, Asn) — no session ever
+        // has RemoteAsn 0 (AS 0 OPENs are rejected, #300) — so the pre-#422 `asn ?? 0` teardown
+        // was a SILENT no-op: the row was deleted while its session kept advertising. The delete
+        // must terminate by IP instead.
+        using var connection = NewOpenConnection();
+        var store = NewStore(connection);
+        InsertLegacyNullAsnRow(connection, "203.0.113.9");
+        var row = (await store.GetPeersByIpAsync("203.0.113.9")).Single();
+        var manager = new RecordingSessionManager();
+        using var api = NewApi(store, manager);
+
+        var response = await api.HandleDeletePeer(row.Id);
+
+        Assert.Equal(200, response.StatusCode);
+        Assert.Empty(manager.Terminated); // the (Ip, Asn=0) match is gone — it never matched anything
+        Assert.Equal("203.0.113.9", Assert.Single(manager.TerminatedByIp));
+        Assert.Null(await store.GetDbPeerByIdAsync(row.Id));
+    }
+
+    /// <summary>A row from the Ip-only era: no Asn column value (#19 pre-#422 legacy shape).</summary>
+    private static void InsertLegacyNullAsnRow(SqliteConnection connection, string ip)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText =
+            "INSERT INTO Peers (Id, Ip, Asn, Description, Status, CreatedAt, LastSessionAt) " +
+            "VALUES ('legacy-row', @ip, NULL, NULL, 'inactive', '2026-01-01T00:00:00.0000000Z', NULL)";
+        var p = cmd.CreateParameter();
+        p.ParameterName = "@ip";
+        p.Value = ip;
+        cmd.Parameters.Add(p);
+        cmd.ExecuteNonQuery();
+    }
+
     // ---- management API: TCP-MD5 key re-arm on delete (#418) ----
 
     [Fact]
@@ -283,6 +319,7 @@ public sealed class PeerDeleteTeardownTests
     private sealed class RecordingSessionManager(Func<string, uint, Task>? onTerminate = null) : ISessionManager
     {
         public List<(string Ip, uint Asn)> Terminated { get; } = [];
+        public List<string> TerminatedByIp { get; } = [];
         public List<(string Ip, string? Password)> Md5Keys { get; } = [];
 
         public Task RefreshPeerAsync(string peerIp, uint asn) => Task.CompletedTask;
@@ -294,6 +331,11 @@ public sealed class PeerDeleteTeardownTests
         {
             Terminated.Add((peerIp, asn));
             if (onTerminate is not null) await onTerminate(peerIp, asn);
+        }
+        public Task TerminatePeerByIpAsync(string peerIp, CancellationToken ct = default)
+        {
+            TerminatedByIp.Add(peerIp);
+            return Task.CompletedTask;
         }
         public void SetPeerMd5Key(string peerIp, string? password) => Md5Keys.Add((peerIp, password));
     }

--- a/BGPLite.Tests/PeerDeleteTeardownTests.cs
+++ b/BGPLite.Tests/PeerDeleteTeardownTests.cs
@@ -266,8 +266,6 @@ public sealed class PeerDeleteTeardownTests
             => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default)
             => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
-        public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default)
-            => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default)
             => Task.FromResult<(IReadOnlyList<IpPrefix>, bool)>(([], false));
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;

--- a/BGPLite.Tests/PeerDeleteTeardownTests.cs
+++ b/BGPLite.Tests/PeerDeleteTeardownTests.cs
@@ -268,6 +268,8 @@ public sealed class PeerDeleteTeardownTests
             => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default)
             => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
+        public Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default)
+            => Task.FromResult<(IReadOnlyList<IpPrefix>, bool)>(([], false));
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);
         public bool SourceSupportsConditional(string sourceName) => false;

--- a/BGPLite.Tests/PeerInputValidationTests.cs
+++ b/BGPLite.Tests/PeerInputValidationTests.cs
@@ -36,8 +36,9 @@ public class PeerInputValidationTests
 
     /// <summary>
     /// Rejected outright: unparseable input, absent input (which reached the store as null and
-    /// surfaced as a 500 from a NOT NULL violation), and IPv6 — BGPLite is IPv4-unicast only, so an
-    /// IPv6 peer row could never match a session either.
+    /// surfaced as a 500 from a NOT NULL violation), and — #421 — addresses no BGP session can
+    /// ever originate from (unspecified / loopback / multicast / broadcast; parity with the YAML
+    /// path's #390 validation, which already rejects 0.0.0.0).
     /// </summary>
     [Theory]
     [InlineData(null)]
@@ -47,6 +48,15 @@ public class PeerInputValidationTests
     [InlineData(" 1.2.3.4")]
     [InlineData("banana")]
     [InlineData("1.2.3.4.5")]
+    [InlineData("0.0.0.0")]              // #421: unspecified (the YAML path rejects it too, #390)
+    [InlineData("0.1.2.3")]              // #421: 0.0.0.0/8
+    [InlineData("127.0.0.1")]            // #421: loopback
+    [InlineData("224.0.0.1")]            // #421: multicast
+    [InlineData("255.255.255.255")]      // #421: broadcast
+    [InlineData("::")]                   // #421: IPv6 unspecified
+    [InlineData("::1")]                  // #421: IPv6 loopback
+    [InlineData("ff02::1")]              // #421: IPv6 multicast
+    [InlineData("::ffff:224.0.0.1")]     // #421: multicast hidden behind the mapped form
     public void NormalizePeerIp_RejectsUnusableInput(string? input)
     {
         Assert.Null(ManagementApi.NormalizePeerIp(input));

--- a/BGPLite.Tests/PeerSetupTemplateTests.cs
+++ b/BGPLite.Tests/PeerSetupTemplateTests.cs
@@ -56,7 +56,9 @@ public class PeerSetupTemplateTests
     public void NormalizePeerIp_Ipv6_AcceptedAndCanonical()
     {
         Assert.Equal("2001:db8:cccc::20", ManagementApi.NormalizePeerIp("2001:db8:cccc:0:0:0:0:20"));
-        Assert.Equal("::1", ManagementApi.NormalizePeerIp("::1"));
+        // #421: ::1 (loopback) is no longer accepted as a peer address — the compressed-form
+        // canonicalization this test pins is covered by a non-special address instead.
+        Assert.Equal("2001:db8:cccc::21", ManagementApi.NormalizePeerIp("2001:0db8:cccc:0000:0000:0000:0000:0021"));
     }
 
     [Fact]

--- a/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
+++ b/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
@@ -40,7 +40,6 @@ public class PrefixAutoRefreshServiceTests
         public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
             => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
-        public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default) => Task.FromResult<(IReadOnlyList<IpPrefix>, bool)>(([], false));
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
     }

--- a/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
+++ b/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
@@ -41,6 +41,7 @@ public class PrefixAutoRefreshServiceTests
             => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
+        public Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default) => Task.FromResult<(IReadOnlyList<IpPrefix>, bool)>(([], false));
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
     }
 

--- a/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
+++ b/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
@@ -53,6 +53,7 @@ public class PrefixAutoRefreshServiceTests
         public int GetAdvertisedPrefixCount(string peerIp, uint asn) => 0;
         public Task RefreshAllEstablishedAsync() { RefreshAllCalls++; return Task.CompletedTask; }
         public Task TerminatePeerAsync(string peerIp, uint asn, CancellationToken ct = default) => Task.CompletedTask;
+        public Task TerminatePeerByIpAsync(string peerIp, CancellationToken ct = default) => Task.CompletedTask;
         public void SetPeerMd5Key(string peerIp, string? password) { }
     }
 

--- a/BGPLite.Tests/PrefixCacheFailureTests.cs
+++ b/BGPLite.Tests/PrefixCacheFailureTests.cs
@@ -1,0 +1,138 @@
+using BGPLite.Configuration;
+using BGPLite.Providers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using BGPLite.Protocol;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// Regression coverage for #417: a failed load of the default prefix source used to reach the RU
+/// cache as a "successful" empty result — either directly (the old GetDefaultAsync swallowed
+/// exceptions) or, after #416's propagation, via the 30s NEGATIVE backoff entry that a retry
+/// within the window hits. In both shapes the empty list was cached POSITIVELY for the full RU
+/// TTL (1h), so a single transient outage dropped every unconfigured peer's routes for up to an
+/// hour. The failure must surface as a failure on every call inside the backoff window; recovery
+/// happens on the first real load after the backoff expires.
+/// </summary>
+public class PrefixCacheFailureTests
+{
+    private sealed class SwitchableProvider : IPrefixSourceProvider
+    {
+        public string Kind => "stub";
+        public bool SupportsConditionalRequests => true;
+        public int Calls { get; private set; }
+        public bool FailNext { get; set; }
+
+        public Task<SourceLoadResult> LoadAsync(PrefixSourceConfig source, string? etag = null, DateTimeOffset? lastModified = null, CancellationToken ct = default)
+        {
+            Calls++;
+            if (FailNext) throw new InvalidOperationException("simulated source outage");
+            return Task.FromResult(SourceLoadResult.Ok(new List<IpPrefix> { new(0x0A000000u, 8) }));
+        }
+    }
+
+    private static (PrefixService Service, SwitchableProvider Provider, FakeTimeProvider Time) Build(TimeSpan? ruTtl = null)
+    {
+        var yaml = "Bgp:\n  Asn: 65444\n  RouterId: 10.0.0.1\n" +
+                   "PrefixSources:\n  - Name: ru\n    Kind: stub\nDefaultPrefixSource: ru\n";
+        var config = ConfigLoader.LoadFromText(yaml);
+        var provider = new SwitchableProvider();
+        var time = new FakeTimeProvider();
+        var sources = new PrefixSourceService(
+            config,
+            new PrefixSourceProviderFactory([provider]),
+            NullLogger<PrefixSourceService>.Instance,
+            timeProvider: time);
+        var service = new PrefixService(
+            config,
+            null!, // RipeStatPrefixCache — not on the GetRuPrefixesAsync path
+            sources,
+            null!, // HttpPrefixProvider — not on the GetRuPrefixesAsync path
+            ruCacheTtl: ruTtl ?? TimeSpan.FromHours(1),
+            logger: NullLogger<PrefixService>.Instance,
+            timeProvider: time);
+        return (service, provider, time);
+    }
+
+    [Fact]
+    public async Task GetRuPrefixesAsync_FailedColdLoad_DoesNotPoisonTheCache()
+    {
+        var (service, provider, time) = Build();
+
+        // 1. Cold failure propagates — nothing stale to serve.
+        provider.FailNext = true;
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetRuPrefixesAsync());
+
+        // 2/3. Retries inside the 30s negative-backoff window surface as failures too — they must
+        // NOT arrive as a successful empty list (pre-#417 they did, and the empty set was cached
+        // positively for the full RU TTL).
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetRuPrefixesAsync());
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetRuPrefixesAsync());
+
+        // 4. Recovery: past the backoff window the next call performs a REAL fetch and serves the
+        // actual content — never a cached empty set.
+        provider.FailNext = false;
+        time.Advance(TimeSpan.FromSeconds(31));
+        var routes = await service.GetRuPrefixesAsync();
+        Assert.Single(routes);
+        Assert.Equal(2, provider.Calls); // exactly two real fetches happened (fail + recover)
+    }
+
+    [Fact]
+    public async Task GetRuPrefixesAsync_FailureWithStaleCopy_ServesStale_NotEmpty()
+    {
+        var (service, provider, time) = Build();
+
+        // A good copy first.
+        var first = await service.GetRuPrefixesAsync();
+        Assert.Single(first);
+
+        // The source dies; after the RU TTL the re-fetch fails — the stale copy is served
+        // (stale-on-failure, #163 parity), never an empty set (#417).
+        provider.FailNext = true;
+        time.Advance(TimeSpan.FromHours(2));
+        var stale = await service.GetRuPrefixesAsync();
+        Assert.Equal(first, stale);
+
+        // And after another full RU TTL the failure path repeats — still stale, still never empty.
+        time.Advance(TimeSpan.FromHours(2));
+        var staleAgain = await service.GetRuPrefixesAsync();
+        Assert.Equal(first, staleAgain);
+    }
+
+    [Fact]
+    public async Task LoadDefaultAsync_LegitimatelyEmptySource_IsNotBackoff()
+    {
+        // A source that SUCCEEDS with zero prefixes is real content ("the operator emptied the
+        // list"), not failure backoff — it must pass through and cache normally, not throw.
+        var yaml = "Bgp:\n  Asn: 65444\n  RouterId: 10.0.0.1\n" +
+                   "PrefixSources:\n  - Name: ru\n    Kind: stub\nDefaultPrefixSource: ru\n";
+        var config = ConfigLoader.LoadFromText(yaml);
+        var time = new FakeTimeProvider();
+        var provider = new EmptyOkProvider();
+        var sources = new PrefixSourceService(
+            config, new PrefixSourceProviderFactory([provider]),
+            NullLogger<PrefixSourceService>.Instance, timeProvider: time);
+        var service = new PrefixService(
+            config, null!, sources, null!,
+            logger: NullLogger<PrefixService>.Instance, timeProvider: time);
+
+        var routes = await service.GetRuPrefixesAsync();
+        Assert.Empty(routes); // legitimately empty — cached as such, no exception
+
+        // Reload past the RU TTL: the empty CONTENT entry is non-negative, so the reload is a
+        // real (successful-empty) load — still no throw, never misread as failure backoff.
+        time.Advance(TimeSpan.FromHours(2));
+        routes = await service.GetRuPrefixesAsync();
+        Assert.Empty(routes);
+    }
+
+    private sealed class EmptyOkProvider : IPrefixSourceProvider
+    {
+        public string Kind => "stub";
+        public bool SupportsConditionalRequests => true;
+        public Task<SourceLoadResult> LoadAsync(PrefixSourceConfig source, string? etag = null, DateTimeOffset? lastModified = null, CancellationToken ct = default)
+            => Task.FromResult(SourceLoadResult.Ok(new List<IpPrefix>()));
+    }
+}

--- a/BGPLite.Tests/PrefixCacheRaceTests.cs
+++ b/BGPLite.Tests/PrefixCacheRaceTests.cs
@@ -28,7 +28,7 @@ public class PrefixCacheRaceTests
         var tasks = Enumerable.Range(0, 10).Select(_ => service.GetRuPrefixesAsync()).ToArray();
         var results = await Task.WhenAll(tasks);
 
-        Assert.Equal(1, source.DefaultCalls); // single fetch, shared across all 10
+        Assert.Equal(1, source.LoadCalls); // single fetch, shared across all 10
         // All callers get the same projected list.
         Assert.All(results, r => Assert.Equal(results[0], r));
         Assert.True(results[0].Count > 0);
@@ -48,7 +48,7 @@ public class PrefixCacheRaceTests
 
         // First call: populates the cache.
         await service.GetRuPrefixesAsync();
-        Assert.Equal(1, source.DefaultCalls);
+        Assert.Equal(1, source.LoadCalls);
 
         // Advance past the TTL.
         fakeTime.Advance(TimeSpan.FromMilliseconds(150));
@@ -56,7 +56,7 @@ public class PrefixCacheRaceTests
         // 10 concurrent callers on the now-expired cache.
         await Task.WhenAll(Enumerable.Range(0, 10).Select(_ => service.GetRuPrefixesAsync()));
 
-        Assert.Equal(2, source.DefaultCalls); // exactly one more fetch, not ten
+        Assert.Equal(2, source.LoadCalls); // exactly one more fetch, not ten
     }
 
     /// <summary>
@@ -77,7 +77,7 @@ public class PrefixCacheRaceTests
 
         // Populate a good copy.
         var first = await service.GetRuPrefixesAsync();
-        Assert.Equal(1, source.DefaultCalls);
+        Assert.Equal(1, source.LoadCalls);
         Assert.True(first.Count > 0);
 
         // Advance past the TTL so the next call must re-fetch, then make the source fail.
@@ -87,7 +87,7 @@ public class PrefixCacheRaceTests
         // The re-fetch fails, but the stale cached copy is served (NOT thrown) — #163 parity.
         var stale = await service.GetRuPrefixesAsync();
         Assert.Equal(first, stale);                  // same projection as the original good copy
-        Assert.Equal(2, source.DefaultCalls);        // the failed fetch DID happen (expired cache)
+        Assert.Equal(2, source.LoadCalls);        // the failed fetch DID happen (expired cache)
     }
 
     /// <summary>
@@ -105,9 +105,88 @@ public class PrefixCacheRaceTests
         await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetRuPrefixesAsync());
     }
 
+    /// <summary>
+    /// #416: a changed default-source load must not deadlock when the convergence push re-enters
+    /// the RU path. Pre-fix, <see cref="PrefixService.GetRuPrefixesAsync"/> held <c>_ruGate</c>
+    /// across the default-source load and a changed load fired <c>onSourceChanged</c> INLINE on
+    /// that stack; the push (<c>RefreshAllEstablishedAsync</c> in production — a second RU consumer
+    /// here) blocked on the gate the outer frame still held, while that frame awaited the push —
+    /// a permanent circular wait with sessions staying Established and nothing in the logs.
+    /// Post-fix the load runs callback-free (<c>LoadDefaultAsync</c>) and the push fires AFTER
+    /// <c>_ruGate.Release()</c>, so the re-entrant caller takes the fast path against the
+    /// just-written cache. The pre-fix deadlock is structural (both waits unconditional), so the
+    /// bounded <see cref="Task.WaitAsync(TimeSpan)"/> makes this test FAIL against the pre-fix
+    /// implementation (TimeoutException) and pass after it — no timing dependence in the green
+    /// direction.
+    /// </summary>
+    [Fact]
+    public async Task GetRuPrefixesAsync_ChangedLoad_PushReenteringTheRuPath_DoesNotDeadlock()
+    {
+        var source = new CountingPrefixSource { ChangedOnNextLoad = true };
+        PrefixService service = null!;
+        Task reentrant = Task.CompletedTask;
+        var pushStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        service = Service(source, onSourceChanged: async _ =>
+        {
+            pushStarted.TrySetResult();
+            // The production push (RefreshAllEstablishedAsync) rebuilds every established session's
+            // route set; a RU-consuming session's build re-enters GetRuPrefixesAsync right here.
+            reentrant = service.GetRuPrefixesAsync();
+            await reentrant;
+        });
+
+        var main = service.GetRuPrefixesAsync();
+
+        // The changed load must trigger the push…
+        await pushStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        // …and both the triggering call and the re-entrant consumer must complete.
+        await main.WaitAsync(TimeSpan.FromSeconds(10));       // pre-fix: TimeoutException (deadlock)
+        await reentrant.WaitAsync(TimeSpan.FromSeconds(10));  // pre-fix: never completes (gate held)
+
+        Assert.Equal(1, source.LoadCalls); // the re-entry hit the fresh cache — no second fetch
+    }
+
+    /// <summary>
+    /// #416: the RU push fires exactly when the load reports a content change — not on the fresh
+    /// fast path, not on an unchanged reload. The name passed through is the configured default
+    /// source name (empty string when none is configured).
+    /// </summary>
+    [Fact]
+    public async Task GetRuPrefixesAsync_PushFiresOnlyOnChange()
+    {
+        var source = new CountingPrefixSource();
+        var fakeTime = new Microsoft.Extensions.Time.Testing.FakeTimeProvider();
+        var pushes = new List<string>();
+        var service = Service(
+            source, cacheTtl: TimeSpan.FromMilliseconds(100), timeProvider: fakeTime,
+            onSourceChanged: name => { lock (pushes) pushes.Add(name); return Task.CompletedTask; });
+
+        // Cold load reporting changed → push #1.
+        source.ChangedOnNextLoad = true;
+        await service.GetRuPrefixesAsync();
+        Assert.Single(pushes);
+        Assert.Equal(string.Empty, pushes[0]); // no DefaultPrefixSource configured in this fixture
+
+        // Fresh fast path → no push.
+        await service.GetRuPrefixesAsync();
+        Assert.Single(pushes);
+
+        // Expired reload, unchanged content → no push.
+        fakeTime.Advance(TimeSpan.FromMilliseconds(150));
+        await service.GetRuPrefixesAsync();
+        Assert.Single(pushes);
+
+        // Expired reload, changed content → push #2.
+        fakeTime.Advance(TimeSpan.FromMilliseconds(150));
+        source.ChangedOnNextLoad = true;
+        await service.GetRuPrefixesAsync();
+        Assert.Equal(2, pushes.Count);
+    }
+
     // ---- helpers ----
 
-    private static PrefixService Service(CountingPrefixSource source, TimeSpan? cacheTtl = null, TimeProvider? timeProvider = null) =>
+    private static PrefixService Service(CountingPrefixSource source, TimeSpan? cacheTtl = null, TimeProvider? timeProvider = null, Func<string, Task>? onSourceChanged = null) =>
         new(new AppConfig(),
             // #263 made both required in production; neither is on the GetRuPrefixesAsync path this
             // fixture exercises, so the fake composition states that explicitly rather than relying
@@ -117,18 +196,22 @@ public class PrefixCacheRaceTests
             httpProvider: null!,
             ruCacheTtl: cacheTtl ?? TimeSpan.FromHours(1),
             logger: NullLogger<PrefixService>.Instance,
-            timeProvider: timeProvider);
+            timeProvider: timeProvider,
+            onSourceChanged: onSourceChanged);
 
     /// <summary>
-    /// Fake IPrefixSourceService that counts GetDefaultAsync calls and can be made to fail. Only
-    /// GetDefaultAsync is exercised by GetRuPrefixesAsync; the other members throw NotImplemented
+    /// Fake IPrefixSourceService that counts LoadDefaultAsync calls, can be made to fail, and can
+    /// report a content change. Only LoadDefaultAsync is exercised by GetRuPrefixesAsync (#416 —
+    /// the RU path no longer goes through GetDefaultAsync); the other members throw NotImplemented
     /// to catch accidental reliance.
     /// </summary>
     private sealed class CountingPrefixSource : IPrefixSourceService
     {
-        private int _defaultCalls;
-        public int DefaultCalls => Volatile.Read(ref _defaultCalls);
+        private int _loadCalls;
+        public int LoadCalls => Volatile.Read(ref _loadCalls);
         public bool FailNext { get; set; }
+        /// <summary>Whether the next completed load reports a content change (#416 push trigger).</summary>
+        public bool ChangedOnNextLoad { get; set; }
 
         public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default) =>
             throw new NotImplementedException();
@@ -136,19 +219,24 @@ public class PrefixCacheRaceTests
         public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default) =>
             throw new NotImplementedException();
 
-        public async Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default)
+        public async Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default)
         {
-            Interlocked.Increment(ref _defaultCalls);
+            Interlocked.Increment(ref _loadCalls);
             // Simulate real I/O latency so concurrent callers actually overlap inside the gate.
             await Task.Delay(20, ct);
             if (FailNext) throw new InvalidOperationException("simulated default-source failure");
-            return new List<IpPrefix>
+            var changed = ChangedOnNextLoad;
+            ChangedOnNextLoad = false;
+            IReadOnlyList<IpPrefix> prefixes = new List<IpPrefix>
             {
                 new(0x0A000000u, 8),
                 new(0xC0A80000u, 16),
             };
+            return (prefixes, changed);
         }
 
+        public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default) =>
+            throw new NotImplementedException();
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);
         public bool SourceSupportsConditional(string sourceName) => false;

--- a/BGPLite.Tests/PrefixServiceTests.cs
+++ b/BGPLite.Tests/PrefixServiceTests.cs
@@ -635,6 +635,46 @@ public class PrefixServiceTests
         Assert.Equal(1, handler.Calls);
     }
 
+    [Fact]
+    public async Task GetUserSourcePrefixesAsync_FetchesThroughTheUserSourceProvider()
+    {
+        // #425: the peer-supplied URL path must fetch through the user-source provider (the
+        // retry-only pipeline), never through the operator provider whose breaker it could open.
+        var operatorProvider = new StubHttpSourceProvider();
+        var userSource = new StubHttpSourceProvider();
+        var service = new PrefixService(
+            new AppConfig(),
+            null!, // RipeStatPrefixCache is not on the user-source path
+            null!, // IPrefixSourceService is not on the user-source path
+            new HttpPrefixProvider(new ThrowingOperatorFactory(), NullLogger<HttpPrefixProvider>.Instance),
+            userSourceHttpProvider: userSource);
+
+        var prefixes = await service.GetUserSourcePrefixesAsync("u", "https://example.com/u.txt", null);
+
+        Assert.NotEmpty(prefixes);
+        Assert.Equal(1, userSource.Calls);
+    }
+
+    private sealed class StubHttpSourceProvider : IPrefixSourceProvider
+    {
+        public string Kind => "http";
+        public bool SupportsConditionalRequests => false;
+        public int Calls { get; private set; }
+
+        public Task<SourceLoadResult> LoadAsync(PrefixSourceConfig source, string? etag = null, DateTimeOffset? lastModified = null, CancellationToken ct = default)
+        {
+            Calls++;
+            return Task.FromResult(SourceLoadResult.Ok(new List<IpPrefix> { new(0x0A000000u, 8) }));
+        }
+    }
+
+    /// <summary>Any touch of the operator pipeline fails the test loudly (#425).</summary>
+    private sealed class ThrowingOperatorFactory : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => throw new NotSupportedException(
+            "the user-source path must not touch the operator client pipeline");
+    }
+
     /// <summary>
     /// #324: a config source that hangs must not wedge sequential seeding — LoadAllAsync awaits
     /// sources one by one, so before the default budget one dripping source stalled every later

--- a/BGPLite.Tests/PrefixSourceServiceTests.cs
+++ b/BGPLite.Tests/PrefixSourceServiceTests.cs
@@ -65,7 +65,7 @@ public class PrefixSourceServiceTests
     }
 
     [Fact]
-    public async Task GetDefaultAsync_ResolvesByName()
+    public async Task LoadDefaultAsync_ResolvesByName_AndReportsFirstLoadAsChanged()
     {
         var provider = new CountingProvider([new IpPrefix(1u, 24), new IpPrefix(2u, 16)]);
         var yaml = "Bgp:\n  Asn: 65444\n  RouterId: 10.0.0.1\n" +
@@ -75,19 +75,22 @@ public class PrefixSourceServiceTests
             new PrefixSourceProviderFactory([provider]),
             NullLogger<PrefixSourceService>.Instance);
 
-        var result = await svc.GetDefaultAsync();
-        Assert.Equal(2, result.Count);
+        var (prefixes, changed) = await svc.LoadDefaultAsync();
+        Assert.Equal(2, prefixes.Count);
+        Assert.True(changed); // first-ever load counts as a content change (#214)
     }
 
     [Fact]
-    public async Task GetDefaultAsync_UnsetReturnsEmpty()
+    public async Task LoadDefaultAsync_UnsetReturnsEmptyNoChange()
     {
         var svc = new PrefixSourceService(
             ConfigWith("ru"),
             new PrefixSourceProviderFactory([new CountingProvider([new(1u, 24)])]),
             NullLogger<PrefixSourceService>.Instance);
 
-        Assert.Empty(await svc.GetDefaultAsync());
+        var (prefixes, changed) = await svc.LoadDefaultAsync();
+        Assert.Empty(prefixes);
+        Assert.False(changed);
     }
 
     [Fact]

--- a/BGPLite.Tests/PrefixSourceUrlValidatorTests.cs
+++ b/BGPLite.Tests/PrefixSourceUrlValidatorTests.cs
@@ -141,7 +141,7 @@ public class PrefixSourceUrlValidatorTests
     [InlineData("::192.168.1.1")]       // IPv4-compatible (deprecated ::a.b.c.d form)
     [InlineData("::ffff:10.0.0.1")]     // IPv4-mapped private (also caught by normalize, defense in depth)
     [InlineData("64:ff9b::0a00:0001")]  // NAT64 well-known embedding 10.0.0.1 (#321)
-    [InlineData("64:ff8:1::c0a8:0101")] // NAT64 local-scope embedding 192.168.1.1 (#321)
+    [InlineData("64:ff9b:1::a9fe:c9fe")] // NAT64 local-use 64:ff9b:1::/48 (RFC 8215) — cloud-metadata embedding (#419)
     public void IsBlockedAddress_Rejects_IPv4EmbeddingForms(string ip)
     {
         // Without the #158 ranges, an attacker controlling DNS returns one of these IPv6 addresses

--- a/BGPLite.Tests/RouteSeedingServiceTests.cs
+++ b/BGPLite.Tests/RouteSeedingServiceTests.cs
@@ -51,6 +51,7 @@ public class RouteSeedingServiceTests
             Task.FromResult(_sources);
         public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
+        public Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default) => Task.FromResult<(IReadOnlyList<IpPrefix>, bool)>(([], false));
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);
         public bool SourceSupportsConditional(string sourceName) => false;

--- a/BGPLite.Tests/RouteSeedingServiceTests.cs
+++ b/BGPLite.Tests/RouteSeedingServiceTests.cs
@@ -50,7 +50,6 @@ public class RouteSeedingServiceTests
         public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default) =>
             Task.FromResult(_sources);
         public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
-        public Task<IReadOnlyList<IpPrefix>> GetDefaultAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default) => Task.FromResult<(IReadOnlyList<IpPrefix>, bool)>(([], false));
         public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);

--- a/BGPLite.Tests/RouteSeedingServiceTests.cs
+++ b/BGPLite.Tests/RouteSeedingServiceTests.cs
@@ -64,6 +64,7 @@ public class RouteSeedingServiceTests
         public int GetAdvertisedPrefixCount(string peerIp, uint asn) => 0;
         public Task RefreshAllEstablishedAsync() { RefreshAllCalls++; return Task.CompletedTask; }
         public Task TerminatePeerAsync(string peerIp, uint asn, CancellationToken ct = default) => Task.CompletedTask;
+        public Task TerminatePeerByIpAsync(string peerIp, CancellationToken ct = default) => Task.CompletedTask;
         public void SetPeerMd5Key(string peerIp, string? password) { }
     }
 

--- a/BGPLite.Tests/UserSourceCacheTests.cs
+++ b/BGPLite.Tests/UserSourceCacheTests.cs
@@ -46,6 +46,56 @@ public class UserSourceCacheTests
     }
 
     [Fact]
+    public async Task ExpiredEntries_Swept_EvenBelowTheCap()
+    {
+        // #426: expired entries used to be PINNED until the entry cap was hit — steady-state
+        // memory was "everything fetched recently", not "live entries". The amortized sweep
+        // drops them regardless of the cap.
+        var time = new Microsoft.Extensions.Time.Testing.FakeTimeProvider();
+        var cache = new UserSourceCache(
+            positiveTtl: TimeSpan.FromMilliseconds(100), timeProvider: time, sweepEvery: 1);
+        var f = new Fetcher { OnSuccess = () => P((0xC0A80000u, (byte)24, true)) };
+
+        await cache.GetOrLoadAsync("https://example.com/a", "src", f.Invoke, CancellationToken.None);
+        time.Advance(TimeSpan.FromMilliseconds(150)); // A expires
+
+        await cache.GetOrLoadAsync("https://example.com/b", "src", f.Invoke, CancellationToken.None); // sweep drops A, loads B
+
+        Assert.Equal(1, cache.TrackedCount);
+    }
+
+    [Fact]
+    public async Task PrefixBudget_EvictsOldestPositives_EvenBelowTheCap()
+    {
+        // #426: the entry-count cap says nothing about MEMORY — a handful of huge entries could
+        // hold millions of parsed prefixes. Over the total-prefix budget the sweep drops the
+        // OLDEST positive entries even though the entry cap is nowhere near reached. Budget = 5:
+        // big(4) + small(2) = 6 over budget; the next sweep evicts big (oldest) → 2 ≤ 5.
+        var cache = new UserSourceCache(maxTotalPrefixes: 5, sweepEvery: 1);
+        var big = new Fetcher
+        {
+            OnSuccess = () => P(
+            (0x0A000000u, (byte)8, true), (0x0A000100u, (byte)8, true),
+            (0x0A000200u, (byte)8, true), (0x0A000300u, (byte)8, true))
+        };
+        var small = new Fetcher
+        {
+            OnSuccess = () => P(
+            (0xC0A80000u, (byte)24, true), (0xC0A80001u, (byte)24, true))
+        };
+        var third = new Fetcher { OnSuccess = () => P((0x0A0B0000u, (byte)16, true)) };
+
+        await cache.GetOrLoadAsync("https://example.com/big", "big", big.Invoke, CancellationToken.None);
+        await cache.GetOrLoadAsync("https://example.com/small", "small", small.Invoke, CancellationToken.None);
+        Assert.Equal(6, cache.TrackedPrefixes); // over the budget — enforced at the next sweep
+
+        await cache.GetOrLoadAsync("https://example.com/third", "third", third.Invoke, CancellationToken.None);
+
+        Assert.Equal(2, cache.TrackedCount);    // small + third
+        Assert.Equal(3, cache.TrackedPrefixes); // small(2) + third(1); big(4) swept
+    }
+
+    [Fact]
     public async Task Concurrent_Same_Url_Fetched_Once_Gate_Serializes()
     {
         // Exercises the per-URL SemaphoreSlim (the actual thundering-herd defense): many concurrent

--- a/BGPLite/Program.cs
+++ b/BGPLite/Program.cs
@@ -95,14 +95,7 @@ builder.Services.AddSingleton(new BgpMetrics());
 // Prefix sources (file / HTTP / ...) resolved by Kind via a provider factory,
 // with an in-memory TTL cache. Add a new loader by implementing IPrefixSourceProvider
 // and registering it here.
-builder.Services.AddHttpClient(HttpPrefixProvider.ClientName, c =>
-{
-    // HttpClient.Timeout MUST be InfiniteTimeSpan when a Polly resilience pipeline is attached —
-    // otherwise the client's own timeout fires prematurely across retries and cancels the whole
-    // pipeline (CodeRabbit #177). The per-attempt timeout is enforced by the pipeline's AddTimeout.
-    c.Timeout = Timeout.InfiniteTimeSpan;
-    c.DefaultRequestHeaders.UserAgent.ParseAdd("BGPLite/1.0");
-})
+builder.Services.AddHttpClient(HttpPrefixProvider.ClientName, ConfigureHttpSourceClient)
 .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
 {
     // SSRF defense (#144): validate DNS resolution at the socket level — no TOCTOU race (every
@@ -118,6 +111,41 @@ builder.Services.AddHttpClient(HttpPrefixProvider.ClientName, c =>
 // with exponential backoff + jitter, plus a circuit breaker. A transient blip on a prefix-source
 // fetch previously returned 0 prefixes for that source until the next refresh; now it is retried.
 .AddResilienceHandler("http-prefix-source", ConfigureDefaultHttpResilience);
+
+// #425: peer-supplied user-source URLs get their OWN named client — retry WITHOUT a circuit
+// breaker. The shared breaker coupled peer-controlled failure rates to operator sources: a few
+// blackholed user URLs opened the shared breaker and suppressed every operator source fetch for
+// 30s windows. Handler, SSRF gate and body cap are identical to the operator client.
+builder.Services.AddHttpClient(HttpPrefixProvider.UserSourceClientName, ConfigureHttpSourceClient)
+.ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
+{
+    ConnectCallback = PrefixSourceUrlValidator.CreateValidatedConnectionAsync,
+    AllowAutoRedirect = false
+})
+.AddResilienceHandler("http-user-source", pipelineBuilder => pipelineBuilder.AddRetry(new HttpRetryStrategyOptions
+{
+    MaxRetryAttempts = 2,
+    Delay = TimeSpan.FromMilliseconds(500),
+    MaxDelay = TimeSpan.FromSeconds(2),
+}));
+
+// #425: the user-source provider instance wired with the retry-only client, keyed so the
+// operator registrations above are untouched.
+builder.Services.AddKeyedSingleton<IPrefixSourceProvider>(HttpPrefixProvider.UserSourceClientName,
+    (sp, _) => new HttpPrefixProvider(
+        sp.GetRequiredService<IHttpClientFactory>(),
+        sp.GetRequiredService<ILogger<HttpPrefixProvider>>(),
+        clientName: HttpPrefixProvider.UserSourceClientName));
+
+static void ConfigureHttpSourceClient(HttpClient c)
+{
+    // HttpClient.Timeout MUST be InfiniteTimeSpan when a Polly resilience pipeline is attached —
+    // otherwise the client's own timeout fires prematurely across retries and cancels the whole
+    // pipeline (CodeRabbit #177). Per-attempt/per-source budgets are enforced downstream (#324).
+    c.Timeout = Timeout.InfiniteTimeSpan;
+    c.DefaultRequestHeaders.UserAgent.ParseAdd("BGPLite/1.0");
+}
+
 builder.Services.AddSingleton<HttpPrefixProvider>();
 builder.Services.AddSingleton<FilePrefixProvider>();
 builder.Services.AddSingleton<IPrefixSourceProvider>(sp => sp.GetRequiredService<HttpPrefixProvider>());
@@ -191,7 +219,10 @@ builder.Services.AddSingleton<IPrefixService>(sp =>
         onSourceChanged: async name =>
         {
             await sp.GetRequiredService<ISessionManager>().RefreshAllEstablishedAsync();
-        });
+        },
+        // #425: the peer-supplied user-source path uses the retry-only client so its failures
+        // cannot open the circuit breaker gating operator sources.
+        userSourceHttpProvider: sp.GetRequiredKeyedService<IPrefixSourceProvider>(HttpPrefixProvider.UserSourceClientName));
 });
 
 // #263: the BGP send path's dependencies are registered explicitly and resolved with

--- a/BGPLite/Program.cs
+++ b/BGPLite/Program.cs
@@ -184,7 +184,14 @@ builder.Services.AddSingleton<IPrefixService>(sp =>
         sp.GetRequiredService<RipeStatPrefixCache>(),
         sources,
         sp.GetRequiredService<HttpPrefixProvider>(),
-        logger: sp.GetRequiredService<ILogger<PrefixService>>());
+        logger: sp.GetRequiredService<ILogger<PrefixService>>(),
+        // #416: the RU path now owns its convergence push — GetRuPrefixesAsync fires it AFTER
+        // releasing _ruGate (the load itself is callback-free via LoadDefaultAsync), so a changed
+        // default source can no longer deadlock the fleet refresh it triggers.
+        onSourceChanged: async name =>
+        {
+            await sp.GetRequiredService<ISessionManager>().RefreshAllEstablishedAsync();
+        });
 });
 
 // #263: the BGP send path's dependencies are registered explicitly and resolved with

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -194,7 +194,10 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
   adversarial UPDATE (#94, #222, #284 lineage). No NOTIFICATION is sent because RFC 4271 §6.3
   requires its receiver to tear down, defeating the purpose. Withdrawal semantics: class (b)
   withdraws the peer's own NLRI (RFC 7606's "treat" half, #288); class (a) cannot — the NLRI is
-  unrecoverable — and discards only (D2).
+  unrecoverable — and discards only (D2). Scope: **UPDATE only**. A malformed OPEN received in
+  Established is an FSM error (NOTIFICATION 5/0, #427) — RFC 4271 §8.2.2 makes ANY OPEN in
+  Established an FSM input regardless of body validity, so there is nothing to "keep alive" for
+  that message class.
 - **Consequence:** a peer sending structurally valid but semantically rejected UPDATEs gets them
   silently dropped (log Warning + `UpdatesRejected` metric) instead of a session reset; operators
   comparing against RFC-strict speakers will see BGPLite retain sessions others would close.


### PR DESCRIPTION
Closes #416
Closes #417
Closes #418
Closes #419
Closes #420
Closes #421
Closes #422
Closes #423
Closes #424
Closes #425
Closes #426
Closes #427
Closes #428
Closes #429
Closes #430
Closes #431

## Summary
16 issues from the 2026-09-03 external audit (1 critical, 3 high, 7 medium, 5 low), one squash-merged PR each into `dev`, each verified individually (full suite + CodeQL 0 alerts on its merge-ref).

### Critical / High
- **#416 / #433** — providers: `_ruGate` deadlock. The RU load is callback-free (`LoadDefaultAsync`) and the convergence push fires after `_ruGate.Release()` — a changed default source no longer permanently stalls every RU consumer. Red/green deadlock test.
- **#417 / #434** — providers: a failed default-source load (including the 30s negative-backoff path) surfaces as a failure — stale-served or thrown — instead of being cached as an empty RU set for 1h. Unused swallowing `GetDefaultAsync` removed.
- **#418 / #435** — api,server: peer delete/PATCH re-arms the per-IP TCP-MD5 key from SURVIVING rows (shared resolver with the startup bootstrap) — deleting one sibling no longer silently disarms RFC 2385 for the others.
- **#419 / #436** — providers: SSRF blocklist literal fixed to the RFC 8215 NAT64 local-use prefix `64:ff9b:1::/48` (was `64:ff8:1::/96`).

### Medium
- **#420 / #437** — server: ROUTE_REFRESH for AFI=2 honored on MP-IPv6 sessions (RFC 2918 §2); v6 peers can re-request routes.
- **#421 / #440** — api: `NormalizePeerIp` rejects unspecified/loopback/multicast/broadcast (both families, mapped forms normalized) — parity with the YAML path's #390 validation.
- **#422 / #439** — api,server: NULL-Asn peer delete terminates its sessions by IP (`ISessionManager.TerminatePeerByIpAsync`) instead of a silent no-op teardown.
- **#423 / #446** — api: `ClientIpRateLimiter` replaces `PartitionedRateLimiter` — idle IP partitions (and their replenishment timers) are evicted; TrustXRealIp key churn no longer grows the table without bound.
- **#424 / #443** — api: 30s wall-clock budget (shutdown-linked) on `/api/asn-lists` and `/api/peers/{id}/prefixes`; expiry serves partial results instead of pinning the in-flight cap.
- **#425 / #444** — providers: peer-supplied user sources fetch on their own named client (retry-only) — their failures can no longer open the shared circuit breaker gating operator sources.
- **#426 / #445** — providers: amortized expired-entry sweeps in both caches + a 2M-prefix budget on `UserSourceCache` — expired entries are no longer pinned until the cap.

### Low
- **#427 / #438** — server: a malformed OPEN in Established is an FSM error (5/0) like a well-formed one (RFC 4271 §8.2.2); D17 scope note added.
- **#428 / #442** — server: 500ms backoff on persistent accept failures (no more hot spin under fd exhaustion).
- **#429 / #447** — perf: custom-prefix suppression via a coverage index (O(routes+customs)); contract projection memoized per native list (ConditionalWeakTable).
- **#430 / #448** — server: the send mirror records a batch only after its UPDATE reaches the wire — no phantom withdrawals after a failed oversize send.
- **#431 / #441** — api: SQLite constraint mapping by extended code (787→404, 2067→409, else 500) — NOT NULL/CHECK no longer mislabeled 409.

## Verification (per PR, and re-run on the dev head)
- Every PR: dotnet format → full `dotnet build` (0 errors) → full `dotnet test` (green; 1010 → 1045 tests, all growth = new regression tests) → CI (build-test, format-check, analyze, CodeQL) → CodeQL alerts on merge-ref: 0.
- Every behavioral fix carries a red/green regression test (fails against the pre-fix code) where deterministically reproducible; two cases (accept-loop backoff, rate-limiter sweep races) document why not.
- Dev head re-verified before this PR: build 0 errors, **1045/1045 tests green**.
- CodeRabbit was disabled on dev-based PRs by `.coderabbit.yaml` — its full review happens HERE; findings will be addressed per-finding (fix or reasoned reply) before merge.

## RFC
- #420: RFC 2918 §2; #427: RFC 4271 §8.2.2 (+ D17 scope note in docs/DESIGN_DECISIONS.md); #419: RFC 6052 §2.1 / RFC 8215; #418: RFC 2385 enforcement consistency.

## Risk notes (behavior changes vs main)
- RU failure path now degrades (stale/throw) instead of advertising an empty set for 1h.
- NULL-Asn deletes actually stop sessions (by IP, with a warning); non-unicast peer IPs return 400 at the API.
- Peer-URL failures no longer suppress operator sources (separate retry-only pipeline).
- Rate-limiter buckets reset after the idle threshold (default ≥5 min) — a returning IP starts refilled.
- Oversize UPDATE sends fail loudly without corrupting the send mirror.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for IPv6 peer addresses while rejecting unusable addresses.
  * Added bounded external fetches that return partial results with warnings when providers time out.
  * Added safer handling for legacy peers and shared TCP-MD5 keys.
  * Added dedicated handling for peer-supplied prefix sources.

* **Bug Fixes**
  * Improved rate-limit and prefix-cache cleanup to remove idle or expired entries.
  * Prevented failed route advertisements from causing incorrect withdrawals.
  * Improved BGP Route Refresh support for negotiated IPv6 routes.
  * Corrected error responses for database conflicts and missing records.
  * Hardened SSRF protection for NAT64 address ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->