### PR TITLE
fix(providers): invalidate the RU projection when the default source changes on the auto-refresh path

### DIFF
--- a/BGPLite.Providers/IPrefixSourceService.cs
+++ b/BGPLite.Providers/IPrefixSourceService.cs
@@ -48,4 +48,15 @@ public interface IPrefixSourceService
     /// interval selection in the auto-refresh timer.
     /// </summary>
     bool SourceSupportsConditional(string sourceName);
+
+    /// <summary>
+    /// #452: fired AFTER a source's freshly loaded content is committed to the cache and the load
+    /// detected an actual change — on EVERY change-detecting entry point, including
+    /// <see cref="RefreshAsync"/> (which deliberately never fires the <c>onSourceChanged</c>
+    /// BGP-push callback). Cache-layer consumers that project a source's list into their own
+    /// longer-TTL cache (the RU projection in <c>PrefixService</c>) subscribe to invalidate
+    /// their projection, so a fleet rebuild always re-projects from the committed content.
+    /// Fired off the per-source gate; handlers must be cheap and non-blocking.
+    /// </summary>
+    event Action<string>? ContentCommitted;
 }

--- a/BGPLite.Providers/PrefixService.cs
+++ b/BGPLite.Providers/PrefixService.cs
@@ -49,6 +49,28 @@ public sealed class PrefixService : IPrefixService
         // pipeline) so peer-controlled failures cannot open the breaker gating operator sources;
         // falls back to the operator provider when not wired (tests).
         _userSourceHttpProvider = userSourceHttpProvider ?? httpProvider;
+        // #452: a committed content change to the DEFAULT source must invalidate the RU projection
+        // immediately — the auto-refresh path (RefreshAsync) never fires the push callback, so
+        // without this the fleet rebuild triggered afterwards re-reads the stale fast path for up
+        // to the RU TTL. The handler is a Volatile.Write: cheap, non-blocking, safe off the
+        // per-source gate (LoadCachedAsync fires the event only after releasing it).
+        // Guarded: tests compose PrefixService WITHOUT a source service (the interface sits only
+        // on the RU paths), passing null — those compositions simply get no invalidation signal.
+        if (prefixSources is not null)
+            _prefixSources.ContentCommitted += OnSourceContentCommitted;
+    }
+
+    /// <summary>
+    /// #452 handler for <see cref="IPrefixSourceService.ContentCommitted"/>: drops the cached RU
+    /// projection when the changed source is the one it is projected from. The next
+    /// <see cref="GetRuPrefixesAsync"/> takes the gate path, re-projects from the already-new
+    /// source-level cache, and reports no change — so the fleet push is not duplicated.
+    /// </summary>
+    private void OnSourceContentCommitted(string sourceName)
+    {
+        if (!string.Equals(sourceName, _config.DefaultPrefixSource, StringComparison.Ordinal))
+            return;
+        Volatile.Write(ref _ruCache, null);
     }
 
     /// <summary>Default per-fetch budget for peer-supplied URL sources (#320).</summary>

--- a/BGPLite.Providers/PrefixSourceService.cs
+++ b/BGPLite.Providers/PrefixSourceService.cs
@@ -26,6 +26,10 @@ public sealed class PrefixSourceService : IPrefixSourceService
     // RefreshAsync (which would see already-new data and report unchanged) — leaving established peers
     // on stale routes. The callback is wired in Program.cs to ISessionManager.RefreshAllEstablishedAsync.
     private readonly Func<string, Task>? _onSourceChanged;
+    // #452: fired on EVERY committed content change (including RefreshAsync, which never fires
+    // _onSourceChanged). The RU projection's cache-layer consumer (PrefixService) subscribes to
+    // invalidate its projection so the next rebuild re-projects from the committed content.
+    public event Action<string>? ContentCommitted;
     // #85: pre-built name→source lookup (replaces per-call FirstOrDefault linear scan).
     private readonly Dictionary<string, PrefixSourceConfig> _sourcesByName;
 
@@ -276,10 +280,20 @@ public sealed class PrefixSourceService : IPrefixSourceService
         // path. Without this, established peers stay on stale routes until the source changes AGAIN.
         // Skipped from RefreshAsync (triggerCallback=false): the auto-refresh timer aggregates all
         // changed sources into ONE peer push in LoopAsync, so firing the callback here would double-push.
