### PR TITLE
fix(server): keep _advertisedCount at wire truth when a group is dropped

### DIFF
--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -1327,15 +1327,15 @@ public sealed class BgpSession : IDisposable
         {
             batch.Add(route);
             if (batch.Count < maxNlriPerUpdate) continue;
-            await SendRouteBatchAsync(nextHop, batch, attrCache);
-            sent += batch.Count;
+            // #457 review: count what actually reached the wire — a community group dropped by
+            // the oversize pre-validation must not inflate _advertisedCount (#212 contract).
+            sent += await SendRouteBatchAsync(nextHop, batch, attrCache);
             batch.Clear();
         }
 
         if (batch.Count > 0)
         {
-            await SendRouteBatchAsync(nextHop, batch, attrCache);
-            sent += batch.Count;
+            sent += await SendRouteBatchAsync(nextHop, batch, attrCache);
         }
 
         var v6NextHop = NextHopIpv6 ?? 0;
@@ -1344,15 +1344,13 @@ public sealed class BgpSession : IDisposable
         {
             batch.Add(route);
             if (batch.Count < maxNlriPerUpdate) continue;
-            await SendV6RouteBatchAsync(v6NextHop, batch, v6AttrCache);
-            sent += batch.Count;
+            sent += await SendV6RouteBatchAsync(v6NextHop, batch, v6AttrCache);
             batch.Clear();
         }
 
         if (batch.Count > 0)
         {
-            await SendV6RouteBatchAsync(v6NextHop, batch, v6AttrCache);
-            sent += batch.Count;
+            sent += await SendV6RouteBatchAsync(v6NextHop, batch, v6AttrCache);
         }
 
         _logger.LogInformation("UpdateSent {Count} routes to {Peer}", sent, _peer);
@@ -1365,9 +1363,12 @@ public sealed class BgpSession : IDisposable
     /// partitioned by community set (the MP_REACH attribute applies to every NLRI in its UPDATE,
     /// same rule as COMMUNITY), base attributes come from the v6 cache (no classic NEXT_HOP),
     /// and the MP_REACH attribute — global next hop + this group's NLRI — is appended per group.
+    /// Returns the number of prefixes that actually reached the wire (#457: dropped groups are
+    /// not counted, keeping <c>_advertisedCount</c> equal to the wire truth, #212).
     /// </summary>
-    private async Task SendV6RouteBatchAsync(UInt128 nextHop6, List<Route> routes, Dictionary<IReadOnlyList<uint>, List<PathAttribute>> v6AttrCache)
+    private async Task<int> SendV6RouteBatchAsync(UInt128 nextHop6, List<Route> routes, Dictionary<IReadOnlyList<uint>, List<PathAttribute>> v6AttrCache)
     {
+        var sent = 0;
         foreach (var groupRoutes in GroupByCommunitySet(routes))
         {
             var attrs = UpdateCodec.GetCachedV6UpdateAttributes(
@@ -1376,8 +1377,10 @@ public sealed class BgpSession : IDisposable
 
             var nlri = groupRoutes.Select(r => new IpPrefix(r.Prefix, r.PrefixLength, r.IsIpv4)).ToList();
             attrs = UpdateCodec.WithMpReachV6Attribute(attrs, nextHop6, nlri);
-            await SendUpdateBatchAsync(attrs, [], mpReach: new MpReachCodec.MpReachV6(nextHop6, nlri));
+            if (await SendUpdateBatchAsync(attrs, [], mpReach: new MpReachCodec.MpReachV6(nextHop6, nlri)))
+                sent += nlri.Count;
         }
+        return sent;
     }
 
     /// <summary>
@@ -1419,12 +1422,19 @@ public sealed class BgpSession : IDisposable
         return [.. merged.Values];
     }
 
-    private async Task SendRouteBatchAsync(uint nextHop, List<Route> routes, Dictionary<IReadOnlyList<uint>, List<PathAttribute>> attrCache)
+    /// <summary>
+    /// Sends one batch of IPv4 routes as classic-NLRI UPDATEs, partitioned by community set.
+    /// Returns the number of prefixes that actually reached the wire — a group dropped by the
+    /// #457 oversize pre-validation is not counted, keeping <c>_advertisedCount</c> equal to the
+    /// wire truth (#212).
+    /// </summary>
+    private async Task<int> SendRouteBatchAsync(uint nextHop, List<Route> routes, Dictionary<IReadOnlyList<uint>, List<PathAttribute>> attrCache)
     {
         // The COMMUNITY/LARGE_COMMUNITY path attributes apply to EVERY NLRI in an UPDATE, so
         // partition the batch by (community set, large-community set) and emit one UPDATE per
         // set. Otherwise prefixes belonging to one group would be tagged with another group's
         // communities on the wire.
+        var sent = 0;
         foreach (var groupRoutes in GroupByCommunitySet(routes))
         {
             var attrs = UpdateCodec.GetCachedUpdateAttributes(_bgpConfig.Asn, _localFourByteAsn, nextHop, groupRoutes[0].Communities, attrCache);
@@ -1435,8 +1445,10 @@ public sealed class BgpSession : IDisposable
             attrs = UpdateCodec.WithLargeCommunityAttribute(attrs, groupRoutes[0].LargeCommunities);
 
             var nlri = groupRoutes.Select(r => new IpPrefix(r.Prefix, r.PrefixLength, r.IsIpv4)).ToList();
-            await SendUpdateBatchAsync(attrs, nlri);
+            if (await SendUpdateBatchAsync(attrs, nlri))
+                sent += nlri.Count;
         }
+        return sent;
     }
 
     /// <summary>
