### PR TITLE
fix(server): guard the four teardown dispose-races in BgpSession (#482)

### DIFF
--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -478,7 +478,15 @@ public sealed class BgpSession : IDisposable
             // Send initial routes. _sendLock is acquired inside SendMessageAsync for byte-level
             // ordering; _advertisedPrefixesLock guards the list across the initial-send vs. a
             // RefreshRoutesAsync fired from the API the instant IsEstablished became true.
-            await _advertisedPrefixesLock.WaitAsync(linkedCts.Token);
+            // #482: the acquire/release are OCE/ODE-guarded exactly like RefreshCycleAsync's —
+            // an external Dispose during the dump otherwise surfaced as an ERROR-logged
+            // "Session error" (WaitAsync on a disposed semaphore / Release after dispose)
+            // instead of a clean unwind.
+            try
+            {
+                await _advertisedPrefixesLock.WaitAsync(linkedCts.Token);
+            }
+            catch (ObjectDisposedException) { return; } // session disposed mid-dump — nothing to send
             try
             {
                 await SendAllRoutesAsync();
@@ -487,7 +495,12 @@ public sealed class BgpSession : IDisposable
                 if (_bgpConfig.GracefulRestart)
                     await SendEndOfRibAsync();
             }
-            finally { _advertisedPrefixesLock.Release(); }
+            finally
+            {
+                try { _advertisedPrefixesLock.Release(); }
+                catch (ObjectDisposedException) { /* session disposed — fine */ }
+                catch (SemaphoreFullException) { /* double-release guard, shouldn't happen */ }
+            }
 
             // Run main loop: read messages + send keepalives
             await RunEstablishedAsync(linkedCts.Token);
@@ -666,7 +679,7 @@ public sealed class BgpSession : IDisposable
         if (_negotiatedHoldTime == 0)
         {
             await ReadLoopAsync(cancellationToken);
-            await _cts.CancelAsync();
+            await CancelSessionCtsAsync();
             return;
         }
 
@@ -677,10 +690,24 @@ public sealed class BgpSession : IDisposable
         var keepaliveTask = HoldTimerLoopAsync(keepaliveTimer, cancellationToken);
 
         await Task.WhenAny(readTask, keepaliveTask);
-        await _cts.CancelAsync();
+        await CancelSessionCtsAsync();
 
         await AwaitLoopTaskAsync(readTask, "read");
         await AwaitLoopTaskAsync(keepaliveTask, "keepalive");
+    }
+
+    /// <summary>
+    /// #482: an external Dispose (API peer deletion / server shutdown) can complete
+    /// <c>_cts.Cancel()</c> + <c>_cts.Dispose()</c> while this session task is still parked on
+    /// <c>Task.WhenAny</c> — <c>CancelAsync</c> on the disposed CTS then throws ObjectDisposedException,
+    /// which escaped to RunAsync's generic catch as an ERROR-logged "Session error" on a routine
+    /// teardown and skipped the loop-task drains. MarkSilentClose/FaultSession already guard the
+    /// synchronous Cancel the same way; unwinding is the goal either way, so the ODE is swallowed.
+    /// </summary>
+    private async Task CancelSessionCtsAsync()
+    {
+        try { await _cts.CancelAsync(); }
+        catch (ObjectDisposedException) { /* session disposed mid-unwind — nothing left to cancel */ }
     }
 
     private async Task AwaitLoopTaskAsync(Task task, string label)
