### PR TITLE
fix(api): arm the create path's shared-IP TCP-MD5 key through the shared resolver

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -992,7 +992,12 @@ public sealed class ManagementApi : IHostedService, IDisposable
             normalizedIp, data.Asn, data.Description, asnLists, customPrefixes, data.CustomAsns ?? [], data.MaxPrefix,
             md5Password: string.IsNullOrEmpty(data.Md5Password) ? null : data.Md5Password);
         if (!string.IsNullOrEmpty(data.Md5Password))
-            _sessionManager.SetPeerMd5Key(normalizedIp, data.Md5Password);
+        {
+            // #455: resolve through the SAME shared-IP re-arm the delete/PATCH/bootstrap paths use —
+            // TCP keys by address (#36), so arming the new row's key directly silently overrode a
+            // sibling's key on the same IP (last-writer-wins, no disagreement warning).
+            await RearmPeerIpMd5KeyAsync(normalizedIp);
+        }
 
         _logger.LogInformation("Created peer {Ip} AS{Asn} ({Id}): {Subs} lists, {Prefixes} custom prefixes, {Asns} custom AS",
             normalizedIp, data.Asn, saved.Id, asnLists.Count, customPrefixes.Count, data.CustomAsns?.Count ?? 0);

--- a/BGPLite.Tests/ApiHandlerBehaviorTests.cs
+++ b/BGPLite.Tests/ApiHandlerBehaviorTests.cs
@@ -43,7 +43,7 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
         _connection.Dispose();
     }
 
-    private async Task<int> StartAsync(AppConfig template)
+    private async Task<int> StartAsync(AppConfig template, ISessionManager? sessions = null)
     {
         for (var attempt = 0; ; attempt++)
         {
@@ -64,7 +64,7 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
                 NullLogger<ManagementApi>.Instance,
                 new InertPrefixService(),
                 new InertPrefixSources(),
-                new InertSessions());
+                sessions ?? new InertSessions());
             try
             {
                 await _api.StartAsync(CancellationToken.None);
@@ -250,6 +250,32 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
         }
     }
 
+    [Fact]
+    public async Task CreatePeer_SecondKeyOnSharedIp_ArmsTheDeterministicResolverKey()
+    {
+        // #455: pre-fix the create path armed the NEW row's key directly (last-writer-wins across
+        // the shared source IP, no disagreement warning) while delete/PATCH/bootstrap resolved
+        // through RearmPeerIpMd5KeyAsync/ResolveSharedIpKey. Create goes through the same resolver:
+        // with "key-a" already keyed on the IP, creating a sibling with "key-b" must arm the
+        // deterministic ordinal pick ("key-a"), not the new row's key.
+        var sessions = new RecordingSessions();
+        _port = await StartAsync(
+            new AppConfig { Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" } },
+            sessions);
+        _client = new HttpClient();
+
+        using (var first = await _client.PostAsync($"http://127.0.0.1:{_port}/api/peers",
+            new StringContent("""{"ip":"203.0.113.11","asn":65001,"md5Password":"key-a"}""", Encoding.UTF8, "application/json")))
+            Assert.True(first.IsSuccessStatusCode, await first.Content.ReadAsStringAsync());
+        using (var second = await _client.PostAsync($"http://127.0.0.1:{_port}/api/peers",
+            new StringContent("""{"ip":"203.0.113.11","asn":65002,"md5Password":"key-b"}""", Encoding.UTF8, "application/json")))
+            Assert.True(second.IsSuccessStatusCode, await second.Content.ReadAsStringAsync());
+
+        var armed = sessions.Md5Keys.Last(k => k.Password is not null);
+        Assert.Equal("203.0.113.11", armed.Ip);
+        Assert.Equal("key-a", armed.Password);
+    }
+
     private static int FreeTcpPort()
     {
         using var socket = new System.Net.Sockets.Socket(System.Net.Sockets.AddressFamily.InterNetwork, System.Net.Sockets.SocketType.Stream, System.Net.Sockets.ProtocolType.Tcp);
@@ -292,6 +318,19 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
         public Task TerminatePeerAsync(string peerIp, uint asn, CancellationToken ct = default) => Task.CompletedTask;
         public Task TerminatePeerByIpAsync(string peerIp, CancellationToken ct = default) => Task.CompletedTask;
         public void SetPeerMd5Key(string peerIp, string? password) { }
+        public int GetAdvertisedPrefixCount(string peerIp, uint asn) => 0;
+        public Task RefreshAllEstablishedAsync() => Task.CompletedTask;
+    }
+
+    /// <summary>Records SetPeerMd5Key calls so a test can assert WHAT was armed (#455).</summary>
+    private sealed class RecordingSessions : ISessionManager
+    {
+        public List<(string Ip, string? Password)> Md5Keys { get; } = [];
+        public Task RefreshPeerAsync(string peerIp, uint asn) => Task.CompletedTask;
+        public List<string> GetActivePeerIps() => [];
+        public Task TerminatePeerAsync(string peerIp, uint asn, CancellationToken ct = default) => Task.CompletedTask;
+        public Task TerminatePeerByIpAsync(string peerIp, CancellationToken ct = default) => Task.CompletedTask;
+        public void SetPeerMd5Key(string peerIp, string? password) => Md5Keys.Add((peerIp, password));
         public int GetAdvertisedPrefixCount(string peerIp, uint asn) => 0;
         public Task RefreshAllEstablishedAsync() => Task.CompletedTask;
     }


### PR DESCRIPTION
Closes #455 — linkage only; the integration PR aggregates the keyword.

## Problem
#418 routed delete, PATCH, and the startup bootstrap through `RearmPeerIpMd5KeyAsync`/`ResolveSharedIpKey` (deterministic ordinal pick among ALL keyed rows on the IP + a warning when siblings declare different keys). `HandleCreatePeer` was missed: it armed the new row's key directly — last-writer-wins across the shared source IP, silently overriding a sibling's key.

## Fix
One line: the create path calls `RearmPeerIpMd5KeyAsync(normalizedIp)` after the row is committed, so all four paths resolve the armed key identically.

## Regression Test
`CreatePeer_SecondKeyOnSharedIp_ArmsTheDeterministicResolverKey` (ApiHandlerBehaviorTests, HTTP-driven with a recording ISessionManager): key-a keyed on the IP, create a sibling with key-b → the armed key is the deterministic pick (`key-a`). RED pre-fix (armed `key-b`), GREEN post-fix.

## Verification
- dotnet format / dotnet build (0 errors) / dotnet test: 1051 passed, 0 failed.

## RFC
RFC 2385 semantics unchanged (TCP keys by address — one key serves all rows on the IP).

## Behavior Change
When a created peer's key sorts after a sibling's existing key on the same source IP, the armed key is the sibling's (deterministic pick) instead of the new row's. Single-keyed IPs are unchanged.

## Deviation from Issue Proposal
None.