### PR TITLE
chore: integrate dev — audit follow-ups #452–#457

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -992,7 +992,12 @@ public sealed class ManagementApi : IHostedService, IDisposable
             normalizedIp, data.Asn, data.Description, asnLists, customPrefixes, data.CustomAsns ?? [], data.MaxPrefix,
             md5Password: string.IsNullOrEmpty(data.Md5Password) ? null : data.Md5Password);
         if (!string.IsNullOrEmpty(data.Md5Password))
-            _sessionManager.SetPeerMd5Key(normalizedIp, data.Md5Password);
+        {
+            // #455: resolve through the SAME shared-IP re-arm the delete/PATCH/bootstrap paths use —
+            // TCP keys by address (#36), so arming the new row's key directly silently overrode a
+            // sibling's key on the same IP (last-writer-wins, no disagreement warning).
+            await RearmPeerIpMd5KeyAsync(normalizedIp);
+        }
 
         _logger.LogInformation("Created peer {Ip} AS{Asn} ({Id}): {Subs} lists, {Prefixes} custom prefixes, {Asns} custom AS",
             normalizedIp, data.Asn, saved.Id, asnLists.Count, customPrefixes.Count, data.CustomAsns?.Count ?? 0);

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -1522,10 +1522,24 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         if (countOnly)
         {
+            // #454: same wall-clock budget as /api/asn-lists (#424) — a cold RIPEstat fetch is
+            // minutes-scale and must not pin the request (and its in-flight slot) for the full
+            // timeout×retries chain. Unlike the two endpoints #424 covered, a count cannot
+            // degrade to a partial list, so budget expiry answers a stable 503; shutdown still
+            // propagates.
+            using var budget = CancellationTokenSource.CreateLinkedTokenSource(_shutdownCts.Token);
+            budget.CancelAfter(ExternalFetchBudget);
             try
             {
-                var count = await _prefixService.GetPrefixCountAsync(asn, _shutdownCts.Token);
+                var count = await _prefixService.GetPrefixCountAsync(asn, budget.Token);
                 return ApiResponse.Ok(new { asn, prefixCount = count });
+            }
+            catch (OperationCanceledException) when (!_shutdownCts.IsCancellationRequested)
+            {
+                _logger.LogWarning(
+                    "GET /api/as/{Asn}/prefixes exceeded the {Seconds:0}s external-fetch budget",
+                    asn, ExternalFetchBudget.TotalSeconds);
+                return ApiResponse.Error("The upstream prefix source did not respond in time", 503);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {

--- a/BGPLite.Providers/IPrefixSourceService.cs
+++ b/BGPLite.Providers/IPrefixSourceService.cs
@@ -48,4 +48,15 @@ public interface IPrefixSourceService
     /// interval selection in the auto-refresh timer.
     /// </summary>
     bool SourceSupportsConditional(string sourceName);
+
+    /// <summary>
+    /// #452: fired AFTER a source's freshly loaded content is committed to the cache and the load
+    /// detected an actual change — on EVERY change-detecting entry point, including
+    /// <see cref="RefreshAsync"/> (which deliberately never fires the <c>onSourceChanged</c>
+    /// BGP-push callback). Cache-layer consumers that project a source's list into their own
+    /// longer-TTL cache (the RU projection in <c>PrefixService</c>) subscribe to invalidate
+    /// their projection, so a fleet rebuild always re-projects from the committed content.
+    /// Fired off the per-source gate; handlers must be cheap and non-blocking.
+    /// </summary>
+    event Action<string>? ContentCommitted;
 }

--- a/BGPLite.Providers/PrefixService.cs
+++ b/BGPLite.Providers/PrefixService.cs
@@ -49,6 +49,28 @@ public sealed class PrefixService : IPrefixService
         // pipeline) so peer-controlled failures cannot open the breaker gating operator sources;
         // falls back to the operator provider when not wired (tests).
         _userSourceHttpProvider = userSourceHttpProvider ?? httpProvider;
+        // #452: a committed content change to the DEFAULT source must invalidate the RU projection
+        // immediately — the auto-refresh path (RefreshAsync) never fires the push callback, so
+        // without this the fleet rebuild triggered afterwards re-reads the stale fast path for up
+        // to the RU TTL. The handler is a Volatile.Write: cheap, non-blocking, safe off the
+        // per-source gate (LoadCachedAsync fires the event only after releasing it).
+        // Guarded: tests compose PrefixService WITHOUT a source service (the interface sits only
+        // on the RU paths), passing null — those compositions simply get no invalidation signal.
+        if (prefixSources is not null)
+            _prefixSources.ContentCommitted += OnSourceContentCommitted;
+    }
+
+    /// <summary>
+    /// #452 handler for <see cref="IPrefixSourceService.ContentCommitted"/>: drops the cached RU
+    /// projection when the changed source is the one it is projected from. The next
+    /// <see cref="GetRuPrefixesAsync"/> takes the gate path, re-projects from the already-new
+    /// source-level cache, and reports no change — so the fleet push is not duplicated.
+    /// </summary>
+    private void OnSourceContentCommitted(string sourceName)
+    {
+        if (!string.Equals(sourceName, _config.DefaultPrefixSource, StringComparison.Ordinal))
+            return;
+        Volatile.Write(ref _ruCache, null);
     }
 
     /// <summary>Default per-fetch budget for peer-supplied URL sources (#320).</summary>

--- a/BGPLite.Providers/PrefixSourceService.cs
+++ b/BGPLite.Providers/PrefixSourceService.cs
@@ -26,6 +26,10 @@ public sealed class PrefixSourceService : IPrefixSourceService
     // RefreshAsync (which would see already-new data and report unchanged) — leaving established peers
     // on stale routes. The callback is wired in Program.cs to ISessionManager.RefreshAllEstablishedAsync.
     private readonly Func<string, Task>? _onSourceChanged;
+    // #452: fired on EVERY committed content change (including RefreshAsync, which never fires
+    // _onSourceChanged). The RU projection's cache-layer consumer (PrefixService) subscribes to
+    // invalidate its projection so the next rebuild re-projects from the committed content.
+    public event Action<string>? ContentCommitted;
     // #85: pre-built name→source lookup (replaces per-call FirstOrDefault linear scan).
     private readonly Dictionary<string, PrefixSourceConfig> _sourcesByName;
 
@@ -276,10 +280,20 @@ public sealed class PrefixSourceService : IPrefixSourceService
         // path. Without this, established peers stay on stale routes until the source changes AGAIN.
         // Skipped from RefreshAsync (triggerCallback=false): the auto-refresh timer aggregates all
         // changed sources into ONE peer push in LoopAsync, so firing the callback here would double-push.
-        if (changed && triggerCallback && _onSourceChanged is not null)
+        // #452: the ContentCommitted event fires on BOTH paths (it is the cache-invalidation signal,
+        // not the push) — otherwise a RefreshAsync-committed change left the RU projection stale for
+        // its full TTL. Fired before _onSourceChanged so the projection is already invalidated when
+        // the push-triggered rebuilds start reading it.
+        if (changed)
         {
-            try { await _onSourceChanged(source.Name); }
-            catch (Exception ex) { _logger.LogWarning(ex, "OnSourceChanged callback failed for '{Name}'.", source.Name); }
+            try { ContentCommitted?.Invoke(source.Name); }
+            catch (Exception ex) { _logger.LogWarning(ex, "ContentCommitted handler failed for '{Name}'.", source.Name); }
+
+            if (triggerCallback && _onSourceChanged is not null)
+            {
+                try { await _onSourceChanged(source.Name); }
+                catch (Exception ex) { _logger.LogWarning(ex, "OnSourceChanged callback failed for '{Name}'.", source.Name); }
+            }
         }
 
         return (loaded, changed);

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -1456,6 +1456,24 @@ public sealed class BgpSession : IDisposable
             MpReachV6 = mpReach
         };
 
