### PR TITLE
fix(protocol): scope MP error recovery to the AFI/SAFI tuple (#467 review)

### DIFF
--- a/BGPLite.Protocol/BgpMessageReader.cs
+++ b/BGPLite.Protocol/BgpMessageReader.cs
@@ -291,7 +291,13 @@ public static class BgpMessageReader
                 // their shape, so a flags conflict is a session-reset error (3/4), not a discard.
                 if (attr.TypeCode is MpReachCodec.MpReachNlriType or MpReachCodec.MpUnreachNlriType)
                 {
-                    if (!attr.Optional || attr.Transitive)
+                    // RFC 4760 §4/§5 make both attributes OPTIONAL NON-TRANSITIVE; the Partial bit
+                    // is equally invalid on them — a non-transitive attribute is never re-advertised
+                    // by a speaker lacking the family, so nothing can set it (#472 review). The
+                    // Extended Length bit stays legal. RFC 7606 leaves the MP attributes explicitly
+                    // unrevised — the RFC 4271 §6.3 baseline applies to their shape, so a flags
+                    // conflict is a session-reset error (3/4), not a discard.
+                    if (!attr.Optional || attr.Transitive || attr.Partial)
                         throw new BgpParseException(
                             $"MP_REACH/MP_UNREACH flags conflict with optional non-transitive (flags=0x{attr.Flags:X2}, RFC 4760 §4)",
                             BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.AttributeFlagsError,
@@ -307,14 +313,15 @@ public static class BgpMessageReader
                             throw new BgpParseException("Duplicate MP_REACH_NLRI attribute (RFC 7606 §3(g))",
                                 BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList,
                                 sessionResetRequired: true);
+                        ScopeMpValueOrThrow(attr.Data);
                         try
                         {
                             mpReachV6 = MpReachCodec.DecodeMpReachV6(attr.Data);
                         }
                         catch (BgpParseException ex)
                         {
-                            // RFC 7606 §3(j): an unparseable MP value must get "session reset" OR
-                            // "AFI/SAFI disable" — marked for the session's disable policy (D17).
+                            // RFC 7606 §3(j): a SUPPORTED tuple whose value cannot be decoded takes
+                            // the "AFI/SAFI disable" choice, scoped to that family (D17).
                             throw new BgpMpParseException(ex.Message, ex.SubErrorCode, ex);
                         }
                         continue;
@@ -324,6 +331,7 @@ public static class BgpMessageReader
                         throw new BgpParseException("Duplicate MP_UNREACH_NLRI attribute (RFC 7606 §3(g))",
                             BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList,
                             sessionResetRequired: true);
+                    ScopeMpValueOrThrow(attr.Data);
                     try
                     {
                         mpUnreachV6 = MpReachCodec.DecodeMpUnreachV6(attr.Data);
@@ -354,6 +362,31 @@ public static class BgpMessageReader
             MpReachV6 = mpReachV6,
             MpUnreachV6 = mpUnreachV6
         };
+    }
+
+    /// <summary>
+    /// #472 review: scope MP value failures to the offending AFI/SAFI tuple. A value too short
+    /// to name its tuple cannot be scoped to any family — the RFC 7606 §3(j) fallback is the
+    /// session reset. A tuple this speaker does not support was never negotiated (RFC 4760 §8):
+    /// its arrival is not a parse failure of the supported family, so it is answered with a
+    /// plain keep-alive body error — the whole UPDATE is discarded (D17) and the supported
+    /// family stays enabled. Only a supported tuple's decode failure reaches the decoder, whose
+    /// <see cref="BgpMpParseException"/> marks the AFI/SAFI disable.
+    /// </summary>
+    private static void ScopeMpValueOrThrow(ReadOnlySpan<byte> value)
+    {
+        if (value.Length < 3)
+            throw new BgpParseException(
+                $"Truncated MP attribute: {value.Length} byte(s) cannot contain an AFI/SAFI tuple",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList,
+                sessionResetRequired: true);
+
+        var afi = BinaryPrimitives.ReadUInt16BigEndian(value);
+        var safi = value[2];
+        if (afi != MpReachCodec.AfiIpv6 || safi != MpReachCodec.SafiUnicast)
+            throw new BgpParseException(
+                $"MP_REACH/MP_UNREACH for an unsupported address family: AFI={afi}, SAFI={safi}",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
     }
 
     private static (PathAttribute attr, int consumed) ParseAttribute(ReadOnlySpan<byte> data)

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -1275,6 +1275,13 @@ public sealed class BgpSession : IDisposable
     {
         _peerMpV6Disabled = true;
         var flushed = _routeTable.RemoveAllOwnedBy(this, isIpv4: false);
+        // #472 review: RemoveAllOwnedBy does not raise EntryOwnershipLost — this session is not
+        // losing keys to a replacing owner, it is discarding its own — so the per-peer prefix
+        // set must drop the family's keys here, or its cap count keeps drifting for prefixes
+        // the peer no longer has with us.
+        foreach (var key in _installedPrefixes.Keys)
+            if (!key.IsIpv4)
+                _installedPrefixes.TryRemove(key, out _);
         if (flushed > 0)
         {
             _logger.LogInformation(

--- a/BGPLite.Tests/MpAttributeErrorPolicyTests.cs
+++ b/BGPLite.Tests/MpAttributeErrorPolicyTests.cs
@@ -18,7 +18,8 @@ namespace BGPLite.Tests;
 /// session reset (RFC 4271 §6.3 baseline);</item>
 /// <item>an UNPARSEABLE MP value → the §3(j) "AFI/SAFI disable" choice: the peer's accepted
 /// IPv6 routes are withdrawn, the family is ignored for the rest of the session, the session
-/// stays up (recorded in D17);</item>
+/// stays up (recorded in D17) — scoped to the SUPPORTED tuple: an unsupported AFI/SAFI only
+/// discards its UPDATE, and a value too short to name its tuple resets the session;</item>
 /// <item>a non-global MP_REACH next hop (RFC 2545 §3) → that attribute's routes are excluded,
 /// route-level, session up.</item>
 /// </list>
@@ -65,6 +66,84 @@ public class MpAttributeErrorPolicyTests
     }
 
     [Fact]
+    public async Task PartialMpReachFlags_TearDownSession_WithNotification_3_4()
+    {
+        // #472 review: the Partial bit is equally invalid on a non-transitive attribute — nothing
+        // ever re-advertises it un-understood — and joins the RFC 4271 §6.3 baseline reset.
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        var value = ReachValue(GlobalNextHop, 32, 0x20, 0x01, 0x0D, 0xB8);
+        conn.EnqueueFrame(UpdateFrame(MpReachAttribute(BgpConstants.Attribute.FlagOptional | BgpConstants.Attribute.FlagPartial, value)));
+
+        await AssertResetAsync(session, conn, expectedSubError: BgpConstants.SubError.AttributeFlagsError);
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task UnsupportedMpFamily_DiscardsTheUpdateOnly_SessionAndFamilyStayUp()
+    {
+        // #472 review: an AFI/SAFI tuple that was never negotiated (RFC 4760 §8) is not a parse
+        // failure of the SUPPORTED family — the whole UPDATE is discarded through the D17
+        // keep-alive path and neither the session nor IPv6/Unicast is touched.
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        conn.EnqueueFrame(UpdateFrame(
+            OriginAsPathAttributes,
+            MpReachAttribute(MpOptionalNonTransitive, ReachValue(GlobalNextHop, 32, 0x20, 0x01, 0x0D, 0xB8))));
+        await SettleAsync(conn, () => routeTable.Count == 1);
+
+        conn.EnqueueFrame(UpdateFrame(MpReachAttribute(MpOptionalNonTransitive,
+            [0x00, 0x01, 0x01, 0x04, 0xC0, 0x00, 0x02, 0x01, 0x00]))); // AFI=1/SAFI=1 — unsupported
+        await SettleAsync(conn);
+
+        Assert.True(session.IsEstablished, "an unsupported tuple is a keep-alive body error, not a reset");
+        Assert.NotNull(routeTable.Get(DocumentedPrefix, 32, isIpv4: false)); // the accepted route survives
+
+        // The supported family is still enabled: a valid announcement still installs.
+        conn.EnqueueFrame(UpdateFrame(
+            OriginAsPathAttributes,
+            MpReachAttribute(MpOptionalNonTransitive, ReachValue(GlobalNextHop, 24, 0x20, 0x01, 0x0D))));
+        await SettleAsync(conn, () => routeTable.Count == 2);
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task AfterFamilyDisable_ThePrefixCapBudgetIsReturned()
+    {
+        // #472 review: RemoveAllOwnedBy does not raise EntryOwnershipLost (the session is
+        // discarding its OWN keys), so DisablePeerMpV6 must drop the family's keys from the
+        // per-peer prefix set itself — otherwise the cap count drifts and phantom IPv6 keys
+        // consume the budget of real IPv4 announcements.
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable, maxPrefixes: 2);
+
+        conn.EnqueueFrame(UpdateFrame(
+            OriginAsPathAttributes,
+            MpReachAttribute(MpOptionalNonTransitive, ReachValue(GlobalNextHop, 32, 0x20, 0x01, 0x0D, 0xB8))));
+        conn.EnqueueFrame(UpdateFrame(
+            OriginAsPathAttributes,
+            MpReachAttribute(MpOptionalNonTransitive, ReachValue(GlobalNextHop, 24, 0x20, 0x01, 0x0D))));
+        await SettleAsync(conn, () => routeTable.Count == 2);
+
+        conn.EnqueueFrame(UpdateFrame(MpReachAttribute(MpOptionalNonTransitive,
+            [0x00, 0x02, 0x01, 0x10, 0x20, 0x01]))); // supported tuple, truncated → disable
+        await SettleAsync(conn, () => routeTable.Count == 0);
+
+        // The two IPv4 announcements must fit the cap of 2 — the withdrawn IPv6 keys must not
+        // be occupying it.
+        conn.EnqueueFrame(AnnounceFrame(24, 0xC0, 0x00, 0x02));
+        conn.EnqueueFrame(AnnounceFrame(24, 0xC0, 0x00, 0x01));
+        await SettleAsync(conn, () => routeTable.Count == 2);
+
+        Assert.True(session.IsEstablished, "reaching the cap through phantom keys would have reset the session");
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
     public async Task MalformedMpReach_WithdrawsAcceptedV6Routes_KeepsSessionUp()
     {
         var routeTable = new RouteTable();
@@ -79,11 +158,11 @@ public class MpAttributeErrorPolicyTests
         await SettleAsync(conn, () => routeTable.Count == 1);
         Assert.NotNull(routeTable.Get(DocumentedPrefix, 32, isIpv4: false));
 
-        // Now an UPDATE whose MP_REACH VALUE cannot be parsed (AFI=1 — the IPv6-only decoder
-        // rejects it structurally). RFC 7606 §3(j): session reset OR AFI/SAFI disable; BGPLite
-        // disables the family — the stale route must NOT survive the malformed update.
+        // Now an UPDATE whose MP_REACH VALUE cannot be parsed — AFI=2/SAFI=1 (the SUPPORTED
+        // tuple) with a truncated body. RFC 7606 §3(j): session reset OR AFI/SAFI disable;
+        // BGPLite disables the family — the stale route must NOT survive the malformed update.
         conn.EnqueueFrame(UpdateFrame(MpReachAttribute(MpOptionalNonTransitive,
-            [0x00, 0x01, 0x01, 0x04, 0xC0, 0x00, 0x02, 0x01, 0x00]))); // AFI=1, truncated value
+            [0x00, 0x02, 0x01, 0x10, 0x20, 0x01]))); // our AFI/SAFI, truncated next hop
         await SettleAsync(conn, () => routeTable.Count == 0);
 
         Assert.Null(routeTable.Get(DocumentedPrefix, 32, isIpv4: false));
@@ -101,7 +180,7 @@ public class MpAttributeErrorPolicyTests
         var (session, run, conn) = await EstablishAsync(routeTable);
 
         conn.EnqueueFrame(UpdateFrame(MpReachAttribute(MpOptionalNonTransitive,
-            [0x00, 0x01, 0x01, 0x04, 0xC0, 0x00, 0x02, 0x01, 0x00]))); // unparseable → disable
+            [0x00, 0x02, 0x01, 0x10, 0x20, 0x01]))); // supported tuple, truncated → disable
         await SettleAsync(conn);
 
         // A later VALID MP_REACH announcement is ignored: the family is disabled.
@@ -115,6 +194,20 @@ public class MpAttributeErrorPolicyTests
         await SettleAsync(conn, () => routeTable.Count == 1);
         Assert.Equal(1, routeTable.Count);
 
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task UnreadableMpTuple_ResetsSession_CannotBeScopedToAFamily()
+    {
+        // #472 review: a value too short to even name its AFI/SAFI cannot be scoped to a
+        // family, so the RFC 7606 §3(j) fallback is the session reset (NOTIFICATION 3/1).
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        conn.EnqueueFrame(UpdateFrame(MpReachAttribute(MpOptionalNonTransitive, [0x00, 0x02])));
+
+        await AssertResetAsync(session, conn, expectedSubError: BgpConstants.SubError.MalformedAttributeList);
         await TeardownAsync(session, run);
     }
 
@@ -214,10 +307,11 @@ public class MpAttributeErrorPolicyTests
 
     // ---- session lifecycle (the #289 test pattern) ----
 
-    private static async Task<(BgpSession Session, Task Run, ScriptedConnection Conn)> EstablishAsync(RouteTable routeTable)
+    private static async Task<(BgpSession Session, Task Run, ScriptedConnection Conn)> EstablishAsync(
+        RouteTable routeTable, uint routerId = 0x0A000002, int? maxPrefixes = null)
     {
         var conn = new ScriptedConnection();
-        var config = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
+        var config = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0, MaxPrefixesPerPeer = maxPrefixes ?? 0 };
         var session = new BgpSession(
             conn,
             new PeerConfig { Address = "127.0.0.1" },

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -203,12 +203,18 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
   policy instead of the paragraph above. A DUPLICATE MP attribute is answered with exactly one
   NOTIFICATION 3/1 (Malformed Attribute List) and a session reset — RFC 7606 §3(g) MUST. An MP
   flags conflict (RFC 4760 §4: both attributes are optional NON-transitive) is a session reset
-  with 3/4 per the RFC 4271 §6.3 baseline. An UNPARSEABLE MP VALUE takes the RFC 7606 §3(j)
-  "AFI/SAFI disable" choice: every IPv6 route the session accepted from the peer is withdrawn,
+  with 3/4 per the RFC 4271 §6.3 baseline (the Partial bit joins the Transitive bit in the
+  conflict mask). An UNPARSEABLE MP VALUE is scoped to the offending AFI/SAFI tuple: a tuple
+  this speaker does not support was never negotiated (RFC 4760 §8), so it only discards its
+  UPDATE through the keep-alive path above — the session and the supported family stay
+  untouched; a supported tuple whose value cannot be decoded takes the RFC 7606 §3(j)
+  "AFI/SAFI disable" choice — every IPv6 route the session accepted from the peer is withdrawn,
   the family is ignored for the rest of the session, and the session itself stays up — the
-  route-server rationale above, family-scoped. Additionally, an MP_REACH next hop that is not
-  a global IPv6 address (::, ::1, ff00::/8, fe80::/10 — RFC 2545 §3) excludes that attribute's
-  routes only: route-level exclusion, like the AS-loop rule, not a session error.
+  route-server rationale above, family-scoped; a value too short to even name its AFI/SAFI
+  cannot be scoped to any family, so the §3(j) fallback is the session reset. Additionally, an
+  MP_REACH next hop that is not a global IPv6 address (::, ::1, ff00::/8, fe80::/10 — RFC 2545
+  §3) excludes that attribute's routes only: route-level exclusion, like the AS-loop rule, not
+  a session error.
 - **Consequence:** a peer sending structurally valid but semantically rejected UPDATEs gets them
   silently dropped (log Warning + `UpdatesRejected` metric) instead of a session reset; operators
   comparing against RFC-strict speakers will see BGPLite retain sessions others would close.


### PR DESCRIPTION
Follow-up to #467 from the integration review (#472, CodeRabbit). Refines the MP error policy; no issue-number change (the work belongs to #467's scope).

## Changes
1. **Partial bit in the flags mask** — MP_REACH/MP_UNREACH are optional non-transitive (RFC 4760 §4) and nothing can set Partial on a non-transitive attribute; valid flag bytes are now exactly `0x80`/`0x90`. A `Partial` conflict resets the session with 3/4 alongside the Transitive conflict. (Accepted from review.)
2. **Tuple-scoped recovery** — the §3(j) "AFI/SAFI disable" now applies only to a SUPPORTED tuple (AFI=2/SAFI=1) whose value cannot be decoded. A tuple that was never negotiated (RFC 4760 §8) is answered with a keep-alive body error: the whole UPDATE is discarded, the session AND the supported family stay untouched — previously a stray AFI=1 attribute disabled the peer's valid IPv6/Unicast family. A value too short to name its tuple cannot be scoped → the §3(j) fallback is the session reset. (Accepted from review.)
3. **Cap-budget leak after disable** — `RemoveAllOwnedBy` does not raise `EntryOwnershipLost` for self-discarded keys, so `DisablePeerMpV6` now drops the family's keys from `_installedPrefixes` itself; otherwise phantom IPv6 entries consumed the per-peer prefix cap. (Accepted from review.)
4. D17 wording updated to the scoped policy.

## Review findings answered inline on #472
- flags mask / Partial — fixed here
- tuple scoping — fixed here
- `_installedPrefixes` — fixed here
- link-local half of 32-byte next hops — won't-fix (the second 16 bytes are deliberately unconsumed; converting an advisory, ignored field into a family-disable trigger would turn harmless garbage into route loss; the consumed global half IS validated)
- "atomic gate lifecycle" for #468 — won't-fix (already guaranteed by the register-before-take ordering: removal requires count 0, registration precedes GetOrAdd, so no removal can interleave with an arriving participant)

## Verification
- dotnet build BGPLite.sln: 0 errors; dotnet test BGPLite.sln: 1069/1069 passed
- 4 new regression tests: Partial flags → 3/4 reset; unsupported tuple → keep-alive, family still installs; cap budget returned after disable; unreadable tuple → 3/1 reset

## RFC
RFC 7606 §3(g)/§3(j), RFC 4271 §6.3, RFC 4760 §4/§5/§8, RFC 2545 §3.