### PR TITLE
fix(config): ship a bounded MaxPrefixesPerPeer default of 1M (#481)

### DIFF
--- a/BGPLite.Configuration/BgpConfig.cs
+++ b/BGPLite.Configuration/BgpConfig.cs
@@ -88,9 +88,12 @@ public sealed class BgpConfig
     /// <summary>#304: per-peer ceiling on prefixes installed from one session (distinct
     /// NLRI this session currently owns); exceeding it tears the session down with
     /// NOTIFICATION(Cease, MaxPrefixesExceeded) per RFC 4271 §6.7 / RFC 4486 §2.
-    /// 0 = unlimited (the convention of OpenTimeoutSeconds / MaxAcceptsPerIpPerMinute).</summary>
+    /// #481: the shipped default is bounded (1,000,000 — above any legitimate provisioning
+    /// peer, far below memory exhaustion) so the RFC 4486 defense is on out of the box;
+    /// 0 = unlimited remains available as an explicit opt-out (the convention of
+    /// OpenTimeoutSeconds / MaxAcceptsPerIpPerMinute).</summary>
     [YamlMember(Alias = "MaxPrefixesPerPeer")]
-    public int MaxPrefixesPerPeer { get; init; } = 0;
+    public int MaxPrefixesPerPeer { get; init; } = 1_000_000;
 
     public IPAddress GetRouterIdAddress() => IPAddress.Parse(RouterId);
 

--- a/BGPLite.Tests/ConfigValidationTests.cs
+++ b/BGPLite.Tests/ConfigValidationTests.cs
@@ -344,6 +344,15 @@ public class ConfigValidationTests
 
     /// <summary>#304: the per-peer prefix cap validates like the other 0=unlimited knobs.</summary>
     [Fact]
+    public void ShippedMaxPrefixesPerPeerDefault_IsBounded()
+    {
+        // #481: the RFC 4486 defense must be on out of the box — the shipped default is a
+        // generous bound (1M prefixes, above any legitimate provisioning peer, far below memory
+        // exhaustion), not unlimited; 0 remains available as an explicit opt-out.
+        Assert.Equal(1_000_000, new BgpConfig().MaxPrefixesPerPeer);
+    }
+
+    [Fact]
     public void Validate_RejectsNegativeMaxPrefixesPerPeer()
     {
         var config = Config(Bgp(maxPrefixesPerPeer: -1));

--- a/appsettings.Example.yml
+++ b/appsettings.Example.yml
@@ -11,6 +11,8 @@ Bgp:
   # accept throttle. Both have secure, generous defaults; set to 0 to disable either.
   # OpenTimeoutSeconds: 30                 # drop a peer that connects but never sends OPEN (default 30, 0 = off)
   # MaxAcceptsPerIpPerMinute: 60           # per-source-IP accept flood limit (default 60, 0 = off)
+  # MaxPrefixesPerPeer: 1000000            # per-peer prefix ceiling (default 1M; exceeding it resets the
+                                           # session per RFC 4486; 0 = unlimited opt-out)
 
 Peers:
   - Address: 10.0.0.1


### PR DESCRIPTION
Closes #481   # linkage only — the integration PR aggregates the closing keywords

## Problem
The per-peer prefix ceiling (NOTIFICATION Cease/MaxPrefixesExceeded per RFC 4486 §2, per-peer overrides, 75% warning — #304/#391) shipped disabled: `Bgp.MaxPrefixesPerPeer` defaulted to `0` = unlimited. Combined with D11 auto-registration (any Internet speaker that completes OPEN becomes a persisted, served peer), one established session could fill the shared table with unique /24-/32 and /48-/128 prefixes with no bound while connected — a remote memory-pressure DoS out of the box.

## Root Cause
The mechanism's default value, not the mechanism.

## Fix
`MaxPrefixesPerPeer` defaults to `1_000_000` — above any legitimate provisioning peer (BGPLite advertises operator-configured sets, not transit), far below memory exhaustion (~150 MB worst case). `0 = unlimited` remains legal as an explicit opt-out (same convention as OpenTimeoutSeconds / MaxAcceptsPerIpPerMinute). appsettings.Example.yml documents the knob.

## Correctness
- Deployments that set the key explicitly: unchanged.
- Deployments relying on the implicit 0: they now get the protection the knob exists for; a peer exceeding 1M distinct prefixes receives exactly one Cease/MaxPrefixesExceeded (RFC 4486) — the correct signal instead of unbounded growth.
- Enforcement behavior itself is unchanged (covered by the #304 tests).

## Regression Test
`ConfigValidationTests.ShippedMaxPrefixesPerPeerDefault_IsBounded` — asserts the shipped default is 1M. **Red/green proven**: fails pre-change (default 0), passes after.

## Verification
- `dotnet format` clean; `dotnet build BGPLite.sln` 0 warnings/0 errors
- `dotnet test BGPLite.sln`: 1080/1080 (baseline 1079 + the new test)

## RFC
- RFC 4486 §2 (Cease/MaxPrefixesExceeded) — the existing enforcement, now enabled by default.

## Behavior Change
**Yes (the point of the issue):** the effective default cap for deployments that never set `Bgp.MaxPrefixesPerPeer` changes from unlimited to 1,000,000 prefixes per peer. Operators who need unlimited must now set `MaxPrefixesPerPeer: 0` explicitly.

## Deviation from Issue Proposal
None — option (a), the issue's preferred shape.