### PR TITLE
fix(server): drop an unsplittable oversized UPDATE group instead of tearing the session down

### DIFF
--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -1456,6 +1456,24 @@ public sealed class BgpSession : IDisposable
             MpReachV6 = mpReach
         };
 
+        // #457: pre-validate the composed frame against the RFC 4271 §4.1 4096-byte maximum
+        // BEFORE it reaches the writer. An oversized frame threw ArgumentOutOfRangeException out
+        // of WriteHeader; on the initial-send path that unwound RunAsync's generic catch —
+        // best-effort Cease + teardown — so a peer whose route set contained one unsplittable
+        // group was reset on every reconnect with zero routes. The batch itself cannot overflow
+        // on NLRI (the 100-per-UPDATE cap bounds it well under the maximum), only the attributes
+        // can — and those are constant per community group, so there is nothing to split the
+        // batch into: the group is dropped loudly instead. Everything else is advertised, the
+        // mirror stays consistent (the dropped prefixes never enter it), the session stays up.
+        var bufferSize = BgpMessageWriter.GetBufferSize(update);
+        if (bufferSize > BgpConstants.MaxMessageSize)
+        {
+            _logger.LogError(
+                "Composed UPDATE to {Peer} is {Size} bytes — over the {Max}-byte BGP maximum and unsplittable (attributes are constant per community group); dropping this group of {Count} prefix(es)",
+                _peer, bufferSize, BgpConstants.MaxMessageSize, mpReach?.Prefixes.Count ?? nlri.Count);
+            return;
+        }
+
         await SendMessageAsync(update);
         // #430 + #450 review: per-UPDATE mirror commit — SendRouteBatchAsync/SendV6RouteBatchAsync
         // emit one UPDATE per community group, so a group that throws after an earlier group

--- a/BGPLite.Tests/BgpSessionPhantomWithdrawalTests.cs
+++ b/BGPLite.Tests/BgpSessionPhantomWithdrawalTests.cs
@@ -68,8 +68,9 @@ public sealed class BgpSessionPhantomWithdrawalTests
         // Healthy refresh #1: the /8 is advertised normally.
         await session.RefreshRoutesAsync();
 
-        // Inject the poison route and refresh: the composed UPDATE exceeds MaxMessageSize, the
-        // writer throws mid-send, and RefreshCycleAsync contains the failure (session stays up).
+        // Inject the poison route and refresh: the composed UPDATE exceeds MaxMessageSize and is
+        // dropped before the wire (#457 pre-validation; pre-#457 the writer threw mid-send and
+        // RefreshCycleAsync contained the failure — same observable outcome, session stays up).
         routeTable.AddOrUpdate(PoisonRoute());
         await session.RefreshRoutesAsync();
 
@@ -112,6 +113,42 @@ public sealed class BgpSessionPhantomWithdrawalTests
         Assert.Contains(updates, u => u.Nlri.Any(p => p.Address == 0x0A000000 && p.Length == 8));
         var withdrawal = updates.LastOrDefault(u => u.WithdrawnRoutes.Any(p => p.Address == 0x0A000000));
         Assert.NotNull(withdrawal);
