### PR TITLE
fix(protocol): scope the §3(j) MP fallback to the failing AFI/SAFI tuple (#472 review)

### DIFF
--- a/BGPLite.Protocol/BgpMessageReader.cs
+++ b/BGPLite.Protocol/BgpMessageReader.cs
@@ -334,7 +334,7 @@ public static class BgpMessageReader
                         {
                             // RFC 7606 §3(j): a SUPPORTED tuple whose value cannot be decoded takes
                             // the "AFI/SAFI disable" choice, scoped to that family (D17).
-                            throw new BgpMpParseException(ex.Message, ex.SubErrorCode, ex);
+                            throw new BgpMpParseException(ex.Message, reachIsV4, ex.SubErrorCode, ex);
                         }
                         continue;
                     }
@@ -354,7 +354,7 @@ public static class BgpMessageReader
                     }
                     catch (BgpParseException ex)
                     {
-                        throw new BgpMpParseException(ex.Message, ex.SubErrorCode, ex);
+                        throw new BgpMpParseException(ex.Message, unreachIsV4, ex.SubErrorCode, ex);
                     }
                     continue;
                 }
@@ -572,8 +572,13 @@ public class BgpParseException : Exception
 /// </summary>
 public sealed class BgpMpParseException : BgpParseException
 {
-    public BgpMpParseException(string message, byte? subErrorCode = null, Exception? innerException = null)
+    /// <summary>True when the failing tuple was AFI=1/SAFI=1 (IPv4/Unicast), false for
+    /// AFI=2/SAFI=1 — the recovery must be scoped to the offending family (#472 review).</summary>
+    public bool IsIpv4 { get; }
+
+    public BgpMpParseException(string message, bool isIpv4, byte? subErrorCode = null, Exception? innerException = null)
         : base(message, BgpConstants.Error.UpdateMessageError, subErrorCode, innerException: innerException)
     {
+        IsIpv4 = isIpv4;
     }
 }

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -770,16 +770,32 @@ public sealed class BgpSession : IDisposable
             {
                 // #467 (RFC 7606 §3(j)): an MP_REACH/MP_UNREACH value that cannot be parsed is
                 // explicitly OUTSIDE the keep-alive revision — the prescribed response is
-                // "session reset" OR "AFI/SAFI disable". The disable choice is recorded in D17:
-                // withdraw every IPv6 route accepted from this peer, stop accepting the family,
-                // keep the session itself up (a route server must not lose every family over one
-                // malformed attribute — the D17/D2 rationale, family-scoped). No NOTIFICATION:
-                // RFC 4271 §6.3 would make its receiver tear down, defeating the disable choice.
+                // "session reset" OR "AFI/SAFI disable", scoped to the offending family
+                // (#472 review: ex.IsIpv4).
+                // IPv6/Unicast → disable (D17): withdraw the peer's accepted IPv6 routes and
+                // ignore the family for the rest of the session; no NOTIFICATION (RFC 4271 §6.3
+                // would make its receiver tear down, defeating the disable choice).
+                // IPv4/Unicast → session reset. That family rides BOTH the classic and the MP
+                // carriage, so disabling only the MP carriage would be incoherent — the §3(j)
+                // fallback applies.
+                if (!ex.IsIpv4)
+                {
+                    _logger.LogWarning(
+                        "Unparseable MP attribute from {Peer}: {Error}/{SubError} — {Reason}; disabling IPv6/Unicast for this session (RFC 7606 §3(j) AFI/SAFI disable)",
+                        _peer, ex.ErrorCode, ex.SubErrorCode ?? BgpConstants.SubError.Unspecific, ex.Message);
+                    DisablePeerMpV6();
+                    continue;
+                }
+
                 _logger.LogWarning(
-                    "Unparseable MP attribute from {Peer}: {Error}/{SubError} — {Reason}; disabling IPv6/Unicast for this session (RFC 7606 §3(j) AFI/SAFI disable)",
+                    "Unparseable IPv4 MP attribute from {Peer}: {Error}/{SubError} — {Reason}; session reset (RFC 7606 §3(j) fallback)",
                     _peer, ex.ErrorCode, ex.SubErrorCode ?? BgpConstants.SubError.Unspecific, ex.Message);
-                DisablePeerMpV6();
-                continue;
+                if (Interlocked.CompareExchange(ref _teardownReason, (int)TeardownReason.LocalCease, (int)TeardownReason.None) == (int)TeardownReason.None)
+                {
+                    try { await SendNotificationAsync(BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAttributeList); }
+                    catch { /* best-effort — partial write counts, see RFC 4271 §8.1 */ }
+                }
+                return;
             }
             catch (BgpParseException ex) when (ex.SessionResetRequired)
             {

--- a/BGPLite.Tests/MpAttributeErrorPolicyTests.cs
+++ b/BGPLite.Tests/MpAttributeErrorPolicyTests.cs
@@ -288,6 +288,28 @@ public class MpAttributeErrorPolicyTests
     }
 
     [Fact]
