### PR TITLE
fix: address the CodeRabbit findings on the integration review (#450)

### DIFF
--- a/BGPLite.Api/ClientIpRateLimiter.cs
+++ b/BGPLite.Api/ClientIpRateLimiter.cs
@@ -73,10 +73,10 @@ internal sealed class ClientIpRateLimiter : IDisposable, IAsyncDisposable
         }
         catch (ObjectDisposedException)
         {
-            // Lost a race with the eviction sweep's Dispose: mint a fresh bucket and retry once.
-            // Narrow and benign — the request sees an unfilled bucket instead of failing.
-            limiter = new TokenBucketRateLimiter(_options);
-            _partitions[clientIp] = (limiter, Stamp());
+            // Lost a race with the eviction sweep's Dispose (CodeRabbit on #450): the sweep
+            // removed the dead partition, so re-read via GetOrAdd — this mints a fresh bucket
+            // WITHOUT blindly overwriting whatever a concurrent request may have installed.
+            limiter = GetOrAdd(clientIp);
             lease = limiter.AttemptAcquire();
         }
 
@@ -90,12 +90,13 @@ internal sealed class ClientIpRateLimiter : IDisposable, IAsyncDisposable
         {
             if (_partitions.TryGetValue(clientIp, out var existing))
             {
-                // Touch last-access; the limiter reference is unchanged, so the tuple write is
-                // safe even against a concurrent sweep (compare-remove either wins before the
-                // touch — the request retries on a fresh bucket — or loses and the touch keeps
-                // the partition alive).
-                _partitions[clientIp] = (existing.Limiter, now);
-                return existing.Limiter;
+                // Touch last-access CONDITIONALLY (CodeRabbit on #450): a sweep may have removed
+                // and disposed this partition between the read and the write — a blind indexer
+                // write would resurrect the disposed limiter. TryUpdate succeeds only against
+                // the exact tuple read; on failure the loop re-reads (or mints a fresh bucket).
+                if (_partitions.TryUpdate(clientIp, (existing.Limiter, now), existing))
+                    return existing.Limiter;
+                continue;
             }
 
             var created = new TokenBucketRateLimiter(_options);

--- a/BGPLite.Providers/UserSourceCache.cs
+++ b/BGPLite.Providers/UserSourceCache.cs
@@ -54,6 +54,10 @@ internal sealed class UserSourceCache
     private readonly ConcurrentDictionary<string, (IReadOnlyList<IpPrefix> List, DateTime CachedAt, bool Negative)> _cache = new();
     // url → gate serializing the cache-miss fetch path (prevents thundering herd on cold/expired keys).
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new();
+    // url → ACTIVE-loader count (#450 review): the sweeps never remove a gate whose loaders are
+    // still inside or queued — otherwise two gates coexist and two loaders race one URL, with the
+    // older response able to overwrite the newer (RipeStatPrefixCache's #267-item-3 invariant).
+    private readonly ConcurrentDictionary<string, int> _inflight = new();
 
     public UserSourceCache(TimeSpan? positiveTtl = null, TimeSpan? negativeTtl = null, ILogger? logger = null, TimeProvider? timeProvider = null, int? maxCacheEntries = null, long? maxTotalPrefixes = null, int? sweepEvery = null)
     {
@@ -94,66 +98,88 @@ internal sealed class UserSourceCache
         // Serialize per-key so concurrent callers (e.g. several peers refreshing the same URL) share
         // a single fetch — no thundering herd.
         var gate = _locks.GetOrAdd(url, _ => new SemaphoreSlim(1, 1));
+        // #450 review: register as an active loader BEFORE the gate is taken — the sweep and
+        // EvictIfAtCapacity never remove a gate that still has loaders (RipeStatPrefixCache's
+        // _inflight invariant, #267 item 3). Without this, a removed-then-recreated gate let two
+        // loaders run concurrently for one URL and the OLDER response could overwrite the newer.
+        _inflight.AddOrUpdate(url, 1, (_, c) => c + 1);
+        var entered = false;
         try
         {
-            await gate.WaitAsync(ct);
-        }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
-        {
-            // #358 review (orphan-lock hygiene for #261): a caller cancelled while queued never
-            // writes a cache entry, so its freshly-created gate would never be evicted (the sweep
-            // removes locks only for removed cache keys) — cancelled URLs accumulated semaphores.
-            // Pair-remove OUR gate instance: a concurrent waiter keeps running on its own
-            // reference, and a fresh caller GetOrAdd's a new gate — the same duplicate-fetch
-            // tradeoff the eviction sweep already accepts.
-            ((ICollection<KeyValuePair<string, SemaphoreSlim>>)_locks).Remove(new KeyValuePair<string, SemaphoreSlim>(url, gate));
-            throw;
-        }
-        try
-        {
-            if (TryGetFresh(url, out var rechecked))
-                return rechecked;
-
-            IReadOnlyList<IpPrefix> prefixes;
             try
             {
-                prefixes = await loadAsync(ct);
+                await gate.WaitAsync(ct);
+                entered = true;
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
             {
-                // #114: CALLER-initiated cancellation always propagates and is never cached — it
-                // is teardown, not a property of the source. A foreign-token OCE (e.g. the #320
-                // per-fetch budget's linked CTS firing on a live caller token) falls through to
-                // the failure handling below instead: stale-on-failure serve if possible, else a
-                // brief negative-cache so repeated refreshes do not re-pay the full budget.
+                // #358 review (orphan-lock hygiene for #261): a caller cancelled while queued never
+                // writes a cache entry, so its freshly-created gate would never be evicted (the sweep
+                // removes locks only for removed cache keys) — cancelled URLs accumulated semaphores.
+                // Pair-remove OUR gate instance: a concurrent waiter keeps running on its own
+                // reference, and a fresh caller GetOrAdd's a new gate — the same duplicate-fetch
+                // tradeoff the eviction sweep already accepts.
+                ((ICollection<KeyValuePair<string, SemaphoreSlim>>)_locks).Remove(new KeyValuePair<string, SemaphoreSlim>(url, gate));
                 throw;
             }
-            catch (Exception ex)
+            try
             {
-                // Serve the last good copy if we have one (regardless of its age).
-                if (_cache.TryGetValue(url, out var stale) && !stale.Negative)
+                if (TryGetFresh(url, out var rechecked))
+                    return rechecked;
+
+                IReadOnlyList<IpPrefix> prefixes;
+                try
                 {
-                    _logger?.LogWarning(ex, "User-source '{Name}' load failed; serving cached copy ({Count} prefixes).",
-                        logLabel, stale.List.Count);
-                    return stale.List;
+                    prefixes = await loadAsync(ct);
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    // #114: CALLER-initiated cancellation always propagates and is never cached — it
+                    // is teardown, not a property of the source. A foreign-token OCE (e.g. the #320
+                    // per-fetch budget's linked CTS firing on a live caller token) falls through to
+                    // the failure handling below instead: stale-on-failure serve if possible, else a
+                    // brief negative-cache so repeated refreshes do not re-pay the full budget.
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    // Serve the last good copy if we have one (regardless of its age).
+                    if (_cache.TryGetValue(url, out var stale) && !stale.Negative)
+                    {
+                        _logger?.LogWarning(ex, "User-source '{Name}' load failed; serving cached copy ({Count} prefixes).",
+                            logLabel, stale.List.Count);
+                        return stale.List;
+                    }
+
+                    // Otherwise remember the failure briefly so repeated calls don't hammer the fetcher.
+                    EvictIfAtCapacity(url);
+                    _cache[url] = ([], _timeProvider.GetUtcNow().UtcDateTime, Negative: true);
+                    _logger?.LogWarning(ex, "User-source '{Name}' load failed (no cached copy); negative-cached for {Seconds}s.",
+                        logLabel, (int)_negativeTtl.TotalSeconds);
+                    throw;
                 }
 
-                // Otherwise remember the failure briefly so repeated calls don't hammer the fetcher.
                 EvictIfAtCapacity(url);
-                _cache[url] = ([], _timeProvider.GetUtcNow().UtcDateTime, Negative: true);
-                _logger?.LogWarning(ex, "User-source '{Name}' load failed (no cached copy); negative-cached for {Seconds}s.",
-                    logLabel, (int)_negativeTtl.TotalSeconds);
-                throw;
+                _cache[url] = (prefixes, _timeProvider.GetUtcNow().UtcDateTime, Negative: false);
+                return prefixes;
             }
-
-            EvictIfAtCapacity(url);
-            _cache[url] = (prefixes, _timeProvider.GetUtcNow().UtcDateTime, Negative: false);
-            return prefixes;
+            finally
+            {
+                if (entered) gate.Release();
+            }
         }
         finally
         {
-            gate.Release();
+            ExitInflight(url);
         }
+    }
+
+    /// <summary>Decrements the active-loader count for <paramref name="url"/> and removes the
+    /// marker when it reaches zero, so the sweeps know the gate is removable (#450 review).</summary>
+    private void ExitInflight(string url)
+    {
+        _inflight.AddOrUpdate(url, 0, (_, c) => c - 1);
+        _inflight.TryRemove(new KeyValuePair<string, int>(url, 0));
     }
 
     /// <summary>
@@ -193,6 +219,8 @@ internal sealed class UserSourceCache
 
         foreach (var key in toEvict)
         {
+            // #450 review: a URL with active loaders keeps its gate (see SweepIfNeeded).
+            if (_inflight.TryGetValue(key, out var active) && active > 0) continue;
             if (_cache.TryRemove(key, out _))
                 _locks.TryRemove(key, out _);
         }
@@ -252,6 +280,9 @@ internal sealed class UserSourceCache
 
         foreach (var key in toEvict)
         {
+            // #450 review: a URL with active loaders keeps its gate (its loader writes the entry
+            // on its own reference) — removing the gate would mint a duplicate concurrent fetch.
+            if (_inflight.TryGetValue(key, out var active) && active > 0) continue;
             if (_cache.TryRemove(key, out _))
                 _locks.TryRemove(key, out _);
         }

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -1301,17 +1301,16 @@ public sealed class BgpSession : IDisposable
         var attrCache = UpdateCodec.CreateUpdateAttributeCache();
         var v6AttrCache = UpdateCodec.CreateV6UpdateAttributeCache();
 
-        // #430: build-then-commit — a batch's prefixes are recorded in _advertisedPrefixes only
-        // AFTER its UPDATE serialized and hit the wire. A send that throws (e.g. a composed
-        // UPDATE over the 4096-byte maximum) leaves the mirror exactly matching reality: a later
-        // WithdrawAllAsync no longer sends withdrawals for prefixes that were never announced.
+        // #430 + #450 review: build-then-commit at UPDATE granularity — each emitted UPDATE's
+        // prefixes join the mirror only after THAT frame is on the wire (a batch may emit several
+        // UPDATEs, one per community group; a group that throws — e.g. a composed UPDATE over the
+        // 4096-byte maximum — must not take earlier groups' mirror entries down with it, nor may
+        // it record its own). The healthy /8 withdraw+re-announce contract is pinned by tests.
         foreach (var route in v4Routes)
         {
             batch.Add(route);
             if (batch.Count < maxNlriPerUpdate) continue;
             await SendRouteBatchAsync(nextHop, batch, attrCache);
-            foreach (var sent_route in batch)
-                _advertisedPrefixes.Add(new IpPrefix(sent_route.Prefix, sent_route.PrefixLength, sent_route.IsIpv4));
             sent += batch.Count;
             batch.Clear();
         }
@@ -1319,8 +1318,6 @@ public sealed class BgpSession : IDisposable
         if (batch.Count > 0)
         {
             await SendRouteBatchAsync(nextHop, batch, attrCache);
-            foreach (var sent_route in batch)
-                _advertisedPrefixes.Add(new IpPrefix(sent_route.Prefix, sent_route.PrefixLength, sent_route.IsIpv4));
             sent += batch.Count;
         }
 
@@ -1331,8 +1328,6 @@ public sealed class BgpSession : IDisposable
             batch.Add(route);
             if (batch.Count < maxNlriPerUpdate) continue;
             await SendV6RouteBatchAsync(v6NextHop, batch, v6AttrCache);
-            foreach (var sent_route in batch)
-                _advertisedPrefixes.Add(new IpPrefix(sent_route.Prefix, sent_route.PrefixLength, sent_route.IsIpv4));
             sent += batch.Count;
             batch.Clear();
         }
@@ -1340,8 +1335,6 @@ public sealed class BgpSession : IDisposable
         if (batch.Count > 0)
         {
             await SendV6RouteBatchAsync(v6NextHop, batch, v6AttrCache);
-            foreach (var sent_route in batch)
-                _advertisedPrefixes.Add(new IpPrefix(sent_route.Prefix, sent_route.PrefixLength, sent_route.IsIpv4));
             sent += batch.Count;
         }
 
@@ -1447,6 +1440,20 @@ public sealed class BgpSession : IDisposable
         };
 
         await SendMessageAsync(update);