+        // #457: pre-validate the composed frame against the RFC 4271 §4.1 4096-byte maximum
+        // BEFORE it reaches the writer. An oversized frame threw ArgumentOutOfRangeException out
+        // of WriteHeader; on the initial-send path that unwound RunAsync's generic catch —
+        // best-effort Cease + teardown — so a peer whose route set contained one unsplittable
+        // group was reset on every reconnect with zero routes. The batch itself cannot overflow
+        // on NLRI (the 100-per-UPDATE cap bounds it well under the maximum), only the attributes
+        // can — and those are constant per community group, so there is nothing to split the
+        // batch into: the group is dropped loudly instead. Everything else is advertised, the
+        // mirror stays consistent (the dropped prefixes never enter it), the session stays up.
+        var bufferSize = BgpMessageWriter.GetBufferSize(update);
+        if (bufferSize > BgpConstants.MaxMessageSize)
+        {
+            _logger.LogError(
+                "Composed UPDATE to {Peer} is {Size} bytes — over the {Max}-byte BGP maximum and unsplittable (attributes are constant per community group); dropping this group of {Count} prefix(es)",
+                _peer, bufferSize, BgpConstants.MaxMessageSize, mpReach?.Prefixes.Count ?? nlri.Count);
+            return;
+        }
+
         await SendMessageAsync(update);
         // #430 + #450 review: per-UPDATE mirror commit — SendRouteBatchAsync/SendV6RouteBatchAsync
         // emit one UPDATE per community group, so a group that throws after an earlier group

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -1327,15 +1327,15 @@ public sealed class BgpSession : IDisposable
         {
             batch.Add(route);
             if (batch.Count < maxNlriPerUpdate) continue;
-            await SendRouteBatchAsync(nextHop, batch, attrCache);
-            sent += batch.Count;
+            // #457 review: count what actually reached the wire — a community group dropped by
+            // the oversize pre-validation must not inflate _advertisedCount (#212 contract).
+            sent += await SendRouteBatchAsync(nextHop, batch, attrCache);
             batch.Clear();
         }
 
         if (batch.Count > 0)
         {
-            await SendRouteBatchAsync(nextHop, batch, attrCache);
-            sent += batch.Count;
+            sent += await SendRouteBatchAsync(nextHop, batch, attrCache);
         }
 
         var v6NextHop = NextHopIpv6 ?? 0;
@@ -1344,15 +1344,13 @@ public sealed class BgpSession : IDisposable
         {
             batch.Add(route);
             if (batch.Count < maxNlriPerUpdate) continue;
-            await SendV6RouteBatchAsync(v6NextHop, batch, v6AttrCache);
-            sent += batch.Count;
+            sent += await SendV6RouteBatchAsync(v6NextHop, batch, v6AttrCache);
             batch.Clear();
         }
 
         if (batch.Count > 0)
         {
-            await SendV6RouteBatchAsync(v6NextHop, batch, v6AttrCache);
-            sent += batch.Count;
+            sent += await SendV6RouteBatchAsync(v6NextHop, batch, v6AttrCache);
         }
 
         _logger.LogInformation("UpdateSent {Count} routes to {Peer}", sent, _peer);
@@ -1365,9 +1363,12 @@ public sealed class BgpSession : IDisposable
     /// partitioned by community set (the MP_REACH attribute applies to every NLRI in its UPDATE,
     /// same rule as COMMUNITY), base attributes come from the v6 cache (no classic NEXT_HOP),
     /// and the MP_REACH attribute — global next hop + this group's NLRI — is appended per group.
+    /// Returns the number of prefixes that actually reached the wire (#457: dropped groups are
+    /// not counted, keeping <c>_advertisedCount</c> equal to the wire truth, #212).
     /// </summary>
-    private async Task SendV6RouteBatchAsync(UInt128 nextHop6, List<Route> routes, Dictionary<IReadOnlyList<uint>, List<PathAttribute>> v6AttrCache)
+    private async Task<int> SendV6RouteBatchAsync(UInt128 nextHop6, List<Route> routes, Dictionary<IReadOnlyList<uint>, List<PathAttribute>> v6AttrCache)
     {
+        var sent = 0;
         foreach (var groupRoutes in GroupByCommunitySet(routes))
         {
             var attrs = UpdateCodec.GetCachedV6UpdateAttributes(
@@ -1376,8 +1377,10 @@ public sealed class BgpSession : IDisposable
 
             var nlri = groupRoutes.Select(r => new IpPrefix(r.Prefix, r.PrefixLength, r.IsIpv4)).ToList();
             attrs = UpdateCodec.WithMpReachV6Attribute(attrs, nextHop6, nlri);
-            await SendUpdateBatchAsync(attrs, [], mpReach: new MpReachCodec.MpReachV6(nextHop6, nlri));
+            if (await SendUpdateBatchAsync(attrs, [], mpReach: new MpReachCodec.MpReachV6(nextHop6, nlri)))
+                sent += nlri.Count;
         }
+        return sent;
     }
 
     /// <summary>
@@ -1419,12 +1422,19 @@ public sealed class BgpSession : IDisposable
         return [.. merged.Values];
     }
 