@@ -1368,6 +1395,14 @@ public sealed class BgpSession : IDisposable
     /// </summary>
     private async Task SendAllRoutesAsync()
     {
+        // #482: _cts.Token throws ObjectDisposedException once Dispose has run — a send cycle that
+        // outlives its session otherwise logs a misleading MaxPrefix/refresh failure (a normal
+        // unwind reads as an ERROR). RefreshRoutesAsync guards the same read; capture the token
+        // once and bail quietly on a disposed session.
+        CancellationToken sessionToken;
+        try { sessionToken = _cts.Token; }
+        catch (ObjectDisposedException) { return; }
+
         // #391: refresh the effective per-peer prefix ceiling once per cycle — the peer row's
         // MaxPrefix override when the peer is configured (operator edits apply on the next
         // refresh), else the global default. Unknown peers (auto-register path) read null here
@@ -1379,7 +1414,7 @@ public sealed class BgpSession : IDisposable
             // until some later successful refresh. Keep the last known cap instead.
             try
             {
-                var overrideCap = await _peerStore.GetPeerMaxPrefixAsync(_peerConfig.Address, _remoteAsn, _cts.Token);
+                var overrideCap = await _peerStore.GetPeerMaxPrefixAsync(_peerConfig.Address, _remoteAsn, sessionToken);
                 Volatile.Write(ref _effectiveMaxPrefix, overrideCap ?? _bgpConfig.MaxPrefixesPerPeer);
             }
             catch (OperationCanceledException) when (_cts.IsCancellationRequested) { throw; }
@@ -1393,7 +1428,7 @@ public sealed class BgpSession : IDisposable
 
         var nextHop = BgpConstants.IPAddressToUint(_bgpConfig.GetRouterIdAddress());
         var routes = await _routeAssembler.BuildOutboundRoutesAsync(
-            _peerConfig.Address, _remoteAsn, GetFilterPeerConfig(), _peer, _cts.Token);
+            _peerConfig.Address, _remoteAsn, GetFilterPeerConfig(), _peer, sessionToken);
         if (routes.Count > 0)
             await SendRoutesAsync(nextHop, routes);
     }
@@ -1645,7 +1680,13 @@ public sealed class BgpSession : IDisposable
             return false;
         }
 
-        await SendMessageAsync(update);
+        // #482: a false here means the send was abandoned (session disposed mid-send — the
+        // #341 dispose-wake or a disposed connection), so NOTHING reached the wire: skip the
+        // mirror commit and report unsent, keeping _advertisedPrefixes/_advertisedCount at wire
+        // truth (#212/#457). A truncated-frame abort still throws IOException from the transport
+        // (#285 latch) and never returns false.
+        if (!await SendMessageAsync(update))
+            return false;
         // #430 + #450 review: per-UPDATE mirror commit — SendRouteBatchAsync/SendV6RouteBatchAsync
         // emit one UPDATE per community group, so a group that throws after an earlier group
         // succeeded must not drag the earlier group's mirror entries down (they ARE on the wire)

--- a/BGPLite.Tests/BgpSessionShutdownTests.cs
+++ b/BGPLite.Tests/BgpSessionShutdownTests.cs
@@ -768,4 +768,53 @@ public class BgpSessionShutdownTests
         Assert.True(sw.Elapsed < TimeSpan.FromSeconds(2),
             $"RefreshRoutesAsync with a cancelled token took {sw.ElapsedMilliseconds}ms — token not honored");
     }
+
+    /// <summary>Captures log events so a test can assert what must never surface at ERROR (#482).</summary>
+    private sealed class RecordingLogger : ILogger<BgpSession>
+    {
+        public List<(LogLevel Level, string Message)> Events { get; } = [];
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            => Events.Add((logLevel, formatter(state, exception)));
+    }
+
+    [Fact]
+    public async Task ExternalDisposeDuringEstablished_TearsDownQuietly_NoErrorLog()
+    {
+        // #482: an external Dispose (the API peer-deletion shape) racing the session task's
+        // Task.WhenAny unwind could make CancelAsync throw ObjectDisposedException, which surfaced
+        // as an ERROR-logged "Session error" on a routine teardown and skipped the loop drains.
+        // The ODE window itself is scheduling-dependent (the WhenAny continuation may run inline
+        // inside Cancel() before Dispose reaches _cts.Dispose()), so this test pins the whole
+        // path instead: dispose during Established must complete RunAsync with zero ERROR events.
+        var logger = new RecordingLogger();
+        var conn = new ScriptedConnection();
+        var session = new BgpSession(
+            conn,
+            new PeerConfig { Address = "127.0.0.1" },
+            new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 30, KeepAlive = 10 },
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            logger);
+        var run = session.RunAsync();
+        conn.EnqueueMessage(new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = 30,
+            RouterId = 0x0A000002,
+            Capabilities = []
+        });
+        conn.EnqueueMessage(BgpKeepaliveMessage.Instance);
+        for (var i = 0; i < 200 && !session.IsEstablished; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        Assert.True(session.IsEstablished, "session must reach Established");
+
+        session.Dispose();
+        await run.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.DoesNotContain(logger.Events, e => e.Level == LogLevel.Error);
+    }
 }