+    public async Task MalformedMpReachV4_ResetsSession_ScopedFallback()
+    {
+        // #472 review, IPv4 half: a supported IPv4/Unicast tuple whose value cannot be decoded
+        // cannot take the disable fallback coherently (the family rides BOTH the classic and
+        // the MP carriage), so the §3(j) fallback is the session reset — with the notification
+        // scoped Malformed Attribute List.
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        conn.EnqueueFrame(UpdateFrame(
+            OriginAsPathAttributes,
+            MpReachAttribute(MpOptionalNonTransitive, ReachValueV4(0xC0000201, 24, 0xC0, 0x00, 0x02))));
+        await SettleAsync(conn, () => routeTable.Count == 1);
+
+        conn.EnqueueFrame(UpdateFrame(MpReachAttribute(MpOptionalNonTransitive,
+            [0x00, 0x01, 0x01, 0x10, 0x20]))); // AFI=1/SAFI=1, truncated next hop
+
+        await AssertResetAsync(session, conn, expectedSubError: BgpConstants.SubError.MalformedAttributeList);
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
     public async Task NonGlobalMpReachNextHop_RoutesExcluded_SessionStaysUp()
     {
         var routeTable = new RouteTable();

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -208,10 +208,12 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
   this speaker does not support was never negotiated (RFC 4760 §8), so it only discards its
   UPDATE through the keep-alive path above — the session and the supported family stay
   untouched; a supported tuple whose value cannot be decoded takes the RFC 7606 §3(j)
-  "AFI/SAFI disable" choice — every IPv6 route the session accepted from the peer is withdrawn,
-  the family is ignored for the rest of the session, and the session itself stays up — the
-  route-server rationale above, family-scoped; a value too short to even name its AFI/SAFI
-  cannot be scoped to any family, so the §3(j) fallback is the session reset. Additionally, an
+  "AFI/SAFI disable" choice for IPv6/Unicast — every IPv6 route the session accepted from the
+  peer is withdrawn, the family is ignored for the rest of the session, and the session itself
+  stays up — the route-server rationale above, family-scoped. For IPv4/Unicast (#466 receive)
+  the §3(j) fallback is the session reset: the family rides BOTH the classic and the MP
+  carriage, so disabling only the MP carriage would be incoherent; a value too short to even
+  name its AFI/SAFI cannot be scoped to any family, so it resets too. Additionally, an
   MP_REACH next hop that is not a global IPv6 address (::, ::1, ff00::/8, fe80::/10 — RFC 2545
   §3) excludes that attribute's routes only: route-level exclusion, like the AS-loop rule, not
   a session error.


### PR DESCRIPTION
Final actionable finding from the #472 integration review: `BgpMpParseException` now carries the failing family (`IsIpv4`), and the RFC 7606 §3(j) recovery is scoped to it:

- **IPv6/Unicast** decode failure → unchanged: the AFI/SAFI-disable choice (withdraw the peer's accepted IPv6 routes, ignore the family, session stays up — D17)
- **IPv4/Unicast** decode failure → session reset with NOTIFICATION 3/1: the IPv4 family rides BOTH the classic and the MP carriage, so disabling only the MP carriage would be incoherent — the §3(j) fallback applies

## Verification
- dotnet build 0 errors; full suite 1074/1074
- new regression test `MalformedMpReachV4_ResetsSession_ScopedFallback` (malformed AFI=1 MP_REACH after a valid announcement → NOTIFICATION 3/1 + teardown)

## RFC
RFC 7606 §3(j) (session reset or AFI/SAFI disable, scoped), RFC 4760.

The repeated link-local-half finding remains won't-fix as answered on the PR: the second 16 bytes are deliberately unconsumed and validating them would escalate ignored garbage into route loss.