### PR TITLE
fix(config,server,providers): tolerate the documented PrefixSources YAML-null (#477)

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -1712,7 +1712,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (config.RipeStat?.AsnLists is { } lists)
             foreach (var l in lists)
                 known.Add(l.Name);
-        foreach (var source in config.PrefixSources)
+        foreach (var source in config.PrefixSources ?? []) // #477: YAML null = no sources
             known.Add(source.Name);
         return names.Where(n => !known.Contains(n)).Distinct(StringComparer.Ordinal).ToList();
     }

--- a/BGPLite.Providers/PrefixSourceService.cs
+++ b/BGPLite.Providers/PrefixSourceService.cs
@@ -48,7 +48,8 @@ public sealed class PrefixSourceService : IPrefixSourceService
         TimeProvider? timeProvider = null,
         Func<string, Task>? onSourceChanged = null)
     {
-        var duplicate = config.PrefixSources
+        // #477: "PrefixSources:" (YAML null) is a documented-valid "no sources" config.
+        var duplicate = (config.PrefixSources ?? [])
             .GroupBy(s => s.Name)
             .FirstOrDefault(g => g.Count() > 1);
         if (duplicate != null)
@@ -62,7 +63,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
         _negativeTtl = negativeTtl ?? TimeSpan.FromSeconds(30);
         _timeProvider = timeProvider ?? TimeProvider.System;
         _onSourceChanged = onSourceChanged;
-        _sourcesByName = config.PrefixSources.ToDictionary(s => s.Name);
+        _sourcesByName = (config.PrefixSources ?? []).ToDictionary(s => s.Name);
     }
 
     public async Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default)
@@ -122,7 +123,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
     public async Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
     {
         var result = new List<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>();
-        foreach (var source in _config.PrefixSources)
+        foreach (var source in _config.PrefixSources ?? [])
         {
             IReadOnlyList<IpPrefix> prefixes;
             try { prefixes = (await LoadCachedAsync(source, ct)).Prefixes; }

--- a/BGPLite.Server/ConfigCommunityResolver.cs
+++ b/BGPLite.Server/ConfigCommunityResolver.cs
@@ -49,7 +49,9 @@ public sealed class ConfigCommunityResolver : ICommunityResolver
         _asnListCommunities = (config.RipeStat?.AsnLists ?? [])
             .GroupBy(l => l.Name)
             .ToDictionary(g => g.Key, g => g.Last().Community);
-        _prefixSourceCommunities = config.PrefixSources
+        // #477: "PrefixSources:" (YAML null) is a documented-valid "no sources" config — treat it
+        // as empty instead of crashing DI resolution (same idiom as the AsnLists line above).
+        _prefixSourceCommunities = (config.PrefixSources ?? [])
             .ToDictionary(s => s.Name, s => s.Community);
     }
 

--- a/BGPLite.Server/RouteAssembler.cs
+++ b/BGPLite.Server/RouteAssembler.cs
@@ -153,7 +153,7 @@ public sealed class RouteAssembler : IRouteAssembler
 
             // Prefix-source subscriptions: subscribed names that match a configured PrefixSource.
             var resolvedAsRipe = subscribedLists.Select(l => l.Name).ToHashSet();
-            var prefixSources = _appConfig.PrefixSources;
+            var prefixSources = _appConfig.PrefixSources ?? []; // #477: YAML null = no sources
             var sourceNames = subscriptionIds
                 .Where(n => !resolvedAsRipe.Contains(n) && prefixSources.Any(s => s.Name == n))
                 .ToList();

--- a/BGPLite.Tests/PrefixSourceServiceTests.cs
+++ b/BGPLite.Tests/PrefixSourceServiceTests.cs
@@ -1,5 +1,6 @@
 using BGPLite.Configuration;
 using BGPLite.Providers;
+using BGPLite.Server;
 using Microsoft.Extensions.Logging.Abstractions;
 using BGPLite.Protocol;
 
@@ -36,6 +37,22 @@ public class PrefixSourceServiceTests
         foreach (var name in names)
             yaml += $"  - Name: {name}\n    Kind: stub\n";
         return ConfigLoader.LoadFromText(yaml);
+    }
+
+    [Fact]
+    public async Task PrefixSources_YamlNull_ConsumersTolerateTheDocumentedEmpty()
+    {
+        // #477: "PrefixSources:" (YAML null) deserializes as a null list — Validate and
+        // ConfigValidationTests bless it as "no sources", so the startup consumers must treat it
+        // as empty instead of crashing with NRE/ANE (ConfigCommunityResolver previously threw
+        // ArgumentNullException at DI resolution → startup failure on a documented-valid config).
+        var config = ConfigWith();
+
+        var resolver = new ConfigCommunityResolver(config, config.Bgp, logger: null);
+        var service = new PrefixSourceService(
+            config, new PrefixSourceProviderFactory([]), NullLogger<PrefixSourceService>.Instance);
+
+        Assert.Empty(await service.LoadAllAsync());
     }
 
     [Fact]