-        if (changed && triggerCallback && _onSourceChanged is not null)
+        // #452: the ContentCommitted event fires on BOTH paths (it is the cache-invalidation signal,
+        // not the push) — otherwise a RefreshAsync-committed change left the RU projection stale for
+        // its full TTL. Fired before _onSourceChanged so the projection is already invalidated when
+        // the push-triggered rebuilds start reading it.
+        if (changed)
         {
-            try { await _onSourceChanged(source.Name); }
-            catch (Exception ex) { _logger.LogWarning(ex, "OnSourceChanged callback failed for '{Name}'.", source.Name); }
+            try { ContentCommitted?.Invoke(source.Name); }
+            catch (Exception ex) { _logger.LogWarning(ex, "ContentCommitted handler failed for '{Name}'.", source.Name); }
+
+            if (triggerCallback && _onSourceChanged is not null)
+            {
+                try { await _onSourceChanged(source.Name); }
+                catch (Exception ex) { _logger.LogWarning(ex, "OnSourceChanged callback failed for '{Name}'.", source.Name); }
+            }
         }
 
         return (loaded, changed);

--- a/BGPLite.Tests/ApiHandlerBehaviorTests.cs
+++ b/BGPLite.Tests/ApiHandlerBehaviorTests.cs
@@ -275,6 +275,8 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
 
     private sealed class InertPrefixSources : IPrefixSourceService
     {
+
+        public event Action<string>? ContentCommitted;
         public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default) => Task.FromResult<(IReadOnlyList<IpPrefix>, bool)>(([], false));

--- a/BGPLite.Tests/ConfigHotReloadTests.cs
+++ b/BGPLite.Tests/ConfigHotReloadTests.cs
@@ -369,6 +369,8 @@ public class ConfigHotReloadTests
     /// <summary>Reports no configured prefix sources; the hot-reload path never calls it.</summary>
     private sealed class InertPrefixSourceService : IPrefixSourceService
     {
+
+        public event Action<string>? ContentCommitted;
         public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
             => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default)

--- a/BGPLite.Tests/ManagementApiShutdownTests.cs
+++ b/BGPLite.Tests/ManagementApiShutdownTests.cs
@@ -333,6 +333,8 @@ public sealed class ManagementApiShutdownTests : IDisposable
     /// <summary>Reports no configured prefix sources; the shutdown path never calls it.</summary>
     private sealed class InertPrefixSourceService : IPrefixSourceService
     {
+
+        public event Action<string>? ContentCommitted;
         public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
             => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default)

--- a/BGPLite.Tests/PeerDeleteTeardownTests.cs
+++ b/BGPLite.Tests/PeerDeleteTeardownTests.cs
@@ -365,6 +365,8 @@ public sealed class PeerDeleteTeardownTests
     /// <summary>Reports no configured prefix sources; the delete path never calls it.</summary>
     private sealed class InertPrefixSourceService : IPrefixSourceService
     {
+
+        public event Action<string>? ContentCommitted;
         public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
             => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default)