-    private async Task SendRouteBatchAsync(uint nextHop, List<Route> routes, Dictionary<IReadOnlyList<uint>, List<PathAttribute>> attrCache)
+    /// <summary>
+    /// Sends one batch of IPv4 routes as classic-NLRI UPDATEs, partitioned by community set.
+    /// Returns the number of prefixes that actually reached the wire — a group dropped by the
+    /// #457 oversize pre-validation is not counted, keeping <c>_advertisedCount</c> equal to the
+    /// wire truth (#212).
+    /// </summary>
+    private async Task<int> SendRouteBatchAsync(uint nextHop, List<Route> routes, Dictionary<IReadOnlyList<uint>, List<PathAttribute>> attrCache)
     {
         // The COMMUNITY/LARGE_COMMUNITY path attributes apply to EVERY NLRI in an UPDATE, so
         // partition the batch by (community set, large-community set) and emit one UPDATE per
         // set. Otherwise prefixes belonging to one group would be tagged with another group's
         // communities on the wire.
+        var sent = 0;
         foreach (var groupRoutes in GroupByCommunitySet(routes))
         {
             var attrs = UpdateCodec.GetCachedUpdateAttributes(_bgpConfig.Asn, _localFourByteAsn, nextHop, groupRoutes[0].Communities, attrCache);
@@ -1435,8 +1445,10 @@ public sealed class BgpSession : IDisposable
             attrs = UpdateCodec.WithLargeCommunityAttribute(attrs, groupRoutes[0].LargeCommunities);
 
             var nlri = groupRoutes.Select(r => new IpPrefix(r.Prefix, r.PrefixLength, r.IsIpv4)).ToList();
-            await SendUpdateBatchAsync(attrs, nlri);
+            if (await SendUpdateBatchAsync(attrs, nlri))
+                sent += nlri.Count;
         }
+        return sent;
     }
 
     /// <summary>
@@ -1447,7 +1459,11 @@ public sealed class BgpSession : IDisposable
     private static List<List<Route>> GroupByCommunitySet(IReadOnlyList<Route> routes)
         => RouteAssembler.GroupByCommunitySet(routes);
 
-    private async Task SendUpdateBatchAsync(List<PathAttribute> attrs, List<IpPrefix> nlri, MpReachCodec.MpReachV6? mpReach = null)
+    /// <summary>Serializes and sends one community-group UPDATE. Returns <c>false</c> when the
+    /// composed frame was dropped by the #457 oversize pre-validation (nothing sent, nothing
+    /// mirrored, nothing counted) so the caller can keep <c>_advertisedCount</c> at wire truth
+    /// (#212); <c>true</c> when the frame reached the wire.</summary>
+    private async Task<bool> SendUpdateBatchAsync(List<PathAttribute> attrs, List<IpPrefix> nlri, MpReachCodec.MpReachV6? mpReach = null)
     {
         var update = new BgpUpdateMessage
         {
@@ -1471,7 +1487,7 @@ public sealed class BgpSession : IDisposable
             _logger.LogError(
                 "Composed UPDATE to {Peer} is {Size} bytes — over the {Max}-byte BGP maximum and unsplittable (attributes are constant per community group); dropping this group of {Count} prefix(es)",
                 _peer, bufferSize, BgpConstants.MaxMessageSize, mpReach?.Prefixes.Count ?? nlri.Count);
-            return;
+            return false;
         }
 
         await SendMessageAsync(update);
@@ -1490,6 +1506,7 @@ public sealed class BgpSession : IDisposable
                 _advertisedPrefixes.Add(p);
         }
         _metrics.UpdateSent();
+        return true;
     }
 
     private PeerConfig GetFilterPeerConfig() => new()

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -426,6 +426,23 @@ public sealed class BgpSession : IDisposable
                     }
                     return;
                 }
+                catch (BgpParseException ex) when (ex.ErrorCode == BgpConstants.Error.OpenMessageError)
+                {
+                    // #453 (RFC 4271 §8.2.2): an OPEN received in OpenConfirm is an FSM error
+                    // regardless of body validity — the handshake phase accepts only KEEPALIVE and
+                    // NOTIFICATION. Without this the parse failure escaped to RunAsync's
+                    // catch(BgpParseException) and answered Open Message Error (2/x), misreporting
+                    // "your OPEN body was malformed" when the real fault is sending a second OPEN.
+                    // Mirrors the #427 Established branch in ReadLoopAsync: CAS-latch the teardown,
+                    // exactly one NOTIFICATION 5/0, then Idle.
+                    _logger.LogWarning("OPEN received from {Peer} in OpenConfirm — FSM error (RFC 4271 §8.2.2)", _peer);
+                    if (Interlocked.CompareExchange(ref _teardownReason, (int)TeardownReason.LocalCease, (int)TeardownReason.None) == (int)TeardownReason.None)
+                    {
+                        try { await SendNotificationAsync(BgpConstants.Error.FiniteStateMachineError, BgpConstants.SubError.Unspecific); }
+                        catch { /* best-effort — partial write counts, see RFC 4271 §8.1 */ }
+                    }
+                    return;
+                }
             }
 
             _logger.LogInformation("Received {Type} from {Peer} in OpenConfirm", response.Type, _peer);

--- a/BGPLite.Tests/ApiHandlerBehaviorTests.cs
+++ b/BGPLite.Tests/ApiHandlerBehaviorTests.cs
@@ -275,6 +275,8 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
 
     private sealed class InertPrefixSources : IPrefixSourceService
     {
+
+        public event Action<string>? ContentCommitted;
         public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
         public Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default) => Task.FromResult<(IReadOnlyList<IpPrefix>, bool)>(([], false));

--- a/BGPLite.Tests/ApiHandlerBehaviorTests.cs
+++ b/BGPLite.Tests/ApiHandlerBehaviorTests.cs
@@ -43,7 +43,7 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
         _connection.Dispose();
     }
 
-    private async Task<int> StartAsync(AppConfig template)
+    private async Task<int> StartAsync(AppConfig template, ISessionManager? sessions = null)
     {
         for (var attempt = 0; ; attempt++)
         {
@@ -64,7 +64,7 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
                 NullLogger<ManagementApi>.Instance,
                 new InertPrefixService(),
                 new InertPrefixSources(),
-                new InertSessions());
+                sessions ?? new InertSessions());
             try
             {
                 await _api.StartAsync(CancellationToken.None);
@@ -250,6 +250,32 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
         }
     }
 