--- a/BGPLite/PrefixAutoRefreshService.cs
+++ b/BGPLite/PrefixAutoRefreshService.cs
@@ -58,7 +58,7 @@ internal sealed class PrefixAutoRefreshService : IHostedService, IDisposable
         _logger = logger;
         _timeProvider = timeProvider ?? TimeProvider.System;
         _jitterRandom = jitterRandom ?? new Random();
-        _sourceNames = [.. appConfig.PrefixSources.Select(s => s.Name)];
+        _sourceNames = [.. (appConfig.PrefixSources ?? []).Select(s => s.Name)]; // #477: YAML null = no sources
     }
 
     public Task StartAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
Closes #477   # linkage only — the integration PR aggregates the closing keywords

## Problem
`PrefixSources:` (explicit YAML null) deserializes as a null list. `AppConfig.Validate` and `ConfigValidationTests.Validate_ExplicitYamlNullCollections_AreTreatedAsEmpty` bless it as a valid "no sources" config — but `ConfigCommunityResolver`'s ctor called `config.PrefixSources.ToDictionary(...)` without a null guard → **ArgumentNullException at DI resolution → startup crash** on a documented-valid config. Six more consumers dereferenced the same null (RouteAssembler's subscription matching, PrefixSourceService's ctor duplicate-check/dictionary and `LoadAllAsync`, PrefixAutoRefreshService's source-name snapshot, ManagementApi's unknown-subscription filter).

## Root Cause
The property's `= []` default does not survive an explicit YAML null (YamlDotNet overwrites it), and the two consumers named in #477 — plus four more found by grepping all `.PrefixSources` dereferences — trusted the Validate-level "null means none" contract without applying it.

## Fix
The established `?? []` idiom (identical to the adjacent `config.RipeStat?.AsnLists ?? []`) at all seven consumer sites. Post-deserialize normalization in one place is not possible: `AppConfig` exposes `get; init;` on a sealed class, so the null cannot be repaired after construction without changing the public member shape.

## Correctness
- Non-null configs: zero behavior change (`?? []` short-circuits).
- Null configs: every consumer now sees "no sources" — exactly what Validate and the blessing test already promise.
- No API surface change.

## Regression Test
`PrefixSourceServiceTests.PrefixSources_YamlNull_ConsumersTolerateTheDocumentedEmpty` — loads the real YAML shape through `ConfigLoader` ("PrefixSources:" with no value), then constructs the two startup-crashing consumers (`ConfigCommunityResolver`, `PrefixSourceService`) and runs `LoadAllAsync`. **Red/green proven**: fails pre-fix with ArgumentNullException at `ConfigCommunityResolver.cs:52`, passes post-fix.

## Verification
- `dotnet format` clean; `dotnet build BGPLite.sln` 0 warnings/0 errors
- `dotnet test BGPLite.sln`: 1076/1076 (baseline 1075 + the new test)

## RFC
- none — no protocol surface.

## Behavior Change
None for valid configs; the documented-valid null config now starts up instead of crashing.

## Deviation from Issue Proposal
Slightly wider than the issue's two named consumers: the same null is dereferenced in five more places, all in the same class of defect — fixing only two would leave the NRE one refactor away. All seven are mechanical `?? []` coalesces.