@@ -1447,7 +1459,11 @@ public sealed class BgpSession : IDisposable
     private static List<List<Route>> GroupByCommunitySet(IReadOnlyList<Route> routes)
         => RouteAssembler.GroupByCommunitySet(routes);
 
-    private async Task SendUpdateBatchAsync(List<PathAttribute> attrs, List<IpPrefix> nlri, MpReachCodec.MpReachV6? mpReach = null)
+    /// <summary>Serializes and sends one community-group UPDATE. Returns <c>false</c> when the
+    /// composed frame was dropped by the #457 oversize pre-validation (nothing sent, nothing
+    /// mirrored, nothing counted) so the caller can keep <c>_advertisedCount</c> at wire truth
+    /// (#212); <c>true</c> when the frame reached the wire.</summary>
+    private async Task<bool> SendUpdateBatchAsync(List<PathAttribute> attrs, List<IpPrefix> nlri, MpReachCodec.MpReachV6? mpReach = null)
     {
         var update = new BgpUpdateMessage
         {
@@ -1471,7 +1487,7 @@ public sealed class BgpSession : IDisposable
             _logger.LogError(
                 "Composed UPDATE to {Peer} is {Size} bytes — over the {Max}-byte BGP maximum and unsplittable (attributes are constant per community group); dropping this group of {Count} prefix(es)",
                 _peer, bufferSize, BgpConstants.MaxMessageSize, mpReach?.Prefixes.Count ?? nlri.Count);
-            return;
+            return false;
         }
 
         await SendMessageAsync(update);
@@ -1490,6 +1506,7 @@ public sealed class BgpSession : IDisposable
                 _advertisedPrefixes.Add(p);
         }
         _metrics.UpdateSent();
+        return true;
     }
 
     private PeerConfig GetFilterPeerConfig() => new()

--- a/BGPLite.Tests/BgpSessionPhantomWithdrawalTests.cs
+++ b/BGPLite.Tests/BgpSessionPhantomWithdrawalTests.cs
@@ -135,6 +135,9 @@ public sealed class BgpSessionPhantomWithdrawalTests
         await Task.Delay(TimeSpan.FromMilliseconds(100)); // let the initial dump finish
 
         Assert.True(session.IsEstablished, "the oversize group must not tear down the initial send");
+        // CodeRabbit on the integration review: the dropped group must not inflate the advertised
+        // count — _advertisedCount is the wire truth (#212), so only the healthy /8 counts.
+        Assert.Equal(1, session.AdvertisedPrefixCount);
         var frames = conn.Sent.Select(f => BgpMessageReader.ReadMessage(f)).ToList();
         Assert.DoesNotContain(frames, m => m is BgpNotificationMessage);
         var updates = frames.OfType<BgpUpdateMessage>().ToList();


### PR DESCRIPTION
Follow-up to #457 from the CodeRabbit review of the integration PR #464 (finding on `BgpSession.cs` SendUpdateBatchAsync/`sent` accounting).

## Problem
`SendRoutesAsync` added the full batch count to `sent` before the per-group outcome was known, so a community group dropped by the #457 oversize pre-validation still inflated `AdvertisedPrefixCount` — violating the #212 contract (`_advertisedCount` = actual wire count, post-dedup) that the management API surfaces to operators.

## Fix
`SendUpdateBatchAsync` returns `Task<bool>` (sent / dropped); `SendRouteBatchAsync` and `SendV6RouteBatchAsync` return the actually-sent prefix count; `SendRoutesAsync` sums those.

## Regression Test
New assertion in `OversizeGroupAtInitialSend_SessionStaysUp_HealthyRoutesAdvertised`: `AdvertisedPrefixCount == 1` (healthy /8 only). RED without the fix (reported 2, wire 1), GREEN with it.

## Verification
dotnet format / build (0 errors) / full suite 1052 passed.

## RFC
None — accounting only.

## Behavior Change
Dropped groups no longer counted in the advertised count (the point of the fix).