### PR TITLE
fix(providers): make UserSourceCache gate bookkeeping one atomic section (#478)

### DIFF
--- a/BGPLite.Providers/UserSourceCache.cs
+++ b/BGPLite.Providers/UserSourceCache.cs
@@ -58,6 +58,13 @@ internal sealed class UserSourceCache
     // still inside or queued — otherwise two gates coexist and two loaders race one URL, with the
     // older response able to overwrite the newer (RipeStatPrefixCache's #267-item-3 invariant).
     private readonly ConcurrentDictionary<string, int> _inflight = new();
+    // #478: serializes the COMPOUND bookkeeping over _inflight and _locks — registration,
+    // last-leaver gate removal, and the sweeps' inflight-check-then-remove. Without it the
+    // decrement→zero-check→gate-removal sequence in ExitInflight could interleave with a fresh
+    // registration, pair-removing a gate its loader still held (duplicate concurrent fetch — the
+    // #468 consequence in a nanosecond window). Never held across an await: the gate Wait/Release
+    // stay outside.
+    private readonly object _gateSync = new();
 
     public UserSourceCache(TimeSpan? positiveTtl = null, TimeSpan? negativeTtl = null, ILogger? logger = null, TimeProvider? timeProvider = null, int? maxCacheEntries = null, long? maxTotalPrefixes = null, int? sweepEvery = null)
     {
@@ -102,9 +109,15 @@ internal sealed class UserSourceCache
         // (now-removed) gate instance but not yet registered, parking it on an orphaned
         // semaphore while the next caller minted a second gate. With this order every
         // participant is counted in _inflight before it can touch _locks, so ExitInflight only
-        // ever removes a gate that nobody holds or queues on.
-        _inflight.AddOrUpdate(url, 1, (_, c) => c + 1);
-        var gate = _locks.GetOrAdd(url, _ => new SemaphoreSlim(1, 1));
+        // ever removes a gate that nobody holds or queues on. #478: register+take run as one
+        // atomic section under _gateSync — the counter bump and the gate lookup must not be
+        // split by a concurrent last-leaver removal.
+        SemaphoreSlim gate;
+        lock (_gateSync)
+        {
+            _inflight.AddOrUpdate(url, 1, (_, c) => c + 1);
+            gate = _locks.GetOrAdd(url, _ => new SemaphoreSlim(1, 1));
+        }
         var entered = false;
         try
         {
@@ -172,17 +185,21 @@ internal sealed class UserSourceCache
     /// hygiene). #468: a cancelled waiter no longer removes the gate directly — that pair-
     /// removed the shared instance out from under the still-running first loader, minted a
     /// second gate for the next caller, and raced a newer load against an older snapshot.
-    /// Removal here can only run when nobody holds or queues on the gate: every participant
-    /// registers in <see cref="_inflight"/> BEFORE taking the gate from <see cref="_locks"/>,
-    /// so a non-zero remaining count means someone else is inside or queued and the gate must
-    /// stay. The sweeps keep their own <c>_inflight &gt; 0</c> guards for the entry-backed path.
+    /// #478: the whole sequence runs as one atomic section under <see cref="_gateSync"/>, with
+    /// registration taking the same lock — the previous unlocked decrement→zero-check→gate-
+    /// removal could interleave with a fresh registration landing between the check and the
+    /// pair-removal, deleting a gate its loader still held (duplicate concurrent fetch,
+    /// last-writer-wins on the cache entry).
     /// </summary>
     private void ExitInflight(string url, SemaphoreSlim gate)
     {
-        var remaining = _inflight.AddOrUpdate(url, 0, (_, c) => c - 1);
-        if (remaining > 0) return;
-        _inflight.TryRemove(new KeyValuePair<string, int>(url, 0));
-        ((ICollection<KeyValuePair<string, SemaphoreSlim>>)_locks).Remove(new KeyValuePair<string, SemaphoreSlim>(url, gate));
+        lock (_gateSync)
+        {
+            var remaining = _inflight.AddOrUpdate(url, 0, (_, c) => c - 1);
+            if (remaining > 0) return;
+            _inflight.TryRemove(new KeyValuePair<string, int>(url, 0));
+            ((ICollection<KeyValuePair<string, SemaphoreSlim>>)_locks).Remove(new KeyValuePair<string, SemaphoreSlim>(url, gate));
+        }
     }
 
     /// <summary>
@@ -223,9 +240,14 @@ internal sealed class UserSourceCache
         foreach (var key in toEvict)
         {
             // #450 review: a URL with active loaders keeps its gate (see SweepIfNeeded).
-            if (_inflight.TryGetValue(key, out var active) && active > 0) continue;
-            if (_cache.TryRemove(key, out _))
-                _locks.TryRemove(key, out _);
+            // #478: inflight-check and gate removal run under _gateSync so a loader registering
+            // between the check and the removal cannot lose its gate to the eviction.
+            lock (_gateSync)
+            {
+                if (_inflight.TryGetValue(key, out var active) && active > 0) continue;
+                if (_cache.TryRemove(key, out _))
+                    _locks.TryRemove(key, out _);
+            }
         }
     }
 
@@ -285,9 +307,13 @@ internal sealed class UserSourceCache
         {
             // #450 review: a URL with active loaders keeps its gate (its loader writes the entry
             // on its own reference) — removing the gate would mint a duplicate concurrent fetch.
-            if (_inflight.TryGetValue(key, out var active) && active > 0) continue;
-            if (_cache.TryRemove(key, out _))
-                _locks.TryRemove(key, out _);
+            // #478: same _gateSync atomicity as EvictIfAtCapacity's removal loop.
+            lock (_gateSync)
+            {
+                if (_inflight.TryGetValue(key, out var active) && active > 0) continue;
+                if (_cache.TryRemove(key, out _))
+                    _locks.TryRemove(key, out _);
+            }
         }
     }
 }

