### PR TITLE
fix(server): carry IsIpv4 through MergeDuplicatePrefixes (#476)

### DIFF
--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -1555,9 +1555,13 @@ public sealed class BgpSession : IDisposable
                 var comms = existing.Communities.Concat(route.Communities).Distinct().OrderBy(c => c).ToArray();
                 var large = existing.LargeCommunities.Concat(route.LargeCommunities).Distinct().ToArray();
                 // Route is a class (init-only props), not a record — mutate via reassignment.
+                // #476: IsIpv4 must be carried over explicitly — the property defaults to true,
+                // and a merged IPv6 duplicate that lost its family bit landed in the IPv4 batch,
+                // where its >32 length crashed the send (or masked down to a bogus 0.0.0.0/N NLRI).
                 merged[key] = new Route
                 {
                     Prefix = existing.Prefix,
+                    IsIpv4 = existing.IsIpv4,
                     PrefixLength = existing.PrefixLength,
                     NextHop = existing.NextHop,
                     AsPath = existing.AsPath,

--- a/BGPLite.Tests/BgpSessionV6AdvertiseTests.cs
+++ b/BGPLite.Tests/BgpSessionV6AdvertiseTests.cs
@@ -136,6 +136,15 @@ public class BgpSessionV6AdvertiseTests
         await TeardownAsync(session, run);
     }
 
+    /// <summary>Serves a fixed outbound route list — the seam for driving SendRoutesAsync with
+    /// inputs the shared RouteTable cannot hold (e.g. cross-community duplicates, #476).</summary>
+    private sealed class StubRouteAssembler(List<Route> routes) : IRouteAssembler
+    {
+        public Task<List<Route>> BuildOutboundRoutesAsync(
+            string peerIp, uint remoteAsn, PeerConfig filterPeerConfig, string peerLabel, CancellationToken ct)
+            => Task.FromResult(routes);
+    }
+
     private static int CountUpdates(ScriptedConnection conn) =>
         conn.Sent.Select(f => BgpMessageReader.ReadMessage(f)).OfType<BgpUpdateMessage>().Count();
 
@@ -281,6 +290,55 @@ public class BgpSessionV6AdvertiseTests
         var eor = await SentUpdatesAsync(conn, u => u.MpUnreachV6 is { Count: 0 });
         var mpEor = Assert.Single(eor, u => u.MpUnreachV6 is { Count: 0 });
         Assert.Empty(mpEor.Nlri);
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task DuplicateV6Prefixes_AcrossCommunitySets_MergeKeepsTheFamily()
+    {
+        // #476: two sources can announce the SAME IPv6 prefix with different community sets (the
+        // aggregator keeps them in separate groups); MergeDuplicatePrefixes then unions them. The
+        // merged route must stay IPv6 — before the fix the family bit was lost, the route landed in
+        // the IPv4 batch and its /48 length crashed the send (AOORE → Cease → teardown on every
+        // connect). The union must ride ONE MP_REACH UPDATE carrying both communities.
+        var routes = new List<Route>
+        {
+            new() { Prefix = V6PrefixNet, IsIpv4 = false, PrefixLength = 48, NextHop = V6NextHop, Communities = [200u] },
+            new() { Prefix = V6PrefixNet, IsIpv4 = false, PrefixLength = 48, NextHop = V6NextHop, Communities = [100u] }
+        };
+        var conn = new ScriptedConnection();
+        var session = new BgpSession(
+            conn,
+            new PeerConfig { Address = "127.0.0.1" },
+            Config(),
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            NullLogger<BgpSession>.Instance,
+            routeAssembler: new StubRouteAssembler(routes));
+        var run = session.RunAsync();
+        conn.EnqueueMessage(new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = 0,
+            RouterId = 0x0A000002,
+            Capabilities = [BgpCapabilityInfo.FourOctetAsn(65002), BgpCapabilityInfo.MultiprotocolIpv6Unicast()]
+        });
+        conn.EnqueueMessage(BgpKeepaliveMessage.Instance);
+        for (var i = 0; i < 200 && !session.IsEstablished; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+
+        var updates = await SentUpdatesAsync(conn, u => u.MpReachV6 is not null);
+        var v6Update = Assert.Single(updates, u => u.MpReachV6 is not null);
+        var pfx = Assert.Single(v6Update.MpReachV6!.Value.Prefixes);
+        Assert.False(pfx.IsIpv4, "the merged duplicate must stay IPv6");
+        Assert.Equal((V6PrefixNet, (byte)48), (pfx.Address, pfx.Length));
+        Assert.Empty(v6Update.Nlri); // never a bogus classic-IPv4 NLRI for a v6 prefix
+        var communityAttr = Assert.Single(v6Update.PathAttributes, a => a.TypeCode == BgpConstants.Attribute.Community);
+        Assert.Equal(new[] { 100u, 200u }, AttributeHelper.ReadCommunities(communityAttr));
+        Assert.True(session.IsEstablished, "the duplicate merge must not tear the session down");
 
         await TeardownAsync(session, run);
     }


### PR DESCRIPTION
Closes #476   # linkage only — the integration PR aggregates the closing keywords

## Problem
An IPv6 prefix announced by two sources with different community sets (RU default + ASN subscription, custom prefix, user source — the aggregator deliberately keeps different community sets in separate groups) is deduplicated by `MergeDuplicatePrefixes`. The merged `Route` was constructed WITHOUT `IsIpv4`, and the property defaults to `true` (`Route.cs:16`) — the merged duplicate came out IPv4.

Consequences on the send path (`new IpPrefix(r.Prefix, r.PrefixLength, r.IsIpv4)`):
- length 33..128 → `ArgumentOutOfRangeException` from the ctor → initial send unwinds to the generic catch → best-effort Cease → teardown → **flap on every reconnect**; refresh path → `WithdrawAllAsync` already ran → peer left with zero routes;
- length 0..32 → no throw; the ctor masks the low 32 bits → **`0.0.0.0/N` announced as classic IPv4 NLRI** for a v6 prefix.

## Root Cause
Initializer omission in the merged-Route reconstruction (`BgpSession.cs` `MergeDuplicatePrefixes`): family is part of the merge KEY but was not part of the merged VALUE.

## Fix
One line: `IsIpv4 = existing.IsIpv4,` (plus a comment). The merge key includes the family, so `existing` and the incoming duplicate always agree — the carried value is by construction the duplicates' own.

## Correctness
- IPv4 duplicates: behavior unchanged (implicit default was already `true`).
- The other carried fields (Prefix/Length/NextHop/AsPath) are untouched.
- No hot-path cost (one property assignment per merged duplicate).

## Regression Test
`BgpSessionV6AdvertiseTests.DuplicateV6Prefixes_AcrossCommunitySets_MergeKeepsTheFamily` — drives the real send path through a stub `IRouteAssembler` returning the same v6 /48 with communities {200} and {100}. Asserts: exactly one MP_REACH UPDATE; the single prefix stays `IsIpv4=false` with the full 128-bit address; no classic NLRI; the COMMUNITY attribute is the ordered union [100,200]; the session stays Established.
**Red/green proven**: fails pre-fix (no MP_REACH frame — the session died in the initial dump), passes post-fix.

## Verification
- `dotnet format` clean; `dotnet build BGPLite.sln` 0 warnings/0 errors
- `dotnet test BGPLite.sln`: 1075/1075 (baseline 1074 + the new test)

## RFC
- RFC 4271 §4.3 (NLRI must encode the announced network) / RFC 4760 §4 (MP_REACH carriage for IPv6 NLRI) — no protocol text change, the fix restores the intended family routing.

## Behavior Change
None beyond the fix: v6 duplicates now reach the peer as one MP_REACH UPDATE instead of crashing the session or injecting a bogus v4 NLRI.

## Deviation from Issue Proposal
None — the one-line fix proposed in #476.