### PR DESCRIPTION
Closes #482   # linkage only — the integration PR aggregates the closing keywords

## Problem
Four spots in `BgpSession` let an external `Dispose()` racing the session task's unwind surface as noise or contract violations instead of a clean teardown (details per spot in the issue):
1. `RunEstablishedAsync`'s `await _cts.CancelAsync()` — ODE when the disposer completes `Cancel()+Dispose()` before the WhenAny continuation runs → ERROR-logged "Session error" on routine peer deletion + skipped loop drains (`BgpSession.cs:680`, `:669`).
2. Initial-send `_advertisedPrefixesLock` acquire/release unguarded (`:481`/`:490`) — OCE/ODE → ERROR noise mid-dump (RefreshCycleAsync guards both).
3. `SendAllRoutesAsync` reads `_cts.Token` without the ODE guard (`:1409`, `:1423`) → misleading "Could not resolve the per-peer MaxPrefix override" / "Failed to refresh routes" for a normal unwind.
4. `SendUpdateBatchAsync` discarded `SendMessageAsync`'s bool (`:1648`) → in the dispose window the mirror/`_advertisedCount` recorded prefixes that never reached the wire (a #212/#457 wire-truth hole).

## Root Cause
The dispose-race hygiene established for the send path (#341) and the refresh path was never applied to these four unwind/bookkeeping points; `MarkSilentClose`/`FaultSession` already ODE-guard the synchronous `Cancel()`, so the pattern existed.

## Fix
1. `CancelSessionCtsAsync()` helper wrapping `CancelAsync` in an ODE-catch (both call sites).
2. Mirror RefreshCycleAsync's acquire (ODE → return) / release (ODE+SemaphoreFull) guards on the initial-send block; cancel-OCE still propagates to the normal "SessionClosed (cancelled)" path.
3. Capture the session token once under an ODE guard at the top of `SendAllRoutesAsync`; disposed → return quietly.
4. `if (!await SendMessageAsync(update)) return false;` — false there means dispose-abandoned (the #341 dispose-wake / disposed connection), nothing reached the wire, so nothing is mirrored or counted. A truncated-frame abort still throws IOException from the transport (#285 latch) and never returns false.

## Correctness
- No protocol behavior changes; the exactly-one-NOTIFICATION latch and route flush are untouched (these paths send nothing).
- Semaphore dispose ordering in `Dispose` (cancel before dispose) is load-bearing and unchanged (probed: reverse order hangs parked waiters).
- Spot 4 cannot mask a real send failure: IOException still propagates (RefreshCycleAsync tears down); only the dispose-abandonment path returns false.

## Regression Test
`BgpSessionShutdownTests.ExternalDisposeDuringEstablished_TearsDownQuietly_NoErrorLog` — establishes a scripted session with live timers, disposes it externally, awaits `RunAsync` completion, asserts zero ERROR-level events. **Red/green note (documented per the issue's own analysis):** the ODE window for spot 1 is scheduling-dependent — the WhenAny continuation may run inline inside `Cancel()` before `Dispose()` reaches `_cts.Dispose()` (verified with a raw .NET 10 probe that `CancelAsync` on a cancelled+disposed CTS DOES throw — the interleaving is what varies; on this machine the test is green pre-fix). The test pins the whole dispose-during-Established path (clean completion, no ERROR) and stays stable post-fix; spots 2–4 are nanosecond windows of the same class.

## Verification
- `dotnet format` clean; `dotnet build BGPLite.sln` 0 warnings/0 errors
- `dotnet test BGPLite.sln`: 1080/1080; the new test run 3× for stability

## RFC
- none — teardown hygiene; no wire behavior change.

## Behavior Change
None observable on the wire; fewer misleading ERROR logs, accurate `_advertisedCount` in the dispose window.

## Deviation from Issue Proposal
None — exactly the four spots, one hygiene PR.