### PR TITLE
chore: integrate dev — MP-BGP error policy and cache gate fixes #466–#468

### DIFF
--- a/BGPLite.Protocol/BgpMessageReader.cs
+++ b/BGPLite.Protocol/BgpMessageReader.cs
@@ -267,6 +267,10 @@ public static class BgpMessageReader
         var attributes = new List<PathAttribute>();
         MpReachCodec.MpReachV6? mpReachV6 = null;
         IReadOnlyList<IpPrefix>? mpUnreachV6 = null;
+        MpReachCodec.MpReachV4? mpReachV4 = null;
+        IReadOnlyList<IpPrefix>? mpUnreachV4 = null;
+        var mpReachSeen = false;
+        var mpUnreachSeen = false;
         if (attrsLen > 0)
         {
             var attrsEnd = offset + attrsLen;
@@ -303,20 +307,28 @@ public static class BgpMessageReader
                             BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.AttributeFlagsError,
                             sessionResetRequired: true);
 
+                    // #466: BOTH supported families decode here — IPv4/Unicast (AFI=1/SAFI=1) into
+                    // the classic NLRI pipeline and IPv6/Unicast (AFI=2/SAFI=1) into MP_REACH_NLRI.
+                    // §3(g) duplicate detection is per ATTRIBUTE TYPE: a second instance of the
+                    // type is a session reset regardless of which family it names.
                     if (attr.TypeCode == MpReachCodec.MpReachNlriType)
                     {
                         // RFC 7606 §3(g): "If the MP_REACH_NLRI attribute or the MP_UNREACH_NLRI
                         // [RFC4760] attribute appears more than once in the UPDATE message then a
                         // NOTIFICATION message MUST be sent with the Error Subcode 'Malformed
                         // Attribute List'." — a session reset, NOT the D17 keep-alive discard.
-                        if (mpReachV6 is not null)
+                        if (mpReachSeen)
                             throw new BgpParseException("Duplicate MP_REACH_NLRI attribute (RFC 7606 §3(g))",
                                 BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList,
                                 sessionResetRequired: true);
-                        ScopeMpValueOrThrow(attr.Data);
+                        mpReachSeen = true;
+                        var reachIsV4 = ScopeMpValueOrThrow(attr.Data);
                         try
                         {
-                            mpReachV6 = MpReachCodec.DecodeMpReachV6(attr.Data);
+                            if (reachIsV4)
+                                mpReachV4 = MpReachCodec.DecodeMpReachV4(attr.Data);
+                            else
+                                mpReachV6 = MpReachCodec.DecodeMpReachV6(attr.Data);
                         }
                         catch (BgpParseException ex)
                         {
@@ -327,14 +339,18 @@ public static class BgpMessageReader
                         continue;
                     }
 
-                    if (mpUnreachV6 is not null)
+                    if (mpUnreachSeen)
                         throw new BgpParseException("Duplicate MP_UNREACH_NLRI attribute (RFC 7606 §3(g))",
                             BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList,
                             sessionResetRequired: true);
-                    ScopeMpValueOrThrow(attr.Data);
+                    mpUnreachSeen = true;
+                    var unreachIsV4 = ScopeMpValueOrThrow(attr.Data);
                     try
                     {
-                        mpUnreachV6 = MpReachCodec.DecodeMpUnreachV6(attr.Data);
+                        if (unreachIsV4)
+                            mpUnreachV4 = MpReachCodec.DecodeMpUnreachV4(attr.Data);
+                        else
+                            mpUnreachV6 = MpReachCodec.DecodeMpUnreachV6(attr.Data);
                     }
                     catch (BgpParseException ex)
                     {
@@ -360,7 +376,9 @@ public static class BgpMessageReader
             PathAttributes = attributes,
             Nlri = nlri,
             MpReachV6 = mpReachV6,
-            MpUnreachV6 = mpUnreachV6
+            MpUnreachV6 = mpUnreachV6,
+            MpReachV4 = mpReachV4,
+            MpUnreachV4 = mpUnreachV4
         };
     }
 
@@ -368,12 +386,12 @@ public static class BgpMessageReader
     /// #472 review: scope MP value failures to the offending AFI/SAFI tuple. A value too short
     /// to name its tuple cannot be scoped to any family — the RFC 7606 §3(j) fallback is the
     /// session reset. A tuple this speaker does not support was never negotiated (RFC 4760 §8):
-    /// its arrival is not a parse failure of the supported family, so it is answered with a
-    /// plain keep-alive body error — the whole UPDATE is discarded (D17) and the supported
-    /// family stays enabled. Only a supported tuple's decode failure reaches the decoder, whose
-    /// <see cref="BgpMpParseException"/> marks the AFI/SAFI disable.
+    /// its arrival is not a parse failure of a supported family, so it is answered with a plain
+    /// keep-alive body error — the whole UPDATE is discarded (D17) and the supported families
+    /// stay enabled. Supported tuples (#466): AFI=1/SAFI=1 and AFI=2/SAFI=1.
     /// </summary>
-    private static void ScopeMpValueOrThrow(ReadOnlySpan<byte> value)
+    /// <returns>true for the IPv4/Unicast tuple, false for IPv6/Unicast.</returns>
+    private static bool ScopeMpValueOrThrow(ReadOnlySpan<byte> value)
     {
         if (value.Length < 3)
             throw new BgpParseException(
@@ -383,10 +401,14 @@ public static class BgpMessageReader
 
         var afi = BinaryPrimitives.ReadUInt16BigEndian(value);
         var safi = value[2];
-        if (afi != MpReachCodec.AfiIpv6 || safi != MpReachCodec.SafiUnicast)
-            throw new BgpParseException(
-                $"MP_REACH/MP_UNREACH for an unsupported address family: AFI={afi}, SAFI={safi}",
-                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
+        if (afi == MpReachCodec.AfiIpv4 && safi == MpReachCodec.SafiUnicast)
+            return true;
+        if (afi == MpReachCodec.AfiIpv6 && safi == MpReachCodec.SafiUnicast)
+            return false;
+
+        throw new BgpParseException(
+            $"MP_REACH/MP_UNREACH for an unsupported address family: AFI={afi}, SAFI={safi}",
+            BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
     }
 
     private static (PathAttribute attr, int consumed) ParseAttribute(ReadOnlySpan<byte> data)

--- a/BGPLite.Protocol/BgpMessageReader.cs
+++ b/BGPLite.Protocol/BgpMessageReader.cs
@@ -334,7 +334,7 @@ public static class BgpMessageReader
                         {
                             // RFC 7606 §3(j): a SUPPORTED tuple whose value cannot be decoded takes
                             // the "AFI/SAFI disable" choice, scoped to that family (D17).
-                            throw new BgpMpParseException(ex.Message, ex.SubErrorCode, ex);
+                            throw new BgpMpParseException(ex.Message, reachIsV4, ex.SubErrorCode, ex);
                         }
                         continue;
                     }
@@ -354,7 +354,7 @@ public static class BgpMessageReader
                     }
                     catch (BgpParseException ex)
                     {
-                        throw new BgpMpParseException(ex.Message, ex.SubErrorCode, ex);
+                        throw new BgpMpParseException(ex.Message, unreachIsV4, ex.SubErrorCode, ex);
                     }
                     continue;
                 }
@@ -572,8 +572,13 @@ public class BgpParseException : Exception
 /// </summary>
 public sealed class BgpMpParseException : BgpParseException
 {
-    public BgpMpParseException(string message, byte? subErrorCode = null, Exception? innerException = null)
+    /// <summary>True when the failing tuple was AFI=1/SAFI=1 (IPv4/Unicast), false for
+    /// AFI=2/SAFI=1 — the recovery must be scoped to the offending family (#472 review).</summary>
+    public bool IsIpv4 { get; }
+
+    public BgpMpParseException(string message, bool isIpv4, byte? subErrorCode = null, Exception? innerException = null)
         : base(message, BgpConstants.Error.UpdateMessageError, subErrorCode, innerException: innerException)
     {
+        IsIpv4 = isIpv4;
     }
 }

