### PR TITLE
fix(protocol): stop advertising the MP IPv4/Unicast capability (#466)

### DIFF
--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -1676,10 +1676,6 @@ public sealed class BgpSession : IDisposable
             BgpCapabilityInfo.FourOctetAsn(_bgpConfig.Asn)
         };
 
-        // Only advertise MP IPv4/Unicast if peer specifically supports IPv4/Unicast
-        if (PeerHasMpIpv4Unicast(remoteOpen.Capabilities))
-            capabilities.Add(BgpCapabilityInfo.MultiprotocolIpv4Unicast());
-
         // Only advertise Route Refresh if peer also supports it
         if (remoteOpen.Capabilities.Any(c => c.Code == BgpConstants.Capability.RouteRefresh))
             capabilities.Add(BgpCapabilityInfo.RouteRefresh());
@@ -1687,6 +1683,13 @@ public sealed class BgpSession : IDisposable
         // #15 phase 2: advertise MP IPv6/Unicast only when the peer also supports it.
         if (CapabilityHelper.SupportsMultiprotocolIpv6Unicast(remoteOpen))
             capabilities.Add(BgpCapabilityInfo.MultiprotocolIpv6Unicast());
+
+        // #466 (D24): MP IPv4/Unicast is deliberately NOT advertised. RFC 5492 §3 makes a
+        // capability advertised by both peers usable, and RFC 4760 §8 ties the advertisement
+        // to actually supporting that <AFI, SAFI> on receive — but the inbound path has no
+        // MP_REACH/MP_UNREACH AFI=1 handling at all, so the old peer-offer echo turned every
+        // negotiated IPv4 MP UPDATE into a discarded treat-as-withdraw. IPv4/Unicast needs no
+        // MP capability: it is the default family and rides the classic NLRI field.
 
         // #318: the Graceful Restart capability is deliberately NOT advertised. RFC 4724 §4.2 obliges
         // a speaker engaging GR procedures to retain and stale-mark a restarting peer's routes;
@@ -1714,19 +1717,6 @@ public sealed class BgpSession : IDisposable
         };
 
         await SendMessageAsync(open);
-    }
-
-    private static bool PeerHasMpIpv4Unicast(List<BgpCapabilityInfo> caps)
-    {
-        foreach (var cap in caps)
-        {
-            if (cap.Code != BgpConstants.Capability.Multiprotocol || cap.Data.Length < 4) continue;
-            var afi = (ushort)((cap.Data[0] << 8) | cap.Data[1]);
-            var safi = cap.Data[3];
-            if (afi == BgpConstants.Afi.IPv4 && safi == BgpConstants.Safi.Unicast)
-                return true;
-        }
-        return false;
     }
 
     private Task SendKeepaliveAsync() => SendMessageAsync(BgpKeepaliveMessage.Instance);

--- a/BGPLite.Tests/BgpSessionOpenCapabilityTests.cs
+++ b/BGPLite.Tests/BgpSessionOpenCapabilityTests.cs
@@ -66,4 +66,67 @@ public class BgpSessionOpenCapabilityTests
             session.Dispose();
         }
     }
+
+    /// <summary>
+    /// #466: the OPEN BGPLite sends must NOT echo the peer's MP IPv4/Unicast capability
+    /// (code 1, AFI=1/SAFI=1). The inbound path has no MP_REACH/MP_UNREACH AFI=1 handling at
+    /// all, and RFC 5492 §3 / RFC 4760 §8 make a mutually-advertised capability usable — so
+    /// the echo invited the peer to send IPv4 NLRI via MP_REACH, which was then discarded
+    /// whole. D24: the advertisement must not precede the implementation (the D6 pattern).
+    /// </summary>
+    [Fact]
+    public async Task SentOpen_DoesNotAdvertise_MpIpv4Unicast_EvenWhenPeerOffersIt()
+    {
+        var conn = new ScriptedConnection();
+        var config = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
+
+        var session = new BgpSession(
+            conn,
+            new PeerConfig { Address = "127.0.0.1" },
+            config,
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            NullLogger<BgpSession>.Instance);
+
+        var run = session.RunAsync();
+        try
+        {
+            // The peer offers MP IPv4/Unicast — the exact trigger of the old conditional echo.
+            conn.EnqueueMessage(new BgpOpenMessage
+            {
+                Version = BgpConstants.BgpVersion,
+                Asn = 65002,
+                HoldTime = 0,
+                RouterId = 0x0A000002,
+                Capabilities =
+                [
+                    BgpCapabilityInfo.FourOctetAsn(65002),
+                    BgpCapabilityInfo.MultiprotocolIpv4Unicast(),
+                ],
+            });
+            conn.EnqueueMessage(BgpKeepaliveMessage.Instance);
+
+            for (var i = 0; i < 200 && !session.IsEstablished; i++)
+                await Task.Delay(TimeSpan.FromMilliseconds(10));
+            Assert.True(session.IsEstablished, "session must reach Established");
+
+            var sent = conn.Sent;
+            Assert.True(sent.Count > 0, "session must have sent its OPEN");
+            var open = Assert.IsType<BgpOpenMessage>(BgpMessageReader.ReadMessage(sent[0]));
+
+            // RED pre-fix: the peer's AFI=1/SAFI=1 offer was echoed back.
+            Assert.DoesNotContain(open.Capabilities, c =>
+                c.Code == BgpConstants.Capability.Multiprotocol &&
+                c.Data.Length >= 4 && c.Data[0] == 0 && c.Data[1] == 1 && c.Data[3] == BgpConstants.Safi.Unicast);
+            // Sanity: the 4-octet ASN capability — advertised unconditionally — is untouched.
+            Assert.Contains(open.Capabilities, c => c.Code == BgpConstants.Capability.FourOctetAsn);
+        }
+        finally
+        {
+            session.MarkSilentClose();
+            await run.WaitAsync(TimeSpan.FromSeconds(5));
+            session.Dispose();
+        }
+    }
 }

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -297,3 +297,22 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
   policy. Operators comparing against RFC-strict speakers should know the advertised paths are
   always exactly one ASN long.
 - **Tracker:** #456 (documentation of long-standing behavior, flagged by the 2026-09-03 audit).