+        // #430 + #450 review: per-UPDATE mirror commit — SendRouteBatchAsync/SendV6RouteBatchAsync
+        // emit one UPDATE per community group, so a group that throws after an earlier group
+        // succeeded must not drag the earlier group's mirror entries down (they ARE on the wire)
+        // nor record its own (they are NOT).
+        if (mpReach is { } reach)
+        {
+            foreach (var p in reach.Prefixes)
+                _advertisedPrefixes.Add(p);
+        }
+        else
+        {
+            foreach (var p in nlri)
+                _advertisedPrefixes.Add(p);
+        }
         _metrics.UpdateSent();
     }
 

--- a/BGPLite.Server/RouteAssembler.cs
+++ b/BGPLite.Server/RouteAssembler.cs
@@ -319,24 +319,24 @@ public sealed class RouteAssembler : IRouteAssembler
         // instead of scanning the custom list per route — O(routes + customs) instead of the
         // O(routes × customs) mask+compare the per-route Where paid (11k routes × 1k customs ≈
         // 11M compares per peer per refresh, multiplied by fleet size on a RefreshAllEstablished).
+        // #450 review: the per-length network sets are HASH sets (per-route Contains is O(1)),
+        // and the mask is stored once per length (identical for every network of that length).
         var exact = new HashSet<(uint Network, byte Length)>(customRanges);