+    [Fact]
+    public async Task CreatePeer_SecondKeyOnSharedIp_ArmsTheDeterministicResolverKey()
+    {
+        // #455: pre-fix the create path armed the NEW row's key directly (last-writer-wins across
+        // the shared source IP, no disagreement warning) while delete/PATCH/bootstrap resolved
+        // through RearmPeerIpMd5KeyAsync/ResolveSharedIpKey. Create goes through the same resolver:
+        // with "key-a" already keyed on the IP, creating a sibling with "key-b" must arm the
+        // deterministic ordinal pick ("key-a"), not the new row's key.
+        var sessions = new RecordingSessions();
+        _port = await StartAsync(
+            new AppConfig { Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" } },
+            sessions);
+        _client = new HttpClient();
+
+        using (var first = await _client.PostAsync($"http://127.0.0.1:{_port}/api/peers",
+            new StringContent("""{"ip":"203.0.113.11","asn":65001,"md5Password":"key-a"}""", Encoding.UTF8, "application/json")))
+            Assert.True(first.IsSuccessStatusCode, await first.Content.ReadAsStringAsync());
+        using (var second = await _client.PostAsync($"http://127.0.0.1:{_port}/api/peers",
+            new StringContent("""{"ip":"203.0.113.11","asn":65002,"md5Password":"key-b"}""", Encoding.UTF8, "application/json")))
+            Assert.True(second.IsSuccessStatusCode, await second.Content.ReadAsStringAsync());
+
+        var armed = sessions.Md5Keys.Last(k => k.Password is not null);
+        Assert.Equal("203.0.113.11", armed.Ip);
+        Assert.Equal("key-a", armed.Password);
+    }
+
     private static int FreeTcpPort()
     {
         using var socket = new System.Net.Sockets.Socket(System.Net.Sockets.AddressFamily.InterNetwork, System.Net.Sockets.SocketType.Stream, System.Net.Sockets.ProtocolType.Tcp);
@@ -292,6 +318,19 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
         public Task TerminatePeerAsync(string peerIp, uint asn, CancellationToken ct = default) => Task.CompletedTask;
         public Task TerminatePeerByIpAsync(string peerIp, CancellationToken ct = default) => Task.CompletedTask;
         public void SetPeerMd5Key(string peerIp, string? password) { }
+        public int GetAdvertisedPrefixCount(string peerIp, uint asn) => 0;
+        public Task RefreshAllEstablishedAsync() => Task.CompletedTask;
+    }
+
+    /// <summary>Records SetPeerMd5Key calls so a test can assert WHAT was armed (#455).</summary>
+    private sealed class RecordingSessions : ISessionManager
+    {
+        public List<(string Ip, string? Password)> Md5Keys { get; } = [];
+        public Task RefreshPeerAsync(string peerIp, uint asn) => Task.CompletedTask;
+        public List<string> GetActivePeerIps() => [];
+        public Task TerminatePeerAsync(string peerIp, uint asn, CancellationToken ct = default) => Task.CompletedTask;
+        public Task TerminatePeerByIpAsync(string peerIp, CancellationToken ct = default) => Task.CompletedTask;
+        public void SetPeerMd5Key(string peerIp, string? password) => Md5Keys.Add((peerIp, password));
         public int GetAdvertisedPrefixCount(string peerIp, uint asn) => 0;
         public Task RefreshAllEstablishedAsync() => Task.CompletedTask;
     }

--- a/BGPLite.Tests/AsnPrefixesBudgetTests.cs
+++ b/BGPLite.Tests/AsnPrefixesBudgetTests.cs
@@ -1,0 +1,124 @@
+using System.Net;
+using BGPLite.Api;
+using BGPLite.Configuration;
+using BGPLite.Contracts;
+using BGPLite.Providers;
+using BGPLite.Protocol;
+using BGPLite.Routing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #454: <c>GET /api/as/{asn}/prefixes?count=true</code> triggers a cold RIPEstat fetch that is
+/// minutes-scale, and pre-fix ran against the shutdown token only — one (or a few) such GETs
+/// pinned in-flight slots (global cap 64) for the full fetch chain. #424 bounded the other two
+/// cold-fetch GET endpoints with <see cref="ManagementApi.ExternalFetchBudget"/>; this endpoint
+/// gets the same wall-clock budget, answering a stable 503 on expiry (a count cannot degrade to
+/// a partial list) while shutdown still propagates.
+/// </summary>
+public sealed class AsnPrefixesBudgetTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private ManagementApi? _api;
+
+    public AsnPrefixesBudgetTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        using (var boot = new BgpDbContext(new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(_connection).Options))
+            BgpDbContext.Initialize(boot);
+    }
+
+    public void Dispose()
+    {
+        try { _api?.StopAsync(CancellationToken.None).Wait(TimeSpan.FromSeconds(5)); } catch { /* best-effort */ }
+        _api?.Dispose();
+        _connection.Dispose();
+    }
+
+    [Fact]
+    public async Task AsnPrefixesCount_ColdFetchExceedsBudget_AnswersWithinBudget()
+    {
+        var port = FreeTcpPort();
+        var config = new AppConfig
+        {
+            Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" },
+            ApiListen = "127.0.0.1",
+            ApiPort = port,
+        };
+        _api = new ManagementApi(
+            new PeerStore(new StaticOptionsFactory(new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(_connection).Options)),
+            new RouteTable(),
+            config,
+            new BgpMetrics(),
+            NullLogger<ManagementApi>.Instance,
+            new HangingPrefixService(),
+            new InertSources(),
+            new InertSessions());
+        await _api.StartAsync(CancellationToken.None);
+        _api.ExternalFetchBudget = TimeSpan.FromMilliseconds(300);
+
+        using var client = new HttpClient();
+        // RED (pre-#454): the hanging fetch pinned the request forever — this WaitAsync fired.
+        using var response = await client.GetAsync($"http://127.0.0.1:{port}/api/as/65001/prefixes?count=true")
+            .WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.DoesNotContain("RIPEstat", body); // non-revealing error policy (#157)
+    }
+
+    private static int FreeTcpPort()
+    {
+        using var socket = new System.Net.Sockets.Socket(System.Net.Sockets.AddressFamily.InterNetwork, System.Net.Sockets.SocketType.Stream, System.Net.Sockets.ProtocolType.Tcp);
+        socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        return ((IPEndPoint)socket.LocalEndPoint!).Port;
+    }
+
+    /// <summary>Cold-fetch stand-in: GetPrefixCountAsync never completes unless cancelled —
+    /// exactly the shape of a RIPEstat request against a blackholed upstream.</summary>
+    private sealed class HangingPrefixService : IPrefixService
+    {
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetPrefixesAsync(uint asn, CancellationToken ct = default) =>
+            Task.Delay(Timeout.InfiniteTimeSpan, ct).ContinueWith<IReadOnlyList<(UInt128, byte, bool)>>(_ => [], ct, TaskContinuationOptions.OnlyOnCanceled, TaskScheduler.Default);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default) => Task.FromResult(new List<(UInt128, byte, bool, uint)>());
+        public async Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+            return 0;
+        }
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default) => Task.FromResult(new List<(UInt128, byte, bool, uint)>());
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(UInt128, byte, bool)>>([]);
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(UInt128, byte, bool)>>([]);
+        public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private sealed class InertSources : IPrefixSourceService
+    {
+        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
+        public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
+        public Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default) => Task.FromResult<(IReadOnlyList<IpPrefix>, bool)>(([], false));
+        public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);
+        public bool SourceSupportsConditional(string sourceName) => true;
+        public event Action<string>? ContentCommitted;
+    }
+
+    private sealed class InertSessions : ISessionManager
+    {
+        public Task RefreshPeerAsync(string peerIp, uint asn) => Task.CompletedTask;
+        public List<string> GetActivePeerIps() => [];
+        public Task TerminatePeerAsync(string peerIp, uint asn, CancellationToken ct = default) => Task.CompletedTask;
+        public Task TerminatePeerByIpAsync(string peerIp, CancellationToken ct = default) => Task.CompletedTask;
+        public void SetPeerMd5Key(string peerIp, string? password) { }
+        public int GetAdvertisedPrefixCount(string peerIp, uint asn) => 0;
+        public Task RefreshAllEstablishedAsync() => Task.CompletedTask;
+    }
+
+    private sealed class StaticOptionsFactory(DbContextOptions<BgpDbContext> options) : IDbContextFactory<BgpDbContext>
+    {
+        public BgpDbContext CreateDbContext() => new(options);
+    }
+}