+
+### D24. The MP IPv4/Unicast capability is never advertised
+- **Decision:** the OPEN BGPLite sends never carries the Multiprotocol Extensions capability
+  for AFI=1/SAFI=1, regardless of what the peer offers (`BgpSession.SendOpenAsync`).
+  IPv4/Unicast is exchanged via the classic NLRI field only.
+- **Context:** `SendOpenAsync` used to echo the peer's MP IPv4/Unicast offer back. RFC 5492 §3
+  makes a capability usable on a peering only when both sides advertised it, and RFC 4760 §8
+  requires the advertisement to mean the speaker supports that \<AFI, SAFI\> on receive — but
+  the inbound path has no MP_REACH/MP_UNREACH AFI=1 handling at all (`MpReachCodec` accepts
+  AFI=2 only). A conformant peer sending IPv4 NLRI via MP_REACH therefore had every such
+  UPDATE discarded whole (RFC 7606 treat-as-withdraw) with the session looking healthy:
+  negotiated route loss with no diagnostic beyond a Warning log line. Same
+  advertise-without-implementing class as the Graceful Restart case (#318, D6) — the
+  advertisement must not precede the implementation.
+- **Consequence:** a peer that prefers MP carriage for IPv4 falls back to classic NLRI, which
+  is the default family and works unchanged. IPv6/Unicast advertisement is untouched
+  (mirrored when the peer offers it — the AFI=2 receiving half IS implemented). Reintroduce
+  the advertisement only together with an AFI=1 decode path.
+- **Tracker:** #466.


### PR DESCRIPTION
Closes #466

## Problem
`BgpSession.SendOpenAsync` echoed a peer's MP IPv4/Unicast (AFI=1/SAFI=1) capability offer back. The inbound path has no MP_REACH/MP_UNREACH AFI=1 handling at all — `MpReachCodec` accepts AFI=2 only — so once both sides advertised, a conformant peer could send IPv4 NLRI via MP_REACH (RFC 5492 §3: a capability advertised by both peers is usable), and every such UPDATE was discarded whole (RFC 7606 treat-as-withdraw) with the session staying Established: silent route loss with only a Warning log line as a trace.

## Root Cause
An advertise-without-implementing mismatch: the conditional echo (`PeerHasMpIpv4Unicast`) promised receive support the decoders never had. Same class as #318 (Graceful Restart), resolved there by removing the advertisement (D6).

## Fix
- never advertise MP IPv4/Unicast, regardless of the peer's offer (D24); IPv4/Unicast is the default family and rides classic NLRI, so it needs no MP capability
- remove the now-dead `PeerHasMpIpv4Unicast` probe
- record D24 in `docs/DESIGN_DECISIONS.md`
- regression test in `BgpSessionOpenCapabilityTests`

## Correctness
IPv6/Unicast advertisement (AFI=2) is untouched — the AFI=2 receiving half is implemented. Classic IPv4 NLRI processing is untouched. The 4-octet-AS and Route-Refresh capability advertisement is untouched.

## Regression Test
`SentOpen_DoesNotAdvertise_MpIpv4Unicast_EvenWhenPeerOffersIt` — peer OPEN carries MP IPv4/Unicast; the session's OPEN must not echo it. Proven RED pre-fix (the sent OPEN carried `Code=1, Data=[0,1,0,1]`), GREEN post-fix.

## Verification
- dotnet format (changed files) / dotnet build BGPLite.sln (0 errors) / dotnet test BGPLite.sln: 1053/1053 passed
- red/green proof for the new test

## RFC
- RFC 4760 §8 (capability advertisement precondition for MP NLRI exchange)
- RFC 5492 §3 (a capability is usable only when advertised by both peers)

## Behavior Change
Outbound OPENs no longer contain the MP IPv4/Unicast capability, even when the peer offers it. A peer that prefers MP carriage for IPv4 falls back to classic NLRI per RFC 4760 §8.

## Deviation from Issue Proposal
None — the issue's recommended fix (remove the advertisement, D6 pattern) is implemented as proposed.