### PR TITLE
docs: record the outbound AS_PATH re-origination decision (D23)

### DIFF
--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -276,3 +276,24 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
   (intentional behavior change, secure by default); such a proxy is otherwise attributed to the
   proxy address, with the one-shot runtime warning pointing at the misconfiguration.
 - **Tracker:** #256.
+
+## Routing
+
+### D23. Outbound routes are re-originated — AS_PATH carries only the local ASN
+- **Decision:** BGPLite never prepends the received AS_PATH. Every advertised prefix
+  (source-fed, custom, or RU-default) is re-originated: the outbound AS_PATH is built from the
+  local ASN alone (`UpdateCodec.BuildUpdateAttributes`/`BuildAsPathAttributes`;
+  `RouteAssembler.MakeRoute` passes `asPath: null`). MED, LOCAL_PREF, and received large
+  communities are likewise not propagated; outbound communities are operator-stamped per source
+  (one community per source/category, `ConfigCommunityResolver`).
+- **Context:** BGPLite is an provisioning route server — it advertises operator-configured prefix
+  sets, not transit routes. Peer-learned routes are never re-advertised at all (D13: the shared
+  table exists for ownership-scoped withdrawals; `SharedTableRouteAssembler` re-advertises only
+  the unowned startup seed). The inbound half of loop prevention IS implemented: a route whose
+  AS_PATH contains the local ASN is excluded from installation (RFC 4271 §9.1.2).
+- **Consequence (RFC 4271 §9.1.2):** AS-loop detection at RECEIVING speakers cannot recognize
+  their own prefix coming back, because the returned path carries only BGPLite's ASN — an origin
+  AS peering with BGPLite will not reject the route by loop detection and must rely on its own
+  policy. Operators comparing against RFC-strict speakers should know the advertised paths are
+  always exactly one ASN long.
+- **Tracker:** #456 (documentation of long-standing behavior, flagged by the 2026-09-03 audit).


### PR DESCRIPTION
Closes #456 — linkage only; the integration PR aggregates the keyword.

## Problem
The D-catalog (D1–D22) did not record that BGPLite re-originates every advertised prefix: the outbound AS_PATH carries only the local ASN (`UpdateCodec.BuildUpdateAttributes`; `RouteAssembler.MakeRoute(asPath: null)`), communities are operator-stamped, and received paths/attributes are never propagated. The catalog is the project's bug-vs-decision adjudicator, so this long-standing behavior gets re-derived and filed repeatedly.

## Change
New **D23** entry: the decision, the context (provisioning route server; peer-learned routes never re-advertised per D13; the inbound loop-exclusion rule IS implemented per RFC 4271 §9.1.2), and the consequence — receiving speakers' AS-loop detection cannot recognize their own prefix coming back.

## Verification
Docs-only: no test run required (per repo policy); solution build sanity-checked (0 errors).

## RFC
RFC 4271 §9.1.2 (AS-loop detection scope), referenced in the entry.

## Behavior Change
None — documentation only.