--- a/BGPLite.Tests/BgpSessionPhantomWithdrawalTests.cs
+++ b/BGPLite.Tests/BgpSessionPhantomWithdrawalTests.cs
@@ -135,6 +135,9 @@ public sealed class BgpSessionPhantomWithdrawalTests
         await Task.Delay(TimeSpan.FromMilliseconds(100)); // let the initial dump finish
 
         Assert.True(session.IsEstablished, "the oversize group must not tear down the initial send");
+        // CodeRabbit on the integration review: the dropped group must not inflate the advertised
+        // count — _advertisedCount is the wire truth (#212), so only the healthy /8 counts.
+        Assert.Equal(1, session.AdvertisedPrefixCount);
         var frames = conn.Sent.Select(f => BgpMessageReader.ReadMessage(f)).ToList();
         Assert.DoesNotContain(frames, m => m is BgpNotificationMessage);
         var updates = frames.OfType<BgpUpdateMessage>().ToList();

--- a/BGPLite.Tests/BgpSessionPhantomWithdrawalTests.cs
+++ b/BGPLite.Tests/BgpSessionPhantomWithdrawalTests.cs
@@ -68,8 +68,9 @@ public sealed class BgpSessionPhantomWithdrawalTests
         // Healthy refresh #1: the /8 is advertised normally.
         await session.RefreshRoutesAsync();
 
-        // Inject the poison route and refresh: the composed UPDATE exceeds MaxMessageSize, the
-        // writer throws mid-send, and RefreshCycleAsync contains the failure (session stays up).
+        // Inject the poison route and refresh: the composed UPDATE exceeds MaxMessageSize and is
+        // dropped before the wire (#457 pre-validation; pre-#457 the writer threw mid-send and
+        // RefreshCycleAsync contained the failure — same observable outcome, session stays up).
         routeTable.AddOrUpdate(PoisonRoute());
         await session.RefreshRoutesAsync();
 
@@ -112,6 +113,42 @@ public sealed class BgpSessionPhantomWithdrawalTests
         Assert.Contains(updates, u => u.Nlri.Any(p => p.Address == 0x0A000000 && p.Length == 8));
         var withdrawal = updates.LastOrDefault(u => u.WithdrawnRoutes.Any(p => p.Address == 0x0A000000));
         Assert.NotNull(withdrawal);
