### PR TITLE
fix(api): keep source URLs with query tokens out of the logs (#479)

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -1250,14 +1250,19 @@ public sealed class ManagementApi : IHostedService, IDisposable
         }
         catch (OperationCanceledException) when (validationCts.IsCancellationRequested)
         {
-            // DNS-resolution timeout (5s).
-            _logger.LogWarning("Save-time URL validation timed out for '{Url}'", SanitizeForLog(data.Url));
+            // DNS-resolution timeout (5s). #479 (#149): source URLs may carry query-string tokens —
+            // the log names the source, never the URL.
+            _logger.LogWarning("Save-time URL validation timed out for source '{Name}'", SanitizeForLog(data.Name));
             return ApiResponse.Error("URL validation timed out (DNS resolution took too long)", 400);
         }
         if (!isValid)
         {
-            _logger.LogWarning("Save-time URL validation rejected '{Url}': {Error}", SanitizeForLog(data.Url), validationError);
-            return ApiResponse.Error($"Invalid URL: the host could not be reached or is not allowed", 400);
+            // #479 (#149): neither the URL nor the validator's message (which embeds it) belongs in
+            // the log. The reason goes to the RESPONSE instead — the operator just submitted this
+            // URL, so echoing it there leaks nothing.
+            _logger.LogWarning("Save-time URL validation rejected source '{Name}' for peer {PeerId}",
+                SanitizeForLog(data.Name), SanitizeForLog(peerId));
+            return ApiResponse.Error($"Invalid URL: {validationError ?? "the host could not be reached or is not allowed"}", 400);
         }
 
         var source = await _store.AddCustomSourceAsync(peerId, data.Name, data.Url, data.Community);
@@ -1266,8 +1271,9 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // same pattern as CreatePeer/UpdatePeer. Pass ASN so shared-IP peers aren't refreshed (#200).
         RequestPeerRefresh(peerId, peer);
 
-        _logger.LogInformation("Added source '{Name}' ({Url}) to peer {PeerId}",
-            SanitizeForLog(data.Name), SanitizeForLog(data.Url), SanitizeForLog(peerId));
+        // #479 (#149): log the source Name, not the URL (query-string tokens are secrets).
+        _logger.LogInformation("Added source '{Name}' to peer {PeerId}",
+            SanitizeForLog(data.Name), SanitizeForLog(peerId));
         return ApiResponse.Ok(new { id = source.Id, name = source.Name, url = source.Url, community = source.Community, active = source.Active });
     }
 

--- a/BGPLite.Tests/ApiHandlerBehaviorTests.cs
+++ b/BGPLite.Tests/ApiHandlerBehaviorTests.cs
@@ -8,6 +8,7 @@ using BGPLite.Providers;
 using BGPLite.Routing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 using BGPLite.Protocol;
@@ -43,7 +44,7 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
         _connection.Dispose();
     }
 
-    private async Task<int> StartAsync(AppConfig template, ISessionManager? sessions = null)
+    private async Task<int> StartAsync(AppConfig template, ISessionManager? sessions = null, ILogger<ManagementApi>? logger = null)
     {
         for (var attempt = 0; ; attempt++)
         {
@@ -61,7 +62,7 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
                 new RouteTable(),
                 config,
                 new BgpMetrics(),
-                NullLogger<ManagementApi>.Instance,
+                logger ?? NullLogger<ManagementApi>.Instance,
                 new InertPrefixService(),
                 new InertPrefixSources(),
                 sessions ?? new InertSessions());
@@ -333,5 +334,35 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
         public void SetPeerMd5Key(string peerIp, string? password) => Md5Keys.Add((peerIp, password));
         public int GetAdvertisedPrefixCount(string peerIp, uint asn) => 0;
         public Task RefreshAllEstablishedAsync() => Task.CompletedTask;
+    }
+
+    /// <summary>Captures formatted log messages so a test can assert what must NEVER be logged (#479).</summary>
+    private sealed class RecordingLogger : ILogger<ManagementApi>
+    {
+        public List<string> Messages { get; } = [];
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            => Messages.Add(formatter(state, exception));
+    }
+
+    [Fact]
+    public async Task AddSource_RejectedUrl_IsNeverLogged()
+    {
+        // #479 (#149): peer-source URLs may carry query-string tokens — the log events around
+        // save-time validation must name the source, never the URL. The loopback host is blocked
+        // by the SSRF validator without any network access, so the rejected path fires offline.
+        var store = new PeerStore(new StaticOptionsFactory(new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(_connection).Options));
+        var id = (await store.SavePeerConfigurationAsync("198.51.100.7", 65090, null, [], [], [])).Id;
+        var logger = new RecordingLogger();
+        _port = await StartAsync(new AppConfig { Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" } }, logger: logger);
+        _client = new HttpClient();
+
+        var body = JsonSerializer.Serialize(new { name = "leaky", url = "http://127.0.0.1:9/list?token=SECRET123" });
+        using var response = await _client.PostAsync($"http://127.0.0.1:{_port}/api/peers/{id}/sources",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);   // the loopback host is rejected
+        Assert.DoesNotContain(logger.Messages, m => m.Contains("SECRET123") || m.Contains("token="));
     }
 }


### PR DESCRIPTION
Closes #479   # linkage only — the integration PR aggregates the closing keywords

## Problem
`HandleAddSource` logged the raw source URL in three events (timeout at `:1254`, rejection at `:1259`, success at `:1270`). `SanitizeForLog` strips control characters and truncates to 200 chars — the query string survives, so `https://host/list?token=SECRET` wrote the token into persistent application logs. The validator's `validationError` (which embeds the URL) was logged verbatim. Direct violation of the #149 policy every other URL-touching site follows (`HttpPrefixProvider`, `UserSourceCache` log the source Name only).

## Root Cause
Three call sites never applied the #149 rule; `SanitizeForLog` was assumed to be a redaction tool, but it is a log-forging defense (control chars + length), not a secret scrubber.

## Fix
- All three events log `data.Name` (+ peer id where useful) instead of the URL.
- The validator's rejection reason moves into the 400 RESPONSE body (`Invalid URL: {validationError}`) — the operator just submitted this URL, so echoing it back leaks nothing; previously the response was generic while the log carried the full URL.

## Correctness
- No functional/API-shape change (same routes, same status codes; the 400 body is now more specific).
- `Md5Password` and all other secret surfaces remain unlogged (grep).

## Regression Test
`ApiHandlerBehaviorTests.AddSource_RejectedUrl_IsNeverLogged` — a real listener + in-memory SQLite harness (extended with an injectable recording logger); POSTs a source whose URL carries `?token=SECRET123` on a loopback host (rejected by the SSRF validator offline, deterministically). Asserts no captured log message contains the token. **Red/green proven**: fails pre-fix (the rejection event logged the URL), passes post-fix.

## Verification
- `dotnet format` clean; `dotnet build BGPLite.sln` 0 warnings/0 errors
- `dotnet test BGPLite.sln`: 1078/1078 (baseline 1077 + the new test)

## RFC
- none — no protocol surface.

## Behavior Change
The 400 response for a rejected URL now includes the validator's specific reason instead of a generic sentence. Log lines no longer name the URL.

## Deviation from Issue Proposal
None.