### PR TITLE
fix(api): degrade /api/asn-lists to the partial response when the fetch budget expires mid-load (#480)

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -1445,20 +1445,31 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         // Append configured PrefixSources (file/http) alongside the legacy RipeStat ASN-lists,
         // reusing the same response shape. "Kind" is intentionally not exposed.
+        // #480: the budget token firing mid-LoadAllAsync surfaces as a foreign-token OCE (live
+        // shutdown token) — without this catch it escaped the handler and closed the connection
+        // without a body, discarding the partial result assembled above. Degrade like the
+        // per-source loops above; the tail warning below reports the budget expiry (both paths).
         var seen = lists.Select(l => l.Name).ToHashSet();
-        foreach (var (source, prefixes) in await _prefixSources.LoadAllAsync(ct))
+        try
         {
-            if (!seen.Add(source.Name)) continue; // skip names already present (e.g. shared "ru")
-            result.Add(new
+            foreach (var (source, prefixes) in await _prefixSources.LoadAllAsync(ct))
             {
-                id = source.Name,
-                Name = source.Name,
-                Description = source.Description,
-                Country = (string?)null,
-                Community = source.Community,
-                prefixCount = prefixes.Count,
-                type = source.Kind == "asn" ? "asn" : "list"
-            });
+                if (!seen.Add(source.Name)) continue; // skip names already present (e.g. shared "ru")
+                result.Add(new
+                {
+                    id = source.Name,
+                    Name = source.Name,
+                    Description = source.Description,
+                    Country = (string?)null,
+                    Community = source.Community,
+                    prefixCount = prefixes.Count,
+                    type = source.Kind == "asn" ? "asn" : "list"
+                });
+            }
+        }
+        catch (OperationCanceledException) when (!_shutdownCts.IsCancellationRequested)
+        {
+            // Budget expiry, not shutdown — serve the partial result (see above).
         }
 
         if (ct.IsCancellationRequested && !_shutdownCts.IsCancellationRequested)

--- a/BGPLite.Tests/ApiHandlerBehaviorTests.cs
+++ b/BGPLite.Tests/ApiHandlerBehaviorTests.cs
@@ -44,7 +44,7 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
         _connection.Dispose();
     }
 
-    private async Task<int> StartAsync(AppConfig template, ISessionManager? sessions = null, ILogger<ManagementApi>? logger = null)
+    private async Task<int> StartAsync(AppConfig template, ISessionManager? sessions = null, ILogger<ManagementApi>? logger = null, IPrefixSourceService? prefixSources = null)
     {
         for (var attempt = 0; ; attempt++)
         {
@@ -54,6 +54,7 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
                 Bgp = template.Bgp,
                 CorsAllowedOrigins = template.CorsAllowedOrigins,
                 ApiRateLimit = template.ApiRateLimit,
+                RipeStat = template.RipeStat,
                 ApiListen = "127.0.0.1",
                 ApiPort = port,
             };
@@ -64,7 +65,7 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
                 new BgpMetrics(),
                 logger ?? NullLogger<ManagementApi>.Instance,
                 new InertPrefixService(),
-                new InertPrefixSources(),
+                prefixSources ?? new InertPrefixSources(),
                 sessions ?? new InertSessions());
             try
             {
@@ -364,5 +365,41 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);   // the loopback host is rejected
         Assert.DoesNotContain(logger.Messages, m => m.Contains("SECRET123") || m.Contains("token="));
+    }
+
+    /// <summary>LoadAllAsync throws a foreign-token OCE — the deterministic stand-in for the
+    /// #424 external-fetch budget firing mid-load (live shutdown token, cancelled budget token).</summary>
+    private sealed class BudgetExhaustedSources : IPrefixSourceService
+    {
+        public event Action<string>? ContentCommitted;
+        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
+            => throw new OperationCanceledException();
+        public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
+        public Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default) => Task.FromResult<(IReadOnlyList<IpPrefix>, bool)>(([], false));
+        public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);
+        public bool SourceSupportsConditional(string sourceName) => false;
+    }
+
+    [Fact]
+    public async Task AsnLists_BudgetExpiryMidSources_ServesPartialJson()
+    {
+        // #480: the budget token firing during LoadAllAsync must degrade to the partial response
+        // (the ASN-list entries collected above), not escape the handler and abort the connection
+        // without a body.
+        _port = await StartAsync(
+            new AppConfig
+            {
+                Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" },
+                RipeStat = new RipeStatConfig { AsnLists = [new AsnList { Name = "ru", Country = "RU", Community = "65000:100" }] }
+            },
+            prefixSources: new BudgetExhaustedSources());
+        _client = new HttpClient();
+
+        using var response = await _client.GetAsync($"http://127.0.0.1:{_port}/api/asn-lists");
+        var body = await response.Content.ReadAsStringAsync();
+
+        Assert.True(response.IsSuccessStatusCode, $"expected a partial response, got {(int)response.StatusCode}");   // RED pre-fix: the connection was aborted (HttpRequestException)
+        Assert.Contains("\"ru\"", body);   // the ASN-list half of the response survived
     }
 }


### PR DESCRIPTION
Closes #480   # linkage only — the integration PR aggregates the closing keywords

## Problem
`HandleAsnLists` awaited `_prefixSources.LoadAllAsync(ct)` unguarded (`ManagementApi.cs:1443`). The per-source fetches inside `LoadAllAsync` degrade correctly on the budget token, but once the 30 s request budget fires, `ct.IsCancellationRequested` is true and `PrefixSourceService`'s caller-cancel filter rethrows — the OCE escaped the handler → not a shutdown cancel → generic catch → **connection closed without a body**, discarding the ASN-list entries already collected. The partial-JSON code right below was dead on exactly the path it was written for.

## Root Cause
The #424 degrade pattern (per-ASN loops in the same handler; `HandleExportPrefixes`) was never applied to the `LoadAllAsync` call.

## Fix
Wrap the `LoadAllAsync` loop in `catch (OperationCanceledException) when (!_shutdownCts.IsCancellationRequested)` → serve the partial result; the existing tail warning reports the budget expiry on both paths. Shutdown cancellation still propagates (same filter shape as every #114/#337/#424 site).

## Correctness
- Shutdown path unchanged (filter rethrows).
- Non-expiry path unchanged.
- One warning per budget expiry (the tail block covers both the degrade-loop path and the new catch path).

## Regression Test
`ApiHandlerBehaviorTests.AsnLists_BudgetExpiryMidSources_ServesPartialJson` — a stub `IPrefixSourceService` whose `LoadAllAsync` throws a foreign-token OCE (the deterministic stand-in for the budget firing mid-load) + one configured ASN list. Asserts HTTP 200 with the "ru" entry present. **Red/green proven**: pre-fix the request ends with the connection aborted (HttpRequestException), post-fix the partial JSON is served.

## Verification
- `dotnet format` clean; `dotnet build BGPLite.sln` 0 warnings/0 errors
- `dotnet test BGPLite.sln`: 1079/1079 (baseline 1078 + the new test)

## RFC
- none — management API only.

## Behavior Change
Budget expiry on `/api/asn-lists` now returns 200 + partial JSON instead of an aborted connection.

## Deviation from Issue Proposal
None.