+
+        session.Dispose();
+        try { await run.WaitAsync(TimeSpan.FromSeconds(2)); } catch (TimeoutException) { }
+    }
+
+    [Fact]
+    public async Task OversizeGroupAtInitialSend_SessionStaysUp_HealthyRoutesAdvertised()
+    {
+        // #457: the poison route present BEFORE establishment exercises the INITIAL-send path.
+        // Pre-fix the composed overflow threw ArgumentOutOfRangeException out of the initial dump
+        // into RunAsync's generic catch: best-effort Cease + teardown — the peer reconnected into
+        // the same state with zero routes, every time. Post-fix the unsplittable group (attributes
+        // are constant per community set; NLRI cannot overflow at the 100-per-UPDATE cap) is
+        // dropped loudly: the session establishes, the healthy seed reaches the wire, no
+        // NOTIFICATION is emitted, and the poison prefix never enters the mirror.
+        var routeTable = new RouteTable();
+        routeTable.AddOrUpdate(new Route { Prefix = 0x0A000000, PrefixLength = 8, NextHop = 1 }); // healthy seed
+        routeTable.AddOrUpdate(PoisonRoute());
+        var (session, run, conn) = await EstablishAsync(routeTable);
+        await Task.Delay(TimeSpan.FromMilliseconds(100)); // let the initial dump finish
+
+        Assert.True(session.IsEstablished, "the oversize group must not tear down the initial send");
+        var frames = conn.Sent.Select(f => BgpMessageReader.ReadMessage(f)).ToList();
+        Assert.DoesNotContain(frames, m => m is BgpNotificationMessage);
+        var updates = frames.OfType<BgpUpdateMessage>().ToList();
+        Assert.Contains(updates, u => u.Nlri.Any(p => p.Address == 0x0A000000 && p.Length == 8));
+        Assert.DoesNotContain(updates, u => u.Nlri.Any(p => p.Address == 0x0A010000 && p.Length == 16));
+        Assert.DoesNotContain(updates, u => u.WithdrawnRoutes.Count > 0);
+
+        // Mirror consistency on top of the dropped group: a later refresh withdraws ONLY the
+        // healthy /8 (the poison prefix was never advertised, so it must never be withdrawn).
+        routeTable.Remove(0x0A000000, 8);
+        await session.RefreshRoutesAsync();
+        await Task.Delay(TimeSpan.FromMilliseconds(100));
+        Assert.DoesNotContain(conn.Sent.Select(f => BgpMessageReader.ReadMessage(f)).OfType<BgpUpdateMessage>(),
+            u => u.WithdrawnRoutes.Any(p => p.Address == 0x0A010000 && p.Length == 16));
 
         session.Dispose();
         try { await run.WaitAsync(TimeSpan.FromSeconds(2)); } catch (TimeoutException) { }

--- a/BGPLite.Tests/ConfigHotReloadTests.cs
+++ b/BGPLite.Tests/ConfigHotReloadTests.cs
@@ -369,6 +369,8 @@ public class ConfigHotReloadTests
     /// <summary>Reports no configured prefix sources; the hot-reload path never calls it.</summary>
     private sealed class InertPrefixSourceService : IPrefixSourceService
     {
+
+        public event Action<string>? ContentCommitted;
         public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
             => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default)

--- a/BGPLite.Tests/ManagementApiShutdownTests.cs
+++ b/BGPLite.Tests/ManagementApiShutdownTests.cs
@@ -333,6 +333,8 @@ public sealed class ManagementApiShutdownTests : IDisposable
     /// <summary>Reports no configured prefix sources; the shutdown path never calls it.</summary>
     private sealed class InertPrefixSourceService : IPrefixSourceService
     {
+
+        public event Action<string>? ContentCommitted;
         public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
             => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default)

--- a/BGPLite.Tests/OpenConfirmFsmErrorTests.cs
+++ b/BGPLite.Tests/OpenConfirmFsmErrorTests.cs
@@ -1,0 +1,142 @@
+using System.Net;
+using System.Net.Sockets;
+using BGPLite.Configuration;
+using BGPLite.Protocol;
+using BGPLite.Routing;
+using BGPLite.Server;
+using Microsoft.Extensions.Logging;
+using BGPLite.Contracts;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #453 (RFC 4271 §8.2.2): an OPEN received in OpenConfirm is an FSM error regardless of body
+/// validity — the handshake phase accepts only KEEPALIVE and NOTIFICATION. Pre-fix, a malformed
+/// OPEN body threw <see cref="BgpParseException"/> with the Open Message Error code out of the
+/// handshake read, escaped to <c>RunAsync</c>'s catch (#223 path) and answered NOTIFICATION 2/x —
+/// misreporting "your OPEN body was malformed" when the real fault is sending a second OPEN.
+/// The same message class in Established is already an FSM error (#427).
+/// </summary>
+public sealed class OpenConfirmFsmErrorTests
+{
+    [Fact]
+    public async Task MalformedOpen_InOpenConfirm_IsFsmError_NotBodyError()
+    {
+        var (server, client) = ConnectedPair();
+        using var clientSock = client;
+        var bgpConfig = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
+        using var session = new BgpSession(
+            new SocketBgpConnection(server),
+            new PeerConfig { Address = "127.0.0.1" },
+            bgpConfig,
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            new NopLogger<BgpSession>());
+        var runTask = session.RunAsync();
+
+        // Drive to OpenConfirm: a valid OPEN; drain the server's OPEN + KEEPALIVE. The client has
+        // not confirmed yet, so the session parks in OpenConfirm awaiting the KEEPALIVE.
+        Send(client, new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = 0,
+            RouterId = 0x0A000002,
+            Capabilities = [BgpCapabilityInfo.FourOctetAsn(65002)]
+        });
+        await DrainAsync(client, TimeSpan.FromSeconds(5));
+        for (var i = 0; i < 50 && session.State != BgpFsmState.OpenConfirm; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(20));
+        Assert.Equal(BgpFsmState.OpenConfirm, session.State);
+
+        // Well-framed OPEN, body-invalid (the #427 construction): declares optParamsLen=5 over a
+        // payload that carries none — ParseOpen throws Open Message Error before any FSM switch.
+        var payload = new byte[10];
+        payload[0] = 4;                       // version
+        payload[1] = 0xFD; payload[2] = 0xE8; // My AS 65002
+        payload[9] = 5;                       // optional-parameters length: mismatches the 0 present
+        var open = BuildMessage(BgpMessageType.Open, payload);
+        client.Send(open, 0, open.Length, SocketFlags.None);
+
+        var sent = await DrainAsync(client, TimeSpan.FromSeconds(2));
+        var notification = Assert.Single(sent.OfType<BgpNotificationMessage>());
+        Assert.Equal(BgpConstants.Error.FiniteStateMachineError, notification.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.Unspecific, notification.SubErrorCode);
+        Assert.False(session.IsEstablished, "an OPEN in OpenConfirm must reset the session (RFC 4271 §8.2.2)");
+
+        await runTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    private static (Socket server, Socket client) ConnectedPair()
+    {
+        using var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        listener.Listen(1);
+        var client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        client.Connect(listener.LocalEndPoint!);
+        return (listener.Accept(), client);
+    }
+
+    private static void Send(Socket s, BgpMessage msg)
+    {
+        var buffer = new byte[BgpMessageWriter.GetBufferSize(msg)];
+        var written = BgpMessageWriter.WriteMessage(msg, buffer);
+        s.Send(buffer, 0, written, SocketFlags.None);
+    }
+
+    private static byte[] BuildMessage(BgpMessageType type, byte[] payload)
+    {
+        var frame = new byte[BgpConstants.MessageHeaderSize + payload.Length];
+        for (var i = 0; i < BgpConstants.MarkerSize; i++) frame[i] = 0xFF;
+        frame[16] = (byte)((frame.Length >> 8) & 0xFF);
+        frame[17] = (byte)(frame.Length & 0xFF);
+        frame[18] = (byte)type;
+        payload.CopyTo(frame, BgpConstants.MessageHeaderSize);
+        return frame;
+    }
+
+    private static async Task<List<BgpMessage>> DrainAsync(Socket client, TimeSpan timeout)
+    {
+        var sent = new List<BgpMessage>();
+        client.ReceiveTimeout = (int)timeout.TotalMilliseconds;
+        var buf = new byte[4096];
+        var deadline = DateTime.UtcNow + timeout;
+        try
+        {
+            while (DateTime.UtcNow < deadline)
+            {
+                if (client.Poll(100_000, SelectMode.SelectRead)) // 100ms
+                {
+                    var available = client.Available;
+                    if (available == 0) break; // peer closed
+                    var got = client.Receive(buf, 0, Math.Min(available, buf.Length), SocketFlags.None);
+                    if (got == 0) break;
+                    ParseAll(buf, got, sent);
+                }
+            }
+        }
+        catch (SocketException) { /* timeout / peer closed */ }
+        return sent;
+    }
+
+    private static void ParseAll(byte[] buffer, int length, List<BgpMessage> into)
+    {
+        var offset = 0;
+        while (offset + BgpConstants.MessageHeaderSize <= length)
+        {
+            var msgLength = (buffer[offset + 16] << 8) | buffer[offset + 17];
+            if (msgLength < BgpConstants.MinMessageSize || offset + msgLength > length)
+                return; // partial tail — not enough bytes yet
+            into.Add(BgpMessageReader.ReadMessage(buffer.AsSpan(offset, msgLength)));
+            offset += msgLength;
+        }
+    }
+
+    private sealed class NopLogger<T> : ILogger<T>
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => false;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) { }
+    }
+}

--- a/BGPLite.Tests/PeerDeleteTeardownTests.cs
+++ b/BGPLite.Tests/PeerDeleteTeardownTests.cs
@@ -365,6 +365,8 @@ public sealed class PeerDeleteTeardownTests
     /// <summary>Reports no configured prefix sources; the delete path never calls it.</summary>
     private sealed class InertPrefixSourceService : IPrefixSourceService
     {
+
+        public event Action<string>? ContentCommitted;
         public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
             => Task.FromResult<IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>>([]);
         public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default)