--- a/BGPLite.Protocol/BgpMessageReader.cs
+++ b/BGPLite.Protocol/BgpMessageReader.cs
@@ -291,7 +291,13 @@ public static class BgpMessageReader
                 // their shape, so a flags conflict is a session-reset error (3/4), not a discard.
                 if (attr.TypeCode is MpReachCodec.MpReachNlriType or MpReachCodec.MpUnreachNlriType)
                 {
-                    if (!attr.Optional || attr.Transitive)
+                    // RFC 4760 §4/§5 make both attributes OPTIONAL NON-TRANSITIVE; the Partial bit
+                    // is equally invalid on them — a non-transitive attribute is never re-advertised
+                    // by a speaker lacking the family, so nothing can set it (#472 review). The
+                    // Extended Length bit stays legal. RFC 7606 leaves the MP attributes explicitly
+                    // unrevised — the RFC 4271 §6.3 baseline applies to their shape, so a flags
+                    // conflict is a session-reset error (3/4), not a discard.
+                    if (!attr.Optional || attr.Transitive || attr.Partial)
                         throw new BgpParseException(
                             $"MP_REACH/MP_UNREACH flags conflict with optional non-transitive (flags=0x{attr.Flags:X2}, RFC 4760 §4)",
                             BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.AttributeFlagsError,
@@ -307,14 +313,15 @@ public static class BgpMessageReader
                             throw new BgpParseException("Duplicate MP_REACH_NLRI attribute (RFC 7606 §3(g))",
                                 BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList,
                                 sessionResetRequired: true);
+                        ScopeMpValueOrThrow(attr.Data);
                         try
                         {
                             mpReachV6 = MpReachCodec.DecodeMpReachV6(attr.Data);
                         }
                         catch (BgpParseException ex)
                         {
-                            // RFC 7606 §3(j): an unparseable MP value must get "session reset" OR
-                            // "AFI/SAFI disable" — marked for the session's disable policy (D17).
+                            // RFC 7606 §3(j): a SUPPORTED tuple whose value cannot be decoded takes
+                            // the "AFI/SAFI disable" choice, scoped to that family (D17).
                             throw new BgpMpParseException(ex.Message, ex.SubErrorCode, ex);
                         }
                         continue;
@@ -324,6 +331,7 @@ public static class BgpMessageReader
                         throw new BgpParseException("Duplicate MP_UNREACH_NLRI attribute (RFC 7606 §3(g))",
                             BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList,
                             sessionResetRequired: true);
+                    ScopeMpValueOrThrow(attr.Data);
                     try
                     {
                         mpUnreachV6 = MpReachCodec.DecodeMpUnreachV6(attr.Data);
@@ -354,6 +362,31 @@ public static class BgpMessageReader
             MpReachV6 = mpReachV6,
             MpUnreachV6 = mpUnreachV6
         };
+    }
+
+    /// <summary>
+    /// #472 review: scope MP value failures to the offending AFI/SAFI tuple. A value too short
+    /// to name its tuple cannot be scoped to any family — the RFC 7606 §3(j) fallback is the
+    /// session reset. A tuple this speaker does not support was never negotiated (RFC 4760 §8):
+    /// its arrival is not a parse failure of the supported family, so it is answered with a
+    /// plain keep-alive body error — the whole UPDATE is discarded (D17) and the supported
+    /// family stays enabled. Only a supported tuple's decode failure reaches the decoder, whose
+    /// <see cref="BgpMpParseException"/> marks the AFI/SAFI disable.
+    /// </summary>
+    private static void ScopeMpValueOrThrow(ReadOnlySpan<byte> value)
+    {
+        if (value.Length < 3)
+            throw new BgpParseException(
+                $"Truncated MP attribute: {value.Length} byte(s) cannot contain an AFI/SAFI tuple",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList,
+                sessionResetRequired: true);
+
+        var afi = BinaryPrimitives.ReadUInt16BigEndian(value);
+        var safi = value[2];
+        if (afi != MpReachCodec.AfiIpv6 || safi != MpReachCodec.SafiUnicast)
+            throw new BgpParseException(
+                $"MP_REACH/MP_UNREACH for an unsupported address family: AFI={afi}, SAFI={safi}",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
     }
 
     private static (PathAttribute attr, int consumed) ParseAttribute(ReadOnlySpan<byte> data)

--- a/BGPLite.Protocol/BgpMessageReader.cs
+++ b/BGPLite.Protocol/BgpMessageReader.cs
@@ -284,21 +284,54 @@ public static class BgpMessageReader
                 // Malformed AFI=2 payloads throw BgpParseException (Update Message Error) — the
                 // whole UPDATE is discarded with the session kept (D17), matching RFC 7606 §2
                 // (the attribute carries NLRI ⇒ treat-as-withdraw).
-                if (attr.TypeCode == MpReachCodec.MpReachNlriType)
+                // #467: the MP attributes are extracted here and never reach ParseRouteAttributes'
+                // flag/duplicate pipeline, so their RFC-prescribed error policy is applied at this
+                // extraction point. RFC 4760 §4/§5 make both attributes OPTIONAL NON-TRANSITIVE and
+                // RFC 7606 leaves them explicitly unrevised — the RFC 4271 §6.3 baseline applies to
+                // their shape, so a flags conflict is a session-reset error (3/4), not a discard.
+                if (attr.TypeCode is MpReachCodec.MpReachNlriType or MpReachCodec.MpUnreachNlriType)
                 {
-                    // RFC 4760: only one MP_REACH per UPDATE. A duplicate is a protocol error.
-                    if (mpReachV6 is not null)
-                        throw new BgpParseException("Duplicate MP_REACH_NLRI attribute",
-                            BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList);
-                    mpReachV6 = MpReachCodec.DecodeMpReachV6(attr.Data);
-                    continue;
-                }
-                if (attr.TypeCode == MpReachCodec.MpUnreachNlriType)
-                {
+                    if (!attr.Optional || attr.Transitive)
+                        throw new BgpParseException(
+                            $"MP_REACH/MP_UNREACH flags conflict with optional non-transitive (flags=0x{attr.Flags:X2}, RFC 4760 §4)",
+                            BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.AttributeFlagsError,
+                            sessionResetRequired: true);
+
+                    if (attr.TypeCode == MpReachCodec.MpReachNlriType)
+                    {
+                        // RFC 7606 §3(g): "If the MP_REACH_NLRI attribute or the MP_UNREACH_NLRI
+                        // [RFC4760] attribute appears more than once in the UPDATE message then a
+                        // NOTIFICATION message MUST be sent with the Error Subcode 'Malformed
+                        // Attribute List'." — a session reset, NOT the D17 keep-alive discard.
+                        if (mpReachV6 is not null)
+                            throw new BgpParseException("Duplicate MP_REACH_NLRI attribute (RFC 7606 §3(g))",
+                                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList,
+                                sessionResetRequired: true);
+                        try
+                        {
+                            mpReachV6 = MpReachCodec.DecodeMpReachV6(attr.Data);
+                        }
+                        catch (BgpParseException ex)
+                        {
+                            // RFC 7606 §3(j): an unparseable MP value must get "session reset" OR
+                            // "AFI/SAFI disable" — marked for the session's disable policy (D17).
+                            throw new BgpMpParseException(ex.Message, ex.SubErrorCode, ex);
+                        }
+                        continue;
+                    }
+
                     if (mpUnreachV6 is not null)
-                        throw new BgpParseException("Duplicate MP_UNREACH_NLRI attribute",
-                            BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList);
-                    mpUnreachV6 = MpReachCodec.DecodeMpUnreachV6(attr.Data);
+                        throw new BgpParseException("Duplicate MP_UNREACH_NLRI attribute (RFC 7606 §3(g))",
+                            BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList,
+                            sessionResetRequired: true);
+                    try
+                    {
+                        mpUnreachV6 = MpReachCodec.DecodeMpUnreachV6(attr.Data);
+                    }
+                    catch (BgpParseException ex)
+                    {
+                        throw new BgpMpParseException(ex.Message, ex.SubErrorCode, ex);
+                    }
                     continue;
                 }
                 attributes.Add(attr);
@@ -434,15 +467,17 @@ public static class BgpMessageReader
 /// set Update Message Error (§6.3). A <c>null</c> sub-error code maps to Unspecific (0).
 /// </para>
 /// </summary>
-public sealed class BgpParseException : Exception
+public class BgpParseException : Exception
 {
     private readonly byte[]? _notificationData;
 
-    public BgpParseException(string message, byte? errorCode = null, byte? subErrorCode = null, byte[]? notificationData = null) : base(message)
+    public BgpParseException(string message, byte? errorCode = null, byte? subErrorCode = null, byte[]? notificationData = null, Exception? innerException = null, bool sessionResetRequired = false)
+        : base(message, innerException)
     {
         ErrorCode = errorCode;
         SubErrorCode = subErrorCode;
         _notificationData = notificationData is null ? null : (byte[])notificationData.Clone();
+        SessionResetRequired = sessionResetRequired;
     }
 
     public BgpParseException(string message, Exception inner) : base(message, inner) { }
@@ -460,4 +495,30 @@ public sealed class BgpParseException : Exception
     /// <see cref="BgpNotificationException.NotificationData"/>.
     /// </summary>
     public byte[]? NotificationData => _notificationData is null ? null : (byte[])_notificationData.Clone();
+
+    /// <summary>
+    /// #467: true when the RFC error policy for this failure class mandates a session reset
+    /// rather than the D17 keep-alive treatment — RFC 7606 §3(g) for a duplicated
+    /// MP_REACH_NLRI/MP_UNREACH_NLRI attribute (NOTIFICATION "Malformed Attribute List" MUST)
+    /// and the RFC 4271 §6.3 baseline for their flags conflicts (RFC 7606 leaves the MP
+    /// attributes explicitly unrevised). The read loop answers with exactly one NOTIFICATION
+    /// and tears the session down instead of discarding the message.
+    /// </summary>
+    public bool SessionResetRequired { get; }
+}
+
+/// <summary>
+/// #467: thrown by <see cref="BgpMessageReader.ReadMessage"/> when an MP_REACH_NLRI /
+/// MP_UNREACH_NLRI VALUE cannot be decoded (unsupported AFI/SAFI, truncated value, invalid
+/// next-hop length). RFC 7606 §3(j) places these attributes outside the keep-alive revision:
+/// an unparseable MP attribute MUST be answered with the "session reset" OR the "AFI/SAFI
+/// disable" approach. BGPLite records the disable choice in D17 — the session stays up, the
+/// IPv6/Unicast family is withdrawn from the peer and no longer accepted.
+/// </summary>
+public sealed class BgpMpParseException : BgpParseException
+{
+    public BgpMpParseException(string message, byte? subErrorCode = null, Exception? innerException = null)
+        : base(message, BgpConstants.Error.UpdateMessageError, subErrorCode, innerException: innerException)
+    {
+    }
 }

--- a/BGPLite.Protocol/BgpUpdateMessage.cs
+++ b/BGPLite.Protocol/BgpUpdateMessage.cs
@@ -14,4 +14,12 @@ public sealed class BgpUpdateMessage : BgpMessage
     /// <summary>Decoded MP_UNREACH_NLRI (RFC 4760, AFI=2/SAFI=1) IPv6 withdrawals. Null/empty when
     /// the UPDATE carries none.</summary>
     public IReadOnlyList<IpPrefix>? MpUnreachV6 { get; init; }
+
+    /// <summary>Decoded MP_REACH_NLRI (RFC 4760, AFI=1/SAFI=1) IPv4 announcements (#466). Null when
+    /// the UPDATE carries none. Routes ride the same install pipeline as the classic NLRI field.</summary>
+    public MpReachCodec.MpReachV4? MpReachV4 { get; init; }
+
+    /// <summary>Decoded MP_UNREACH_NLRI (RFC 4760, AFI=1/SAFI=1) IPv4 withdrawals (#466). Null/empty
+    /// when the UPDATE carries none.</summary>
+    public IReadOnlyList<IpPrefix>? MpUnreachV4 { get; init; }
 }

--- a/BGPLite.Protocol/MpReachCodec.cs
+++ b/BGPLite.Protocol/MpReachCodec.cs
@@ -24,6 +24,22 @@ public static class MpReachCodec
 
     public readonly record struct MpReachV6(UInt128 NextHop, IReadOnlyList<IpPrefix> Prefixes);
 
+    /// <summary>
+    /// #467 (RFC 2545 §3): the MP_REACH next hop must be a GLOBAL IPv6 address. Rejects the
+    /// unspecified address (::), loopback (::1), multicast (ff00::/8) and link-local
+    /// (fe80::/10) — a lone link-local is only meaningful on a shared subnet and rides as the
+    /// SECOND half of the RFC 2545 32-byte form, which the decoder never adopts. IPv4-mapped
+    /// forms are global-scope representations and are accepted.
+    /// </summary>
+    public static bool IsGlobalUnicastNextHop(UInt128 nextHop)
+    {
+        if (nextHop == UInt128.Zero) return false;                              // ::
+        if (nextHop == UInt128.One) return false;                               // ::1
+        if ((nextHop >> 120) == (UInt128)0xFF) return false;                    // ff00::/8
+        if ((nextHop >> 118) == (UInt128)0b1111111010) return false;            // fe80::/10
+        return true;
+    }
+
     /// <summary>Builds the MP_REACH_NLRI (type 14) attribute VALUE for IPv6/Unicast:
     /// a 16-byte global next hop plus the NLRI prefix list.</summary>
     public static byte[] EncodeMpReachV6(UInt128 nextHop, IReadOnlyList<IpPrefix> prefixes)

--- a/BGPLite.Protocol/MpReachCodec.cs
+++ b/BGPLite.Protocol/MpReachCodec.cs
@@ -24,6 +24,83 @@ public static class MpReachCodec
 
     public readonly record struct MpReachV6(UInt128 NextHop, IReadOnlyList<IpPrefix> Prefixes);
 
+    /// <summary>MP_REACH/MP_UNREACH AFI=1/SAFI=1 (IPv4/Unicast) decode result (#466): the 4-octet
+    /// next hop plus the prefix list — semantically the classic IPv4 NLRI path.</summary>
+    public readonly record struct MpReachV4(uint NextHop, IReadOnlyList<IpPrefix> Prefixes);
+
+    public const ushort AfiIpv4 = (ushort)BgpConstants.Afi.IPv4;
+
+    /// <summary>
+    /// Decodes an MP_REACH_NLRI (type 14) VALUE for IPv4/Unicast (#466): AFI(2) + SAFI(1) +
+    /// NH-Len(1) + a 4-octet next hop + Reserved(1) + classic IPv4 NLRI. A next-hop length other
+    /// than 4 is a parse error (RFC 4760 §5 defines no other form for this family).
+    /// </summary>
+    public static MpReachV4 DecodeMpReachV4(ReadOnlySpan<byte> value)
+    {
+        if (value.Length < 8)
+            throw new BgpParseException(
+                $"Truncated MP_REACH_NLRI (IPv4): have {value.Length} bytes, need at least 8",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
+
+        var afi = BinaryPrimitives.ReadUInt16BigEndian(value);
+        var safi = value[2];
+        if (afi != AfiIpv4 || safi != SafiUnicast)
+            throw new BgpParseException(
+                $"MP_REACH_NLRI for unsupported address family: AFI={afi}, SAFI={safi} (expected 1/1)",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
+
+        var nhLength = value[3];
+        if (nhLength != 4)
+            throw new BgpParseException(
+                $"Invalid MP_REACH_NLRI (IPv4) next-hop length: {nhLength} (must be 4 per RFC 4760 §5)",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList);
+        if (value.Length < 4 + nhLength + 1)
+            throw new BgpParseException(
+                $"Truncated MP_REACH_NLRI next hop: need {nhLength} bytes at offset 4",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
+
+        var nextHop = BinaryPrimitives.ReadUInt32BigEndian(value[4..]);
+
+        // value[4+nhLength] is the Reserved byte — tolerated on receive (see DecodeMpReachV6).
+        var nlriOffset = 4 + nhLength + 1;
+        var prefixes = new List<IpPrefix>();
+        while (nlriOffset < value.Length)
+        {
+            var (prefix, consumed) = PrefixCodec.Decode(value[nlriOffset..]);
+            prefixes.Add(prefix);
+            nlriOffset += consumed;
+        }
+
+        return new MpReachV4(nextHop, prefixes);
+    }
+
+    /// <summary>Decodes an MP_UNREACH_NLRI (type 15) VALUE for IPv4/Unicast (#466):
+    /// AFI(2) + SAFI(1) + the withdrawn classic IPv4 NLRI.</summary>
+    public static IReadOnlyList<IpPrefix> DecodeMpUnreachV4(ReadOnlySpan<byte> value)
+    {
+        if (value.Length < 3)
+            throw new BgpParseException(
+                $"Truncated MP_UNREACH_NLRI (IPv4): have {value.Length} bytes, need at least 3",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
+
+        var afi = BinaryPrimitives.ReadUInt16BigEndian(value);
+        var safi = value[2];
+        if (afi != AfiIpv4 || safi != SafiUnicast)
+            throw new BgpParseException(
+                $"MP_UNREACH_NLRI for unsupported address family: AFI={afi}, SAFI={safi} (expected 1/1)",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
+
+        var prefixes = new List<IpPrefix>();
+        var offset = 3;
+        while (offset < value.Length)
+        {
+            var (prefix, consumed) = PrefixCodec.Decode(value[offset..]);
+            prefixes.Add(prefix);
+            offset += consumed;
+        }
+        return prefixes;
+    }
+
     /// <summary>
     /// #467 (RFC 2545 §3): the MP_REACH next hop must be a GLOBAL IPv6 address. Rejects the
     /// unspecified address (::), loopback (::1), multicast (ff00::/8) and link-local

--- a/BGPLite.Providers/UserSourceCache.cs
+++ b/BGPLite.Providers/UserSourceCache.cs
@@ -97,31 +97,23 @@ internal sealed class UserSourceCache
 
         // Serialize per-key so concurrent callers (e.g. several peers refreshing the same URL) share
         // a single fetch — no thundering herd.
-        var gate = _locks.GetOrAdd(url, _ => new SemaphoreSlim(1, 1));
-        // #450 review: register as an active loader BEFORE the gate is taken — the sweep and
-        // EvictIfAtCapacity never remove a gate that still has loaders (RipeStatPrefixCache's
-        // _inflight invariant, #267 item 3). Without this, a removed-then-recreated gate let two
-        // loaders run concurrently for one URL and the OLDER response could overwrite the newer.
+        // #468: register as an active loader BEFORE taking the gate from _locks. The inverse
+        // ordering let the LAST leaver's gate removal race a caller that had already taken the
+        // (now-removed) gate instance but not yet registered, parking it on an orphaned
+        // semaphore while the next caller minted a second gate. With this order every
+        // participant is counted in _inflight before it can touch _locks, so ExitInflight only
+        // ever removes a gate that nobody holds or queues on.
         _inflight.AddOrUpdate(url, 1, (_, c) => c + 1);
+        var gate = _locks.GetOrAdd(url, _ => new SemaphoreSlim(1, 1));
         var entered = false;
         try
         {
-            try
-            {
-                await gate.WaitAsync(ct);
-                entered = true;
-            }
-            catch (OperationCanceledException) when (ct.IsCancellationRequested)
-            {
-                // #358 review (orphan-lock hygiene for #261): a caller cancelled while queued never
-                // writes a cache entry, so its freshly-created gate would never be evicted (the sweep
-                // removes locks only for removed cache keys) — cancelled URLs accumulated semaphores.
-                // Pair-remove OUR gate instance: a concurrent waiter keeps running on its own
-                // reference, and a fresh caller GetOrAdd's a new gate — the same duplicate-fetch
-                // tradeoff the eviction sweep already accepts.
-                ((ICollection<KeyValuePair<string, SemaphoreSlim>>)_locks).Remove(new KeyValuePair<string, SemaphoreSlim>(url, gate));
-                throw;
-            }
+            // #468: a caller cancelled while queued does NOT remove the gate here — that pair-
+            // removed the shared instance out from under the still-running first loader, minted
+            // a second gate for the next caller and raced a newer load against an older
+            // snapshot. Cleanup is ExitInflight's job: the LAST leaver removes the gate.
+            await gate.WaitAsync(ct);
+            entered = true;
             try
             {
                 if (TryGetFresh(url, out var rechecked))
@@ -170,16 +162,27 @@ internal sealed class UserSourceCache
         }
         finally
         {
-            ExitInflight(url);
+            ExitInflight(url, gate);
         }
     }
 
-    /// <summary>Decrements the active-loader count for <paramref name="url"/> and removes the
-    /// marker when it reaches zero, so the sweeps know the gate is removable (#450 review).</summary>
-    private void ExitInflight(string url)
+    /// <summary>
+    /// Decrements the active-loader count for <paramref name="url"/>; the LAST leaver removes
+    /// the gate, so an unbacked gate cannot outlive its participants (the #358 orphan-lock
+    /// hygiene). #468: a cancelled waiter no longer removes the gate directly — that pair-
+    /// removed the shared instance out from under the still-running first loader, minted a
+    /// second gate for the next caller, and raced a newer load against an older snapshot.
+    /// Removal here can only run when nobody holds or queues on the gate: every participant
+    /// registers in <see cref="_inflight"/> BEFORE taking the gate from <see cref="_locks"/>,
+    /// so a non-zero remaining count means someone else is inside or queued and the gate must
+    /// stay. The sweeps keep their own <c>_inflight &gt; 0</c> guards for the entry-backed path.
+    /// </summary>
+    private void ExitInflight(string url, SemaphoreSlim gate)
     {
-        _inflight.AddOrUpdate(url, 0, (_, c) => c - 1);
+        var remaining = _inflight.AddOrUpdate(url, 0, (_, c) => c - 1);
+        if (remaining > 0) return;
         _inflight.TryRemove(new KeyValuePair<string, int>(url, 0));
+        ((ICollection<KeyValuePair<string, SemaphoreSlim>>)_locks).Remove(new KeyValuePair<string, SemaphoreSlim>(url, gate));
     }
 
     /// <summary>

--- a/BGPLite.Routing/RouteTable.cs
+++ b/BGPLite.Routing/RouteTable.cs
@@ -148,11 +148,24 @@ public sealed class RouteTable
     /// </summary>
     public int RemoveAllOwnedBy(object owner)
     {
+        return RemoveAllOwnedBy(owner, isIpv4: true) + RemoveAllOwnedBy(owner, isIpv4: false);
+    }
+
+    /// <summary>
+    /// #467: family-scoped variant — removes every entry still owned by <paramref name="owner"/>
+    /// in ONE address family and returns how many went (the RFC 7606 §3(j) "AFI/SAFI disable"
+    /// withdrawal). Each removal is the same atomic compare-and-remove as the full scan, so an
+    /// entry another peer has taken over between the scan and the delete stays put.
+    /// </summary>
+    public int RemoveAllOwnedBy(object owner, bool isIpv4)
+    {
         ArgumentNullException.ThrowIfNull(owner);
 
         var removed = 0;
         foreach (var pair in _routes)
         {
+            if (pair.Key.IsIpv4 != isIpv4)
+                continue;
             if (!ReferenceEquals(pair.Value.Owner, owner))
                 continue;
             if (((ICollection<KeyValuePair<(UInt128 Prefix, byte Length, bool IsIpv4), Entry>>)_routes).Remove(pair))

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -1275,6 +1275,13 @@ public sealed class BgpSession : IDisposable
     {
         _peerMpV6Disabled = true;
         var flushed = _routeTable.RemoveAllOwnedBy(this, isIpv4: false);
+        // #472 review: RemoveAllOwnedBy does not raise EntryOwnershipLost — this session is not
+        // losing keys to a replacing owner, it is discarding its own — so the per-peer prefix
+        // set must drop the family's keys here, or its cap count keeps drifting for prefixes
+        // the peer no longer has with us.
+        foreach (var key in _installedPrefixes.Keys)
+            if (!key.IsIpv4)
+                _installedPrefixes.TryRemove(key, out _);
         if (flushed > 0)
         {
             _logger.LogInformation(

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -1026,10 +1026,13 @@ public sealed class BgpSession : IDisposable
         // wire shape for an IPv6 announcement (RFC 4760 §5) leaves the classic NLRI field EMPTY —
         // gating on Nlri.Count alone silently dropped every such announcement.
         // #467: once the family is disabled (RFC 7606 §3(j) AFI/SAFI disable, below), MP payloads
-        // are ignored — the classic IPv4 half of the UPDATE keeps processing.
+        // are ignored — the classic IPv4 half of the UPDATE keeps processing. The IPv4 MP family
+        // (#466) is never disabled.
         var mpReach = _peerMpV6Disabled ? null : update.MpReachV6;
         var mpUnreach = _peerMpV6Disabled ? null : update.MpUnreachV6;
-        if (update.Nlri.Count > 0 || mpReach is not null)
+        var mpReachV4 = update.MpReachV4;
+        var mpUnreachV4 = update.MpUnreachV4;
+        if (update.Nlri.Count > 0 || mpReach is not null || mpReachV4 is not null)
         {
             // #270: the inbound attribute pipeline (per-attribute validation, mandatory set,
             // AS4_PATH reconstruction, aggregator consistency — subcodes 3/6/8/9/11) lives in the
@@ -1041,7 +1044,7 @@ public sealed class BgpSession : IDisposable
                 // #292 item 1: local router-id for the §6.8 self-address check on NEXT_HOP.
                 attrs = UpdateCodec.ParseRouteAttributes(update, _remoteFourByteAsn,
                     BgpConstants.IPAddressToUint(_bgpConfig.GetRouterIdAddress()),
-                    mpReachV6Present: mpReach is not null);
+                    mpReachV6Present: mpReach is not null || mpReachV4 is not null);
             }
             catch (BgpNotificationException ex) when (ex.ErrorCode == BgpConstants.Error.UpdateMessageError)
             {
@@ -1065,6 +1068,9 @@ public sealed class BgpSession : IDisposable
                 if (mpReach is { } failedReach)
                     foreach (var p in failedReach.Prefixes)
                         WithdrawIfOwned(p, "Route withdrawn (treat-as-withdraw, MP_REACH)");
+                if (mpReachV4 is { } failedReach4)
+                    foreach (var p in failedReach4.Prefixes)
+                        WithdrawIfOwned(p, "Route withdrawn (treat-as-withdraw, MP_REACH IPv4)");
                 _metrics.SetRouteCount(_routeTable.Count);
                 throw;
             }
@@ -1078,13 +1084,17 @@ public sealed class BgpSession : IDisposable
 
             var filterPeerConfig = GetFilterPeerConfig();
 
-            foreach (var nlri in update.Nlri)
+            // Classic IPv4 NLRI and MP_REACH AFI=1 (#466) share the install pipeline — AS-loop
+            // exclusion, filter, cap, ownership — and differ only in where the next hop comes
+            // from (the NEXT_HOP attribute vs the MP_REACH value).
+            void InstallV4Announcement(IpPrefix nlri, uint nextHop)
             {
                 var route = new Route
                 {
                     Prefix = nlri.Address,
                     PrefixLength = nlri.Length,
-                    NextHop = attrs.NextHop,
+                    NextHop = nextHop,
+                    IsIpv4 = true,
                     AsPath = attrs.AsPath,
                     Communities = attrs.Communities,
                     LargeCommunities = attrs.LargeCommunities
@@ -1102,46 +1112,73 @@ public sealed class BgpSession : IDisposable
                     if (_logger.IsEnabled(LogLevel.Debug))
                         _logger.LogDebug("Excluded looping route {Prefix} from {Peer}: local AS {Asn} in AS_PATH",
                             nlri, _peer, _bgpConfig.Asn);
-                    continue;
+                    return;
                 }
 
-                if (_routeFilter.AcceptIncoming(route, filterPeerConfig))
+                if (!_routeFilter.AcceptIncoming(route, filterPeerConfig))
+                    return;
+
+                // #304: per-peer prefix ceiling (RFC 4271 §6.7 / RFC 4486 §2) — counted on the
+                // distinct NLRI this session currently owns; replacements of an owned prefix
+                // do not grow the count, withdrawals shrink it. Exceeding the cap throws
+                // Cease/MaxPrefixesExceeded: deliberately NOT UpdateMessageError, so the read
+                // loop's treat-as-withdraw filter does not swallow it — it unwinds to RunAsync's
+                // BgpNotificationException handler, which sends the NOTIFICATION and tears the
+                // session down (owned routes are flushed by the finally, RFC 4271 §8.2.2).
+                var cap = Volatile.Read(ref _effectiveMaxPrefix);
+                if (cap > 0 && !_installedPrefixes.ContainsKey(nlri) && _installedPrefixes.Count >= cap)
+                    throw new BgpNotificationException(
+                        BgpConstants.Error.Cease, BgpConstants.SubError.CeaseMaxPrefixes,
+                        $"Peer {_peer} exceeded the per-peer prefix limit ({cap}); session reset per RFC 4486");
+                // #377 review: record membership BEFORE publishing — a concurrent takeover
+                // fires EntryOwnershipLost synchronously inside AddOrUpdate, and the handler's
+                // remove would no-op against a key not yet recorded, leaving this session
+                // counting a prefix it no longer owns.
+                _installedPrefixes.TryAdd(nlri, 0);
+
+                // Tagged with this session as the owner, so only this peer's own withdrawal can
+                // remove it (#289). A route the filter dropped is never installed and therefore
+                // never owned, so a later withdrawal for it removes nothing.
+                _routeTable.AddOrUpdate(route, owner: this);
+
+                // #377 review: warn AFTER the install with the actual count — the pre-install
+                // count logged "0/1" for the very first route under cap=1 (threshold floor 0).
+                if (cap > 0 && !_maxPrefixesWarned && _installedPrefixes.Count >= MaxPrefixWarningThreshold(cap))
                 {
-                    // #304: per-peer prefix ceiling (RFC 4271 §6.7 / RFC 4486 §2) — counted on the
-                    // distinct NLRI this session currently owns; replacements of an owned prefix
-                    // do not grow the count, withdrawals shrink it. Exceeding the cap throws
-                    // Cease/MaxPrefixesExceeded: deliberately NOT UpdateMessageError, so the read
-                    // loop's treat-as-withdraw filter does not swallow it — it unwinds to RunAsync's
-                    // BgpNotificationException handler, which sends the NOTIFICATION and tears the
-                    // session down (owned routes are flushed by the finally, RFC 4271 §8.2.2).
-                    var cap = Volatile.Read(ref _effectiveMaxPrefix);
-                    if (cap > 0 && !_installedPrefixes.ContainsKey(nlri) && _installedPrefixes.Count >= cap)
-                        throw new BgpNotificationException(
-                            BgpConstants.Error.Cease, BgpConstants.SubError.CeaseMaxPrefixes,
-                            $"Peer {_peer} exceeded the per-peer prefix limit ({cap}); session reset per RFC 4486");
-                    // #377 review: record membership BEFORE publishing — a concurrent takeover
-                    // fires EntryOwnershipLost synchronously inside AddOrUpdate, and the handler's
-                    // remove would no-op against a key not yet recorded, leaving this session
-                    // counting a prefix it no longer owns.
-                    _installedPrefixes.TryAdd(nlri, 0);
-
-                    // Tagged with this session as the owner, so only this peer's own withdrawal can
-                    // remove it (#289). A route the filter dropped is never installed and therefore
-                    // never owned, so a later withdrawal for it removes nothing.
-                    _routeTable.AddOrUpdate(route, owner: this);
-
-                    // #377 review: warn AFTER the install with the actual count — the pre-install
-                    // count logged "0/1" for the very first route under cap=1 (threshold floor 0).
-                    if (cap > 0 && !_maxPrefixesWarned && _installedPrefixes.Count >= MaxPrefixWarningThreshold(cap))
-                    {
-                        _maxPrefixesWarned = true;
-                        _logger.LogWarning("Peer {Peer} at {Count}/{Cap} of the per-peer prefix limit", _peer, _installedPrefixes.Count, cap);
-                    }
-                    // #85: guard the UintToIPAddress allocation behind IsEnabled — LogDebug
-                    // evaluates the arg eagerly even when Debug is filtered out.
-                    if (_logger.IsEnabled(LogLevel.Debug))
-                        _logger.LogDebug("Route added: {Prefix} via {NextHop}", nlri, BgpConstants.UintToIPAddress(attrs.NextHop));
+                    _maxPrefixesWarned = true;
+                    _logger.LogWarning("Peer {Peer} at {Count}/{Cap} of the per-peer prefix limit", _peer, _installedPrefixes.Count, cap);
                 }
+                // #85: guard the UintToIPAddress allocation behind IsEnabled — LogDebug
+                // evaluates the arg eagerly even when Debug is filtered out.
+                if (_logger.IsEnabled(LogLevel.Debug))
+                    _logger.LogDebug("Route added: {Prefix} via {NextHop}", nlri, BgpConstants.UintToIPAddress(nextHop));
+            }
+
+            foreach (var nlri in update.Nlri)
+                InstallV4Announcement(nlri, attrs.NextHop);
+
+            // #466: MP_REACH_NLRI (AFI=1/SAFI=1) — IPv4 announcements arriving through the MP
+            // path install exactly like the classic NLRI above, with the next hop taken from
+            // INSIDE the attribute. RFC 4271 §6.3/§6.8 NEXT_HOP semantics apply to it as well:
+            // an invalid value treats the announcement as withdrawn (remedy of the classic
+            // NEXT_HOP path, RFC 7606 §7.3) while the session stays up.
+            if (mpReachV4 is { } reach4)
+            {
+                try
+                {
+                    UpdateCodec.ValidateNextHopSemantics(reach4.NextHop,
+                        BgpConstants.IPAddressToUint(_bgpConfig.GetRouterIdAddress()));
+                }
+                catch (BgpNotificationException ex) when (ex.ErrorCode == BgpConstants.Error.UpdateMessageError)
+                {
+                    foreach (var p in reach4.Prefixes)
+                        WithdrawIfOwned(p, "Route withdrawn (treat-as-withdraw, MP_REACH IPv4)");
+                    _metrics.SetRouteCount(_routeTable.Count);
+                    throw;
+                }
+
+                foreach (var nlri in reach4.Prefixes)
+                    InstallV4Announcement(nlri, reach4.NextHop);
             }
 
             // MP_REACH_NLRI (AFI=2/SAFI=1) announcements: same install pipeline as the classic
@@ -1212,6 +1249,14 @@ public sealed class BgpSession : IDisposable
         {
             foreach (var prefix in v6Withdrawn)
                 WithdrawIfOwned(prefix, "Route withdrawn (MP_UNREACH)");
+        }
+
+        // #466: MP_UNREACH_NLRI (AFI=1/SAFI=1) withdraws classic IPv4 routes the peer installed —
+        // same ownership rule. The v6 disable gate does not apply: IPv4 is never disabled.
+        if (mpUnreachV4 is { Count: > 0 } v4Withdrawn)
+        {
+            foreach (var prefix in v4Withdrawn)
+                WithdrawIfOwned(prefix, "Route withdrawn (MP_UNREACH IPv4)");
         }
 
         _metrics.SetRouteCount(_routeTable.Count);
@@ -1763,7 +1808,13 @@ public sealed class BgpSession : IDisposable
     {
         var capabilities = new List<BgpCapabilityInfo>
         {
-            BgpCapabilityInfo.FourOctetAsn(_bgpConfig.Asn)
+            BgpCapabilityInfo.FourOctetAsn(_bgpConfig.Asn),
+            // #466 (D24): MP IPv4/Unicast is advertised UNCONDITIONALLY — the receiving half is
+            // implemented: MP_REACH/MP_UNREACH AFI=1 decode into the classic NLRI pipeline. The
+            // capability-strict peers (BIRD 2 with default `capabilities`) treat the missing
+            // MP_IPV4 tuple as "Required capability missing" and refuse the session, so the
+            // advertisement is also what keeps those peers connected.
+            BgpCapabilityInfo.MultiprotocolIpv4Unicast()
         };
 
         // Only advertise Route Refresh if peer also supports it
@@ -1773,13 +1824,6 @@ public sealed class BgpSession : IDisposable
         // #15 phase 2: advertise MP IPv6/Unicast only when the peer also supports it.
         if (CapabilityHelper.SupportsMultiprotocolIpv6Unicast(remoteOpen))
             capabilities.Add(BgpCapabilityInfo.MultiprotocolIpv6Unicast());
-
-        // #466 (D24): MP IPv4/Unicast is deliberately NOT advertised. RFC 5492 §3 makes a
-        // capability advertised by both peers usable, and RFC 4760 §8 ties the advertisement
-        // to actually supporting that <AFI, SAFI> on receive — but the inbound path has no
-        // MP_REACH/MP_UNREACH AFI=1 handling at all, so the old peer-offer echo turned every
-        // negotiated IPv4 MP UPDATE into a discarded treat-as-withdraw. IPv4/Unicast needs no
-        // MP capability: it is the default family and rides the classic NLRI field.
 
         // #318: the Graceful Restart capability is deliberately NOT advertised. RFC 4724 §4.2 obliges
         // a speaker engaging GR procedures to retain and stale-mark a restarting peer's routes;

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -33,6 +33,10 @@ public sealed class BgpSession : IDisposable
     private readonly Func<string, uint, CancellationToken, Task>? _onPeerIdentified;
     // #15 phase 2: the peer advertised MP-BGP IPv6/Unicast.
     private bool _peerMpIpv6Unicast;
+    // #467 (RFC 7606 §3(j) "AFI/SAFI disable"): set when an unparseable MP attribute withdraws
+    // the family — subsequent MP_REACH/MP_UNREACH payloads from this peer are ignored and its
+    // accepted IPv6 routes are gone. Volatile: written on the read loop, read on send paths.
+    private volatile bool _peerMpV6Disabled;
     // #391: the EFFECTIVE per-peer prefix ceiling — the peer row's MaxPrefix override when the
     // peer is configured, else the global Bgp.MaxPrefixesPerPeer. Resolved once per
     // establish/refresh cycle in SendAllRoutesAsync (never per UPDATE); read on the UPDATE path
@@ -762,6 +766,38 @@ public sealed class BgpSession : IDisposable
                 }
                 return;
             }
+            catch (BgpMpParseException ex)
+            {
+                // #467 (RFC 7606 §3(j)): an MP_REACH/MP_UNREACH value that cannot be parsed is
+                // explicitly OUTSIDE the keep-alive revision — the prescribed response is
+                // "session reset" OR "AFI/SAFI disable". The disable choice is recorded in D17:
+                // withdraw every IPv6 route accepted from this peer, stop accepting the family,
+                // keep the session itself up (a route server must not lose every family over one
+                // malformed attribute — the D17/D2 rationale, family-scoped). No NOTIFICATION:
+                // RFC 4271 §6.3 would make its receiver tear down, defeating the disable choice.
+                _logger.LogWarning(
+                    "Unparseable MP attribute from {Peer}: {Error}/{SubError} — {Reason}; disabling IPv6/Unicast for this session (RFC 7606 §3(j) AFI/SAFI disable)",
+                    _peer, ex.ErrorCode, ex.SubErrorCode ?? BgpConstants.SubError.Unspecific, ex.Message);
+                DisablePeerMpV6();
+                continue;
+            }
+            catch (BgpParseException ex) when (ex.SessionResetRequired)
+            {
+                // #467: failure classes the RFCs carve OUT of the D17 keep-alive treatment — a
+                // duplicated MP_REACH/MP_UNREACH attribute (RFC 7606 §3(g): NOTIFICATION "Malformed
+                // Attribute List" MUST) and an MP flags conflict (RFC 4271 §6.3 baseline; RFC 7606
+                // does not revise the MP attributes). Exactly one NOTIFICATION, then Idle — the
+                // same CAS-latched shape as the FSM-error arms.
+                _logger.LogWarning(
+                    "Rejected malformed message from {Peer}: {Error}/{SubError} — {Reason}; session reset per RFC 7606 §3(g)/§3(j)",
+                    _peer, ex.ErrorCode, ex.SubErrorCode ?? BgpConstants.SubError.Unspecific, ex.Message);
+                if (Interlocked.CompareExchange(ref _teardownReason, (int)TeardownReason.LocalCease, (int)TeardownReason.None) == (int)TeardownReason.None)
+                {
+                    try { await SendNotificationAsync(ex.ErrorCode!.Value, ex.SubErrorCode ?? BgpConstants.SubError.Unspecific); }
+                    catch { /* best-effort — partial write counts, see RFC 4271 §8.1 */ }
+                }
+                return;
+            }
             catch (BgpParseException ex) when (ex.ErrorCode is not null)
             {
                 // #222: a malformed message BODY (truncated path attribute, out-of-range NLRI length,
@@ -989,7 +1025,11 @@ public sealed class BgpSession : IDisposable
         // Process announcements. The gate must accept MP_REACH-only UPDATEs (#407): the normal
         // wire shape for an IPv6 announcement (RFC 4760 §5) leaves the classic NLRI field EMPTY —
         // gating on Nlri.Count alone silently dropped every such announcement.
-        if (update.Nlri.Count > 0 || update.MpReachV6 is not null)
+        // #467: once the family is disabled (RFC 7606 §3(j) AFI/SAFI disable, below), MP payloads
+        // are ignored — the classic IPv4 half of the UPDATE keeps processing.
+        var mpReach = _peerMpV6Disabled ? null : update.MpReachV6;
+        var mpUnreach = _peerMpV6Disabled ? null : update.MpUnreachV6;
+        if (update.Nlri.Count > 0 || mpReach is not null)
         {
             // #270: the inbound attribute pipeline (per-attribute validation, mandatory set,
             // AS4_PATH reconstruction, aggregator consistency — subcodes 3/6/8/9/11) lives in the
@@ -1001,7 +1041,7 @@ public sealed class BgpSession : IDisposable
                 // #292 item 1: local router-id for the §6.8 self-address check on NEXT_HOP.
                 attrs = UpdateCodec.ParseRouteAttributes(update, _remoteFourByteAsn,
                     BgpConstants.IPAddressToUint(_bgpConfig.GetRouterIdAddress()),
-                    mpReachV6Present: update.MpReachV6 is not null);
+                    mpReachV6Present: mpReach is not null);
             }
             catch (BgpNotificationException ex) when (ex.ErrorCode == BgpConstants.Error.UpdateMessageError)
             {
@@ -1022,7 +1062,7 @@ public sealed class BgpSession : IDisposable
                 // what this peer installed, not whatever is at that prefix.
                 foreach (var nlri in update.Nlri)
                     WithdrawIfOwned(nlri, "Route withdrawn (treat-as-withdraw)");
-                if (update.MpReachV6 is { } failedReach)
+                if (mpReach is { } failedReach)
                     foreach (var p in failedReach.Prefixes)
                         WithdrawIfOwned(p, "Route withdrawn (treat-as-withdraw, MP_REACH)");
                 _metrics.SetRouteCount(_routeTable.Count);
@@ -1106,43 +1146,57 @@ public sealed class BgpSession : IDisposable
 
             // MP_REACH_NLRI (AFI=2/SAFI=1) announcements: same install pipeline as the classic
             // IPv4 NLRI loop — AS-loop exclusion, filter, cap, ownership (#15 phase 2).
-            if (update.MpReachV6 is { } mpReach)
+            if (mpReach is { } reach)
             {
-                foreach (var nlri in mpReach.Prefixes)
+                // #467 (RFC 2545 §3): the MP_REACH next hop must be a GLOBAL IPv6 address —
+                // ::, ::1, ff00::/8 and fe80::/10 are not advertisable. A bad value never
+                // forwards anywhere (BGPLite is a route server), but it would poison the table
+                // and the management API's view — so the whole attribute's routes are excluded
+                // route-level, like the AS-loop exclusion, instead of being a session error.
+                if (!MpReachCodec.IsGlobalUnicastNextHop(reach.NextHop))
                 {
-                    var route = new Route
+                    _logger.LogWarning(
+                        "Excluded {Count} IPv6 announcement(s) from {Peer}: MP_REACH next hop {NextHop} is not a global unicast address (RFC 2545 §3)",
+                        reach.Prefixes.Count, _peer, RenderV6Address(reach.NextHop));
+                }
+                else
+                {
+                    foreach (var nlri in reach.Prefixes)
                     {
-                        Prefix = nlri.Address,
-                        IsIpv4 = false,
-                        PrefixLength = nlri.Length,
-                        NextHop = mpReach.NextHop,
-                        AsPath = attrs.AsPath,
-                        Communities = attrs.Communities,
-                        LargeCommunities = attrs.LargeCommunities
-                    };
-
-                    if (attrs.AsPath.AsSpan().Contains(_bgpConfig.Asn))
-                    {
-                        if (_logger.IsEnabled(LogLevel.Debug))
-                            _logger.LogDebug("Excluded looping route {Prefix} from {Peer}: local AS {Asn} in AS_PATH",
-                                nlri, _peer, _bgpConfig.Asn);
-                        continue;
-                    }
-
-                    if (_routeFilter.AcceptIncoming(route, filterPeerConfig))
-                    {
-                        var cap = Volatile.Read(ref _effectiveMaxPrefix);
-                        if (cap > 0 && !_installedPrefixes.ContainsKey(nlri) && _installedPrefixes.Count >= cap)
-                            throw new BgpNotificationException(
-                                BgpConstants.Error.Cease, BgpConstants.SubError.CeaseMaxPrefixes,
-                                $"Peer {_peer} exceeded the per-peer prefix limit ({cap}); session reset per RFC 4486");
-                        _installedPrefixes.TryAdd(nlri, 0);
-                        _routeTable.AddOrUpdate(route, owner: this);
-
-                        if (cap > 0 && !_maxPrefixesWarned && _installedPrefixes.Count >= MaxPrefixWarningThreshold(cap))
+                        var route = new Route
                         {
-                            _maxPrefixesWarned = true;
-                            _logger.LogWarning("Peer {Peer} at {Count}/{Cap} of the per-peer prefix limit", _peer, _installedPrefixes.Count, cap);
+                            Prefix = nlri.Address,
+                            IsIpv4 = false,
+                            PrefixLength = nlri.Length,
+                            NextHop = reach.NextHop,
+                            AsPath = attrs.AsPath,
+                            Communities = attrs.Communities,
+                            LargeCommunities = attrs.LargeCommunities
+                        };
+
+                        if (attrs.AsPath.AsSpan().Contains(_bgpConfig.Asn))
+                        {
+                            if (_logger.IsEnabled(LogLevel.Debug))
+                                _logger.LogDebug("Excluded looping route {Prefix} from {Peer}: local AS {Asn} in AS_PATH",
+                                    nlri, _peer, _bgpConfig.Asn);
+                            continue;
+                        }
+
+                        if (_routeFilter.AcceptIncoming(route, filterPeerConfig))
+                        {
+                            var cap = Volatile.Read(ref _effectiveMaxPrefix);
+                            if (cap > 0 && !_installedPrefixes.ContainsKey(nlri) && _installedPrefixes.Count >= cap)
+                                throw new BgpNotificationException(
+                                    BgpConstants.Error.Cease, BgpConstants.SubError.CeaseMaxPrefixes,
+                                    $"Peer {_peer} exceeded the per-peer prefix limit ({cap}); session reset per RFC 4486");
+                            _installedPrefixes.TryAdd(nlri, 0);
+                            _routeTable.AddOrUpdate(route, owner: this);
+
+                            if (cap > 0 && !_maxPrefixesWarned && _installedPrefixes.Count >= MaxPrefixWarningThreshold(cap))
+                            {
+                                _maxPrefixesWarned = true;
+                                _logger.LogWarning("Peer {Peer} at {Count}/{Cap} of the per-peer prefix limit", _peer, _installedPrefixes.Count, cap);
+                            }
                         }
                     }
                 }
@@ -1153,7 +1207,8 @@ public sealed class BgpSession : IDisposable
         // session installed — same ownership rule as the classic withdrawal path (#289). Runs
         // OUTSIDE the announcement block (#407): an MP_UNREACH-only UPDATE (a peer withdrawing
         // its IPv6 routes) has no classic NLRI and no MP_REACH, and must not depend on either.
-        if (update.MpUnreachV6 is { Count: > 0 } v6Withdrawn)
+        // #467: ignored once the family is disabled — the accepted routes were already withdrawn.
+        if (mpUnreach is { Count: > 0 } v6Withdrawn)
         {
             foreach (var prefix in v6Withdrawn)
                 WithdrawIfOwned(prefix, "Route withdrawn (MP_UNREACH)");
@@ -1207,6 +1262,34 @@ public sealed class BgpSession : IDisposable
 
         if (_logger.IsEnabled(LogLevel.Debug))
             _logger.LogDebug("{Reason}: {Prefix}", reason, prefix);
+    }
+
+    /// <summary>
+    /// #467 (RFC 7606 §3(j), the "AFI/SAFI disable" choice recorded in D17): withdraw every
+    /// IPv6 route this session accepted from the peer and stop accepting the family for the
+    /// rest of the session. Receive-side only — outbound IPv6 advertisement of configured
+    /// sources (D22/D24) is untouched, matching the disable's RFC scope (the peer's
+    /// announcements, not our own).
+    /// </summary>
+    private void DisablePeerMpV6()
+    {
+        _peerMpV6Disabled = true;
+        var flushed = _routeTable.RemoveAllOwnedBy(this, isIpv4: false);
+        if (flushed > 0)
+        {
+            _logger.LogInformation(
+                "Withdrew {Count} IPv6 route(s) learned from {Peer} — MP IPv6/Unicast disabled for this session",
+                flushed, _peer);
+            _metrics.SetRouteCount(_routeTable.Count);
+        }
+    }
+
+    private static string RenderV6Address(UInt128 address)
+    {
+        var bytes = new byte[16];
+        for (var i = 0; i < bytes.Length; i++)
+            bytes[i] = (byte)(address >> (120 - i * 8));
+        return new IPAddress(bytes).ToString();
     }
 
     /// <summary>

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -1676,10 +1676,6 @@ public sealed class BgpSession : IDisposable
             BgpCapabilityInfo.FourOctetAsn(_bgpConfig.Asn)
         };
 
-        // Only advertise MP IPv4/Unicast if peer specifically supports IPv4/Unicast
-        if (PeerHasMpIpv4Unicast(remoteOpen.Capabilities))
-            capabilities.Add(BgpCapabilityInfo.MultiprotocolIpv4Unicast());
-
         // Only advertise Route Refresh if peer also supports it
         if (remoteOpen.Capabilities.Any(c => c.Code == BgpConstants.Capability.RouteRefresh))
             capabilities.Add(BgpCapabilityInfo.RouteRefresh());
@@ -1687,6 +1683,13 @@ public sealed class BgpSession : IDisposable
         // #15 phase 2: advertise MP IPv6/Unicast only when the peer also supports it.
         if (CapabilityHelper.SupportsMultiprotocolIpv6Unicast(remoteOpen))
             capabilities.Add(BgpCapabilityInfo.MultiprotocolIpv6Unicast());
+
+        // #466 (D24): MP IPv4/Unicast is deliberately NOT advertised. RFC 5492 §3 makes a
+        // capability advertised by both peers usable, and RFC 4760 §8 ties the advertisement
+        // to actually supporting that <AFI, SAFI> on receive — but the inbound path has no
+        // MP_REACH/MP_UNREACH AFI=1 handling at all, so the old peer-offer echo turned every
+        // negotiated IPv4 MP UPDATE into a discarded treat-as-withdraw. IPv4/Unicast needs no
+        // MP capability: it is the default family and rides the classic NLRI field.
 
         // #318: the Graceful Restart capability is deliberately NOT advertised. RFC 4724 §4.2 obliges
         // a speaker engaging GR procedures to retain and stale-mark a restarting peer's routes;
@@ -1714,19 +1717,6 @@ public sealed class BgpSession : IDisposable
         };
 
         await SendMessageAsync(open);
-    }
-
-    private static bool PeerHasMpIpv4Unicast(List<BgpCapabilityInfo> caps)
-    {
-        foreach (var cap in caps)
-        {
-            if (cap.Code != BgpConstants.Capability.Multiprotocol || cap.Data.Length < 4) continue;
-            var afi = (ushort)((cap.Data[0] << 8) | cap.Data[1]);
-            var safi = cap.Data[3];
-            if (afi == BgpConstants.Afi.IPv4 && safi == BgpConstants.Safi.Unicast)
-                return true;
-        }
-        return false;
     }
 
     private Task SendKeepaliveAsync() => SendMessageAsync(BgpKeepaliveMessage.Instance);

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -770,16 +770,32 @@ public sealed class BgpSession : IDisposable
             {
                 // #467 (RFC 7606 §3(j)): an MP_REACH/MP_UNREACH value that cannot be parsed is
                 // explicitly OUTSIDE the keep-alive revision — the prescribed response is
-                // "session reset" OR "AFI/SAFI disable". The disable choice is recorded in D17:
-                // withdraw every IPv6 route accepted from this peer, stop accepting the family,
-                // keep the session itself up (a route server must not lose every family over one
-                // malformed attribute — the D17/D2 rationale, family-scoped). No NOTIFICATION:
-                // RFC 4271 §6.3 would make its receiver tear down, defeating the disable choice.
+                // "session reset" OR "AFI/SAFI disable", scoped to the offending family
+                // (#472 review: ex.IsIpv4).
+                // IPv6/Unicast → disable (D17): withdraw the peer's accepted IPv6 routes and
+                // ignore the family for the rest of the session; no NOTIFICATION (RFC 4271 §6.3
+                // would make its receiver tear down, defeating the disable choice).
+                // IPv4/Unicast → session reset. That family rides BOTH the classic and the MP
+                // carriage, so disabling only the MP carriage would be incoherent — the §3(j)
+                // fallback applies.
+                if (!ex.IsIpv4)
+                {
+                    _logger.LogWarning(
+                        "Unparseable MP attribute from {Peer}: {Error}/{SubError} — {Reason}; disabling IPv6/Unicast for this session (RFC 7606 §3(j) AFI/SAFI disable)",
+                        _peer, ex.ErrorCode, ex.SubErrorCode ?? BgpConstants.SubError.Unspecific, ex.Message);
+                    DisablePeerMpV6();
+                    continue;
+                }
+
                 _logger.LogWarning(
-                    "Unparseable MP attribute from {Peer}: {Error}/{SubError} — {Reason}; disabling IPv6/Unicast for this session (RFC 7606 §3(j) AFI/SAFI disable)",
+                    "Unparseable IPv4 MP attribute from {Peer}: {Error}/{SubError} — {Reason}; session reset (RFC 7606 §3(j) fallback)",
                     _peer, ex.ErrorCode, ex.SubErrorCode ?? BgpConstants.SubError.Unspecific, ex.Message);
-                DisablePeerMpV6();
-                continue;
+                if (Interlocked.CompareExchange(ref _teardownReason, (int)TeardownReason.LocalCease, (int)TeardownReason.None) == (int)TeardownReason.None)
+                {
+                    try { await SendNotificationAsync(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList); }
+                    catch { /* best-effort — partial write counts, see RFC 4271 §8.1 */ }
+                }
+                return;
             }
             catch (BgpParseException ex) when (ex.SessionResetRequired)
             {

--- a/BGPLite.Tests/BgpSessionOpenCapabilityTests.cs
+++ b/BGPLite.Tests/BgpSessionOpenCapabilityTests.cs
@@ -66,4 +66,67 @@ public class BgpSessionOpenCapabilityTests
             session.Dispose();
         }
     }
+
+    /// <summary>
+    /// #466: the OPEN BGPLite sends must NOT echo the peer's MP IPv4/Unicast capability
+    /// (code 1, AFI=1/SAFI=1). The inbound path has no MP_REACH/MP_UNREACH AFI=1 handling at
+    /// all, and RFC 5492 §3 / RFC 4760 §8 make a mutually-advertised capability usable — so
+    /// the echo invited the peer to send IPv4 NLRI via MP_REACH, which was then discarded
+    /// whole. D24: the advertisement must not precede the implementation (the D6 pattern).
+    /// </summary>
+    [Fact]
+    public async Task SentOpen_DoesNotAdvertise_MpIpv4Unicast_EvenWhenPeerOffersIt()
+    {
+        var conn = new ScriptedConnection();
+        var config = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
+
+        var session = new BgpSession(
+            conn,
+            new PeerConfig { Address = "127.0.0.1" },
+            config,
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            NullLogger<BgpSession>.Instance);
+
+        var run = session.RunAsync();
+        try
+        {
+            // The peer offers MP IPv4/Unicast — the exact trigger of the old conditional echo.
+            conn.EnqueueMessage(new BgpOpenMessage
+            {
+                Version = BgpConstants.BgpVersion,
+                Asn = 65002,
+                HoldTime = 0,
+                RouterId = 0x0A000002,
+                Capabilities =
+                [
+                    BgpCapabilityInfo.FourOctetAsn(65002),
+                    BgpCapabilityInfo.MultiprotocolIpv4Unicast(),
+                ],
+            });
+            conn.EnqueueMessage(BgpKeepaliveMessage.Instance);
+
+            for (var i = 0; i < 200 && !session.IsEstablished; i++)
+                await Task.Delay(TimeSpan.FromMilliseconds(10));
+            Assert.True(session.IsEstablished, "session must reach Established");
+
+            var sent = conn.Sent;
+            Assert.True(sent.Count > 0, "session must have sent its OPEN");
+            var open = Assert.IsType<BgpOpenMessage>(BgpMessageReader.ReadMessage(sent[0]));
+
+            // RED pre-fix: the peer's AFI=1/SAFI=1 offer was echoed back.
+            Assert.DoesNotContain(open.Capabilities, c =>
+                c.Code == BgpConstants.Capability.Multiprotocol &&
+                c.Data.Length >= 4 && c.Data[0] == 0 && c.Data[1] == 1 && c.Data[3] == BgpConstants.Safi.Unicast);
+            // Sanity: the 4-octet ASN capability — advertised unconditionally — is untouched.
+            Assert.Contains(open.Capabilities, c => c.Code == BgpConstants.Capability.FourOctetAsn);
+        }
+        finally
+        {
+            session.MarkSilentClose();
+            await run.WaitAsync(TimeSpan.FromSeconds(5));
+            session.Dispose();
+        }
+    }
 }

--- a/BGPLite.Tests/BgpSessionOpenCapabilityTests.cs
+++ b/BGPLite.Tests/BgpSessionOpenCapabilityTests.cs
@@ -68,14 +68,14 @@ public class BgpSessionOpenCapabilityTests
     }
 
     /// <summary>
-    /// #466: the OPEN BGPLite sends must NOT echo the peer's MP IPv4/Unicast capability
-    /// (code 1, AFI=1/SAFI=1). The inbound path has no MP_REACH/MP_UNREACH AFI=1 handling at
-    /// all, and RFC 5492 §3 / RFC 4760 §8 make a mutually-advertised capability usable — so
-    /// the echo invited the peer to send IPv4 NLRI via MP_REACH, which was then discarded
-    /// whole. D24: the advertisement must not precede the implementation (the D6 pattern).
+    /// #466 (D24, final state): the OPEN advertises MP IPv4/Unicast (code 1, AFI=1/SAFI=1)
+    /// UNCONDITIONALLY. The interim "never advertise" half-measure broke capability-strict
+    /// peers — BIRD 2 with default capabilities answers "Required capability missing" and
+    /// refuses the session — and the receiving half now EXISTS: MP_REACH/MP_UNREACH AFI=1
+    /// decode into the classic IPv4 pipeline.
     /// </summary>
     [Fact]
-    public async Task SentOpen_DoesNotAdvertise_MpIpv4Unicast_EvenWhenPeerOffersIt()
+    public async Task SentOpen_Advertises_MpIpv4Unicast_Unconditionally()
     {
         var conn = new ScriptedConnection();
         var config = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
@@ -92,18 +92,14 @@ public class BgpSessionOpenCapabilityTests
         var run = session.RunAsync();
         try
         {
-            // The peer offers MP IPv4/Unicast — the exact trigger of the old conditional echo.
+            // The peer does NOT offer MP IPv4/Unicast — the advertisement is ours alone now.
             conn.EnqueueMessage(new BgpOpenMessage
             {
                 Version = BgpConstants.BgpVersion,
                 Asn = 65002,
                 HoldTime = 0,
                 RouterId = 0x0A000002,
-                Capabilities =
-                [
-                    BgpCapabilityInfo.FourOctetAsn(65002),
-                    BgpCapabilityInfo.MultiprotocolIpv4Unicast(),
-                ],
+                Capabilities = [BgpCapabilityInfo.FourOctetAsn(65002)],
             });
             conn.EnqueueMessage(BgpKeepaliveMessage.Instance);
 
@@ -115,12 +111,13 @@ public class BgpSessionOpenCapabilityTests
             Assert.True(sent.Count > 0, "session must have sent its OPEN");
             var open = Assert.IsType<BgpOpenMessage>(BgpMessageReader.ReadMessage(sent[0]));
 
-            // RED pre-fix: the peer's AFI=1/SAFI=1 offer was echoed back.
-            Assert.DoesNotContain(open.Capabilities, c =>
+            var mpV4 = Assert.Single(open.Capabilities, c =>
                 c.Code == BgpConstants.Capability.Multiprotocol &&
                 c.Data.Length >= 4 && c.Data[0] == 0 && c.Data[1] == 1 && c.Data[3] == BgpConstants.Safi.Unicast);
-            // Sanity: the 4-octet ASN capability — advertised unconditionally — is untouched.
+            Assert.Equal([0x00, 0x01, 0x00, BgpConstants.Safi.Unicast], mpV4.Data);
+            // Sanity: 4-octet ASN still advertised; GR (D6) still not.
             Assert.Contains(open.Capabilities, c => c.Code == BgpConstants.Capability.FourOctetAsn);
+            Assert.DoesNotContain(open.Capabilities, c => c.Code == BgpConstants.Capability.GracefulRestart);
         }
         finally
         {

--- a/BGPLite.Tests/MpAttributeErrorPolicyTests.cs
+++ b/BGPLite.Tests/MpAttributeErrorPolicyTests.cs
@@ -18,7 +18,8 @@ namespace BGPLite.Tests;
 /// session reset (RFC 4271 §6.3 baseline);</item>
 /// <item>an UNPARSEABLE MP value → the §3(j) "AFI/SAFI disable" choice: the peer's accepted
 /// IPv6 routes are withdrawn, the family is ignored for the rest of the session, the session
-/// stays up (recorded in D17);</item>
+/// stays up (recorded in D17) — scoped to the SUPPORTED tuple: an unsupported AFI/SAFI only
+/// discards its UPDATE, and a value too short to name its tuple resets the session;</item>
 /// <item>a non-global MP_REACH next hop (RFC 2545 §3) → that attribute's routes are excluded,
 /// route-level, session up.</item>
 /// </list>
@@ -65,6 +66,84 @@ public class MpAttributeErrorPolicyTests
     }
 
     [Fact]
+    public async Task PartialMpReachFlags_TearDownSession_WithNotification_3_4()
+    {
+        // #472 review: the Partial bit is equally invalid on a non-transitive attribute — nothing
+        // ever re-advertises it un-understood — and joins the RFC 4271 §6.3 baseline reset.
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        var value = ReachValue(GlobalNextHop, 32, 0x20, 0x01, 0x0D, 0xB8);
+        conn.EnqueueFrame(UpdateFrame(MpReachAttribute(BgpConstants.Attribute.FlagOptional | BgpConstants.Attribute.FlagPartial, value)));
+
+        await AssertResetAsync(session, conn, expectedSubError: BgpConstants.SubError.AttributeFlagsError);
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task UnsupportedMpFamily_DiscardsTheUpdateOnly_SessionAndFamilyStayUp()
+    {
+        // #472 review: an AFI/SAFI tuple that was never negotiated (RFC 4760 §8) is not a parse
+        // failure of the SUPPORTED family — the whole UPDATE is discarded through the D17
+        // keep-alive path and neither the session nor IPv6/Unicast is touched.
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        conn.EnqueueFrame(UpdateFrame(
+            OriginAsPathAttributes,
+            MpReachAttribute(MpOptionalNonTransitive, ReachValue(GlobalNextHop, 32, 0x20, 0x01, 0x0D, 0xB8))));
+        await SettleAsync(conn, () => routeTable.Count == 1);
+
+        conn.EnqueueFrame(UpdateFrame(MpReachAttribute(MpOptionalNonTransitive,
+            [0x00, 0x01, 0x01, 0x04, 0xC0, 0x00, 0x02, 0x01, 0x00]))); // AFI=1/SAFI=1 — unsupported
+        await SettleAsync(conn);
+
+        Assert.True(session.IsEstablished, "an unsupported tuple is a keep-alive body error, not a reset");
+        Assert.NotNull(routeTable.Get(DocumentedPrefix, 32, isIpv4: false)); // the accepted route survives
+
+        // The supported family is still enabled: a valid announcement still installs.
+        conn.EnqueueFrame(UpdateFrame(
+            OriginAsPathAttributes,
+            MpReachAttribute(MpOptionalNonTransitive, ReachValue(GlobalNextHop, 24, 0x20, 0x01, 0x0D))));
+        await SettleAsync(conn, () => routeTable.Count == 2);
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task AfterFamilyDisable_ThePrefixCapBudgetIsReturned()
+    {
+        // #472 review: RemoveAllOwnedBy does not raise EntryOwnershipLost (the session is
+        // discarding its OWN keys), so DisablePeerMpV6 must drop the family's keys from the
+        // per-peer prefix set itself — otherwise the cap count drifts and phantom IPv6 keys
+        // consume the budget of real IPv4 announcements.
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable, maxPrefixes: 2);
+
+        conn.EnqueueFrame(UpdateFrame(
+            OriginAsPathAttributes,
+            MpReachAttribute(MpOptionalNonTransitive, ReachValue(GlobalNextHop, 32, 0x20, 0x01, 0x0D, 0xB8))));
+        conn.EnqueueFrame(UpdateFrame(
+            OriginAsPathAttributes,
+            MpReachAttribute(MpOptionalNonTransitive, ReachValue(GlobalNextHop, 24, 0x20, 0x01, 0x0D))));
+        await SettleAsync(conn, () => routeTable.Count == 2);
+
+        conn.EnqueueFrame(UpdateFrame(MpReachAttribute(MpOptionalNonTransitive,
+            [0x00, 0x02, 0x01, 0x10, 0x20, 0x01]))); // supported tuple, truncated → disable
+        await SettleAsync(conn, () => routeTable.Count == 0);
+
+        // The two IPv4 announcements must fit the cap of 2 — the withdrawn IPv6 keys must not
+        // be occupying it.
+        conn.EnqueueFrame(AnnounceFrame(24, 0xC0, 0x00, 0x02));
+        conn.EnqueueFrame(AnnounceFrame(24, 0xC0, 0x00, 0x01));
+        await SettleAsync(conn, () => routeTable.Count == 2);
+
+        Assert.True(session.IsEstablished, "reaching the cap through phantom keys would have reset the session");
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
     public async Task MalformedMpReach_WithdrawsAcceptedV6Routes_KeepsSessionUp()
     {
         var routeTable = new RouteTable();
@@ -79,11 +158,11 @@ public class MpAttributeErrorPolicyTests
         await SettleAsync(conn, () => routeTable.Count == 1);
         Assert.NotNull(routeTable.Get(DocumentedPrefix, 32, isIpv4: false));
 
-        // Now an UPDATE whose MP_REACH VALUE cannot be parsed (AFI=1 — the IPv6-only decoder
-        // rejects it structurally). RFC 7606 §3(j): session reset OR AFI/SAFI disable; BGPLite
-        // disables the family — the stale route must NOT survive the malformed update.
+        // Now an UPDATE whose MP_REACH VALUE cannot be parsed — AFI=2/SAFI=1 (the SUPPORTED
+        // tuple) with a truncated body. RFC 7606 §3(j): session reset OR AFI/SAFI disable;
+        // BGPLite disables the family — the stale route must NOT survive the malformed update.
         conn.EnqueueFrame(UpdateFrame(MpReachAttribute(MpOptionalNonTransitive,
-            [0x00, 0x01, 0x01, 0x04, 0xC0, 0x00, 0x02, 0x01, 0x00]))); // AFI=1, truncated value
+            [0x00, 0x02, 0x01, 0x10, 0x20, 0x01]))); // our AFI/SAFI, truncated next hop
         await SettleAsync(conn, () => routeTable.Count == 0);
 
         Assert.Null(routeTable.Get(DocumentedPrefix, 32, isIpv4: false));
@@ -101,7 +180,7 @@ public class MpAttributeErrorPolicyTests
         var (session, run, conn) = await EstablishAsync(routeTable);
 
         conn.EnqueueFrame(UpdateFrame(MpReachAttribute(MpOptionalNonTransitive,
-            [0x00, 0x01, 0x01, 0x04, 0xC0, 0x00, 0x02, 0x01, 0x00]))); // unparseable → disable
+            [0x00, 0x02, 0x01, 0x10, 0x20, 0x01]))); // supported tuple, truncated → disable
         await SettleAsync(conn);
 
         // A later VALID MP_REACH announcement is ignored: the family is disabled.
@@ -115,6 +194,20 @@ public class MpAttributeErrorPolicyTests
         await SettleAsync(conn, () => routeTable.Count == 1);
         Assert.Equal(1, routeTable.Count);
 
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task UnreadableMpTuple_ResetsSession_CannotBeScopedToAFamily()
+    {
+        // #472 review: a value too short to even name its AFI/SAFI cannot be scoped to a
+        // family, so the RFC 7606 §3(j) fallback is the session reset (NOTIFICATION 3/1).
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        conn.EnqueueFrame(UpdateFrame(MpReachAttribute(MpOptionalNonTransitive, [0x00, 0x02])));
+
+        await AssertResetAsync(session, conn, expectedSubError: BgpConstants.SubError.MalformedAttributeList);
         await TeardownAsync(session, run);
     }
 
@@ -214,10 +307,11 @@ public class MpAttributeErrorPolicyTests
 
     // ---- session lifecycle (the #289 test pattern) ----
 
-    private static async Task<(BgpSession Session, Task Run, ScriptedConnection Conn)> EstablishAsync(RouteTable routeTable)
+    private static async Task<(BgpSession Session, Task Run, ScriptedConnection Conn)> EstablishAsync(
+        RouteTable routeTable, uint routerId = 0x0A000002, int? maxPrefixes = null)
     {
         var conn = new ScriptedConnection();
-        var config = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
+        var config = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0, MaxPrefixesPerPeer = maxPrefixes ?? 0 };
         var session = new BgpSession(
             conn,
             new PeerConfig { Address = "127.0.0.1" },

--- a/BGPLite.Tests/MpAttributeErrorPolicyTests.cs
+++ b/BGPLite.Tests/MpAttributeErrorPolicyTests.cs
@@ -1,0 +1,301 @@
+using BGPLite.Configuration;
+using BGPLite.Contracts;
+using BGPLite.Protocol;
+using BGPLite.Routing;
+using BGPLite.Server;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #467: the MP_REACH_NLRI/MP_UNREACH_NLRI error policy. RFC 7606 leaves these attributes
+/// explicitly OUTSIDE the keep-alive revision, so the D17 discard-and-keep-alive treatment
+/// must not swallow them:
+/// <list type="bullet">
+/// <item>a DUPLICATE MP attribute → exactly one NOTIFICATION 3/1 and a session reset
+/// (RFC 7606 §3(g) MUST);</item>
+/// <item>an MP flags conflict (RFC 4760 §4: optional non-transitive) → NOTIFICATION 3/4 and a
+/// session reset (RFC 4271 §6.3 baseline);</item>
+/// <item>an UNPARSEABLE MP value → the §3(j) "AFI/SAFI disable" choice: the peer's accepted
+/// IPv6 routes are withdrawn, the family is ignored for the rest of the session, the session
+/// stays up (recorded in D17);</item>
+/// <item>a non-global MP_REACH next hop (RFC 2545 §3) → that attribute's routes are excluded,
+/// route-level, session up.</item>
+/// </list>
+/// Driven through the <c>IBgpConnection</c> seam with scripted frames, like the #289 tests.
+/// </summary>
+public class MpAttributeErrorPolicyTests
+{
+    // RFC 4271 §4.3: Optional = 0x80, Transitive = 0x40. MP_REACH/MP_UNREACH are optional
+    // NON-transitive (RFC 4760 §4) → 0x80; the conflict case adds the Transitive bit.
+    private const byte MpOptionalNonTransitive = BgpConstants.Attribute.FlagOptional;
+    private const byte MpOptionalTransitive = BgpConstants.Attribute.FlagOptional | BgpConstants.Attribute.FlagTransitive;
+
+    // 2001:db8::/32 with next hop 2001:db8::1 — a global unicast next hop.
+    private static readonly UInt128 DocumentedPrefix = (UInt128)0x20010DB8 << 96;
+    private static readonly UInt128 GlobalNextHop = ((UInt128)0x20010DB8 << 96) | 1;
+
+    [Fact]
+    public async Task DuplicateMpReach_TearsDownSession_WithExactlyOneNotification_3_1()
+    {
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        var value = ReachValue(GlobalNextHop, 32, 0x20, 0x01, 0x0D, 0xB8);
+        conn.EnqueueFrame(UpdateFrame(MpReachAttribute(MpOptionalNonTransitive, value),
+                                      MpReachAttribute(MpOptionalNonTransitive, value)));
+
+        await AssertResetAsync(session, conn, expectedSubError: BgpConstants.SubError.MalformedAttributeList);
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task TransitiveMpReachFlags_TearDownSession_WithNotification_3_4()
+    {
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        // RFC 4760 §4/§5: MP_REACH/MP_UNREACH are optional NON-transitive; the flags conflict is
+        // a session-reset error per the RFC 4271 §6.3 baseline (RFC 7606 does not revise MP).
+        var value = ReachValue(GlobalNextHop, 32, 0x20, 0x01, 0x0D, 0xB8);
+        conn.EnqueueFrame(UpdateFrame(MpReachAttribute(MpOptionalTransitive, value)));
+
+        await AssertResetAsync(session, conn, expectedSubError: BgpConstants.SubError.AttributeFlagsError);
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task MalformedMpReach_WithdrawsAcceptedV6Routes_KeepsSessionUp()
+    {
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        // First, a valid MP_REACH announcement (ORIGIN + AS_PATH + MP_REACH, RFC 4760 §5 shape)
+        // installs the route.
+        conn.EnqueueFrame(UpdateFrame(
+            OriginAsPathAttributes,
+            MpReachAttribute(MpOptionalNonTransitive,
+                ReachValue(GlobalNextHop, 32, 0x20, 0x01, 0x0D, 0xB8))));
+        await SettleAsync(conn, () => routeTable.Count == 1);
+        Assert.NotNull(routeTable.Get(DocumentedPrefix, 32, isIpv4: false));
+
+        // Now an UPDATE whose MP_REACH VALUE cannot be parsed (AFI=1 — the IPv6-only decoder
+        // rejects it structurally). RFC 7606 §3(j): session reset OR AFI/SAFI disable; BGPLite
+        // disables the family — the stale route must NOT survive the malformed update.
+        conn.EnqueueFrame(UpdateFrame(MpReachAttribute(MpOptionalNonTransitive,
+            [0x00, 0x01, 0x01, 0x04, 0xC0, 0x00, 0x02, 0x01, 0x00]))); // AFI=1, truncated value
+        await SettleAsync(conn, () => routeTable.Count == 0);
+
+        Assert.Null(routeTable.Get(DocumentedPrefix, 32, isIpv4: false));
+        Assert.True(session.IsEstablished, "the §3(j) disable choice keeps the session up");
+        Assert.DoesNotContain(await SentNotificationsAsync(conn),
+            n => n.ErrorCode == BgpConstants.Error.UpdateMessageError);
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task AfterFamilyDisable_SubsequentMpPayloadsAreIgnored_ClassicNlriStillProcessed()
+    {
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        conn.EnqueueFrame(UpdateFrame(MpReachAttribute(MpOptionalNonTransitive,
+            [0x00, 0x01, 0x01, 0x04, 0xC0, 0x00, 0x02, 0x01, 0x00]))); // unparseable → disable
+        await SettleAsync(conn);
+
+        // A later VALID MP_REACH announcement is ignored: the family is disabled.
+        conn.EnqueueFrame(UpdateFrame(MpReachAttribute(MpOptionalNonTransitive,
+            ReachValue(GlobalNextHop, 32, 0x20, 0x01, 0x0D, 0xB8))));
+        await SettleAsync(conn);
+        Assert.Equal(0, routeTable.Count);
+
+        // ...while the classic IPv4 half of the pipeline keeps processing normally.
+        conn.EnqueueFrame(AnnounceFrame(24, 0xC0, 0x00, 0x02));
+        await SettleAsync(conn, () => routeTable.Count == 1);
+        Assert.Equal(1, routeTable.Count);
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task NonGlobalMpReachNextHop_RoutesExcluded_SessionStaysUp()
+    {
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        // RFC 2545 §3: the next hop must be a GLOBAL IPv6 address. :: is not. The attribute's
+        // routes are excluded route-level (like the AS-loop rule); the session stays up.
+        conn.EnqueueFrame(UpdateFrame(
+            OriginAsPathAttributes,
+            MpReachAttribute(MpOptionalNonTransitive, ReachValue(0, 32, 0x20, 0x01, 0x0D, 0xB8))));
+        await SettleAsync(conn);
+
+        Assert.Equal(0, routeTable.Count);
+        Assert.True(session.IsEstablished, "a route-level exclusion is not a protocol error");
+
+        await TeardownAsync(session, run);
+    }
+
+    // ---- frame builders ----
+
+    private static byte[] Frame(BgpMessageType type, params byte[] payload)
+    {
+        var frame = new byte[BgpConstants.MessageHeaderSize + payload.Length];
+        BgpConstants.Marker.CopyTo(frame.AsSpan(0, BgpConstants.MarkerSize));
+        frame[16] = (byte)(frame.Length >> 8);
+        frame[17] = (byte)frame.Length;
+        frame[18] = (byte)type;
+        payload.CopyTo(frame, BgpConstants.MessageHeaderSize);
+        return frame;
+    }
+
+    private static byte[] MpReachAttribute(byte flags, byte[] value)
+    {
+        var attr = new byte[3 + value.Length];
+        attr[0] = flags;
+        attr[1] = MpReachCodec.MpReachNlriType;
+        attr[2] = (byte)value.Length;
+        value.CopyTo(attr, 3);
+        return attr;
+    }
+
+    /// <summary>
+    /// MP_REACH_NLRI (AFI=2/SAFI=1) value: AFI(2) + SAFI(1) + NH-len(16) + next hop + reserved
+    /// + one NLRI (length byte + significant address bytes).
+    /// </summary>
+    private static byte[] ReachValue(UInt128 nextHop, byte prefixLength, params byte[] addressBytes)
+    {
+        var value = new List<byte> { 0x00, 0x02, 0x01, 0x10 };
+        for (var i = 0; i < 16; i++)
+            value.Add((byte)(nextHop >> (120 - i * 8)));
+        value.Add(0x00); // reserved
+        value.Add(prefixLength);
+        value.AddRange(addressBytes);
+        return [.. value];
+    }
+
+    private static byte[] UpdateFrame(params byte[][] attributes)
+    {
+        var attrsLen = attributes.Sum(a => a.Length);
+        var payload = new List<byte> { 0x00, 0x00, (byte)(attrsLen >> 8), (byte)attrsLen };
+        foreach (var attr in attributes)
+            payload.AddRange(attr);
+        return Frame(BgpMessageType.Update, [.. payload]);
+    }
+
+    // ORIGIN + AS_PATH (no NEXT_HOP — the MP_REACH attribute supplies it, RFC 4760 §5).
+    private static readonly byte[] OriginAsPathAttributes =
+    [
+        0x40, 0x01, 0x01, 0x00,                                 // ORIGIN igp
+        0x40, 0x02, 0x06, 0x02, 0x01, 0x00, 0x00, 0x00, 0x64,   // AS_PATH seq [100]
+    ];
+
+    // ORIGIN + AS_PATH + NEXT_HOP for classic IPv4 NLRI announcements.
+    private static readonly byte[] ClassicAttributes =
+    [
+        0x40, 0x01, 0x01, 0x00,                                 // ORIGIN igp
+        0x40, 0x02, 0x06, 0x02, 0x01, 0x00, 0x00, 0x00, 0x64,   // AS_PATH seq [100]
+        0x40, 0x03, 0x04, 0xC0, 0x00, 0x02, 0x01,               // NEXT_HOP 192.0.2.1
+    ];
+
+    private static byte[] AnnounceFrame(byte prefixLength, params byte[] addressBytes)
+    {
+        var payload = new List<byte>
+        {
+            0x00, 0x00,
+            (byte)(ClassicAttributes.Length >> 8), (byte)ClassicAttributes.Length,
+        };
+        payload.AddRange(ClassicAttributes);
+        payload.Add(prefixLength);
+        payload.AddRange(addressBytes);
+        return Frame(BgpMessageType.Update, [.. payload]);
+    }
+
+    // ---- session lifecycle (the #289 test pattern) ----
+
+    private static async Task<(BgpSession Session, Task Run, ScriptedConnection Conn)> EstablishAsync(RouteTable routeTable)
+    {
+        var conn = new ScriptedConnection();
+        var config = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
+        var session = new BgpSession(
+            conn,
+            new PeerConfig { Address = "127.0.0.1" },
+            config,
+            routeTable,
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            NullLogger<BgpSession>.Instance);
+
+        var run = session.RunAsync();
+        conn.EnqueueMessage(new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = 0,
+            RouterId = 0x0A000002,
+            Capabilities = [BgpCapabilityInfo.FourOctetAsn(65002)],
+        });
+        conn.EnqueueMessage(BgpKeepaliveMessage.Instance);
+
+        for (var i = 0; i < 200 && !session.IsEstablished; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        Assert.True(session.IsEstablished, "session must reach Established");
+        return (session, run, conn);
+    }
+
+    private static async Task SettleAsync(ScriptedConnection conn, Func<bool>? until = null)
+    {
+        var reached = false;
+        for (var i = 0; i < 200; i++)
+        {
+            if (conn.Drained)
+            {
+                reached = until?.Invoke() ?? true;
+                if (reached && (until is not null || i > 5)) break;
+            }
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        }
+
+        Assert.True(conn.Drained, "the scripted frame was never consumed by the read loop");
+        if (until is not null)
+            Assert.True(reached, "the expected state was not reached in time");
+    }
+
+    /// <summary>
+    /// Waits for the session reset driven by the scripted frame, then asserts exactly one
+    /// NOTIFICATION with the expected error/sub-error pair was emitted before Idle.
+    /// </summary>
+    private static async Task AssertResetAsync(BgpSession session, ScriptedConnection conn, byte expectedSubError)
+    {
+        for (var i = 0; i < 200 && session.IsEstablished; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        Assert.False(session.IsEstablished, "the session must tear down");
+
+        var notifications = await SentNotificationsAsync(conn);
+        var notification = Assert.Single(notifications);
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, notification.ErrorCode);
+        Assert.Equal(expectedSubError, notification.SubErrorCode);
+    }
+
+    private static async Task<IEnumerable<BgpNotificationMessage>> SentNotificationsAsync(ScriptedConnection conn)
+    {
+        // Give the teardown NOTIFICATION's send a moment to land in the script before reading.
+        for (var i = 0; i < 100; i++)
+        {
+            if (conn.Sent.Select(f => BgpMessageReader.ReadMessage(f)).OfType<BgpNotificationMessage>().Any())
+                break;
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        }
+        return conn.Sent.Select(f => BgpMessageReader.ReadMessage(f)).OfType<BgpNotificationMessage>();
+    }
+
+    private static async Task TeardownAsync(BgpSession session, Task run)
+    {
+        session.MarkSilentClose();
+        try { await run.WaitAsync(TimeSpan.FromSeconds(5)); }
+        catch (OperationCanceledException) { /* expected */ }
+        catch (IOException) { /* expected */ }
+        session.Dispose();
+    }
+}

--- a/BGPLite.Tests/MpAttributeErrorPolicyTests.cs
+++ b/BGPLite.Tests/MpAttributeErrorPolicyTests.cs
@@ -288,6 +288,28 @@ public class MpAttributeErrorPolicyTests
     }
 
     [Fact]
+    public async Task MalformedMpReachV4_ResetsSession_ScopedFallback()
+    {
+        // #472 review, IPv4 half: a supported IPv4/Unicast tuple whose value cannot be decoded
+        // cannot take the disable fallback coherently (the family rides BOTH the classic and
+        // the MP carriage), so the §3(j) fallback is the session reset — with the notification
+        // scoped Malformed Attribute List.
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        conn.EnqueueFrame(UpdateFrame(
+            OriginAsPathAttributes,
+            MpReachAttribute(MpOptionalNonTransitive, ReachValueV4(0xC0000201, 24, 0xC0, 0x00, 0x02))));
+        await SettleAsync(conn, () => routeTable.Count == 1);
+
+        conn.EnqueueFrame(UpdateFrame(MpReachAttribute(MpOptionalNonTransitive,
+            [0x00, 0x01, 0x01, 0x10, 0x20]))); // AFI=1/SAFI=1, truncated next hop
+
+        await AssertResetAsync(session, conn, expectedSubError: BgpConstants.SubError.MalformedAttributeList);
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
     public async Task NonGlobalMpReachNextHop_RoutesExcluded_SessionStaysUp()
     {
         var routeTable = new RouteTable();

--- a/BGPLite.Tests/MpAttributeErrorPolicyTests.cs
+++ b/BGPLite.Tests/MpAttributeErrorPolicyTests.cs
@@ -84,7 +84,7 @@ public class MpAttributeErrorPolicyTests
     public async Task UnsupportedMpFamily_DiscardsTheUpdateOnly_SessionAndFamilyStayUp()
     {
         // #472 review: an AFI/SAFI tuple that was never negotiated (RFC 4760 §8) is not a parse
-        // failure of the SUPPORTED family — the whole UPDATE is discarded through the D17
+        // failure of a SUPPORTED family — the whole UPDATE is discarded through the D17
         // keep-alive path and neither the session nor IPv6/Unicast is touched.
         var routeTable = new RouteTable();
         var (session, run, conn) = await EstablishAsync(routeTable);
@@ -95,7 +95,7 @@ public class MpAttributeErrorPolicyTests
         await SettleAsync(conn, () => routeTable.Count == 1);
 
         conn.EnqueueFrame(UpdateFrame(MpReachAttribute(MpOptionalNonTransitive,
-            [0x00, 0x01, 0x01, 0x04, 0xC0, 0x00, 0x02, 0x01, 0x00]))); // AFI=1/SAFI=1 — unsupported
+            [0x00, 0x03, 0x01, 0x04, 0xC0, 0x00, 0x02, 0x01, 0x00]))); // AFI=3/SAFI=1 — unsupported
         await SettleAsync(conn);
 
         Assert.True(session.IsEstablished, "an unsupported tuple is a keep-alive body error, not a reset");
@@ -106,6 +106,82 @@ public class MpAttributeErrorPolicyTests
             OriginAsPathAttributes,
             MpReachAttribute(MpOptionalNonTransitive, ReachValue(GlobalNextHop, 24, 0x20, 0x01, 0x0D))));
         await SettleAsync(conn, () => routeTable.Count == 2);
+
+        await TeardownAsync(session, run);
+    }
+
+    // ---- #466: MP_REACH/MP_UNREACH AFI=1/SAFI=1 (IPv4/Unicast) ----
+
+    /// <summary>MP_REACH_NLRI (AFI=1/SAFI=1) value: AFI(2) + SAFI(1) + NH-Len(4) + next hop +
+    /// Reserved(1) + classic IPv4 NLRI (length byte + significant address bytes).</summary>
+    private static byte[] ReachValueV4(uint nextHop, byte prefixLength, params byte[] addressBytes)
+    {
+        var value = new List<byte> { 0x00, 0x01, 0x01, 0x04 };
+        value.AddRange([(byte)(nextHop >> 24), (byte)(nextHop >> 16), (byte)(nextHop >> 8), (byte)nextHop]);
+        value.Add(0x00); // reserved
+        value.Add(prefixLength);
+        value.AddRange(addressBytes);
+        return [.. value];
+    }
+
+    [Fact]
+    public async Task MpReachV4_Announcement_InstallsLikeClassicNlri()
+    {
+        // #466 final state: an IPv4 announcement riding MP_REACH installs through the same
+        // pipeline as the classic NLRI field — BIRD negotiates MP_IPV4 by default and may
+        // carry IPv4 unicast this way.
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        conn.EnqueueFrame(UpdateFrame(
+            OriginAsPathAttributes,
+            MpReachAttribute(MpOptionalNonTransitive, ReachValueV4(0xC0000201, 24, 0xC0, 0x00, 0x02))));
+        await SettleAsync(conn, () => routeTable.Count == 1);
+
+        Assert.NotNull(routeTable.Get(0xC0000200, 24, isIpv4: true));
+        Assert.True(session.IsEstablished);
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task MpReachV4_InvalidNextHop_TreatAsWithdraw_KeepsSession()
+    {
+        // RFC 4271 §6.3/§6.8 + RFC 7606 §7.3: the MP-carried IPv4 next hop obeys the classic
+        // NEXT_HOP semantics — a multicast value treats the announcement as withdrawn and
+        // keeps the session up.
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        conn.EnqueueFrame(UpdateFrame(
+            OriginAsPathAttributes,
+            MpReachAttribute(MpOptionalNonTransitive, ReachValueV4(0xE0000001, 24, 0xC0, 0x00, 0x02))));
+        await SettleAsync(conn);
+
+        Assert.Equal(0, routeTable.Count);
+        Assert.True(session.IsEstablished, "treat-as-withdraw keeps the session up");
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task MpUnreachV4_WithdrawsTheRoute()
+    {
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        conn.EnqueueFrame(UpdateFrame(
+            OriginAsPathAttributes,
+            MpReachAttribute(MpOptionalNonTransitive, ReachValueV4(0xC0000201, 24, 0xC0, 0x00, 0x02))));
+        await SettleAsync(conn, () => routeTable.Count == 1);
+
+        // MP_UNREACH (AFI=1/SAFI=1): AFI(2) + SAFI(1) + the withdrawn NLRI.
+        conn.EnqueueFrame(UpdateFrame(
+            MpUnreachAttribute(MpOptionalNonTransitive, [0x00, 0x01, 0x01, 0x18, 0xC0, 0x00, 0x02])));
+        await SettleAsync(conn, () => routeTable.Count == 0);
+
+        Assert.Null(routeTable.Get(0xC0000200, 24, isIpv4: true));
+        Assert.True(session.IsEstablished);
 
         await TeardownAsync(session, run);
     }
@@ -248,6 +324,16 @@ public class MpAttributeErrorPolicyTests
         var attr = new byte[3 + value.Length];
         attr[0] = flags;
         attr[1] = MpReachCodec.MpReachNlriType;
+        attr[2] = (byte)value.Length;
+        value.CopyTo(attr, 3);
+        return attr;
+    }
+
+    private static byte[] MpUnreachAttribute(byte flags, byte[] value)
+    {
+        var attr = new byte[3 + value.Length];
+        attr[0] = flags;
+        attr[1] = MpReachCodec.MpUnreachNlriType;
         attr[2] = (byte)value.Length;
         value.CopyTo(attr, 3);
         return attr;

--- a/BGPLite.Tests/MpReachCodecTests.cs
+++ b/BGPLite.Tests/MpReachCodecTests.cs
@@ -159,4 +159,22 @@ public class MpReachCodecTests
         foreach (var c in hex) value = (value << 4) | (UInt128)Uri.FromHex(c);
         return value;
     }
+
+    /// <summary>
+    /// #467 (RFC 2545 §3): the MP_REACH next hop must be a GLOBAL IPv6 address — ::, ::1,
+    /// ff00::/8 (multicast) and fe80::/10 (link-local) are rejected; global unicast and
+    /// IPv4-mapped representations are accepted.
+    /// </summary>
+    [Theory]
+    [InlineData("00000000000000000000000000000000", false)] // ::
+    [InlineData("00000000000000000000000000000001", false)] // ::1 loopback
+    [InlineData("ff020000000000000000000000000001", false)] // ff02::1 multicast
+    [InlineData("fe800000000000000000000000000001", false)] // fe80::1 link-local
+    [InlineData("20010db8000000000000000000000001", true)]  // 2001:db8::1 global
+    [InlineData("26060670000000000000000000001111", true)]  // global unicast
+    [InlineData("00000000000000000000ffffc0000201", true)]  // ::ffff:192.0.2.1 (mapped, global scope)
+    public void IsGlobalUnicastNextHop_FollowsRfc2545(string hex, bool expected)
+    {
+        Assert.Equal(expected, MpReachCodec.IsGlobalUnicastNextHop(ToV6(hex)));
+    }
 }

--- a/BGPLite.Tests/UserSourceCacheTests.cs
+++ b/BGPLite.Tests/UserSourceCacheTests.cs
@@ -380,4 +380,64 @@ public class UserSourceCacheTests
 
         Assert.Equal(0, cache.TrackedGateCount);   // pre-fix: 5 orphan gates
     }
+
+    /// <summary>
+    /// #468: a waiter cancelled while queued must not split the gate. Pre-fix it pair-removed
+    /// the shared gate instance out from under the still-running first loader, so the NEXT
+    /// caller minted a second gate and fetched the same URL concurrently — and could overwrite
+    /// the newer snapshot with an older one. The cancelled waiter now leaves the gate alone;
+    /// the last leaver removes it.
+    /// </summary>
+    [Fact]
+    public async Task CancelledWaiter_DoesNotSplitTheGate_SecondLoadNeverStartsEarly()
+    {
+        var cache = new UserSourceCache();
+        var holderEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var holderRelease = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var holderCalls = 0;
+
+        Task<IReadOnlyList<IpPrefix>> Holder(CancellationToken ct)
+        {
+            Interlocked.Increment(ref holderCalls);
+            holderEntered.TrySetResult();
+            return holderRelease.Task.ContinueWith<IReadOnlyList<IpPrefix>>(
+                _ => P((1u, (byte)1, true)), CancellationToken.None);
+        }
+
+        // First caller holds the gate, load parked.
+        var holding = cache.GetOrLoadAsync("https://example.com/l", "src", Holder, CancellationToken.None);
+        await holderEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(1, holderCalls);
+
+        // Second caller queues behind the holder, then is cancelled while queued.
+        var queuedCts = new CancellationTokenSource();
+        var queued = Task.Run(() => cache.GetOrLoadAsync("https://example.com/l", "src", Holder, queuedCts.Token));
+        await Task.Delay(50);            // let it queue behind the holder (the #358 test's idiom)
+        queuedCts.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => queued);
+
+        // A third caller arrives while the holder is STILL parked: it must queue on the SAME
+        // gate. Pre-fix the cancelled waiter had removed that gate, so this load started
+        // immediately in parallel with the holder's.
+        var thirdCalls = 0;
+        Task<IReadOnlyList<IpPrefix>> Third(CancellationToken ct)
+        {
+            Interlocked.Increment(ref thirdCalls);
+            return holderRelease.Task.ContinueWith<IReadOnlyList<IpPrefix>>(_ => [], CancellationToken.None);
+        }
+        var third = cache.GetOrLoadAsync("https://example.com/l", "src", Third, CancellationToken.None);
+        await Task.Delay(100);
+        Assert.Equal(0, thirdCalls);     // RED pre-fix: the parallel second fetch ran here
+
+        // Release the holder. The third caller is then served by the holder's just-written
+        // cache entry (the #450 in-gate recheck) — either way its loader must never run: the
+        // whole scenario fetches the URL exactly once.
+        holderRelease.TrySetResult();
+        await Task.WhenAll(holding, third).WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(1, holderCalls);
+        Assert.Equal(0, thirdCalls);               // served from cache — no second fetch ever
+        Assert.Equal(1, cache.TrackedCount);       // exactly one cache write
+        Assert.Equal(0, cache.TrackedGateCount);   // the last leaver took the gate with it
+    }
 }

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -208,10 +208,12 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
   this speaker does not support was never negotiated (RFC 4760 §8), so it only discards its
   UPDATE through the keep-alive path above — the session and the supported family stay
   untouched; a supported tuple whose value cannot be decoded takes the RFC 7606 §3(j)
-  "AFI/SAFI disable" choice — every IPv6 route the session accepted from the peer is withdrawn,
-  the family is ignored for the rest of the session, and the session itself stays up — the
-  route-server rationale above, family-scoped; a value too short to even name its AFI/SAFI
-  cannot be scoped to any family, so the §3(j) fallback is the session reset. Additionally, an
+  "AFI/SAFI disable" choice for IPv6/Unicast — every IPv6 route the session accepted from the
+  peer is withdrawn, the family is ignored for the rest of the session, and the session itself
+  stays up — the route-server rationale above, family-scoped. For IPv4/Unicast (#466 receive)
+  the §3(j) fallback is the session reset: the family rides BOTH the classic and the MP
+  carriage, so disabling only the MP carriage would be incoherent; a value too short to even
+  name its AFI/SAFI cannot be scoped to any family, so it resets too. Additionally, an
   MP_REACH next hop that is not a global IPv6 address (::, ::1, ff00::/8, fe80::/10 — RFC 2545
   §3) excludes that attribute's routes only: route-level exclusion, like the AS-loop rule, not
   a session error.

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -297,3 +297,22 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
   policy. Operators comparing against RFC-strict speakers should know the advertised paths are
   always exactly one ASN long.
 - **Tracker:** #456 (documentation of long-standing behavior, flagged by the 2026-09-03 audit).
+
+### D24. The MP IPv4/Unicast capability is never advertised
+- **Decision:** the OPEN BGPLite sends never carries the Multiprotocol Extensions capability
+  for AFI=1/SAFI=1, regardless of what the peer offers (`BgpSession.SendOpenAsync`).
+  IPv4/Unicast is exchanged via the classic NLRI field only.
+- **Context:** `SendOpenAsync` used to echo the peer's MP IPv4/Unicast offer back. RFC 5492 §3
+  makes a capability usable on a peering only when both sides advertised it, and RFC 4760 §8
+  requires the advertisement to mean the speaker supports that \<AFI, SAFI\> on receive — but
+  the inbound path has no MP_REACH/MP_UNREACH AFI=1 handling at all (`MpReachCodec` accepts
+  AFI=2 only). A conformant peer sending IPv4 NLRI via MP_REACH therefore had every such
+  UPDATE discarded whole (RFC 7606 treat-as-withdraw) with the session looking healthy:
+  negotiated route loss with no diagnostic beyond a Warning log line. Same
+  advertise-without-implementing class as the Graceful Restart case (#318, D6) — the
+  advertisement must not precede the implementation.
+- **Consequence:** a peer that prefers MP carriage for IPv4 falls back to classic NLRI, which
+  is the default family and works unchanged. IPv6/Unicast advertisement is untouched
+  (mirrored when the peer offers it — the AFI=2 receiving half IS implemented). Reintroduce
+  the advertisement only together with an AFI=1 decode path.
+- **Tracker:** #466.

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -315,21 +315,21 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
   always exactly one ASN long.
 - **Tracker:** #456 (documentation of long-standing behavior, flagged by the 2026-09-03 audit).
 
-### D24. The MP IPv4/Unicast capability is never advertised
-- **Decision:** the OPEN BGPLite sends never carries the Multiprotocol Extensions capability
-  for AFI=1/SAFI=1, regardless of what the peer offers (`BgpSession.SendOpenAsync`).
-  IPv4/Unicast is exchanged via the classic NLRI field only.
-- **Context:** `SendOpenAsync` used to echo the peer's MP IPv4/Unicast offer back. RFC 5492 §3
-  makes a capability usable on a peering only when both sides advertised it, and RFC 4760 §8
-  requires the advertisement to mean the speaker supports that \<AFI, SAFI\> on receive — but
-  the inbound path has no MP_REACH/MP_UNREACH AFI=1 handling at all (`MpReachCodec` accepts
-  AFI=2 only). A conformant peer sending IPv4 NLRI via MP_REACH therefore had every such
-  UPDATE discarded whole (RFC 7606 treat-as-withdraw) with the session looking healthy:
-  negotiated route loss with no diagnostic beyond a Warning log line. Same
-  advertise-without-implementing class as the Graceful Restart case (#318, D6) — the
-  advertisement must not precede the implementation.
-- **Consequence:** a peer that prefers MP carriage for IPv4 falls back to classic NLRI, which
-  is the default family and works unchanged. IPv6/Unicast advertisement is untouched
-  (mirrored when the peer offers it — the AFI=2 receiving half IS implemented). Reintroduce
-  the advertisement only together with an AFI=1 decode path.
-- **Tracker:** #466.
+### D24. MP IPv4/Unicast is advertised AND received
+- **Decision:** the OPEN carries the Multiprotocol Extensions capability for AFI=1/SAFI=1
+  unconditionally, and inbound MP_REACH_NLRI / MP_UNREACH_NLRI AFI=1/SAFI=1 decode into the
+  classic IPv4 pipeline: announcements install like classic NLRI (NEXT_HOP semantics applied
+  to the MP-carried next hop), withdrawals remove the peer's routes.
+- **Context:** `SendOpenAsync` used to ECHO the peer's MP IPv4/Unicast offer while the inbound
+  path had no AFI=1 handling — a negotiated IPv4 MP UPDATE was discarded whole
+  (treat-as-withdraw) with the session looking healthy: silent route loss (#466). The interim
+  removal of the advertisement closed the route loss but broke capability-strict peers in
+  return: BIRD 2 with default `capabilities` requires the peer's MP_IPV4 tuple for the ipv4
+  channel ("Required capability missing") and refuses the session — caught by the
+  `compose-integration` stand. The honest fix is both halves: receive AFI=1 AND advertise it.
+- **Consequence:** a conformant peer may carry IPv4 NLRI in MP_REACH on any session; BGPLite
+  installs it through the same ownership/filter/cap pipeline as classic NLRI. Outbound
+  IPv4/Unicast still rides the classic NLRI field. IPv6/Unicast advertisement stays
+  conditional on the peer's offer (its receiving half has existed since #14).
+- **Tracker:** #466 (echo removed 2026-09-03, receive implemented same day after the
+  `compose-integration` finding).

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -203,12 +203,18 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
   policy instead of the paragraph above. A DUPLICATE MP attribute is answered with exactly one
   NOTIFICATION 3/1 (Malformed Attribute List) and a session reset — RFC 7606 §3(g) MUST. An MP
   flags conflict (RFC 4760 §4: both attributes are optional NON-transitive) is a session reset
-  with 3/4 per the RFC 4271 §6.3 baseline. An UNPARSEABLE MP VALUE takes the RFC 7606 §3(j)
-  "AFI/SAFI disable" choice: every IPv6 route the session accepted from the peer is withdrawn,
+  with 3/4 per the RFC 4271 §6.3 baseline (the Partial bit joins the Transitive bit in the
+  conflict mask). An UNPARSEABLE MP VALUE is scoped to the offending AFI/SAFI tuple: a tuple
+  this speaker does not support was never negotiated (RFC 4760 §8), so it only discards its
+  UPDATE through the keep-alive path above — the session and the supported family stay
+  untouched; a supported tuple whose value cannot be decoded takes the RFC 7606 §3(j)
+  "AFI/SAFI disable" choice — every IPv6 route the session accepted from the peer is withdrawn,
   the family is ignored for the rest of the session, and the session itself stays up — the
-  route-server rationale above, family-scoped. Additionally, an MP_REACH next hop that is not
-  a global IPv6 address (::, ::1, ff00::/8, fe80::/10 — RFC 2545 §3) excludes that attribute's
-  routes only: route-level exclusion, like the AS-loop rule, not a session error.
+  route-server rationale above, family-scoped; a value too short to even name its AFI/SAFI
+  cannot be scoped to any family, so the §3(j) fallback is the session reset. Additionally, an
+  MP_REACH next hop that is not a global IPv6 address (::, ::1, ff00::/8, fe80::/10 — RFC 2545
+  §3) excludes that attribute's routes only: route-level exclusion, like the AS-loop rule, not
+  a session error.
 - **Consequence:** a peer sending structurally valid but semantically rejected UPDATEs gets them
   silently dropped (log Warning + `UpdatesRejected` metric) instead of a session reset; operators
   comparing against RFC-strict speakers will see BGPLite retain sessions others would close.

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -198,6 +198,17 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
   Established is an FSM error (NOTIFICATION 5/0, #427) — RFC 4271 §8.2.2 makes ANY OPEN in
   Established an FSM input regardless of body validity, so there is nothing to "keep alive" for
   that message class.
+- **MP carve-out (#467, recorded 2026-09-03):** RFC 7606 explicitly leaves MP_REACH_NLRI and
+  MP_UNREACH_NLRI outside the keep-alive revision, so their failure classes follow their own
+  policy instead of the paragraph above. A DUPLICATE MP attribute is answered with exactly one
+  NOTIFICATION 3/1 (Malformed Attribute List) and a session reset — RFC 7606 §3(g) MUST. An MP
+  flags conflict (RFC 4760 §4: both attributes are optional NON-transitive) is a session reset
+  with 3/4 per the RFC 4271 §6.3 baseline. An UNPARSEABLE MP VALUE takes the RFC 7606 §3(j)
+  "AFI/SAFI disable" choice: every IPv6 route the session accepted from the peer is withdrawn,
+  the family is ignored for the rest of the session, and the session itself stays up — the
+  route-server rationale above, family-scoped. Additionally, an MP_REACH next hop that is not
+  a global IPv6 address (::, ::1, ff00::/8, fe80::/10 — RFC 2545 §3) excludes that attribute's
+  routes only: route-level exclusion, like the AS-loop rule, not a session error.
 - **Consequence:** a peer sending structurally valid but semantically rejected UPDATEs gets them
   silently dropped (log Warning + `UpdatesRejected` metric) instead of a session reset; operators
   comparing against RFC-strict speakers will see BGPLite retain sessions others would close.


### PR DESCRIPTION
Closes #466
Closes #467
Closes #468

## #466 — stop advertising the MP IPv4/Unicast capability (PR #469)
The OPEN echoed a peer's MP IPv4/Unicast (AFI=1/SAFI=1) offer while the inbound path has no MP_REACH/MP_UNREACH AFI=1 handling at all: RFC 5492 §3 / RFC 4760 §8 made the capability usable, and every negotiated IPv4 MP UPDATE was discarded whole (treat-as-withdraw) with the session looking healthy — silent route loss. Fix: never advertise MP IPv4/Unicast (D24, the D6 pattern); IPv4/Unicast rides classic NLRI. Verified: red/green capability test, full suite, CodeQL clean.

## #467 — enforce the RFC error policy for MP_REACH/MP_UNREACH (PR #470)
MP attributes were extracted before the mandatory-attribute pipeline, so RFC 7606's carve-out was bypassed: flags conflicts accepted, duplicates silently discarded, unparseable MP values left stale peer routes in the table. Fix: duplicate MP attribute → NOTIFICATION 3/1 + session reset (RFC 7606 §3(g) MUST); flags conflict → 3/4 + reset (RFC 4271 §6.3 baseline); unparseable MP value → the §3(j) "AFI/SAFI disable" choice (withdraw the peer's accepted IPv6 routes, ignore the family for the session, keep the session up — recorded in D17); MP_REACH next hop must be a global IPv6 address (RFC 2545 §3), otherwise route-level exclusion. Verified: 4/5 new session tests proven red pre-fix, full suite 1065/1065, CodeQL clean.

## #468 — a cancelled waiter must not split the UserSourceCache gate (PR #471)
A waiter cancelled while queued removed the shared per-URL gate out from under the still-running first loader; the next caller minted a second gate and fetched the same URL concurrently, and the older load could overwrite the newer snapshot (different sessions observing different prefix lists). Fix: register in _inflight before taking the gate; the gate is removed by the LAST leaver only — no mid-load removal, #358 orphan hygiene preserved. Verified: red/green concurrency test, both #358 tests unchanged and green, full suite 1066/1066, CodeQL clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added MP_REACH_NLRI and MP_UNREACH_NLRI support for IPv4 and IPv6 unicast routing.
  - IPv4 multiprotocol capability is now advertised automatically.
  - Added address-family-specific route removal and IPv6 next-hop validation.

- **Bug Fixes**
  - Improved malformed multiprotocol attribute handling, including session resets and IPv6 family disablement.
  - IPv4 updates continue processing when IPv6 multiprotocol data is disabled.
  - Prevented duplicate concurrent URL loads after cancellation.

- **Documentation**
  - Documented multiprotocol error handling and IPv4 capability behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->