### PR TITLE
fix(providers): a cancelled waiter must not split the UserSourceCache gate (#468)

### DIFF
--- a/BGPLite.Providers/UserSourceCache.cs
+++ b/BGPLite.Providers/UserSourceCache.cs
@@ -97,31 +97,23 @@ internal sealed class UserSourceCache
 
         // Serialize per-key so concurrent callers (e.g. several peers refreshing the same URL) share
         // a single fetch — no thundering herd.
-        var gate = _locks.GetOrAdd(url, _ => new SemaphoreSlim(1, 1));
-        // #450 review: register as an active loader BEFORE the gate is taken — the sweep and
-        // EvictIfAtCapacity never remove a gate that still has loaders (RipeStatPrefixCache's
-        // _inflight invariant, #267 item 3). Without this, a removed-then-recreated gate let two
-        // loaders run concurrently for one URL and the OLDER response could overwrite the newer.
+        // #468: register as an active loader BEFORE taking the gate from _locks. The inverse
+        // ordering let the LAST leaver's gate removal race a caller that had already taken the
+        // (now-removed) gate instance but not yet registered, parking it on an orphaned
+        // semaphore while the next caller minted a second gate. With this order every
+        // participant is counted in _inflight before it can touch _locks, so ExitInflight only
+        // ever removes a gate that nobody holds or queues on.
         _inflight.AddOrUpdate(url, 1, (_, c) => c + 1);
+        var gate = _locks.GetOrAdd(url, _ => new SemaphoreSlim(1, 1));
         var entered = false;
         try
         {
-            try
-            {
-                await gate.WaitAsync(ct);
-                entered = true;
-            }
-            catch (OperationCanceledException) when (ct.IsCancellationRequested)
-            {
-                // #358 review (orphan-lock hygiene for #261): a caller cancelled while queued never
-                // writes a cache entry, so its freshly-created gate would never be evicted (the sweep
-                // removes locks only for removed cache keys) — cancelled URLs accumulated semaphores.
-                // Pair-remove OUR gate instance: a concurrent waiter keeps running on its own
-                // reference, and a fresh caller GetOrAdd's a new gate — the same duplicate-fetch
-                // tradeoff the eviction sweep already accepts.
-                ((ICollection<KeyValuePair<string, SemaphoreSlim>>)_locks).Remove(new KeyValuePair<string, SemaphoreSlim>(url, gate));
-                throw;
-            }
+            // #468: a caller cancelled while queued does NOT remove the gate here — that pair-
+            // removed the shared instance out from under the still-running first loader, minted
+            // a second gate for the next caller and raced a newer load against an older
+            // snapshot. Cleanup is ExitInflight's job: the LAST leaver removes the gate.
+            await gate.WaitAsync(ct);
+            entered = true;
             try
             {
                 if (TryGetFresh(url, out var rechecked))
@@ -170,16 +162,27 @@ internal sealed class UserSourceCache
         }
         finally
         {
-            ExitInflight(url);
+            ExitInflight(url, gate);
         }
     }
 
-    /// <summary>Decrements the active-loader count for <paramref name="url"/> and removes the
-    /// marker when it reaches zero, so the sweeps know the gate is removable (#450 review).</summary>
-    private void ExitInflight(string url)
+    /// <summary>
+    /// Decrements the active-loader count for <paramref name="url"/>; the LAST leaver removes
+    /// the gate, so an unbacked gate cannot outlive its participants (the #358 orphan-lock
+    /// hygiene). #468: a cancelled waiter no longer removes the gate directly — that pair-
+    /// removed the shared instance out from under the still-running first loader, minted a
+    /// second gate for the next caller, and raced a newer load against an older snapshot.
+    /// Removal here can only run when nobody holds or queues on the gate: every participant
+    /// registers in <see cref="_inflight"/> BEFORE taking the gate from <see cref="_locks"/>,
+    /// so a non-zero remaining count means someone else is inside or queued and the gate must
+    /// stay. The sweeps keep their own <c>_inflight &gt; 0</c> guards for the entry-backed path.
+    /// </summary>
+    private void ExitInflight(string url, SemaphoreSlim gate)
     {
-        _inflight.AddOrUpdate(url, 0, (_, c) => c - 1);
+        var remaining = _inflight.AddOrUpdate(url, 0, (_, c) => c - 1);
+        if (remaining > 0) return;
         _inflight.TryRemove(new KeyValuePair<string, int>(url, 0));
+        ((ICollection<KeyValuePair<string, SemaphoreSlim>>)_locks).Remove(new KeyValuePair<string, SemaphoreSlim>(url, gate));
     }
 
     /// <summary>

--- a/BGPLite.Tests/UserSourceCacheTests.cs
+++ b/BGPLite.Tests/UserSourceCacheTests.cs
@@ -380,4 +380,64 @@ public class UserSourceCacheTests
 
         Assert.Equal(0, cache.TrackedGateCount);   // pre-fix: 5 orphan gates
     }