-        var networksByLength = new Dictionary<byte, List<(uint Network, UInt128 Mask)>>(customRanges.Count);
+        var networksByLength = new Dictionary<byte, (UInt128 Mask, HashSet<UInt128> Networks)>(customRanges.Count);
         foreach (var cr in customRanges)
         {
-            if (!networksByLength.TryGetValue(cr.Length, out var networks))
-                networksByLength[cr.Length] = networks = [];
-            networks.Add((cr.Network, Mask(cr.Length)));
+            if (!networksByLength.TryGetValue(cr.Length, out var entry))
+                networksByLength[cr.Length] = entry = (Mask(cr.Length), []);
+            entry.Networks.Add(cr.Network);
         }
 
         bool IsCovered(Route r)
         {
-            foreach (var (length, networks) in networksByLength)
+            foreach (var (length, (mask, networks)) in networksByLength)
             {
                 if (length >= r.PrefixLength) continue; // only a STRICTLY broader custom covers
-                var mask = Mask(length);
-                foreach (var (network, _) in networks)
-                    if (((uint)r.Prefix & mask) == network)
-                        return true;
+                if (networks.Contains((uint)r.Prefix & mask))
+                    return true;
             }
             return false;
         }

--- a/BGPLite.Tests/BgpSessionV6AdvertiseTests.cs
+++ b/BGPLite.Tests/BgpSessionV6AdvertiseTests.cs
@@ -120,7 +120,11 @@ public class BgpSessionV6AdvertiseTests
         routeTable.AddOrUpdate(new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 1 });
         var (session, run, conn) = await EstablishAsync(routeTable, routeRefresh: true);
 
