### PR TITLE
fix(protocol): enforce the RFC error policy for MP_REACH/MP_UNREACH (#467)

### DIFF
--- a/BGPLite.Protocol/BgpMessageReader.cs
+++ b/BGPLite.Protocol/BgpMessageReader.cs
@@ -284,21 +284,54 @@ public static class BgpMessageReader
                 // Malformed AFI=2 payloads throw BgpParseException (Update Message Error) — the
                 // whole UPDATE is discarded with the session kept (D17), matching RFC 7606 §2
                 // (the attribute carries NLRI ⇒ treat-as-withdraw).
-                if (attr.TypeCode == MpReachCodec.MpReachNlriType)
+                // #467: the MP attributes are extracted here and never reach ParseRouteAttributes'
+                // flag/duplicate pipeline, so their RFC-prescribed error policy is applied at this
+                // extraction point. RFC 4760 §4/§5 make both attributes OPTIONAL NON-TRANSITIVE and
+                // RFC 7606 leaves them explicitly unrevised — the RFC 4271 §6.3 baseline applies to
+                // their shape, so a flags conflict is a session-reset error (3/4), not a discard.
+                if (attr.TypeCode is MpReachCodec.MpReachNlriType or MpReachCodec.MpUnreachNlriType)
                 {
-                    // RFC 4760: only one MP_REACH per UPDATE. A duplicate is a protocol error.
-                    if (mpReachV6 is not null)
-                        throw new BgpParseException("Duplicate MP_REACH_NLRI attribute",
-                            BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList);
-                    mpReachV6 = MpReachCodec.DecodeMpReachV6(attr.Data);
-                    continue;
-                }
-                if (attr.TypeCode == MpReachCodec.MpUnreachNlriType)
-                {
+                    if (!attr.Optional || attr.Transitive)
+                        throw new BgpParseException(
+                            $"MP_REACH/MP_UNREACH flags conflict with optional non-transitive (flags=0x{attr.Flags:X2}, RFC 4760 §4)",
+                            BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.AttributeFlagsError,
+                            sessionResetRequired: true);
+
+                    if (attr.TypeCode == MpReachCodec.MpReachNlriType)
+                    {
+                        // RFC 7606 §3(g): "If the MP_REACH_NLRI attribute or the MP_UNREACH_NLRI
+                        // [RFC4760] attribute appears more than once in the UPDATE message then a
+                        // NOTIFICATION message MUST be sent with the Error Subcode 'Malformed
+                        // Attribute List'." — a session reset, NOT the D17 keep-alive discard.
+                        if (mpReachV6 is not null)
+                            throw new BgpParseException("Duplicate MP_REACH_NLRI attribute (RFC 7606 §3(g))",
+                                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList,
+                                sessionResetRequired: true);
+                        try
+                        {
+                            mpReachV6 = MpReachCodec.DecodeMpReachV6(attr.Data);
+                        }
+                        catch (BgpParseException ex)
+                        {
+                            // RFC 7606 §3(j): an unparseable MP value must get "session reset" OR
+                            // "AFI/SAFI disable" — marked for the session's disable policy (D17).
+                            throw new BgpMpParseException(ex.Message, ex.SubErrorCode, ex);
+                        }
+                        continue;
+                    }
+
                     if (mpUnreachV6 is not null)
-                        throw new BgpParseException("Duplicate MP_UNREACH_NLRI attribute",
-                            BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList);
-                    mpUnreachV6 = MpReachCodec.DecodeMpUnreachV6(attr.Data);
+                        throw new BgpParseException("Duplicate MP_UNREACH_NLRI attribute (RFC 7606 §3(g))",
+                            BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList,
+                            sessionResetRequired: true);
+                    try
+                    {
+                        mpUnreachV6 = MpReachCodec.DecodeMpUnreachV6(attr.Data);
+                    }
+                    catch (BgpParseException ex)
+                    {
+                        throw new BgpMpParseException(ex.Message, ex.SubErrorCode, ex);
+                    }
                     continue;
                 }
                 attributes.Add(attr);
@@ -434,15 +467,17 @@ public static class BgpMessageReader
 /// set Update Message Error (§6.3). A <c>null</c> sub-error code maps to Unspecific (0).
 /// </para>
 /// </summary>
-public sealed class BgpParseException : Exception
+public class BgpParseException : Exception
 {
     private readonly byte[]? _notificationData;
 
-    public BgpParseException(string message, byte? errorCode = null, byte? subErrorCode = null, byte[]? notificationData = null) : base(message)
+    public BgpParseException(string message, byte? errorCode = null, byte? subErrorCode = null, byte[]? notificationData = null, Exception? innerException = null, bool sessionResetRequired = false)
+        : base(message, innerException)
     {
         ErrorCode = errorCode;
         SubErrorCode = subErrorCode;
         _notificationData = notificationData is null ? null : (byte[])notificationData.Clone();
+        SessionResetRequired = sessionResetRequired;
     }
 
     public BgpParseException(string message, Exception inner) : base(message, inner) { }
@@ -460,4 +495,30 @@ public sealed class BgpParseException : Exception
     /// <see cref="BgpNotificationException.NotificationData"/>.
     /// </summary>
     public byte[]? NotificationData => _notificationData is null ? null : (byte[])_notificationData.Clone();
+
+    /// <summary>
+    /// #467: true when the RFC error policy for this failure class mandates a session reset
+    /// rather than the D17 keep-alive treatment — RFC 7606 §3(g) for a duplicated
+    /// MP_REACH_NLRI/MP_UNREACH_NLRI attribute (NOTIFICATION "Malformed Attribute List" MUST)
+    /// and the RFC 4271 §6.3 baseline for their flags conflicts (RFC 7606 leaves the MP
+    /// attributes explicitly unrevised). The read loop answers with exactly one NOTIFICATION
+    /// and tears the session down instead of discarding the message.
+    /// </summary>
+    public bool SessionResetRequired { get; }
+}
+
+/// <summary>
+/// #467: thrown by <see cref="BgpMessageReader.ReadMessage"/> when an MP_REACH_NLRI /
+/// MP_UNREACH_NLRI VALUE cannot be decoded (unsupported AFI/SAFI, truncated value, invalid
+/// next-hop length). RFC 7606 §3(j) places these attributes outside the keep-alive revision:
+/// an unparseable MP attribute MUST be answered with the "session reset" OR the "AFI/SAFI
+/// disable" approach. BGPLite records the disable choice in D17 — the session stays up, the
+/// IPv6/Unicast family is withdrawn from the peer and no longer accepted.
+/// </summary>
+public sealed class BgpMpParseException : BgpParseException
+{
+    public BgpMpParseException(string message, byte? subErrorCode = null, Exception? innerException = null)
+        : base(message, BgpConstants.Error.UpdateMessageError, subErrorCode, innerException: innerException)
+    {
+    }
 }

--- a/BGPLite.Protocol/MpReachCodec.cs
+++ b/BGPLite.Protocol/MpReachCodec.cs
@@ -24,6 +24,22 @@ public static class MpReachCodec
 
     public readonly record struct MpReachV6(UInt128 NextHop, IReadOnlyList<IpPrefix> Prefixes);
 
+    /// <summary>
+    /// #467 (RFC 2545 §3): the MP_REACH next hop must be a GLOBAL IPv6 address. Rejects the
+    /// unspecified address (::), loopback (::1), multicast (ff00::/8) and link-local
+    /// (fe80::/10) — a lone link-local is only meaningful on a shared subnet and rides as the
+    /// SECOND half of the RFC 2545 32-byte form, which the decoder never adopts. IPv4-mapped
+    /// forms are global-scope representations and are accepted.
+    /// </summary>
+    public static bool IsGlobalUnicastNextHop(UInt128 nextHop)
+    {
+        if (nextHop == UInt128.Zero) return false;                              // ::
+        if (nextHop == UInt128.One) return false;                               // ::1
+        if ((nextHop >> 120) == (UInt128)0xFF) return false;                    // ff00::/8
+        if ((nextHop >> 118) == (UInt128)0b1111111010) return false;            // fe80::/10
+        return true;
+    }
+
     /// <summary>Builds the MP_REACH_NLRI (type 14) attribute VALUE for IPv6/Unicast:
     /// a 16-byte global next hop plus the NLRI prefix list.</summary>
     public static byte[] EncodeMpReachV6(UInt128 nextHop, IReadOnlyList<IpPrefix> prefixes)

--- a/BGPLite.Routing/RouteTable.cs
+++ b/BGPLite.Routing/RouteTable.cs
@@ -148,11 +148,24 @@ public sealed class RouteTable
     /// </summary>
     public int RemoveAllOwnedBy(object owner)
     {
+        return RemoveAllOwnedBy(owner, isIpv4: true) + RemoveAllOwnedBy(owner, isIpv4: false);
+    }
+
+    /// <summary>
+    /// #467: family-scoped variant — removes every entry still owned by <paramref name="owner"/>
+    /// in ONE address family and returns how many went (the RFC 7606 §3(j) "AFI/SAFI disable"
+    /// withdrawal). Each removal is the same atomic compare-and-remove as the full scan, so an
+    /// entry another peer has taken over between the scan and the delete stays put.
+    /// </summary>
+    public int RemoveAllOwnedBy(object owner, bool isIpv4)
+    {
         ArgumentNullException.ThrowIfNull(owner);
 
         var removed = 0;
         foreach (var pair in _routes)
         {
+            if (pair.Key.IsIpv4 != isIpv4)
+                continue;
             if (!ReferenceEquals(pair.Value.Owner, owner))
                 continue;
             if (((ICollection<KeyValuePair<(UInt128 Prefix, byte Length, bool IsIpv4), Entry>>)_routes).Remove(pair))

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -33,6 +33,10 @@ public sealed class BgpSession : IDisposable
     private readonly Func<string, uint, CancellationToken, Task>? _onPeerIdentified;
     // #15 phase 2: the peer advertised MP-BGP IPv6/Unicast.
     private bool _peerMpIpv6Unicast;
+    // #467 (RFC 7606 §3(j) "AFI/SAFI disable"): set when an unparseable MP attribute withdraws
+    // the family — subsequent MP_REACH/MP_UNREACH payloads from this peer are ignored and its
+    // accepted IPv6 routes are gone. Volatile: written on the read loop, read on send paths.
+    private volatile bool _peerMpV6Disabled;
     // #391: the EFFECTIVE per-peer prefix ceiling — the peer row's MaxPrefix override when the
     // peer is configured, else the global Bgp.MaxPrefixesPerPeer. Resolved once per
     // establish/refresh cycle in SendAllRoutesAsync (never per UPDATE); read on the UPDATE path
@@ -762,6 +766,38 @@ public sealed class BgpSession : IDisposable
                 }
                 return;
             }
+            catch (BgpMpParseException ex)
+            {
+                // #467 (RFC 7606 §3(j)): an MP_REACH/MP_UNREACH value that cannot be parsed is
+                // explicitly OUTSIDE the keep-alive revision — the prescribed response is
+                // "session reset" OR "AFI/SAFI disable". The disable choice is recorded in D17:
+                // withdraw every IPv6 route accepted from this peer, stop accepting the family,
+                // keep the session itself up (a route server must not lose every family over one
+                // malformed attribute — the D17/D2 rationale, family-scoped). No NOTIFICATION:
+                // RFC 4271 §6.3 would make its receiver tear down, defeating the disable choice.
+                _logger.LogWarning(
+                    "Unparseable MP attribute from {Peer}: {Error}/{SubError} — {Reason}; disabling IPv6/Unicast for this session (RFC 7606 §3(j) AFI/SAFI disable)",
+                    _peer, ex.ErrorCode, ex.SubErrorCode ?? BgpConstants.SubError.Unspecific, ex.Message);
+                DisablePeerMpV6();
+                continue;
+            }
+            catch (BgpParseException ex) when (ex.SessionResetRequired)
+            {
+                // #467: failure classes the RFCs carve OUT of the D17 keep-alive treatment — a
+                // duplicated MP_REACH/MP_UNREACH attribute (RFC 7606 §3(g): NOTIFICATION "Malformed
+                // Attribute List" MUST) and an MP flags conflict (RFC 4271 §6.3 baseline; RFC 7606
+                // does not revise the MP attributes). Exactly one NOTIFICATION, then Idle — the
+                // same CAS-latched shape as the FSM-error arms.
+                _logger.LogWarning(
+                    "Rejected malformed message from {Peer}: {Error}/{SubError} — {Reason}; session reset per RFC 7606 §3(g)/§3(j)",
+                    _peer, ex.ErrorCode, ex.SubErrorCode ?? BgpConstants.SubError.Unspecific, ex.Message);
+                if (Interlocked.CompareExchange(ref _teardownReason, (int)TeardownReason.LocalCease, (int)TeardownReason.None) == (int)TeardownReason.None)
+                {
+                    try { await SendNotificationAsync(ex.ErrorCode!.Value, ex.SubErrorCode ?? BgpConstants.SubError.Unspecific); }
+                    catch { /* best-effort — partial write counts, see RFC 4271 §8.1 */ }
+                }
+                return;
+            }
             catch (BgpParseException ex) when (ex.ErrorCode is not null)
             {
                 // #222: a malformed message BODY (truncated path attribute, out-of-range NLRI length,
@@ -989,7 +1025,11 @@ public sealed class BgpSession : IDisposable
         // Process announcements. The gate must accept MP_REACH-only UPDATEs (#407): the normal
         // wire shape for an IPv6 announcement (RFC 4760 §5) leaves the classic NLRI field EMPTY —
         // gating on Nlri.Count alone silently dropped every such announcement.
-        if (update.Nlri.Count > 0 || update.MpReachV6 is not null)
+        // #467: once the family is disabled (RFC 7606 §3(j) AFI/SAFI disable, below), MP payloads
+        // are ignored — the classic IPv4 half of the UPDATE keeps processing.
+        var mpReach = _peerMpV6Disabled ? null : update.MpReachV6;
+        var mpUnreach = _peerMpV6Disabled ? null : update.MpUnreachV6;
+        if (update.Nlri.Count > 0 || mpReach is not null)
         {
             // #270: the inbound attribute pipeline (per-attribute validation, mandatory set,
             // AS4_PATH reconstruction, aggregator consistency — subcodes 3/6/8/9/11) lives in the
@@ -1001,7 +1041,7 @@ public sealed class BgpSession : IDisposable
                 // #292 item 1: local router-id for the §6.8 self-address check on NEXT_HOP.
                 attrs = UpdateCodec.ParseRouteAttributes(update, _remoteFourByteAsn,
                     BgpConstants.IPAddressToUint(_bgpConfig.GetRouterIdAddress()),
-                    mpReachV6Present: update.MpReachV6 is not null);
+                    mpReachV6Present: mpReach is not null);
             }
             catch (BgpNotificationException ex) when (ex.ErrorCode == BgpConstants.Error.UpdateMessageError)
             {
@@ -1022,7 +1062,7 @@ public sealed class BgpSession : IDisposable
                 // what this peer installed, not whatever is at that prefix.
                 foreach (var nlri in update.Nlri)
                     WithdrawIfOwned(nlri, "Route withdrawn (treat-as-withdraw)");
-                if (update.MpReachV6 is { } failedReach)
+                if (mpReach is { } failedReach)
                     foreach (var p in failedReach.Prefixes)
                         WithdrawIfOwned(p, "Route withdrawn (treat-as-withdraw, MP_REACH)");
                 _metrics.SetRouteCount(_routeTable.Count);
@@ -1106,43 +1146,57 @@ public sealed class BgpSession : IDisposable
 
             // MP_REACH_NLRI (AFI=2/SAFI=1) announcements: same install pipeline as the classic
             // IPv4 NLRI loop — AS-loop exclusion, filter, cap, ownership (#15 phase 2).
-            if (update.MpReachV6 is { } mpReach)
+            if (mpReach is { } reach)
             {
-                foreach (var nlri in mpReach.Prefixes)
+                // #467 (RFC 2545 §3): the MP_REACH next hop must be a GLOBAL IPv6 address —
+                // ::, ::1, ff00::/8 and fe80::/10 are not advertisable. A bad value never
+                // forwards anywhere (BGPLite is a route server), but it would poison the table
+                // and the management API's view — so the whole attribute's routes are excluded
+                // route-level, like the AS-loop exclusion, instead of being a session error.
+                if (!MpReachCodec.IsGlobalUnicastNextHop(reach.NextHop))
                 {
-                    var route = new Route
+                    _logger.LogWarning(
+                        "Excluded {Count} IPv6 announcement(s) from {Peer}: MP_REACH next hop {NextHop} is not a global unicast address (RFC 2545 §3)",
+                        reach.Prefixes.Count, _peer, RenderV6Address(reach.NextHop));
+                }
+                else
+                {
+                    foreach (var nlri in reach.Prefixes)
                     {
-                        Prefix = nlri.Address,
-                        IsIpv4 = false,
-                        PrefixLength = nlri.Length,
-                        NextHop = mpReach.NextHop,
-                        AsPath = attrs.AsPath,
-                        Communities = attrs.Communities,
-                        LargeCommunities = attrs.LargeCommunities
-                    };
-
-                    if (attrs.AsPath.AsSpan().Contains(_bgpConfig.Asn))
-                    {
-                        if (_logger.IsEnabled(LogLevel.Debug))
-                            _logger.LogDebug("Excluded looping route {Prefix} from {Peer}: local AS {Asn} in AS_PATH",
-                                nlri, _peer, _bgpConfig.Asn);
-                        continue;
-                    }
-
-                    if (_routeFilter.AcceptIncoming(route, filterPeerConfig))
-                    {
-                        var cap = Volatile.Read(ref _effectiveMaxPrefix);
-                        if (cap > 0 && !_installedPrefixes.ContainsKey(nlri) && _installedPrefixes.Count >= cap)
-                            throw new BgpNotificationException(
-                                BgpConstants.Error.Cease, BgpConstants.SubError.CeaseMaxPrefixes,
-                                $"Peer {_peer} exceeded the per-peer prefix limit ({cap}); session reset per RFC 4486");
-                        _installedPrefixes.TryAdd(nlri, 0);
-                        _routeTable.AddOrUpdate(route, owner: this);
-
-                        if (cap > 0 && !_maxPrefixesWarned && _installedPrefixes.Count >= MaxPrefixWarningThreshold(cap))
+                        var route = new Route
                         {
-                            _maxPrefixesWarned = true;
-                            _logger.LogWarning("Peer {Peer} at {Count}/{Cap} of the per-peer prefix limit", _peer, _installedPrefixes.Count, cap);
+                            Prefix = nlri.Address,
+                            IsIpv4 = false,
+                            PrefixLength = nlri.Length,
+                            NextHop = reach.NextHop,
+                            AsPath = attrs.AsPath,
+                            Communities = attrs.Communities,
+                            LargeCommunities = attrs.LargeCommunities
+                        };
+
+                        if (attrs.AsPath.AsSpan().Contains(_bgpConfig.Asn))
+                        {
+                            if (_logger.IsEnabled(LogLevel.Debug))
+                                _logger.LogDebug("Excluded looping route {Prefix} from {Peer}: local AS {Asn} in AS_PATH",
+                                    nlri, _peer, _bgpConfig.Asn);
+                            continue;
+                        }
+
+                        if (_routeFilter.AcceptIncoming(route, filterPeerConfig))
+                        {
+                            var cap = Volatile.Read(ref _effectiveMaxPrefix);
+                            if (cap > 0 && !_installedPrefixes.ContainsKey(nlri) && _installedPrefixes.Count >= cap)
+                                throw new BgpNotificationException(
+                                    BgpConstants.Error.Cease, BgpConstants.SubError.CeaseMaxPrefixes,
+                                    $"Peer {_peer} exceeded the per-peer prefix limit ({cap}); session reset per RFC 4486");
+                            _installedPrefixes.TryAdd(nlri, 0);
+                            _routeTable.AddOrUpdate(route, owner: this);
+
+                            if (cap > 0 && !_maxPrefixesWarned && _installedPrefixes.Count >= MaxPrefixWarningThreshold(cap))
+                            {
+                                _maxPrefixesWarned = true;
+                                _logger.LogWarning("Peer {Peer} at {Count}/{Cap} of the per-peer prefix limit", _peer, _installedPrefixes.Count, cap);
+                            }
                         }
                     }
                 }
@@ -1153,7 +1207,8 @@ public sealed class BgpSession : IDisposable
         // session installed — same ownership rule as the classic withdrawal path (#289). Runs
         // OUTSIDE the announcement block (#407): an MP_UNREACH-only UPDATE (a peer withdrawing
         // its IPv6 routes) has no classic NLRI and no MP_REACH, and must not depend on either.
-        if (update.MpUnreachV6 is { Count: > 0 } v6Withdrawn)
+        // #467: ignored once the family is disabled — the accepted routes were already withdrawn.
+        if (mpUnreach is { Count: > 0 } v6Withdrawn)
         {
             foreach (var prefix in v6Withdrawn)
                 WithdrawIfOwned(prefix, "Route withdrawn (MP_UNREACH)");
@@ -1207,6 +1262,34 @@ public sealed class BgpSession : IDisposable
 
         if (_logger.IsEnabled(LogLevel.Debug))
             _logger.LogDebug("{Reason}: {Prefix}", reason, prefix);
+    }
+
+    /// <summary>
+    /// #467 (RFC 7606 §3(j), the "AFI/SAFI disable" choice recorded in D17): withdraw every
+    /// IPv6 route this session accepted from the peer and stop accepting the family for the
+    /// rest of the session. Receive-side only — outbound IPv6 advertisement of configured
+    /// sources (D22/D24) is untouched, matching the disable's RFC scope (the peer's
+    /// announcements, not our own).
+    /// </summary>
+    private void DisablePeerMpV6()
+    {
+        _peerMpV6Disabled = true;
+        var flushed = _routeTable.RemoveAllOwnedBy(this, isIpv4: false);
+        if (flushed > 0)
+        {
+            _logger.LogInformation(
+                "Withdrew {Count} IPv6 route(s) learned from {Peer} — MP IPv6/Unicast disabled for this session",
+                flushed, _peer);
+            _metrics.SetRouteCount(_routeTable.Count);
+        }
+    }
+
+    private static string RenderV6Address(UInt128 address)
+    {
+        var bytes = new byte[16];
+        for (var i = 0; i < bytes.Length; i++)
+            bytes[i] = (byte)(address >> (120 - i * 8));
+        return new IPAddress(bytes).ToString();
     }
 
     /// <summary>

--- a/BGPLite.Tests/MpAttributeErrorPolicyTests.cs
+++ b/BGPLite.Tests/MpAttributeErrorPolicyTests.cs
@@ -1,0 +1,301 @@
+using BGPLite.Configuration;
+using BGPLite.Contracts;
+using BGPLite.Protocol;
+using BGPLite.Routing;
+using BGPLite.Server;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #467: the MP_REACH_NLRI/MP_UNREACH_NLRI error policy. RFC 7606 leaves these attributes
+/// explicitly OUTSIDE the keep-alive revision, so the D17 discard-and-keep-alive treatment
+/// must not swallow them:
+/// <list type="bullet">
+/// <item>a DUPLICATE MP attribute → exactly one NOTIFICATION 3/1 and a session reset
+/// (RFC 7606 §3(g) MUST);</item>
+/// <item>an MP flags conflict (RFC 4760 §4: optional non-transitive) → NOTIFICATION 3/4 and a
+/// session reset (RFC 4271 §6.3 baseline);</item>
+/// <item>an UNPARSEABLE MP value → the §3(j) "AFI/SAFI disable" choice: the peer's accepted
+/// IPv6 routes are withdrawn, the family is ignored for the rest of the session, the session
+/// stays up (recorded in D17);</item>
+/// <item>a non-global MP_REACH next hop (RFC 2545 §3) → that attribute's routes are excluded,
+/// route-level, session up.</item>
+/// </list>
+/// Driven through the <c>IBgpConnection</c> seam with scripted frames, like the #289 tests.
+/// </summary>
+public class MpAttributeErrorPolicyTests
+{
+    // RFC 4271 §4.3: Optional = 0x80, Transitive = 0x40. MP_REACH/MP_UNREACH are optional
+    // NON-transitive (RFC 4760 §4) → 0x80; the conflict case adds the Transitive bit.
+    private const byte MpOptionalNonTransitive = BgpConstants.Attribute.FlagOptional;
+    private const byte MpOptionalTransitive = BgpConstants.Attribute.FlagOptional | BgpConstants.Attribute.FlagTransitive;
+
+    // 2001:db8::/32 with next hop 2001:db8::1 — a global unicast next hop.
+    private static readonly UInt128 DocumentedPrefix = (UInt128)0x20010DB8 << 96;
+    private static readonly UInt128 GlobalNextHop = ((UInt128)0x20010DB8 << 96) | 1;
+
+    [Fact]
+    public async Task DuplicateMpReach_TearsDownSession_WithExactlyOneNotification_3_1()
+    {
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        var value = ReachValue(GlobalNextHop, 32, 0x20, 0x01, 0x0D, 0xB8);
+        conn.EnqueueFrame(UpdateFrame(MpReachAttribute(MpOptionalNonTransitive, value),
+                                      MpReachAttribute(MpOptionalNonTransitive, value)));
+
+        await AssertResetAsync(session, conn, expectedSubError: BgpConstants.SubError.MalformedAttributeList);
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task TransitiveMpReachFlags_TearDownSession_WithNotification_3_4()
+    {
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        // RFC 4760 §4/§5: MP_REACH/MP_UNREACH are optional NON-transitive; the flags conflict is
+        // a session-reset error per the RFC 4271 §6.3 baseline (RFC 7606 does not revise MP).
+        var value = ReachValue(GlobalNextHop, 32, 0x20, 0x01, 0x0D, 0xB8);
+        conn.EnqueueFrame(UpdateFrame(MpReachAttribute(MpOptionalTransitive, value)));
+
+        await AssertResetAsync(session, conn, expectedSubError: BgpConstants.SubError.AttributeFlagsError);
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task MalformedMpReach_WithdrawsAcceptedV6Routes_KeepsSessionUp()
+    {
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        // First, a valid MP_REACH announcement (ORIGIN + AS_PATH + MP_REACH, RFC 4760 §5 shape)
+        // installs the route.
+        conn.EnqueueFrame(UpdateFrame(
+            OriginAsPathAttributes,
+            MpReachAttribute(MpOptionalNonTransitive,
+                ReachValue(GlobalNextHop, 32, 0x20, 0x01, 0x0D, 0xB8))));
+        await SettleAsync(conn, () => routeTable.Count == 1);
+        Assert.NotNull(routeTable.Get(DocumentedPrefix, 32, isIpv4: false));
+
+        // Now an UPDATE whose MP_REACH VALUE cannot be parsed (AFI=1 — the IPv6-only decoder
+        // rejects it structurally). RFC 7606 §3(j): session reset OR AFI/SAFI disable; BGPLite
+        // disables the family — the stale route must NOT survive the malformed update.
+        conn.EnqueueFrame(UpdateFrame(MpReachAttribute(MpOptionalNonTransitive,
+            [0x00, 0x01, 0x01, 0x04, 0xC0, 0x00, 0x02, 0x01, 0x00]))); // AFI=1, truncated value
+        await SettleAsync(conn, () => routeTable.Count == 0);
+
+        Assert.Null(routeTable.Get(DocumentedPrefix, 32, isIpv4: false));
+        Assert.True(session.IsEstablished, "the §3(j) disable choice keeps the session up");
+        Assert.DoesNotContain(await SentNotificationsAsync(conn),
+            n => n.ErrorCode == BgpConstants.Error.UpdateMessageError);
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task AfterFamilyDisable_SubsequentMpPayloadsAreIgnored_ClassicNlriStillProcessed()
+    {
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        conn.EnqueueFrame(UpdateFrame(MpReachAttribute(MpOptionalNonTransitive,
+            [0x00, 0x01, 0x01, 0x04, 0xC0, 0x00, 0x02, 0x01, 0x00]))); // unparseable → disable
+        await SettleAsync(conn);
+
+        // A later VALID MP_REACH announcement is ignored: the family is disabled.
+        conn.EnqueueFrame(UpdateFrame(MpReachAttribute(MpOptionalNonTransitive,
+            ReachValue(GlobalNextHop, 32, 0x20, 0x01, 0x0D, 0xB8))));
+        await SettleAsync(conn);
+        Assert.Equal(0, routeTable.Count);
+
+        // ...while the classic IPv4 half of the pipeline keeps processing normally.
+        conn.EnqueueFrame(AnnounceFrame(24, 0xC0, 0x00, 0x02));
+        await SettleAsync(conn, () => routeTable.Count == 1);
+        Assert.Equal(1, routeTable.Count);
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task NonGlobalMpReachNextHop_RoutesExcluded_SessionStaysUp()
+    {
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        // RFC 2545 §3: the next hop must be a GLOBAL IPv6 address. :: is not. The attribute's
+        // routes are excluded route-level (like the AS-loop rule); the session stays up.
+        conn.EnqueueFrame(UpdateFrame(
+            OriginAsPathAttributes,
+            MpReachAttribute(MpOptionalNonTransitive, ReachValue(0, 32, 0x20, 0x01, 0x0D, 0xB8))));
+        await SettleAsync(conn);
+
+        Assert.Equal(0, routeTable.Count);
+        Assert.True(session.IsEstablished, "a route-level exclusion is not a protocol error");
+
+        await TeardownAsync(session, run);
+    }
+
+    // ---- frame builders ----
+
+    private static byte[] Frame(BgpMessageType type, params byte[] payload)
+    {
+        var frame = new byte[BgpConstants.MessageHeaderSize + payload.Length];
+        BgpConstants.Marker.CopyTo(frame.AsSpan(0, BgpConstants.MarkerSize));
+        frame[16] = (byte)(frame.Length >> 8);
+        frame[17] = (byte)frame.Length;
+        frame[18] = (byte)type;
+        payload.CopyTo(frame, BgpConstants.MessageHeaderSize);
+        return frame;
+    }
+
+    private static byte[] MpReachAttribute(byte flags, byte[] value)
+    {
+        var attr = new byte[3 + value.Length];
+        attr[0] = flags;
+        attr[1] = MpReachCodec.MpReachNlriType;
+        attr[2] = (byte)value.Length;
+        value.CopyTo(attr, 3);
+        return attr;
+    }
+
+    /// <summary>
+    /// MP_REACH_NLRI (AFI=2/SAFI=1) value: AFI(2) + SAFI(1) + NH-len(16) + next hop + reserved
+    /// + one NLRI (length byte + significant address bytes).
+    /// </summary>
+    private static byte[] ReachValue(UInt128 nextHop, byte prefixLength, params byte[] addressBytes)
+    {
+        var value = new List<byte> { 0x00, 0x02, 0x01, 0x10 };
+        for (var i = 0; i < 16; i++)
+            value.Add((byte)(nextHop >> (120 - i * 8)));
+        value.Add(0x00); // reserved
+        value.Add(prefixLength);
+        value.AddRange(addressBytes);
+        return [.. value];
+    }
+
+    private static byte[] UpdateFrame(params byte[][] attributes)
+    {
+        var attrsLen = attributes.Sum(a => a.Length);
+        var payload = new List<byte> { 0x00, 0x00, (byte)(attrsLen >> 8), (byte)attrsLen };
+        foreach (var attr in attributes)
+            payload.AddRange(attr);
+        return Frame(BgpMessageType.Update, [.. payload]);
+    }
+
+    // ORIGIN + AS_PATH (no NEXT_HOP — the MP_REACH attribute supplies it, RFC 4760 §5).
+    private static readonly byte[] OriginAsPathAttributes =
+    [
+        0x40, 0x01, 0x01, 0x00,                                 // ORIGIN igp
+        0x40, 0x02, 0x06, 0x02, 0x01, 0x00, 0x00, 0x00, 0x64,   // AS_PATH seq [100]
+    ];
+
+    // ORIGIN + AS_PATH + NEXT_HOP for classic IPv4 NLRI announcements.
+    private static readonly byte[] ClassicAttributes =
+    [
+        0x40, 0x01, 0x01, 0x00,                                 // ORIGIN igp
+        0x40, 0x02, 0x06, 0x02, 0x01, 0x00, 0x00, 0x00, 0x64,   // AS_PATH seq [100]
+        0x40, 0x03, 0x04, 0xC0, 0x00, 0x02, 0x01,               // NEXT_HOP 192.0.2.1
+    ];
+
+    private static byte[] AnnounceFrame(byte prefixLength, params byte[] addressBytes)
+    {
+        var payload = new List<byte>
+        {
+            0x00, 0x00,
+            (byte)(ClassicAttributes.Length >> 8), (byte)ClassicAttributes.Length,
+        };
+        payload.AddRange(ClassicAttributes);
+        payload.Add(prefixLength);
+        payload.AddRange(addressBytes);
+        return Frame(BgpMessageType.Update, [.. payload]);
+    }
+
+    // ---- session lifecycle (the #289 test pattern) ----
+
+    private static async Task<(BgpSession Session, Task Run, ScriptedConnection Conn)> EstablishAsync(RouteTable routeTable)
+    {
+        var conn = new ScriptedConnection();
+        var config = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
+        var session = new BgpSession(
+            conn,
+            new PeerConfig { Address = "127.0.0.1" },
+            config,
+            routeTable,
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            NullLogger<BgpSession>.Instance);
+
+        var run = session.RunAsync();
+        conn.EnqueueMessage(new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = 0,
+            RouterId = 0x0A000002,
+            Capabilities = [BgpCapabilityInfo.FourOctetAsn(65002)],
+        });
+        conn.EnqueueMessage(BgpKeepaliveMessage.Instance);
+
+        for (var i = 0; i < 200 && !session.IsEstablished; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        Assert.True(session.IsEstablished, "session must reach Established");
+        return (session, run, conn);
+    }
+
+    private static async Task SettleAsync(ScriptedConnection conn, Func<bool>? until = null)
+    {
+        var reached = false;
+        for (var i = 0; i < 200; i++)
+        {
+            if (conn.Drained)
+            {
+                reached = until?.Invoke() ?? true;
+                if (reached && (until is not null || i > 5)) break;
+            }
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        }
+
+        Assert.True(conn.Drained, "the scripted frame was never consumed by the read loop");
+        if (until is not null)
+            Assert.True(reached, "the expected state was not reached in time");
+    }
+
+    /// <summary>
+    /// Waits for the session reset driven by the scripted frame, then asserts exactly one
+    /// NOTIFICATION with the expected error/sub-error pair was emitted before Idle.
+    /// </summary>
+    private static async Task AssertResetAsync(BgpSession session, ScriptedConnection conn, byte expectedSubError)
+    {
+        for (var i = 0; i < 200 && session.IsEstablished; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        Assert.False(session.IsEstablished, "the session must tear down");
+
+        var notifications = await SentNotificationsAsync(conn);
+        var notification = Assert.Single(notifications);
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, notification.ErrorCode);
+        Assert.Equal(expectedSubError, notification.SubErrorCode);
+    }
+
+    private static async Task<IEnumerable<BgpNotificationMessage>> SentNotificationsAsync(ScriptedConnection conn)
+    {
+        // Give the teardown NOTIFICATION's send a moment to land in the script before reading.
+        for (var i = 0; i < 100; i++)
+        {
+            if (conn.Sent.Select(f => BgpMessageReader.ReadMessage(f)).OfType<BgpNotificationMessage>().Any())
+                break;
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        }
+        return conn.Sent.Select(f => BgpMessageReader.ReadMessage(f)).OfType<BgpNotificationMessage>();
+    }
+
+    private static async Task TeardownAsync(BgpSession session, Task run)
+    {
+        session.MarkSilentClose();
+        try { await run.WaitAsync(TimeSpan.FromSeconds(5)); }
+        catch (OperationCanceledException) { /* expected */ }
+        catch (IOException) { /* expected */ }
+        session.Dispose();
+    }
+}

--- a/BGPLite.Tests/MpReachCodecTests.cs
+++ b/BGPLite.Tests/MpReachCodecTests.cs
@@ -159,4 +159,22 @@ public class MpReachCodecTests
         foreach (var c in hex) value = (value << 4) | (UInt128)Uri.FromHex(c);
         return value;
     }
+
+    /// <summary>
+    /// #467 (RFC 2545 §3): the MP_REACH next hop must be a GLOBAL IPv6 address — ::, ::1,
+    /// ff00::/8 (multicast) and fe80::/10 (link-local) are rejected; global unicast and
+    /// IPv4-mapped representations are accepted.
+    /// </summary>
+    [Theory]
+    [InlineData("00000000000000000000000000000000", false)] // ::
+    [InlineData("00000000000000000000000000000001", false)] // ::1 loopback
+    [InlineData("ff020000000000000000000000000001", false)] // ff02::1 multicast
+    [InlineData("fe800000000000000000000000000001", false)] // fe80::1 link-local
+    [InlineData("20010db8000000000000000000000001", true)]  // 2001:db8::1 global
+    [InlineData("26060670000000000000000000001111", true)]  // global unicast
+    [InlineData("00000000000000000000ffffc0000201", true)]  // ::ffff:192.0.2.1 (mapped, global scope)
+    public void IsGlobalUnicastNextHop_FollowsRfc2545(string hex, bool expected)
+    {
+        Assert.Equal(expected, MpReachCodec.IsGlobalUnicastNextHop(ToV6(hex)));
+    }
 }

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -198,6 +198,17 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
   Established is an FSM error (NOTIFICATION 5/0, #427) — RFC 4271 §8.2.2 makes ANY OPEN in
   Established an FSM input regardless of body validity, so there is nothing to "keep alive" for
   that message class.
+- **MP carve-out (#467, recorded 2026-09-03):** RFC 7606 explicitly leaves MP_REACH_NLRI and
+  MP_UNREACH_NLRI outside the keep-alive revision, so their failure classes follow their own
+  policy instead of the paragraph above. A DUPLICATE MP attribute is answered with exactly one
+  NOTIFICATION 3/1 (Malformed Attribute List) and a session reset — RFC 7606 §3(g) MUST. An MP
+  flags conflict (RFC 4760 §4: both attributes are optional NON-transitive) is a session reset
+  with 3/4 per the RFC 4271 §6.3 baseline. An UNPARSEABLE MP VALUE takes the RFC 7606 §3(j)
+  "AFI/SAFI disable" choice: every IPv6 route the session accepted from the peer is withdrawn,
+  the family is ignored for the rest of the session, and the session itself stays up — the
+  route-server rationale above, family-scoped. Additionally, an MP_REACH next hop that is not
+  a global IPv6 address (::, ::1, ff00::/8, fe80::/10 — RFC 2545 §3) excludes that attribute's
+  routes only: route-level exclusion, like the AS-loop rule, not a session error.
 - **Consequence:** a peer sending structurally valid but semantically rejected UPDATEs gets them
   silently dropped (log Warning + `UpdatesRejected` metric) instead of a session reset; operators
   comparing against RFC-strict speakers will see BGPLite retain sessions others would close.


### PR DESCRIPTION
Closes #467

## Problem
`BgpMessageReader.ParseUpdate` extracts MP attributes before the generic attribute pipeline, so the mandatory-attribute policy never applies to them: flags conflicts were silently accepted, duplicates were routed into the D17 keep-alive discard, and an unparseable MP value left the peer's previously accepted IPv6 routes in the table — a peer could pin stale routes past their withdrawal with one malformed attribute.

## Root Cause
RFC 7606 explicitly leaves MP_REACH_NLRI/MP_UNREACH_NLRI outside its keep-alive revision; BGPLite treated them like every other body error anyway. RFC 7606 §3(g) mandates a NOTIFICATION "Malformed Attribute List" for duplicates; §3(j) mandates session reset OR AFI/SAFI disable for unparseable MP values; RFC 4271 §6.3 baseline governs their shape.

## Fix
- duplicate MP attribute → exactly one NOTIFICATION 3/1 + session reset (CAS-latched, one-notification invariant preserved)
- MP flags conflict (RFC 4760 §4: optional non-transitive) → NOTIFICATION 3/4 + session reset
- unparseable MP value → the §3(j) "AFI/SAFI disable" choice: withdraw every IPv6 route the session accepted from the peer (`RouteTable.RemoveAllOwnedBy(owner, isIpv4)`), ignore subsequent MP payloads for the session, keep the session up — recorded in D17
- MP_REACH next hop must be a global IPv6 address (RFC 2545 §3): `::`, `::1`, ff00::/8, fe80::/10 → that attribute's routes are excluded route-level (like the AS-loop rule), session stays up
- new: `BgpParseException.SessionResetRequired` marker and `BgpMpParseException` family-disable marker; D17 updated with the MP carve-out

## Correctness
The keep-alive treatment of non-MP body errors (D17/D2) is untouched. Classic IPv4 NLRI processing is untouched — after a family disable, the classic half of an UPDATE still processes. The `_peerMpV6Disabled` flag is written and read only on the session's read loop, so no new synchronization is introduced. Teardown paths reuse the existing CAS-latched one-NOTIFICATION invariant.

## Regression Test
`MpAttributeErrorPolicyTests` (5 wire-level session tests) + `MpReachCodecTests.IsGlobalUnicastNextHop` (7-case theory). Proven RED against the pre-fix implementation: 4/5 session tests fail (duplicate → no reset; flags conflict → accepted; malformed → stale route survived; non-global NH → route installed), then GREEN after the fix. Full suite: 1065/1065.

## Verification
- dotnet format (changed files) / dotnet build BGPLite.sln (0 errors) / dotnet test BGPLite.sln: 1065/1065 passed
- red/green proof per the fix protocol

## RFC
- RFC 7606 §3(g) (duplicate MP attribute → NOTIFICATION Malformed Attribute List, MUST)
- RFC 7606 §3(j) (unparseable MP attribute → session reset or AFI/SAFI disable, MUST)
- RFC 4271 §6.3 (baseline for flags conflicts; RFC 7606 does not revise MP attributes)
- RFC 4760 §4/§5 (MP attributes are optional non-transitive), §8
- RFC 2545 §3 (global IPv6 next hop requirement)

## Behavior Change
- a duplicated MP attribute now resets the session (previously silently discarded)
- an MP flags conflict now resets the session (previously accepted)
- an unparseable MP value now withdraws the peer's accepted IPv6 routes and disables the family for the session (previously: discard-only, stale routes survived)
- non-global MP_REACH next hops no longer install routes

## Deviation from Issue Proposal
The issue offered session reset or AFI/SAFI disable for unparseable MP values; this implements the split exactly as its fix shape lists it (duplicates → 3/1 reset; unparseable → disable; NH hardening → route-level exclusion). Flag conflicts resolve to the strict RFC 4271 baseline (3/4 reset) rather than the issue's softer alternative.