+
+    /// <summary>
+    /// #468: a waiter cancelled while queued must not split the gate. Pre-fix it pair-removed
+    /// the shared gate instance out from under the still-running first loader, so the NEXT
+    /// caller minted a second gate and fetched the same URL concurrently — and could overwrite
+    /// the newer snapshot with an older one. The cancelled waiter now leaves the gate alone;
+    /// the last leaver removes it.
+    /// </summary>
+    [Fact]
+    public async Task CancelledWaiter_DoesNotSplitTheGate_SecondLoadNeverStartsEarly()
+    {
+        var cache = new UserSourceCache();
+        var holderEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var holderRelease = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var holderCalls = 0;
+
+        Task<IReadOnlyList<IpPrefix>> Holder(CancellationToken ct)
+        {
+            Interlocked.Increment(ref holderCalls);
+            holderEntered.TrySetResult();
+            return holderRelease.Task.ContinueWith<IReadOnlyList<IpPrefix>>(
+                _ => P((1u, (byte)1, true)), CancellationToken.None);
+        }
+
+        // First caller holds the gate, load parked.
+        var holding = cache.GetOrLoadAsync("https://example.com/l", "src", Holder, CancellationToken.None);
+        await holderEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(1, holderCalls);
+
+        // Second caller queues behind the holder, then is cancelled while queued.
+        var queuedCts = new CancellationTokenSource();
+        var queued = Task.Run(() => cache.GetOrLoadAsync("https://example.com/l", "src", Holder, queuedCts.Token));
+        await Task.Delay(50);            // let it queue behind the holder (the #358 test's idiom)
+        queuedCts.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => queued);
+
+        // A third caller arrives while the holder is STILL parked: it must queue on the SAME
+        // gate. Pre-fix the cancelled waiter had removed that gate, so this load started
+        // immediately in parallel with the holder's.
+        var thirdCalls = 0;
+        Task<IReadOnlyList<IpPrefix>> Third(CancellationToken ct)
+        {
+            Interlocked.Increment(ref thirdCalls);
+            return holderRelease.Task.ContinueWith<IReadOnlyList<IpPrefix>>(_ => [], CancellationToken.None);
+        }
+        var third = cache.GetOrLoadAsync("https://example.com/l", "src", Third, CancellationToken.None);
+        await Task.Delay(100);
+        Assert.Equal(0, thirdCalls);     // RED pre-fix: the parallel second fetch ran here
+
+        // Release the holder. The third caller is then served by the holder's just-written
+        // cache entry (the #450 in-gate recheck) — either way its loader must never run: the
+        // whole scenario fetches the URL exactly once.
+        holderRelease.TrySetResult();
+        await Task.WhenAll(holding, third).WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(1, holderCalls);
+        Assert.Equal(0, thirdCalls);               // served from cache — no second fetch ever
+        Assert.Equal(1, cache.TrackedCount);       // exactly one cache write
+        Assert.Equal(0, cache.TrackedGateCount);   // the last leaver took the gate with it
+    }
 }


### PR DESCRIPTION
Closes #468

## Problem
A caller cancelled while queued on the per-URL gate pair-removed the shared gate from `_locks` (`UserSourceCache.cs:122` pre-fix) even though the first loader was still running on it. The next caller `GetOrAdd`ed a second gate and fetched the same URL concurrently — breaking the thundering-herd invariant the `_inflight` map exists for — and whichever load landed last overwrote `_cache[url]` with a fresh timestamp, so BGP sessions refreshing the same URL could observe different prefix snapshots.

## Root Cause
The cancel path performed cleanup that belongs to gate lifecycle ownership, without checking whether other participants were still inside or queued. The in-code comment acknowledged the duplicate-fetch tradeoff only for the case where the cancelled caller was the sole participant.

## Fix
- `_inflight` is now incremented BEFORE the gate is taken from `_locks`: every participant is counted before it can touch the gate dictionary, so a last-leaver removal can never race an arriving caller onto an orphaned semaphore
- the cancelled-waiter path no longer removes the gate; `ExitInflight(url, gate)` removes it when the LAST participant leaves (count reaches 0), preserving the #358 orphan-lock hygiene (an unbacked gate cannot outlive its participants)
- both pre-existing #358 tests pass unchanged; `RipeStatPrefixCache` already had the safe ordering and has no cancel-path removal — checked, untouched

## Correctness
Invariant after the fix: a gate is removed only when its `_inflight` count is 0, and registration precedes `GetOrAdd` — therefore no participant ever queues on a removed gate, and two gates for one URL never coexist with active loaders. No new synchronization; the gate wait itself is unchanged.

## Regression Test
`CancelledWaiter_DoesNotSplitTheGate_SecondLoadNeverStartsEarly`: holder parked on the gate, waiter queued + cancelled, third caller must not start a second fetch while the holder is parked, and the scenario ends with exactly one fetch and one cache write. Proven RED against the pre-fix implementation (the third caller's fetch started immediately), GREEN after. Full suite: 1066/1066.

## Verification
- dotnet format (changed files) / dotnet build BGPLite.sln (0 errors) / dotnet test BGPLite.sln: 1066/1066 passed
- red/green proof per the fix protocol

## RFC
none — providers/cache surface, no protocol behavior.

## Behavior Change
A cancelled queued waiter no longer removes the shared gate mid-load. The gate now lives exactly as long as its participants (plus any backing cache entry, reclaimed by the sweeps). The stale-snapshot overwrite window is closed.

## Deviation from Issue Proposal
The issue suggested conditioning gate removal on "no cache entry backs it"; the implemented removal condition is stronger and simpler — the last participant leaves (count reaches 0) — which also keeps both #358 tests green unchanged and cannot orphan a gate.