--- a/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
+++ b/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
@@ -23,6 +23,8 @@ public class PrefixAutoRefreshServiceTests
     /// </summary>
     private class CountingPrefixSourceService : IPrefixSourceService
     {
+
+        public event Action<string>? ContentCommitted;
         public Dictionary<string, int> RefreshCalls { get; } = new();
         public Dictionary<string, bool> Conditional { get; } = new();
         public bool ReportChanged { get; set; }

--- a/BGPLite.Tests/PrefixCacheRaceTests.cs
+++ b/BGPLite.Tests/PrefixCacheRaceTests.cs
@@ -207,6 +207,8 @@ public class PrefixCacheRaceTests
     /// </summary>
     private sealed class CountingPrefixSource : IPrefixSourceService
     {
+
+        public event Action<string>? ContentCommitted;
         private int _loadCalls;
         public int LoadCalls => Volatile.Read(ref _loadCalls);
         public bool FailNext { get; set; }

--- a/BGPLite.Tests/PrefixServiceRuInvalidationTests.cs
+++ b/BGPLite.Tests/PrefixServiceRuInvalidationTests.cs
@@ -1,0 +1,146 @@
+using BGPLite.Configuration;
+using BGPLite.Providers;
+using BGPLite.Protocol;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #452: the RU/default projection (<c>PrefixService._ruCache</c>) is a second cache layer with
+/// its own 1h TTL above the source-level cache. A committed content change to the DEFAULT source
+/// must be visible to the next route rebuild — including (and especially) on the auto-refresh
+/// path, where <see cref="IPrefixSourceService.RefreshAsync"/> is deliberately callback-free
+/// (#214): without an invalidation signal the fleet rebuild re-reads the stale fast path and
+/// re-advertises the old RU set for up to the RU TTL.
+/// </summary>
+public sealed class PrefixServiceRuInvalidationTests
+{
+    /// <summary>Source provider whose content the test mutates between loads.</summary>
+    private sealed class MutableProvider(IReadOnlyList<IpPrefix> initial) : IPrefixSourceProvider
+    {
+        public string Kind => "http";
+        public bool SupportsConditionalRequests => false;
+        public IReadOnlyList<IpPrefix> Content { get; set; } = initial;
+
+        public Task<SourceLoadResult> LoadAsync(PrefixSourceConfig source, string? etag = null, DateTimeOffset? lastModified = null, CancellationToken ct = default) =>
+            Task.FromResult(SourceLoadResult.Ok(Content));
+    }
+
+    private static readonly IpPrefix InitialPrefix = new(0x0A000000u, 8);   // 10.0.0.0/8
+    private static readonly IpPrefix UpdatedPrefix = new(0x0A000100u, 24);  // 10.0.1.0/24
+
+    private static (PrefixService Service, PrefixSourceService Sources, MutableProvider Provider, Func<int> Pushes) Build()
+    {
+        var provider = new MutableProvider([InitialPrefix]);
+        var yaml = """
+                   Bgp:
+                     Asn: 65444
+                     RouterId: 10.0.0.1
+                   DefaultPrefixSource: ru
+                   PrefixSources:
+                     - Name: ru
+                       Kind: http
+                       Url: https://example.com/ru.txt
+                     - Name: other
+                       Kind: http
+                       Url: https://example.com/other.txt
+                   """;
+        var config = ConfigLoader.LoadFromText(yaml);
+        var sources = new PrefixSourceService(
+            config,
+            new PrefixSourceProviderFactory([provider]),
+            NullLogger<PrefixSourceService>.Instance);
+        var pushes = 0;
+        var service = new PrefixService(
+            config,
+            new RipeStatPrefixCache(
+                new RipeStatProvider(new ThrowingFactory(), NullLogger<RipeStatProvider>.Instance),
+                NullLogger<RipeStatPrefixCache>.Instance),
+            sources,
+            null!, // HttpPrefixProvider is only on the per-peer user-source path (#263)
+            onSourceChanged: _ =>
+            {
+                Interlocked.Increment(ref pushes);
+                return Task.CompletedTask;
+            });
+        return (service, sources, provider, () => Volatile.Read(ref pushes));
+    }
+
+    private sealed class ThrowingFactory : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => throw new NotSupportedException("not on the RU path");
+    }
+
+    [Fact]
+    public async Task DefaultSourceChange_AutoRefreshPath_RebuildsRuProjectionImmediately()
+    {
+        var (service, sources, provider, pushes) = Build();
+
+        // 1. Warm the RU projection — cold load caches the initial content for the full RU TTL
+        //    (and legitimately fires the #416 convergence push once — record the baseline).
+        var first = await service.GetRuPrefixesAsync();
+        Assert.Single(first);
+        Assert.Equal(InitialPrefix.Address, first[0].Prefix);
+        Assert.Equal(InitialPrefix.Length, first[0].Length);
+        var baselinePushes = pushes();
+
+        // 2. The source content changes and the auto-refresh timer force-refreshes the source
+        //    (RefreshAsync — the callback-free path; the fleet push happens afterwards).
+        provider.Content = [UpdatedPrefix];
+        Assert.True(await sources.RefreshAsync("ru"));
+
+        // 3. The rebuild that the auto-refresh push triggers must advertise the NEW content —
+        //    pre-#452 this returned the stale projection until the RU TTL elapsed.
+        var rebuilt = await service.GetRuPrefixesAsync();
+        Assert.Single(rebuilt);
+        Assert.Equal(UpdatedPrefix.Address, rebuilt[0].Prefix);
+        Assert.Equal(UpdatedPrefix.Length, rebuilt[0].Length);
+
+        // 4. The auto-refresh path stays callback-free (#214 — no double push): the only push so
+        //    far is the warm-up's own; the invalidation signal must not turn RefreshAsync into
+        //    a pusher.
+        Assert.Equal(baselinePushes, pushes());
+    }
+
+    [Fact]
+    public async Task DefaultSourceChange_ConnectPathStillReportsChanged_ExactlyOnce()
+    {
+        var (service, sources, provider, pushes) = Build();
+
+        // Warm the projection, then change the source. (The cold load fires its own #416 push —
+        // that is the baseline; the assertions below check for no ADDITIONAL push.)
+        await service.GetRuPrefixesAsync();
+        var baselinePushes = pushes();
+        provider.Content = [UpdatedPrefix];
+
+        // Auto-refresh commits the new content (invalidation fires here).
+        Assert.True(await sources.RefreshAsync("ru"));
+
+        // A subsequent connect-path load reads the ALREADY-NEW source cache: changed=false —
+        // the invalidation must not fabricate a phantom change (no duplicate fleet push).
+        var (_, changed) = await sources.LoadDefaultAsync();
+        Assert.False(changed);
+        Assert.Equal(baselinePushes, pushes());
+
+        // And the projection serves the new content.
+        var rebuilt = await service.GetRuPrefixesAsync();
+        Assert.Equal(UpdatedPrefix.Address, rebuilt[0].Prefix);
+    }
+
+    [Fact]
+    public async Task NonDefaultSourceChange_DoesNotInvalidateRuProjection()
+    {
+        var (service, sources, provider, pushes) = Build();
+        await service.GetRuPrefixesAsync();
+        var baselinePushes = pushes();
+
+        // A change to a DIFFERENT source (same PrefixSourceService instance) is invisible to the
+        // RU projection — the committed-change signal must not tear a projection it doesn't feed.
+        provider.Content = [UpdatedPrefix];
+        Assert.True(await sources.RefreshAsync("other"));
+
+        var cached = await service.GetRuPrefixesAsync();
+        Assert.Equal(InitialPrefix.Address, cached[0].Prefix);
+        Assert.Equal(baselinePushes, pushes());
+    }
+}

--- a/BGPLite.Tests/RouteSeedingServiceTests.cs
+++ b/BGPLite.Tests/RouteSeedingServiceTests.cs
@@ -38,6 +38,8 @@ public class RouteSeedingServiceTests
 
     private sealed class FakeSourceService : IPrefixSourceService
     {
+
+        public event Action<string>? ContentCommitted;
         private readonly IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)> _sources;
 
         public FakeSourceService(IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>? sources = null) =>


### PR DESCRIPTION
Closes #452 — linkage only; the integration PR aggregates the keyword that actually closes it.

## Problem
The RU/default projection (`PrefixService._ruCache`, 1h TTL) is a second cache layer above the source-level cache. The auto-refresh path commits new content via `RefreshAsync` — deliberately callback-free (#214) — so a `RefreshAllEstablishedAsync` fleet rebuild re-read the STALE fast path and re-advertised the old RU set for up to the RU TTL.

## Root Cause
No invalidation signal exists between the source-cache layer and the projection layer for changes committed by `RefreshAsync` (the connect path invalidated implicitly via `LoadDefaultAsync`'s `changed`, which is why only the auto-refresh path was broken).

## Fix
- `IPrefixSourceService`/`PrefixSourceService`: new `ContentCommitted` event, fired after the gate on EVERY committed content change (including `RefreshAsync`, which still never fires the BGP-push callback — no double push).
- `PrefixService`: subscribes; drops `_ruCache` when the changed source is the configured default. The next `GetRuPrefixesAsync` re-projects from the already-new source cache and reports `changed=false`.

## Correctness
Handler is a `Volatile.Write` (cheap, no re-entrancy; event fires after gate release). Invalidation is idempotent and ordered before the push-triggered rebuilds (fired synchronously inside `RefreshAsync` before `LoopAsync` calls the push). Null-guarded subscription keeps the existing null-source test compositions valid.

## Regression Test
`PrefixServiceRuInvalidationTests` (3 tests): auto-refresh change → next rebuild advertises NEW content immediately (RED pre-fix, GREEN post-fix); no phantom `changed` on the follow-up connect path and no additional push; non-default source change does not tear the projection.

## Verification
- dotnet format (clean) / dotnet build BGPLite.sln (0 errors, 0 warnings) / dotnet test: 1048 passed, 0 failed (baseline 1045 + 3 new).
- Red/green proven: test 1 fails on pre-fix code with the stale prefix, passes post-fix.

## RFC
None — provisioning layer, no protocol surface.

## Behavior Change
None beyond the fix (RefreshAsync stays callback-free; connect-path push semantics unchanged).

## Deviation from Issue Proposal
The issue proposed version-stamping the projection. Implemented instead as an invalidation event: same guarantee (invalidate before the fleet rebuild), less machinery, covers every change-detecting entry point (LoadAllAsync/GetAsync/RefreshAsync) generically.