+
+        session.Dispose();
+        try { await run.WaitAsync(TimeSpan.FromSeconds(2)); } catch (TimeoutException) { }
+    }
+
+    [Fact]
+    public async Task OversizeGroupAtInitialSend_SessionStaysUp_HealthyRoutesAdvertised()
+    {
+        // #457: the poison route present BEFORE establishment exercises the INITIAL-send path.
+        // Pre-fix the composed overflow threw ArgumentOutOfRangeException out of the initial dump
+        // into RunAsync's generic catch: best-effort Cease + teardown — the peer reconnected into
+        // the same state with zero routes, every time. Post-fix the unsplittable group (attributes
+        // are constant per community set; NLRI cannot overflow at the 100-per-UPDATE cap) is
+        // dropped loudly: the session establishes, the healthy seed reaches the wire, no
+        // NOTIFICATION is emitted, and the poison prefix never enters the mirror.
+        var routeTable = new RouteTable();
+        routeTable.AddOrUpdate(new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 1 }); // healthy seed
+        routeTable.AddOrUpdate(PoisonRoute());
+        var (session, run, conn) = await EstablishAsync(routeTable);
+        await Task.Delay(TimeSpan.FromMilliseconds(100)); // let the initial dump finish
+
+        Assert.True(session.IsEstablished, "the oversize group must not tear down the initial send");
+        var frames = conn.Sent.Select(f => BgpMessageReader.ReadMessage(f)).ToList();
+        Assert.DoesNotContain(frames, m => m is BgpNotificationMessage);
+        var updates = frames.OfType<BgpUpdateMessage>().ToList();
+        Assert.Contains(updates, u => u.Nlri.Any(p => p.Address == 0x0A000000 && p.Length == 8));
+        Assert.DoesNotContain(updates, u => u.Nlri.Any(p => p.Address == 0x0A010000 && p.Length == 16));
+        Assert.DoesNotContain(updates, u => u.WithdrawnRoutes.Count > 0);
+
+        // Mirror consistency on top of the dropped group: a later refresh withdraws ONLY the
+        // healthy /8 (the poison prefix was never advertised, so it must never be withdrawn).
+        routeTable.Remove(0x0A000000, 8);
+        await session.RefreshRoutesAsync();
+        await Task.Delay(TimeSpan.FromMilliseconds(100));
+        Assert.DoesNotContain(conn.Sent.Select(f => BgpMessageReader.ReadMessage(f)).OfType<BgpUpdateMessage>(),
+            u => u.WithdrawnRoutes.Any(p => p.Address == 0x0A010000 && p.Length == 16));
 
         session.Dispose();
         try { await run.WaitAsync(TimeSpan.FromSeconds(2)); } catch (TimeoutException) { }


### PR DESCRIPTION
Closes #457 — linkage only; the integration PR aggregates the keyword.

## Problem
An oversized composed UPDATE (only ever attribute-driven: outbound communities are operator-stamped, NLRI is capped at 100/UPDATE well under the 4096 maximum) threw ArgumentOutOfRangeException out of `WriteHeader`. On the initial-send path that reached `RunAsync`'s generic catch → best-effort Cease + session teardown: the victim peer reconnected into the same state with zero routes, repeatedly. The refresh path was contained (session up, group silently missing).

## Root Cause / History
#292 item 9 proposed size-aware batching; #430 fixed only the mirror ordering; the root fix never landed. Analysis shows splitting is moot — attributes are constant per community group, so an overflowing group cannot be made smaller by batching NLRI.

## Fix
`SendUpdateBatchAsync` pre-validates via `BgpMessageWriter.GetBufferSize` (already the exact frame-size computation) and drops the group with an Error log naming peer, size, and prefix count. Everything else is advertised; the mirror never records the dropped prefixes; the session stays up on both the initial-send and refresh paths.

## Regression Test
`OversizeGroupAtInitialSend_SessionStaysUp_HealthyRoutesAdvertised` (extends BgpSessionPhantomWithdrawalTests): poison group present before establishment → session establishes, healthy seed on the wire, no NOTIFICATION, no poison NLRI, and a later refresh never withdraws the dropped prefix (mirror contract). RED pre-fix (session torn down), GREEN post-fix.

## Verification
- dotnet format / dotnet build (0 errors) / dotnet test: 1052 passed, 0 failed.

## RFC
RFC 4271 §4.1 (4096-byte message maximum) — enforced pre-send instead of by writer exception.

## Behavior Change
An unsplittable group is skipped with an Error log; initial send previously reset the session, refresh previously skipped it via the exception path.

## Deviation from Issue Proposal
Implements the correct subset of #292-item-9's size-aware batching: pre-validation + loud drop. NLRI-level splitting is intentionally not implemented (cannot overflow at the existing 100-per-UPDATE cap).