--- a/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
+++ b/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
@@ -23,6 +23,8 @@ public class PrefixAutoRefreshServiceTests
     /// </summary>
     private class CountingPrefixSourceService : IPrefixSourceService
     {
+
+        public event Action<string>? ContentCommitted;
         public Dictionary<string, int> RefreshCalls { get; } = new();
         public Dictionary<string, bool> Conditional { get; } = new();
         public bool ReportChanged { get; set; }

--- a/BGPLite.Tests/PrefixCacheRaceTests.cs
+++ b/BGPLite.Tests/PrefixCacheRaceTests.cs
@@ -207,6 +207,8 @@ public class PrefixCacheRaceTests
     /// </summary>
     private sealed class CountingPrefixSource : IPrefixSourceService
     {
+
+        public event Action<string>? ContentCommitted;
         private int _loadCalls;
         public int LoadCalls => Volatile.Read(ref _loadCalls);
         public bool FailNext { get; set; }

--- a/BGPLite.Tests/PrefixServiceRuInvalidationTests.cs
+++ b/BGPLite.Tests/PrefixServiceRuInvalidationTests.cs
@@ -1,0 +1,146 @@
+using BGPLite.Configuration;
+using BGPLite.Providers;
+using BGPLite.Protocol;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #452: the RU/default projection (<c>PrefixService._ruCache</c>) is a second cache layer with
+/// its own 1h TTL above the source-level cache. A committed content change to the DEFAULT source
+/// must be visible to the next route rebuild — including (and especially) on the auto-refresh
+/// path, where <see cref="IPrefixSourceService.RefreshAsync"/> is deliberately callback-free
+/// (#214): without an invalidation signal the fleet rebuild re-reads the stale fast path and
+/// re-advertises the old RU set for up to the RU TTL.
+/// </summary>
+public sealed class PrefixServiceRuInvalidationTests
+{
+    /// <summary>Source provider whose content the test mutates between loads.</summary>
+    private sealed class MutableProvider(IReadOnlyList<IpPrefix> initial) : IPrefixSourceProvider
+    {
+        public string Kind => "http";
+        public bool SupportsConditionalRequests => false;
+        public IReadOnlyList<IpPrefix> Content { get; set; } = initial;
+
+        public Task<SourceLoadResult> LoadAsync(PrefixSourceConfig source, string? etag = null, DateTimeOffset? lastModified = null, CancellationToken ct = default) =>
+            Task.FromResult(SourceLoadResult.Ok(Content));
+    }
+
+    private static readonly IpPrefix InitialPrefix = new(0x0A000000u, 8);   // 10.0.0.0/8
+    private static readonly IpPrefix UpdatedPrefix = new(0x0A000100u, 24);  // 10.0.1.0/24
+
+    private static (PrefixService Service, PrefixSourceService Sources, MutableProvider Provider, Func<int> Pushes) Build()
+    {
+        var provider = new MutableProvider([InitialPrefix]);
+        var yaml = """
+                   Bgp:
+                     Asn: 65444
+                     RouterId: 10.0.0.1
+                   DefaultPrefixSource: ru
+                   PrefixSources:
+                     - Name: ru
+                       Kind: http
+                       Url: https://example.com/ru.txt
+                     - Name: other
+                       Kind: http
+                       Url: https://example.com/other.txt
+                   """;
+        var config = ConfigLoader.LoadFromText(yaml);
+        var sources = new PrefixSourceService(
+            config,
+            new PrefixSourceProviderFactory([provider]),
+            NullLogger<PrefixSourceService>.Instance);
+        var pushes = 0;
+        var service = new PrefixService(
+            config,
+            new RipeStatPrefixCache(
+                new RipeStatProvider(new ThrowingFactory(), NullLogger<RipeStatProvider>.Instance),
+                NullLogger<RipeStatPrefixCache>.Instance),
+            sources,
+            null!, // HttpPrefixProvider is only on the per-peer user-source path (#263)
+            onSourceChanged: _ =>
+            {
+                Interlocked.Increment(ref pushes);
+                return Task.CompletedTask;
+            });
+        return (service, sources, provider, () => Volatile.Read(ref pushes));
+    }
+
+    private sealed class ThrowingFactory : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => throw new NotSupportedException("not on the RU path");
+    }
+
+    [Fact]
+    public async Task DefaultSourceChange_AutoRefreshPath_RebuildsRuProjectionImmediately()
+    {
+        var (service, sources, provider, pushes) = Build();
+
+        // 1. Warm the RU projection — cold load caches the initial content for the full RU TTL
+        //    (and legitimately fires the #416 convergence push once — record the baseline).
+        var first = await service.GetRuPrefixesAsync();
+        Assert.Single(first);
+        Assert.Equal(InitialPrefix.Address, first[0].Prefix);
+        Assert.Equal(InitialPrefix.Length, first[0].Length);
+        var baselinePushes = pushes();
+
+        // 2. The source content changes and the auto-refresh timer force-refreshes the source
+        //    (RefreshAsync — the callback-free path; the fleet push happens afterwards).
+        provider.Content = [UpdatedPrefix];
+        Assert.True(await sources.RefreshAsync("ru"));
+
+        // 3. The rebuild that the auto-refresh push triggers must advertise the NEW content —
+        //    pre-#452 this returned the stale projection until the RU TTL elapsed.
+        var rebuilt = await service.GetRuPrefixesAsync();
+        Assert.Single(rebuilt);
+        Assert.Equal(UpdatedPrefix.Address, rebuilt[0].Prefix);
+        Assert.Equal(UpdatedPrefix.Length, rebuilt[0].Length);
+
+        // 4. The auto-refresh path stays callback-free (#214 — no double push): the only push so
+        //    far is the warm-up's own; the invalidation signal must not turn RefreshAsync into
+        //    a pusher.
+        Assert.Equal(baselinePushes, pushes());
+    }
+
+    [Fact]
+    public async Task DefaultSourceChange_ConnectPathStillReportsChanged_ExactlyOnce()
+    {
+        var (service, sources, provider, pushes) = Build();
+
+        // Warm the projection, then change the source. (The cold load fires its own #416 push —
+        // that is the baseline; the assertions below check for no ADDITIONAL push.)
+        await service.GetRuPrefixesAsync();
+        var baselinePushes = pushes();
+        provider.Content = [UpdatedPrefix];
+
+        // Auto-refresh commits the new content (invalidation fires here).
+        Assert.True(await sources.RefreshAsync("ru"));
+
+        // A subsequent connect-path load reads the ALREADY-NEW source cache: changed=false —
+        // the invalidation must not fabricate a phantom change (no duplicate fleet push).
+        var (_, changed) = await sources.LoadDefaultAsync();
+        Assert.False(changed);
+        Assert.Equal(baselinePushes, pushes());
+
+        // And the projection serves the new content.
+        var rebuilt = await service.GetRuPrefixesAsync();
+        Assert.Equal(UpdatedPrefix.Address, rebuilt[0].Prefix);
+    }
+
+    [Fact]
+    public async Task NonDefaultSourceChange_DoesNotInvalidateRuProjection()
+    {
+        var (service, sources, provider, pushes) = Build();
+        await service.GetRuPrefixesAsync();
+        var baselinePushes = pushes();
+
+        // A change to a DIFFERENT source (same PrefixSourceService instance) is invisible to the
+        // RU projection — the committed-change signal must not tear a projection it doesn't feed.
+        provider.Content = [UpdatedPrefix];
+        Assert.True(await sources.RefreshAsync("other"));
+
+        var cached = await service.GetRuPrefixesAsync();
+        Assert.Equal(InitialPrefix.Address, cached[0].Prefix);
+        Assert.Equal(baselinePushes, pushes());
+    }
+}

--- a/BGPLite.Tests/RouteSeedingServiceTests.cs
+++ b/BGPLite.Tests/RouteSeedingServiceTests.cs
@@ -38,6 +38,8 @@ public class RouteSeedingServiceTests
 
     private sealed class FakeSourceService : IPrefixSourceService
     {
+
+        public event Action<string>? ContentCommitted;
         private readonly IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)> _sources;
 
         public FakeSourceService(IReadOnlyList<(PrefixSourceConfig, IReadOnlyList<IpPrefix>)>? sources = null) =>

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -276,3 +276,24 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
   (intentional behavior change, secure by default); such a proxy is otherwise attributed to the
   proxy address, with the one-shot runtime warning pointing at the misconfiguration.
 - **Tracker:** #256.
+
+## Routing
+
+### D23. Outbound routes are re-originated — AS_PATH carries only the local ASN
+- **Decision:** BGPLite never prepends the received AS_PATH. Every advertised prefix
+  (source-fed, custom, or RU-default) is re-originated: the outbound AS_PATH is built from the
+  local ASN alone (`UpdateCodec.BuildUpdateAttributes`/`BuildAsPathAttributes`;
+  `RouteAssembler.MakeRoute` passes `asPath: null`). MED, LOCAL_PREF, and received large
+  communities are likewise not propagated; outbound communities are operator-stamped per source
+  (one community per source/category, `ConfigCommunityResolver`).
+- **Context:** BGPLite is an provisioning route server — it advertises operator-configured prefix
+  sets, not transit routes. Peer-learned routes are never re-advertised at all (D13: the shared
+  table exists for ownership-scoped withdrawals; `SharedTableRouteAssembler` re-advertises only
+  the unowned startup seed). The inbound half of loop prevention IS implemented: a route whose
+  AS_PATH contains the local ASN is excluded from installation (RFC 4271 §9.1.2).
+- **Consequence (RFC 4271 §9.1.2):** AS-loop detection at RECEIVING speakers cannot recognize
+  their own prefix coming back, because the returned path carries only BGPLite's ASN — an origin
+  AS peering with BGPLite will not reject the route by loop detection and must rely on its own
+  policy. Operators comparing against RFC-strict speakers should know the advertised paths are
+  always exactly one ASN long.
+- **Tracker:** #456 (documentation of long-standing behavior, flagged by the 2026-09-03 audit).


### PR DESCRIPTION
Closes #452
Closes #453
Closes #454
Closes #455
Closes #456
Closes #457

Batch of six audit-follow-up fixes, each individually reviewed and merged into `dev` (PRs #458–#463). Full suite **1052 passed / 0 failed**; every fix carries a red/green regression test.

## #452 — providers: invalidate the 1h RU projection on auto-refresh changes (PR #458)
`PrefixService._ruCache` (1h TTL) sat above the source-level cache with no invalidation signal from the callback-free auto-refresh path (`RefreshAsync`): a fleet rebuild re-advertised the stale RU set for up to an hour. New `IPrefixSourceService.ContentCommitted` event fires on every committed content change; `PrefixService` drops the projection when the default source changed and re-projects from the already-new cache (no duplicate push). 3 regression tests.

## #453 — server,protocol: OPEN in OpenConfirm is an FSM error (PR #459)
A malformed OPEN body in OpenConfirm escaped the handshake to RunAsync's parse-error catch and answered NOTIFICATION 2/x; RFC 4271 §8.2.2 makes any OPEN in OpenConfirm an FSM error regardless of body validity (same reasoning as #427 for Established). The handshake read now mirrors the #427 branch: exactly one NOTIFICATION 5/0, then Idle. Socket-pair red/green test.

## #454 — api: fetch budget for GET /api/as/{asn}/prefixes?count=true (PR #460)
The one cold-fetch GET endpoint #424 missed: a cold RIPEstat fetch (minutes-scale) pinned the request and its in-flight slot against the shutdown token only. Now bounded by the same linked `ExternalFetchBudget`; expiry answers a stable non-revealing 503 (a count cannot degrade to a partial list); shutdown still propagates. Hanging-provider test.

## #455 — api,server: create arms the shared-IP TCP-MD5 key via the #418 resolver (PR #461)
`HandleCreatePeer` armed the new row's key directly — last-writer-wins across the shared source IP, no disagreement warning — while delete/PATCH/bootstrap resolve via `RearmPeerIpMd5KeyAsync`/`ResolveSharedIpKey`. Create now goes through the same re-arm (deterministic ordinal pick). HTTP-driven regression test with a recording session manager.

## #456 — docs: D23 records the outbound AS_PATH re-origination (PR #462)
The D-catalog did not record that every advertised prefix is re-originated (AS_PATH = local ASN only, operator-stamped communities, no received-path propagation). D23 documents the decision and its RFC 4271 §9.1.2 consequence for receiving speakers' loop detection. Docs-only.

## #457 — protocol,server: oversized outbound UPDATE groups are dropped, not fatal (PR #463)
`SendUpdateBatchAsync` pre-validates the composed frame via `GetBufferSize` against the RFC 4271 §4.1 4096-byte maximum and drops an unsplittable group with an Error log — pre-fix the writer exception tore down the victim peer's session on every initial send. NLRI cannot overflow at the 100-per-UPDATE cap and attributes are constant per community group, so the #292-item-9 splitting reduces to this check. Initial-send red/green test + mirror-consistency assertions.

## Verification
- Per-PR: dotnet format / full solution build / full test suite; CI build-test + format-check + analyze (CodeQL) green; CodeQL merge-ref alerts 0 on every PR.
- Aggregate: 1052 tests green on the dev head; CodeRabbit review on THIS integration diff (per .coderabbit.yaml base-branch policy).

## Risk / changelog notes
- #454: a cold fetch slower than the 30s budget now answers 503 instead of holding the request for minutes.
- #455: on a source IP with differently-keyed siblings, the armed key is the deterministic ordinal pick (previously: last created won).
- #457: an unsplittable community group is skipped with an Error log (initial send previously reset the session).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TCP-MD5 key handling when multiple peers share an IP address.
  - ASN prefix-count requests now return a consistent 503 response when external data exceeds the configured time limit.
  - Corrected BGP error handling for unexpected OPEN messages.
  - Prevented oversized route updates from terminating active sessions; valid routes continue to be advertised.
  - Refreshed cached routing projections promptly when the default prefix source changes.

- **Documentation**
  - Documented outbound route re-origination, AS path handling, and community behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->