-        var initial = CountUpdates(conn);
+        // Wait for the initial dump before snapshotting (Established ≠ dump-complete,
+        // CodeRabbit on #450).
+        var initial = 0;
+        for (var i = 0; i < 300 && (initial = CountUpdates(conn)) == 0; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
         Assert.True(initial > 0);
 
         conn.EnqueueMessage(new BgpRouteRefreshMessage { Afi = BgpConstants.Afi.IPv4, Reserved = 0, Safi = BgpConstants.Safi.Unicast });


### PR DESCRIPTION
Follow-up to the integration PR #450 (findings on dev code already merged; scoped follow-up per the review protocol).

## Findings addressed (all independently verified against the code first)
1. **ClientIpRateLimiter race (Major)** — the GetOrAdd last-access touch was a blind indexer write: a sweep that removed+disposed the partition between the read and the write had the disposed limiter written back, and the OCE retry path blindly overwrote a partition a concurrent request may have just minted. Now: conditional `TryUpdate` against the exact tuple read (disposed limiters can never be resurrected) and a re-read via GetOrAdd on the OCE retry.
2. **UserSourceCache gate lifetime (Major)** — sweeps/eviction could remove `_locks[url]` while a loader still held it; a later GetOrAdd minted a second gate and a second concurrent loader ran for the same URL, with the OLDER response able to overwrite the newer (unconditional cache write). Per-URL active-loader refcount added (the RipeStatPrefixCache #267-item-3 invariant); neither sweep nor eviction removes a live gate.
3. **BgpSession mirror granularity (Major)** — the mirror is now committed PER EMITTED UPDATE (in SendUpdateBatchAsync, covering both the classic-NLRI and the MP_REACH prefixes) instead of per 100-route batch: a community group whose UPDATE throws no longer drags previously-emitted groups' mirror entries down, nor records its own.
4. **RouteAssembler perf (quick)** — per-length custom network sets are hash sets with the mask stored once per length (O(1) coverage lookup).
5. **Test determinism (minor)** — the AFI=1 refresh control waits for the initial dump before snapshotting (Established ≠ dump-complete).

## Not addressed in code (reasoned)
- **PrefixService RU-projection invalidation on external default-source refreshes (Major, pre-existing asymmetry)**: a default-source change detected via the auto-refresh path (RefreshAsync, no callback) updates the source cache but not the 1h RU projection; the connect-path push then re-advertises stale RU routes until the RU TTL expires. This asymmetry predates this integration (the 1h RU projection is the #229 design); the proper fix (source-version stamp in the projection cache) is a design change, not an integration-review tweak — tracked separately as a follow-up issue.

## Verification
- dotnet format / dotnet build (0 errors) / dotnet test — full suite green (1045/1045).