### PR TITLE
fix(protocol): implement MP IPv4/Unicast receive and advertise the capability (#466)

### DIFF
--- a/BGPLite.Protocol/BgpMessageReader.cs
+++ b/BGPLite.Protocol/BgpMessageReader.cs
@@ -267,6 +267,10 @@ public static class BgpMessageReader
         var attributes = new List<PathAttribute>();
         MpReachCodec.MpReachV6? mpReachV6 = null;
         IReadOnlyList<IpPrefix>? mpUnreachV6 = null;
+        MpReachCodec.MpReachV4? mpReachV4 = null;
+        IReadOnlyList<IpPrefix>? mpUnreachV4 = null;
+        var mpReachSeen = false;
+        var mpUnreachSeen = false;
         if (attrsLen > 0)
         {
             var attrsEnd = offset + attrsLen;
@@ -303,20 +307,28 @@ public static class BgpMessageReader
                             BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.AttributeFlagsError,
                             sessionResetRequired: true);
 
+                    // #466: BOTH supported families decode here — IPv4/Unicast (AFI=1/SAFI=1) into
+                    // the classic NLRI pipeline and IPv6/Unicast (AFI=2/SAFI=1) into MP_REACH_NLRI.
+                    // §3(g) duplicate detection is per ATTRIBUTE TYPE: a second instance of the
+                    // type is a session reset regardless of which family it names.
                     if (attr.TypeCode == MpReachCodec.MpReachNlriType)
                     {
                         // RFC 7606 §3(g): "If the MP_REACH_NLRI attribute or the MP_UNREACH_NLRI
                         // [RFC4760] attribute appears more than once in the UPDATE message then a
                         // NOTIFICATION message MUST be sent with the Error Subcode 'Malformed
                         // Attribute List'." — a session reset, NOT the D17 keep-alive discard.
-                        if (mpReachV6 is not null)
+                        if (mpReachSeen)
                             throw new BgpParseException("Duplicate MP_REACH_NLRI attribute (RFC 7606 §3(g))",
                                 BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList,
                                 sessionResetRequired: true);
-                        ScopeMpValueOrThrow(attr.Data);
+                        mpReachSeen = true;
+                        var reachIsV4 = ScopeMpValueOrThrow(attr.Data);
                         try
                         {
-                            mpReachV6 = MpReachCodec.DecodeMpReachV6(attr.Data);
+                            if (reachIsV4)
+                                mpReachV4 = MpReachCodec.DecodeMpReachV4(attr.Data);
+                            else
+                                mpReachV6 = MpReachCodec.DecodeMpReachV6(attr.Data);
                         }
                         catch (BgpParseException ex)
                         {
@@ -327,14 +339,18 @@ public static class BgpMessageReader
                         continue;
                     }
 
-                    if (mpUnreachV6 is not null)
+                    if (mpUnreachSeen)
                         throw new BgpParseException("Duplicate MP_UNREACH_NLRI attribute (RFC 7606 §3(g))",
                             BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList,
                             sessionResetRequired: true);
-                    ScopeMpValueOrThrow(attr.Data);
+                    mpUnreachSeen = true;
+                    var unreachIsV4 = ScopeMpValueOrThrow(attr.Data);
                     try
                     {
-                        mpUnreachV6 = MpReachCodec.DecodeMpUnreachV6(attr.Data);
+                        if (unreachIsV4)
+                            mpUnreachV4 = MpReachCodec.DecodeMpUnreachV4(attr.Data);
+                        else
+                            mpUnreachV6 = MpReachCodec.DecodeMpUnreachV6(attr.Data);
                     }
                     catch (BgpParseException ex)
                     {
@@ -360,7 +376,9 @@ public static class BgpMessageReader
             PathAttributes = attributes,
             Nlri = nlri,
             MpReachV6 = mpReachV6,
-            MpUnreachV6 = mpUnreachV6
+            MpUnreachV6 = mpUnreachV6,
+            MpReachV4 = mpReachV4,
+            MpUnreachV4 = mpUnreachV4
         };
     }
 
@@ -368,12 +386,12 @@ public static class BgpMessageReader
     /// #472 review: scope MP value failures to the offending AFI/SAFI tuple. A value too short
     /// to name its tuple cannot be scoped to any family — the RFC 7606 §3(j) fallback is the
     /// session reset. A tuple this speaker does not support was never negotiated (RFC 4760 §8):
-    /// its arrival is not a parse failure of the supported family, so it is answered with a
-    /// plain keep-alive body error — the whole UPDATE is discarded (D17) and the supported
-    /// family stays enabled. Only a supported tuple's decode failure reaches the decoder, whose
-    /// <see cref="BgpMpParseException"/> marks the AFI/SAFI disable.
+    /// its arrival is not a parse failure of a supported family, so it is answered with a plain
+    /// keep-alive body error — the whole UPDATE is discarded (D17) and the supported families
+    /// stay enabled. Supported tuples (#466): AFI=1/SAFI=1 and AFI=2/SAFI=1.
     /// </summary>
-    private static void ScopeMpValueOrThrow(ReadOnlySpan<byte> value)
+    /// <returns>true for the IPv4/Unicast tuple, false for IPv6/Unicast.</returns>
+    private static bool ScopeMpValueOrThrow(ReadOnlySpan<byte> value)
     {
         if (value.Length < 3)
             throw new BgpParseException(
@@ -383,10 +401,14 @@ public static class BgpMessageReader
 
         var afi = BinaryPrimitives.ReadUInt16BigEndian(value);
         var safi = value[2];
-        if (afi != MpReachCodec.AfiIpv6 || safi != MpReachCodec.SafiUnicast)
-            throw new BgpParseException(
-                $"MP_REACH/MP_UNREACH for an unsupported address family: AFI={afi}, SAFI={safi}",
-                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
+        if (afi == MpReachCodec.AfiIpv4 && safi == MpReachCodec.SafiUnicast)
+            return true;
+        if (afi == MpReachCodec.AfiIpv6 && safi == MpReachCodec.SafiUnicast)
+            return false;
+
+        throw new BgpParseException(
+            $"MP_REACH/MP_UNREACH for an unsupported address family: AFI={afi}, SAFI={safi}",
+            BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
     }
 
     private static (PathAttribute attr, int consumed) ParseAttribute(ReadOnlySpan<byte> data)

--- a/BGPLite.Protocol/BgpUpdateMessage.cs
+++ b/BGPLite.Protocol/BgpUpdateMessage.cs
@@ -14,4 +14,12 @@ public sealed class BgpUpdateMessage : BgpMessage
     /// <summary>Decoded MP_UNREACH_NLRI (RFC 4760, AFI=2/SAFI=1) IPv6 withdrawals. Null/empty when
     /// the UPDATE carries none.</summary>
     public IReadOnlyList<IpPrefix>? MpUnreachV6 { get; init; }
+
+    /// <summary>Decoded MP_REACH_NLRI (RFC 4760, AFI=1/SAFI=1) IPv4 announcements (#466). Null when
+    /// the UPDATE carries none. Routes ride the same install pipeline as the classic NLRI field.</summary>
+    public MpReachCodec.MpReachV4? MpReachV4 { get; init; }
+
+    /// <summary>Decoded MP_UNREACH_NLRI (RFC 4760, AFI=1/SAFI=1) IPv4 withdrawals (#466). Null/empty
+    /// when the UPDATE carries none.</summary>
+    public IReadOnlyList<IpPrefix>? MpUnreachV4 { get; init; }
 }

--- a/BGPLite.Protocol/MpReachCodec.cs
+++ b/BGPLite.Protocol/MpReachCodec.cs
@@ -24,6 +24,83 @@ public static class MpReachCodec
 
     public readonly record struct MpReachV6(UInt128 NextHop, IReadOnlyList<IpPrefix> Prefixes);
 
+    /// <summary>MP_REACH/MP_UNREACH AFI=1/SAFI=1 (IPv4/Unicast) decode result (#466): the 4-octet
+    /// next hop plus the prefix list — semantically the classic IPv4 NLRI path.</summary>
+    public readonly record struct MpReachV4(uint NextHop, IReadOnlyList<IpPrefix> Prefixes);
+
+    public const ushort AfiIpv4 = (ushort)BgpConstants.Afi.IPv4;
+
+    /// <summary>
+    /// Decodes an MP_REACH_NLRI (type 14) VALUE for IPv4/Unicast (#466): AFI(2) + SAFI(1) +
+    /// NH-Len(1) + a 4-octet next hop + Reserved(1) + classic IPv4 NLRI. A next-hop length other
+    /// than 4 is a parse error (RFC 4760 §5 defines no other form for this family).
+    /// </summary>
+    public static MpReachV4 DecodeMpReachV4(ReadOnlySpan<byte> value)
+    {
+        if (value.Length < 8)
+            throw new BgpParseException(
+                $"Truncated MP_REACH_NLRI (IPv4): have {value.Length} bytes, need at least 8",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
+
+        var afi = BinaryPrimitives.ReadUInt16BigEndian(value);
+        var safi = value[2];
+        if (afi != AfiIpv4 || safi != SafiUnicast)
+            throw new BgpParseException(
+                $"MP_REACH_NLRI for unsupported address family: AFI={afi}, SAFI={safi} (expected 1/1)",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
+
+        var nhLength = value[3];
+        if (nhLength != 4)
+            throw new BgpParseException(
+                $"Invalid MP_REACH_NLRI (IPv4) next-hop length: {nhLength} (must be 4 per RFC 4760 §5)",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList);
+        if (value.Length < 4 + nhLength + 1)
+            throw new BgpParseException(
+                $"Truncated MP_REACH_NLRI next hop: need {nhLength} bytes at offset 4",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
+
+        var nextHop = BinaryPrimitives.ReadUInt32BigEndian(value[4..]);
+
+        // value[4+nhLength] is the Reserved byte — tolerated on receive (see DecodeMpReachV6).
+        var nlriOffset = 4 + nhLength + 1;
+        var prefixes = new List<IpPrefix>();
+        while (nlriOffset < value.Length)
+        {
+            var (prefix, consumed) = PrefixCodec.Decode(value[nlriOffset..]);
+            prefixes.Add(prefix);
+            nlriOffset += consumed;
+        }
+
+        return new MpReachV4(nextHop, prefixes);
+    }
+
+    /// <summary>Decodes an MP_UNREACH_NLRI (type 15) VALUE for IPv4/Unicast (#466):
+    /// AFI(2) + SAFI(1) + the withdrawn classic IPv4 NLRI.</summary>
+    public static IReadOnlyList<IpPrefix> DecodeMpUnreachV4(ReadOnlySpan<byte> value)
+    {
+        if (value.Length < 3)
+            throw new BgpParseException(
+                $"Truncated MP_UNREACH_NLRI (IPv4): have {value.Length} bytes, need at least 3",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
+
+        var afi = BinaryPrimitives.ReadUInt16BigEndian(value);
+        var safi = value[2];
+        if (afi != AfiIpv4 || safi != SafiUnicast)
+            throw new BgpParseException(
+                $"MP_UNREACH_NLRI for unsupported address family: AFI={afi}, SAFI={safi} (expected 1/1)",
+                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.InvalidNetworkField);
+
+        var prefixes = new List<IpPrefix>();
+        var offset = 3;
+        while (offset < value.Length)
+        {
+            var (prefix, consumed) = PrefixCodec.Decode(value[offset..]);
+            prefixes.Add(prefix);
+            offset += consumed;
+        }
+        return prefixes;
+    }
+
     /// <summary>
     /// #467 (RFC 2545 §3): the MP_REACH next hop must be a GLOBAL IPv6 address. Rejects the
     /// unspecified address (::), loopback (::1), multicast (ff00::/8) and link-local

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -1026,10 +1026,13 @@ public sealed class BgpSession : IDisposable
         // wire shape for an IPv6 announcement (RFC 4760 §5) leaves the classic NLRI field EMPTY —
         // gating on Nlri.Count alone silently dropped every such announcement.
         // #467: once the family is disabled (RFC 7606 §3(j) AFI/SAFI disable, below), MP payloads
-        // are ignored — the classic IPv4 half of the UPDATE keeps processing.
+        // are ignored — the classic IPv4 half of the UPDATE keeps processing. The IPv4 MP family
+        // (#466) is never disabled.
         var mpReach = _peerMpV6Disabled ? null : update.MpReachV6;
         var mpUnreach = _peerMpV6Disabled ? null : update.MpUnreachV6;
-        if (update.Nlri.Count > 0 || mpReach is not null)
+        var mpReachV4 = update.MpReachV4;
+        var mpUnreachV4 = update.MpUnreachV4;
+        if (update.Nlri.Count > 0 || mpReach is not null || mpReachV4 is not null)
         {
             // #270: the inbound attribute pipeline (per-attribute validation, mandatory set,
             // AS4_PATH reconstruction, aggregator consistency — subcodes 3/6/8/9/11) lives in the
@@ -1041,7 +1044,7 @@ public sealed class BgpSession : IDisposable
                 // #292 item 1: local router-id for the §6.8 self-address check on NEXT_HOP.
                 attrs = UpdateCodec.ParseRouteAttributes(update, _remoteFourByteAsn,
                     BgpConstants.IPAddressToUint(_bgpConfig.GetRouterIdAddress()),
-                    mpReachV6Present: mpReach is not null);
+                    mpReachV6Present: mpReach is not null || mpReachV4 is not null);
             }
             catch (BgpNotificationException ex) when (ex.ErrorCode == BgpConstants.Error.UpdateMessageError)
             {
@@ -1065,6 +1068,9 @@ public sealed class BgpSession : IDisposable
                 if (mpReach is { } failedReach)
                     foreach (var p in failedReach.Prefixes)
                         WithdrawIfOwned(p, "Route withdrawn (treat-as-withdraw, MP_REACH)");
+                if (mpReachV4 is { } failedReach4)
+                    foreach (var p in failedReach4.Prefixes)
+                        WithdrawIfOwned(p, "Route withdrawn (treat-as-withdraw, MP_REACH IPv4)");
                 _metrics.SetRouteCount(_routeTable.Count);
                 throw;
             }
@@ -1078,13 +1084,17 @@ public sealed class BgpSession : IDisposable
 
             var filterPeerConfig = GetFilterPeerConfig();
 
-            foreach (var nlri in update.Nlri)
+            // Classic IPv4 NLRI and MP_REACH AFI=1 (#466) share the install pipeline — AS-loop
+            // exclusion, filter, cap, ownership — and differ only in where the next hop comes
+            // from (the NEXT_HOP attribute vs the MP_REACH value).
+            void InstallV4Announcement(IpPrefix nlri, uint nextHop)
             {
                 var route = new Route
                 {
                     Prefix = nlri.Address,
                     PrefixLength = nlri.Length,
-                    NextHop = attrs.NextHop,
+                    NextHop = nextHop,
+                    IsIpv4 = true,
                     AsPath = attrs.AsPath,
                     Communities = attrs.Communities,
                     LargeCommunities = attrs.LargeCommunities
@@ -1102,46 +1112,73 @@ public sealed class BgpSession : IDisposable
                     if (_logger.IsEnabled(LogLevel.Debug))
                         _logger.LogDebug("Excluded looping route {Prefix} from {Peer}: local AS {Asn} in AS_PATH",
                             nlri, _peer, _bgpConfig.Asn);
-                    continue;
+                    return;
                 }
 
-                if (_routeFilter.AcceptIncoming(route, filterPeerConfig))
+                if (!_routeFilter.AcceptIncoming(route, filterPeerConfig))
+                    return;
+
+                // #304: per-peer prefix ceiling (RFC 4271 §6.7 / RFC 4486 §2) — counted on the
+                // distinct NLRI this session currently owns; replacements of an owned prefix
+                // do not grow the count, withdrawals shrink it. Exceeding the cap throws
+                // Cease/MaxPrefixesExceeded: deliberately NOT UpdateMessageError, so the read
+                // loop's treat-as-withdraw filter does not swallow it — it unwinds to RunAsync's
+                // BgpNotificationException handler, which sends the NOTIFICATION and tears the
+                // session down (owned routes are flushed by the finally, RFC 4271 §8.2.2).
+                var cap = Volatile.Read(ref _effectiveMaxPrefix);
+                if (cap > 0 && !_installedPrefixes.ContainsKey(nlri) && _installedPrefixes.Count >= cap)
+                    throw new BgpNotificationException(
+                        BgpConstants.Error.Cease, BgpConstants.SubError.CeaseMaxPrefixes,
+                        $"Peer {_peer} exceeded the per-peer prefix limit ({cap}); session reset per RFC 4486");
+                // #377 review: record membership BEFORE publishing — a concurrent takeover
+                // fires EntryOwnershipLost synchronously inside AddOrUpdate, and the handler's
+                // remove would no-op against a key not yet recorded, leaving this session
+                // counting a prefix it no longer owns.
+                _installedPrefixes.TryAdd(nlri, 0);
+
+                // Tagged with this session as the owner, so only this peer's own withdrawal can
+                // remove it (#289). A route the filter dropped is never installed and therefore
+                // never owned, so a later withdrawal for it removes nothing.
+                _routeTable.AddOrUpdate(route, owner: this);
+
+                // #377 review: warn AFTER the install with the actual count — the pre-install
+                // count logged "0/1" for the very first route under cap=1 (threshold floor 0).
+                if (cap > 0 && !_maxPrefixesWarned && _installedPrefixes.Count >= MaxPrefixWarningThreshold(cap))
                 {
-                    // #304: per-peer prefix ceiling (RFC 4271 §6.7 / RFC 4486 §2) — counted on the
-                    // distinct NLRI this session currently owns; replacements of an owned prefix
-                    // do not grow the count, withdrawals shrink it. Exceeding the cap throws
-                    // Cease/MaxPrefixesExceeded: deliberately NOT UpdateMessageError, so the read
-                    // loop's treat-as-withdraw filter does not swallow it — it unwinds to RunAsync's
-                    // BgpNotificationException handler, which sends the NOTIFICATION and tears the
-                    // session down (owned routes are flushed by the finally, RFC 4271 §8.2.2).
-                    var cap = Volatile.Read(ref _effectiveMaxPrefix);
-                    if (cap > 0 && !_installedPrefixes.ContainsKey(nlri) && _installedPrefixes.Count >= cap)
-                        throw new BgpNotificationException(
-                            BgpConstants.Error.Cease, BgpConstants.SubError.CeaseMaxPrefixes,
-                            $"Peer {_peer} exceeded the per-peer prefix limit ({cap}); session reset per RFC 4486");
-                    // #377 review: record membership BEFORE publishing — a concurrent takeover
-                    // fires EntryOwnershipLost synchronously inside AddOrUpdate, and the handler's
-                    // remove would no-op against a key not yet recorded, leaving this session
-                    // counting a prefix it no longer owns.
-                    _installedPrefixes.TryAdd(nlri, 0);
-
-                    // Tagged with this session as the owner, so only this peer's own withdrawal can
-                    // remove it (#289). A route the filter dropped is never installed and therefore
-                    // never owned, so a later withdrawal for it removes nothing.
-                    _routeTable.AddOrUpdate(route, owner: this);
-
-                    // #377 review: warn AFTER the install with the actual count — the pre-install
-                    // count logged "0/1" for the very first route under cap=1 (threshold floor 0).
-                    if (cap > 0 && !_maxPrefixesWarned && _installedPrefixes.Count >= MaxPrefixWarningThreshold(cap))
-                    {
-                        _maxPrefixesWarned = true;
-                        _logger.LogWarning("Peer {Peer} at {Count}/{Cap} of the per-peer prefix limit", _peer, _installedPrefixes.Count, cap);
-                    }
-                    // #85: guard the UintToIPAddress allocation behind IsEnabled — LogDebug
-                    // evaluates the arg eagerly even when Debug is filtered out.
-                    if (_logger.IsEnabled(LogLevel.Debug))
-                        _logger.LogDebug("Route added: {Prefix} via {NextHop}", nlri, BgpConstants.UintToIPAddress(attrs.NextHop));
+                    _maxPrefixesWarned = true;
+                    _logger.LogWarning("Peer {Peer} at {Count}/{Cap} of the per-peer prefix limit", _peer, _installedPrefixes.Count, cap);
                 }
+                // #85: guard the UintToIPAddress allocation behind IsEnabled — LogDebug
+                // evaluates the arg eagerly even when Debug is filtered out.
+                if (_logger.IsEnabled(LogLevel.Debug))
+                    _logger.LogDebug("Route added: {Prefix} via {NextHop}", nlri, BgpConstants.UintToIPAddress(nextHop));
+            }
+
+            foreach (var nlri in update.Nlri)
+                InstallV4Announcement(nlri, attrs.NextHop);
+
+            // #466: MP_REACH_NLRI (AFI=1/SAFI=1) — IPv4 announcements arriving through the MP
+            // path install exactly like the classic NLRI above, with the next hop taken from
+            // INSIDE the attribute. RFC 4271 §6.3/§6.8 NEXT_HOP semantics apply to it as well:
+            // an invalid value treats the announcement as withdrawn (remedy of the classic
+            // NEXT_HOP path, RFC 7606 §7.3) while the session stays up.
+            if (mpReachV4 is { } reach4)
+            {
+                try
+                {
+                    UpdateCodec.ValidateNextHopSemantics(reach4.NextHop,
+                        BgpConstants.IPAddressToUint(_bgpConfig.GetRouterIdAddress()));
+                }
+                catch (BgpNotificationException ex) when (ex.ErrorCode == BgpConstants.Error.UpdateMessageError)
+                {
+                    foreach (var p in reach4.Prefixes)
+                        WithdrawIfOwned(p, "Route withdrawn (treat-as-withdraw, MP_REACH IPv4)");
+                    _metrics.SetRouteCount(_routeTable.Count);
+                    throw;
+                }
+
+                foreach (var nlri in reach4.Prefixes)
+                    InstallV4Announcement(nlri, reach4.NextHop);
             }
 
             // MP_REACH_NLRI (AFI=2/SAFI=1) announcements: same install pipeline as the classic
@@ -1212,6 +1249,14 @@ public sealed class BgpSession : IDisposable
         {
             foreach (var prefix in v6Withdrawn)
                 WithdrawIfOwned(prefix, "Route withdrawn (MP_UNREACH)");
+        }
+
+        // #466: MP_UNREACH_NLRI (AFI=1/SAFI=1) withdraws classic IPv4 routes the peer installed —
+        // same ownership rule. The v6 disable gate does not apply: IPv4 is never disabled.
+        if (mpUnreachV4 is { Count: > 0 } v4Withdrawn)
+        {
+            foreach (var prefix in v4Withdrawn)
+                WithdrawIfOwned(prefix, "Route withdrawn (MP_UNREACH IPv4)");
         }
 
         _metrics.SetRouteCount(_routeTable.Count);
@@ -1763,7 +1808,13 @@ public sealed class BgpSession : IDisposable
     {
         var capabilities = new List<BgpCapabilityInfo>
         {
-            BgpCapabilityInfo.FourOctetAsn(_bgpConfig.Asn)
+            BgpCapabilityInfo.FourOctetAsn(_bgpConfig.Asn),
+            // #466 (D24): MP IPv4/Unicast is advertised UNCONDITIONALLY — the receiving half is
+            // implemented: MP_REACH/MP_UNREACH AFI=1 decode into the classic NLRI pipeline. The
+            // capability-strict peers (BIRD 2 with default `capabilities`) treat the missing
+            // MP_IPV4 tuple as "Required capability missing" and refuse the session, so the
+            // advertisement is also what keeps those peers connected.
+            BgpCapabilityInfo.MultiprotocolIpv4Unicast()
         };
 
         // Only advertise Route Refresh if peer also supports it
@@ -1773,13 +1824,6 @@ public sealed class BgpSession : IDisposable
         // #15 phase 2: advertise MP IPv6/Unicast only when the peer also supports it.
         if (CapabilityHelper.SupportsMultiprotocolIpv6Unicast(remoteOpen))
             capabilities.Add(BgpCapabilityInfo.MultiprotocolIpv6Unicast());
-
-        // #466 (D24): MP IPv4/Unicast is deliberately NOT advertised. RFC 5492 §3 makes a
-        // capability advertised by both peers usable, and RFC 4760 §8 ties the advertisement
-        // to actually supporting that <AFI, SAFI> on receive — but the inbound path has no
-        // MP_REACH/MP_UNREACH AFI=1 handling at all, so the old peer-offer echo turned every
-        // negotiated IPv4 MP UPDATE into a discarded treat-as-withdraw. IPv4/Unicast needs no
-        // MP capability: it is the default family and rides the classic NLRI field.
 
         // #318: the Graceful Restart capability is deliberately NOT advertised. RFC 4724 §4.2 obliges
         // a speaker engaging GR procedures to retain and stale-mark a restarting peer's routes;

--- a/BGPLite.Tests/BgpSessionOpenCapabilityTests.cs
+++ b/BGPLite.Tests/BgpSessionOpenCapabilityTests.cs
@@ -68,14 +68,14 @@ public class BgpSessionOpenCapabilityTests
     }
 
     /// <summary>
-    /// #466: the OPEN BGPLite sends must NOT echo the peer's MP IPv4/Unicast capability
-    /// (code 1, AFI=1/SAFI=1). The inbound path has no MP_REACH/MP_UNREACH AFI=1 handling at
-    /// all, and RFC 5492 §3 / RFC 4760 §8 make a mutually-advertised capability usable — so
-    /// the echo invited the peer to send IPv4 NLRI via MP_REACH, which was then discarded
-    /// whole. D24: the advertisement must not precede the implementation (the D6 pattern).
+    /// #466 (D24, final state): the OPEN advertises MP IPv4/Unicast (code 1, AFI=1/SAFI=1)
+    /// UNCONDITIONALLY. The interim "never advertise" half-measure broke capability-strict
+    /// peers — BIRD 2 with default capabilities answers "Required capability missing" and
+    /// refuses the session — and the receiving half now EXISTS: MP_REACH/MP_UNREACH AFI=1
+    /// decode into the classic IPv4 pipeline.
     /// </summary>
     [Fact]
-    public async Task SentOpen_DoesNotAdvertise_MpIpv4Unicast_EvenWhenPeerOffersIt()
+    public async Task SentOpen_Advertises_MpIpv4Unicast_Unconditionally()
     {
         var conn = new ScriptedConnection();
         var config = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 };
@@ -92,18 +92,14 @@ public class BgpSessionOpenCapabilityTests
         var run = session.RunAsync();
         try
         {
-            // The peer offers MP IPv4/Unicast — the exact trigger of the old conditional echo.
+            // The peer does NOT offer MP IPv4/Unicast — the advertisement is ours alone now.
             conn.EnqueueMessage(new BgpOpenMessage
             {
                 Version = BgpConstants.BgpVersion,
                 Asn = 65002,
                 HoldTime = 0,
                 RouterId = 0x0A000002,
-                Capabilities =
-                [
-                    BgpCapabilityInfo.FourOctetAsn(65002),
-                    BgpCapabilityInfo.MultiprotocolIpv4Unicast(),
-                ],
+                Capabilities = [BgpCapabilityInfo.FourOctetAsn(65002)],
             });
             conn.EnqueueMessage(BgpKeepaliveMessage.Instance);
 
@@ -115,12 +111,13 @@ public class BgpSessionOpenCapabilityTests
             Assert.True(sent.Count > 0, "session must have sent its OPEN");
             var open = Assert.IsType<BgpOpenMessage>(BgpMessageReader.ReadMessage(sent[0]));
 
-            // RED pre-fix: the peer's AFI=1/SAFI=1 offer was echoed back.
-            Assert.DoesNotContain(open.Capabilities, c =>
+            var mpV4 = Assert.Single(open.Capabilities, c =>
                 c.Code == BgpConstants.Capability.Multiprotocol &&
                 c.Data.Length >= 4 && c.Data[0] == 0 && c.Data[1] == 1 && c.Data[3] == BgpConstants.Safi.Unicast);
-            // Sanity: the 4-octet ASN capability — advertised unconditionally — is untouched.
+            Assert.Equal([0x00, 0x01, 0x00, BgpConstants.Safi.Unicast], mpV4.Data);
+            // Sanity: 4-octet ASN still advertised; GR (D6) still not.
             Assert.Contains(open.Capabilities, c => c.Code == BgpConstants.Capability.FourOctetAsn);
+            Assert.DoesNotContain(open.Capabilities, c => c.Code == BgpConstants.Capability.GracefulRestart);
         }
         finally
         {

--- a/BGPLite.Tests/MpAttributeErrorPolicyTests.cs
+++ b/BGPLite.Tests/MpAttributeErrorPolicyTests.cs
@@ -84,7 +84,7 @@ public class MpAttributeErrorPolicyTests
     public async Task UnsupportedMpFamily_DiscardsTheUpdateOnly_SessionAndFamilyStayUp()
     {
         // #472 review: an AFI/SAFI tuple that was never negotiated (RFC 4760 §8) is not a parse
-        // failure of the SUPPORTED family — the whole UPDATE is discarded through the D17
+        // failure of a SUPPORTED family — the whole UPDATE is discarded through the D17
         // keep-alive path and neither the session nor IPv6/Unicast is touched.
         var routeTable = new RouteTable();
         var (session, run, conn) = await EstablishAsync(routeTable);
@@ -95,7 +95,7 @@ public class MpAttributeErrorPolicyTests
         await SettleAsync(conn, () => routeTable.Count == 1);
 
         conn.EnqueueFrame(UpdateFrame(MpReachAttribute(MpOptionalNonTransitive,
-            [0x00, 0x01, 0x01, 0x04, 0xC0, 0x00, 0x02, 0x01, 0x00]))); // AFI=1/SAFI=1 — unsupported
+            [0x00, 0x03, 0x01, 0x04, 0xC0, 0x00, 0x02, 0x01, 0x00]))); // AFI=3/SAFI=1 — unsupported
         await SettleAsync(conn);
 
         Assert.True(session.IsEstablished, "an unsupported tuple is a keep-alive body error, not a reset");
@@ -106,6 +106,82 @@ public class MpAttributeErrorPolicyTests
             OriginAsPathAttributes,
             MpReachAttribute(MpOptionalNonTransitive, ReachValue(GlobalNextHop, 24, 0x20, 0x01, 0x0D))));
         await SettleAsync(conn, () => routeTable.Count == 2);
+
+        await TeardownAsync(session, run);
+    }
+
+    // ---- #466: MP_REACH/MP_UNREACH AFI=1/SAFI=1 (IPv4/Unicast) ----
+
+    /// <summary>MP_REACH_NLRI (AFI=1/SAFI=1) value: AFI(2) + SAFI(1) + NH-Len(4) + next hop +
+    /// Reserved(1) + classic IPv4 NLRI (length byte + significant address bytes).</summary>
+    private static byte[] ReachValueV4(uint nextHop, byte prefixLength, params byte[] addressBytes)
+    {
+        var value = new List<byte> { 0x00, 0x01, 0x01, 0x04 };
+        value.AddRange([(byte)(nextHop >> 24), (byte)(nextHop >> 16), (byte)(nextHop >> 8), (byte)nextHop]);
+        value.Add(0x00); // reserved
+        value.Add(prefixLength);
+        value.AddRange(addressBytes);
+        return [.. value];
+    }
+
+    [Fact]
+    public async Task MpReachV4_Announcement_InstallsLikeClassicNlri()
+    {
+        // #466 final state: an IPv4 announcement riding MP_REACH installs through the same
+        // pipeline as the classic NLRI field — BIRD negotiates MP_IPV4 by default and may
+        // carry IPv4 unicast this way.
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        conn.EnqueueFrame(UpdateFrame(
+            OriginAsPathAttributes,
+            MpReachAttribute(MpOptionalNonTransitive, ReachValueV4(0xC0000201, 24, 0xC0, 0x00, 0x02))));
+        await SettleAsync(conn, () => routeTable.Count == 1);
+
+        Assert.NotNull(routeTable.Get(0xC0000200, 24, isIpv4: true));
+        Assert.True(session.IsEstablished);
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task MpReachV4_InvalidNextHop_TreatAsWithdraw_KeepsSession()
+    {
+        // RFC 4271 §6.3/§6.8 + RFC 7606 §7.3: the MP-carried IPv4 next hop obeys the classic
+        // NEXT_HOP semantics — a multicast value treats the announcement as withdrawn and
+        // keeps the session up.
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        conn.EnqueueFrame(UpdateFrame(
+            OriginAsPathAttributes,
+            MpReachAttribute(MpOptionalNonTransitive, ReachValueV4(0xE0000001, 24, 0xC0, 0x00, 0x02))));
+        await SettleAsync(conn);
+
+        Assert.Equal(0, routeTable.Count);
+        Assert.True(session.IsEstablished, "treat-as-withdraw keeps the session up");
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task MpUnreachV4_WithdrawsTheRoute()
+    {
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        conn.EnqueueFrame(UpdateFrame(
+            OriginAsPathAttributes,
+            MpReachAttribute(MpOptionalNonTransitive, ReachValueV4(0xC0000201, 24, 0xC0, 0x00, 0x02))));
+        await SettleAsync(conn, () => routeTable.Count == 1);
+
+        // MP_UNREACH (AFI=1/SAFI=1): AFI(2) + SAFI(1) + the withdrawn NLRI.
+        conn.EnqueueFrame(UpdateFrame(
+            MpUnreachAttribute(MpOptionalNonTransitive, [0x00, 0x01, 0x01, 0x18, 0xC0, 0x00, 0x02])));
+        await SettleAsync(conn, () => routeTable.Count == 0);
+
+        Assert.Null(routeTable.Get(0xC0000200, 24, isIpv4: true));
+        Assert.True(session.IsEstablished);
 
         await TeardownAsync(session, run);
     }
@@ -248,6 +324,16 @@ public class MpAttributeErrorPolicyTests
         var attr = new byte[3 + value.Length];
         attr[0] = flags;
         attr[1] = MpReachCodec.MpReachNlriType;
+        attr[2] = (byte)value.Length;
+        value.CopyTo(attr, 3);
+        return attr;
+    }
+
+    private static byte[] MpUnreachAttribute(byte flags, byte[] value)
+    {
+        var attr = new byte[3 + value.Length];
+        attr[0] = flags;
+        attr[1] = MpReachCodec.MpUnreachNlriType;
         attr[2] = (byte)value.Length;
         value.CopyTo(attr, 3);
         return attr;

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -315,21 +315,21 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
   always exactly one ASN long.
 - **Tracker:** #456 (documentation of long-standing behavior, flagged by the 2026-09-03 audit).
 
-### D24. The MP IPv4/Unicast capability is never advertised
-- **Decision:** the OPEN BGPLite sends never carries the Multiprotocol Extensions capability
-  for AFI=1/SAFI=1, regardless of what the peer offers (`BgpSession.SendOpenAsync`).
-  IPv4/Unicast is exchanged via the classic NLRI field only.
-- **Context:** `SendOpenAsync` used to echo the peer's MP IPv4/Unicast offer back. RFC 5492 §3
-  makes a capability usable on a peering only when both sides advertised it, and RFC 4760 §8
-  requires the advertisement to mean the speaker supports that \<AFI, SAFI\> on receive — but
-  the inbound path has no MP_REACH/MP_UNREACH AFI=1 handling at all (`MpReachCodec` accepts
-  AFI=2 only). A conformant peer sending IPv4 NLRI via MP_REACH therefore had every such
-  UPDATE discarded whole (RFC 7606 treat-as-withdraw) with the session looking healthy:
-  negotiated route loss with no diagnostic beyond a Warning log line. Same
-  advertise-without-implementing class as the Graceful Restart case (#318, D6) — the
-  advertisement must not precede the implementation.
-- **Consequence:** a peer that prefers MP carriage for IPv4 falls back to classic NLRI, which
-  is the default family and works unchanged. IPv6/Unicast advertisement is untouched
-  (mirrored when the peer offers it — the AFI=2 receiving half IS implemented). Reintroduce
-  the advertisement only together with an AFI=1 decode path.
-- **Tracker:** #466.
+### D24. MP IPv4/Unicast is advertised AND received
+- **Decision:** the OPEN carries the Multiprotocol Extensions capability for AFI=1/SAFI=1
+  unconditionally, and inbound MP_REACH_NLRI / MP_UNREACH_NLRI AFI=1/SAFI=1 decode into the
+  classic IPv4 pipeline: announcements install like classic NLRI (NEXT_HOP semantics applied
+  to the MP-carried next hop), withdrawals remove the peer's routes.
+- **Context:** `SendOpenAsync` used to ECHO the peer's MP IPv4/Unicast offer while the inbound
+  path had no AFI=1 handling — a negotiated IPv4 MP UPDATE was discarded whole
+  (treat-as-withdraw) with the session looking healthy: silent route loss (#466). The interim
+  removal of the advertisement closed the route loss but broke capability-strict peers in
+  return: BIRD 2 with default `capabilities` requires the peer's MP_IPV4 tuple for the ipv4
+  channel ("Required capability missing") and refuses the session — caught by the
+  `compose-integration` stand. The honest fix is both halves: receive AFI=1 AND advertise it.
+- **Consequence:** a conformant peer may carry IPv4 NLRI in MP_REACH on any session; BGPLite
+  installs it through the same ownership/filter/cap pipeline as classic NLRI. Outbound
+  IPv4/Unicast still rides the classic NLRI field. IPv6/Unicast advertisement stays
+  conditional on the peer's offer (its receiving half has existed since #14).
+- **Tracker:** #466 (echo removed 2026-09-03, receive implemented same day after the
+  `compose-integration` finding).


### PR DESCRIPTION
Closes #466 (final state)

## Problem
The `compose-integration` check failed after the interim #466 fix ("never advertise MP IPv4/Unicast"): BIRD 2 with default `capabilities` requires the peer's MP_IPV4 tuple for the ipv4 channel and answers `Error: Required capability missing` — the IPv4 session never establishes. Reproduced locally with the BIRD stand (bird stderr captured). Re-adding the advertisement alone would resurrect the original bug: we still would not accept MP_REACH AFI=1, so a peer preferring MP carriage would silently lose routes again.

## Root Cause
The interim measure fixed the contract violation only from the advertising side. The honest fix — already named as the long-term path in #466 — is to implement the receiving half and advertise for real.

## Fix
- `MpReachCodec.DecodeMpReachV4/DecodeMpUnreachV4` (AFI=1/SAFI=1, 4-octet next hop) and `BgpUpdateMessage.MpReachV4/MpUnreachV4`
- `ParseUpdate` dispatches by tuple: AFI=1 → classic pipeline, AFI=2 → v6, other tuples keep the keep-alive unsupported treatment; duplicate-MP detection is per attribute TYPE (RFC 7606 §3(g)) across families
- `HandleUpdateAsync`: MP-carried IPv4 announcements install through the SAME pipeline as classic NLRI (AS-loop, filter, cap, ownership — shared `InstallV4Announcement`); the MP-carried next hop obeys the classic NEXT_HOP semantics (invalid → treat-as-withdraw, session stays up, RFC 4271 §6.3/§6.8 + RFC 7606 §7.3); MP_UNREACH AFI=1 withdraws
- `SendOpenAsync` advertises MP IPv4/Unicast unconditionally; the v6 AFI/SAFI-disable gate does not affect the IPv4 family
- D24 rewritten to the final decision; #466's advertisement test inverted accordingly

## Correctness
Classic NLRI handling is behavior-identical (the loop moved into a shared local function). The v6 MP error policy from #467/#473 is untouched. MP-carried IPv4 routes obey ownership, so only the peer's own withdrawal removes them.

## Regression Test
- `MpReachV4_Announcement_InstallsLikeClassicNlri`, `MpReachV4_InvalidNextHop_TreatAsWithdraw_KeepsSession`, `MpUnreachV4_WithdrawsTheRoute` (new)
- `SentOpen_Advertises_MpIpv4Unicast_Unconditionally` (inverts the interim test)
- **Integration: `./run-tests.sh` locally — ALL INTEGRATION TESTS PASSED** (bgplite4 + bgplite6 Established, BIRD→server and server→BIRD route exchange), where the same stand FAILED on the interim state
- Full unit suite: 1073/1073

## Verification
- dotnet format (changed files) / dotnet build BGPLite.sln (0 errors) / dotnet test BGPLite.sln: 1073/1073
- local compose-integration reproduction: FAIL before → PASS after

## RFC
RFC 4760 §5 (MP_REACH IPv4/Unicast encoding), RFC 5492 §3, RFC 4271 §6.3/§6.8, RFC 7606 §7.3.

## Behavior Change
BGPLite now advertises MP IPv4/Unicast on every session and accepts IPv4 NLRI carried in MP_REACH/MP_UNREACH AFI=1 (previously discarded whole).

## Deviation from Issue Proposal
This supersedes the interim "never advertise" decision recorded when closing #466 — the issue's own long-term path ("implementing AFI=1 decode") is now implemented because the interim state broke capability-strict peers.