--- a/BGPLite.Tests/UserSourceCacheTests.cs
+++ b/BGPLite.Tests/UserSourceCacheTests.cs
@@ -354,11 +354,61 @@ public class UserSourceCacheTests
         holder.TrySetResult();
         await holding.WaitAsync(TimeSpan.FromSeconds(5));
 
-        // The cancelled caller's pair-remove took the SHARED gate instance (the holder kept
-        // running on its own reference — the accepted duplicate-fetch tradeoff), and nothing
-        // re-adds a gate until the next call: zero gates, one cached entry, no orphan.
+        // The holder is the last participant out, so ExitInflight pair-removes the shared gate
+        // (the cancelled waiter no longer touches it — #468): zero gates, one cached entry,
+        // no orphan.
         Assert.Equal(0, cache.TrackedGateCount);
         Assert.Equal(1, cache.TrackedCount);
+    }
+
+    /// <summary>
+    /// #478: the #468 single-fetch invariant, end-to-end — across a waiter cancelled mid-queue AND
+    /// a caller arriving after it, exactly one loadAsync may run for the URL. Any gate split (the
+    /// cancelled waiter removing the shared gate, or a registration racing the first loader's
+    /// last-leaver exit) manifests as a second concurrent load, which the counting fetcher records
+    /// deterministically: every load blocks on the same release signal, so nobody finishes before
+    /// the assertion point. (The pre-#478 lock-free window between the decrement and the gate
+    /// pair-removal is nanosecond-narrow and cannot be forced from outside; this test pins the
+    /// invariant class, the lock closes the window by construction.)
+    /// </summary>
+    [Fact]
+    public async Task CancelledWaiterThenNewCaller_StillExactlyOneLoad()
+    {
+        var cache = new UserSourceCache();
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource<IReadOnlyList<IpPrefix>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var loads = 0;
+
+        Task<IReadOnlyList<IpPrefix>> BlockingLoad(CancellationToken ct)
+        {
+            Interlocked.Increment(ref loads);
+            entered.TrySetResult();
+            return release.Task.WaitAsync(ct);
+        }
+
+        // Loader A holds the gate.
+        var a = cache.GetOrLoadAsync("https://example.com/l", "src", BlockingLoad, CancellationToken.None);
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Waiter B queues behind A and is cancelled while queued (the #468 trigger).
+        var queuedCts = new CancellationTokenSource();
+        var queued = Task.Run(() => cache.GetOrLoadAsync("https://example.com/l", "src", BlockingLoad, queuedCts.Token));
+        await Task.Delay(50);            // let it queue behind the holder
+        queuedCts.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => queued);
+
+        // Caller C arrives while A is still inside — it must wait on A's gate (or hit the fresh
+        // cache entry after A completes), never start a second load.
+        var c = cache.GetOrLoadAsync("https://example.com/l", "src", BlockingLoad, CancellationToken.None);
+
+        release.TrySetResult(P((0x0A000000, 8, true)));
+        await a.WaitAsync(TimeSpan.FromSeconds(5));
+        var fromC = await c.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(1, loads);
+        Assert.Single(fromC);
+        Assert.Equal(1, cache.TrackedCount);
+        Assert.Equal(0, cache.TrackedGateCount);   // last leaver reclaimed the gate
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #478   # linkage only — the integration PR aggregates the closing keywords

## Problem
`ExitInflight` executed decrement → zero-check → gate pair-removal as three separate steps (`UserSourceCache.cs:180-186`). A fresh registration landing between the decrement and the pair-removal made the `_inflight.TryRemove(url, 0)` fail — but the `_locks.Remove((url, gate))` still ran, deleting the gate the new loader had just taken. The next caller minted a second gate → two loaders inside the "serialized" path concurrently → duplicate upstream fetch + last-writer-wins on the cache entry: exactly the #468 consequence class in a nanosecond window. The two sweep paths (inflight-check-then-remove) had the same check-then-act shape.

## Root Cause
The single-fetch invariant is a compound statement over two dictionaries (`_inflight` + `_locks`), but nothing made the compound atomic. Conditionalizing the removal on `TryRemove` success alone is insufficient — the window just moves to between a SUCCESSFUL `TryRemove` and the `_locks` pair-removal.

## Fix
One private object lock (`_gateSync`) serializes exactly the compound sections: (a) register + take-gate in `GetOrLoadAsync`, (b) decrement + zero-check + `_inflight` remove + gate pair-remove in `ExitInflight`, (c) the inflight-check-then-remove loops in `EvictIfAtCapacity` and `SweepIfNeeded`. The semaphore `WaitAsync`/`Release` stay outside the lock — it is never held across an await, and the sections are a handful of dictionary operations (cold path: cache-miss registration). With registration and removal mutually exclusive, "count reached zero and stayed zero" holds through the gate removal by construction.

## Correctness
- Single-threaded behavior unchanged (lock uncontended).
- The #358 orphan-gate hygiene is preserved (last leaver still removes the gate; `CancelledWhileQueued_DoesNotLeaveAnOrphanGate` and `CancelledFreshUrls_DoNotAccumulateGates` stay green).
- No deadlock surface: single lock, no await inside, no nesting.

## Regression Test
`UserSourceCacheTests.CancelledWaiterThenNewCaller_StillExactlyOneLoad` — loader A blocks inside the fetch on a shared release signal; waiter B queues and is cancelled mid-queue (the #468 trigger); caller C arrives while A is inside. Asserts exactly one `loadAsync` invocation, one cache entry, zero leftover gates — deterministic because every load blocks on the same signal, so any gate split is counted before the assertion point.
**Red/green note:** the pre-fix window (a registration interleaving two adjacent in-method statements) cannot be forced deterministically from outside — the test pins the invariant class and catches any coarser gate split; the lock closes the narrow window by construction (documented in the issue and the PR).

## Verification
- `dotnet format` clean; `dotnet build BGPLite.sln` 0 warnings/0 errors
- `dotnet test BGPLite.sln`: 1077/1077 (baseline 1076 + the new test); `UserSourceCacheTests` run 3× for flake check — stable

## RFC
- none — no protocol surface.

## Behavior Change
None observable for callers; the single-fetch invariant now holds unconditionally.

## Deviation from Issue Proposal
The issue suggested gating the removal on `TryRemove` success — analysis showed that leaves a (smaller) window between a successful `TryRemove` and the `_locks` removal; the lock closes the class instead. The alternative from the issue (never remove gates in the exit path + sweep redesign) is a larger change for the same guarantee.