### PR TITLE
fix(server): handle the pre-OPEN phase per the FSM — never reply to a NOTIFICATION, 5/0 for other non-OPEN first messages (#483)

### DIFF
--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -368,9 +368,31 @@ public sealed class BgpSession : IDisposable
                 openMessage = await ReceiveMessageAsync(linkedCts.Token);
             }
 
+            if (openMessage is BgpNotificationMessage earlyNotification)
+            {
+                // #483 (RFC 4271 §6.3/§4.5, D8): on receiving a NOTIFICATION, release resources and
+                // close — NEVER reply. Previously this fell into the not-OPEN branch below and
+                // answered 2/0, violating the no-reply rule the OpenConfirm and Established arms
+                // follow. Latch RemoteNotification so the finally-block stays silent too.
+                _logger.LogWarning("NotificationReceived from {Peer} before OPEN: {Error}/{SubError}",
+                    _peer, earlyNotification.ErrorCode, earlyNotification.SubErrorCode);
+                Interlocked.CompareExchange(ref _teardownReason, (int)TeardownReason.RemoteNotification, (int)TeardownReason.None);
+                return;
+            }
+
             if (openMessage is not BgpOpenMessage remoteOpen)
             {
-                await SendNotificationAsync(BgpConstants.Error.OpenMessageError, BgpConstants.SubError.Unspecific);
+                // #483 (RFC 4271 §8.2.2, the #427/#453 class): the handshake phase accepts only
+                // OPEN and NOTIFICATION — any other first message is an FSM error, not an OPEN-body
+                // problem (the previous 2/0 misreported "your OPEN body was malformed"). CAS-latch
+                // the teardown before sending, like every other pre-close NOTIFICATION send.
+                _logger.LogWarning("Unexpected message {Type} from {Peer} before OPEN — FSM error (RFC 4271 §8.2.2)",
+                    openMessage.Type, _peer);
+                if (Interlocked.CompareExchange(ref _teardownReason, (int)TeardownReason.LocalCease, (int)TeardownReason.None) == (int)TeardownReason.None)
+                {
+                    try { await SendNotificationAsync(BgpConstants.Error.FiniteStateMachineError, BgpConstants.SubError.Unspecific); }
+                    catch { /* best-effort — partial write counts, see RFC 4271 §8.1 */ }
+                }
                 return;
             }
 
@@ -464,8 +486,15 @@ public sealed class BgpSession : IDisposable
                         _peer, notif.ErrorCode, notif.SubErrorCode, dataHex);
                     return;
                 default:
-                    _logger.LogError("Unexpected message {Type} from {Peer} in OpenConfirm", response.Type, _peer);
-                    await SendNotificationAsync(BgpConstants.Error.FiniteStateMachineError, BgpConstants.SubError.Unspecific);
+                    // #483: CAS-latch before sending (the #453/#427 shape) — the un-latched send
+                    // let a concurrent replacement's SilentClose be answered with a 5/0.
+                    _logger.LogWarning("Unexpected message {Type} from {Peer} in OpenConfirm — FSM error (RFC 4271 §8.2.2)",
+                        response.Type, _peer);
+                    if (Interlocked.CompareExchange(ref _teardownReason, (int)TeardownReason.LocalCease, (int)TeardownReason.None) == (int)TeardownReason.None)
+                    {
+                        try { await SendNotificationAsync(BgpConstants.Error.FiniteStateMachineError, BgpConstants.SubError.Unspecific); }
+                        catch { /* best-effort — partial write counts, see RFC 4271 §8.1 */ }
+                    }
                     return;
             }
 

--- a/BGPLite.Tests/OpenConfirmFsmErrorTests.cs
+++ b/BGPLite.Tests/OpenConfirmFsmErrorTests.cs
@@ -68,6 +68,64 @@ public sealed class OpenConfirmFsmErrorTests
         await runTask.WaitAsync(TimeSpan.FromSeconds(5));
     }
 
+    [Fact]
+    public async Task NotificationBeforeOpen_IsNeverRepliedTo()
+    {
+        // #483 (RFC 4271 §6.3/§4.5, D8): a peer NOTIFICATION as the FIRST message must close the
+        // session silently. Pre-fix, it fell into the not-OPEN branch and was answered with
+        // NOTIFICATION 2/0 — replying to a NOTIFICATION.
+        var (server, client) = ConnectedPair();
+        using var clientSock = client;
+        using var session = new BgpSession(
+            new SocketBgpConnection(server),
+            new PeerConfig { Address = "127.0.0.1" },
+            new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 },
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            new NopLogger<BgpSession>());
+        var runTask = session.RunAsync();
+
+        Send(client, new BgpNotificationMessage
+        {
+            ErrorCode = BgpConstants.Error.Cease,
+            SubErrorCode = BgpConstants.SubError.Unspecific
+        });
+
+        await runTask.WaitAsync(TimeSpan.FromSeconds(5));
+        var sent = await DrainAsync(client, TimeSpan.FromSeconds(1));
+        Assert.Empty(sent.OfType<BgpNotificationMessage>());   // RED pre-fix: exactly one 2/0 reply
+        Assert.Empty(sent.OfType<BgpOpenMessage>());           // no OPEN is sent after a NOTIFICATION
+    }
+
+    [Fact]
+    public async Task KeepaliveBeforeOpen_IsFsmError_5_0_NotOpenMessageError()
+    {
+        // #483 (RFC 4271 §8.2.2, the #427/#453 class): the handshake accepts only OPEN and
+        // NOTIFICATION — a KEEPALIVE as the first message is an FSM error (5/0), not an
+        // Open Message Error (the previous 2/0 misreported an OPEN-body problem).
+        var (server, client) = ConnectedPair();
+        using var clientSock = client;
+        using var session = new BgpSession(
+            new SocketBgpConnection(server),
+            new PeerConfig { Address = "127.0.0.1" },
+            new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 },
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            new NopLogger<BgpSession>());
+        var runTask = session.RunAsync();
+
+        Send(client, BgpKeepaliveMessage.Instance);
+
+        await runTask.WaitAsync(TimeSpan.FromSeconds(5));
+        var sent = await DrainAsync(client, TimeSpan.FromSeconds(1));
+        var notification = Assert.Single(sent.OfType<BgpNotificationMessage>());
+        Assert.Equal(BgpConstants.Error.FiniteStateMachineError, notification.ErrorCode);   // RED pre-fix: OpenMessageError
+        Assert.Equal(BgpConstants.SubError.Unspecific, notification.SubErrorCode);
+        Assert.False(session.IsEstablished);
+    }
+
     private static (Socket server, Socket client) ConnectedPair()
     {
         using var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);


### PR DESCRIPTION
Closes #483   # linkage only — the integration PR aggregates the closing keywords

## Problem
The first-message branch in `RunAsync` answered every non-OPEN first message with NOTIFICATION 2/0:
1. **A peer NOTIFICATION as the first message got a reply** — violating RFC 4271 §6.3/§4.5 and the project's own D8 ("a peer NOTIFICATION is never replied to") — the OpenConfirm arm right below and the Established arm both handle it correctly (log + silent close).
2. **KEEPALIVE/UPDATE/ROUTE_REFRESH as the first message was answered 2/0** (Open Message Error) — misreporting "your OPEN body was malformed" for what is an FSM-level violation; #453 (OpenConfirm) and #427 (Established) settled this class as 5/0.
3. Both pre-Established sends (this branch and the OpenConfirm `default` arm) bypassed the `_teardownReason` CAS latch — a session being replaced (`MarkSilentClose`) could still emit a NOTIFICATION from these sites.

## Root Cause
The #427/#453 FSM-error cleanup never covered the pre-OPEN phase; the catch-all branch predates it.

## Fix
- NOTIFICATION-first → log + latch `RemoteNotification` + silent return (no reply, finally stays silent).
- Other non-OPEN first messages → CAS-latch `LocalCease` + exactly one NOTIFICATION 5/0 (Finite State Machine Error).
- OpenConfirm `default` arm → same CAS-latch shape (also aligned to Warning, matching the #453 arm).
- RFC note: RFC 4271 §8.2.2 (state-machine error handling; the handshake accepts only OPEN and NOTIFICATION per the #453 rationale), §6.3/§4.5 (NOTIFICATION receipt → release resources, no reply), §8.1 (exactly one NOTIFICATION per teardown — the CAS).

## Correctness
- OPEN-first flows unchanged; OpenConfirm/E stablished behaviors (#453/#427) unchanged; fixed-header failures (marker/length/type) still take the MessageHeaderError path.
- The single-NOTIFICATION invariant: enumerated all senders pre-fix — these two sites could not overlap another sender (external Cease senders filter IsEstablished; hold loop not yet running), so the latch is hardening (the SilentClose intent) rather than an invariant repair.

## Regression Tests
`OpenConfirmFsmErrorTests`:
- `NotificationBeforeOpen_IsNeverRepliedTo` — NOTIFICATION(6,0) first → zero outbound NOTIFICATION and zero outbound OPEN. **Red/green proven** (pre-fix: one 2/0 reply).
- `KeepaliveBeforeOpen_IsFsmError_5_0_NotOpenMessageError` — KEEPALIVE first → exactly one NOTIFICATION with Error=5. **Red/green proven** (pre-fix: Error=2).

## Verification
- `dotnet format` clean; `dotnet build BGPLite.sln` 0 warnings/0 errors
- `dotnet test BGPLite.sln`: 1082/1082 (baseline 1080 + the two new tests)

## RFC
- RFC 4271 §4.5/§6.3 (NOTIFICATION receipt), §8.2.2 (FSM error), §8.1 (single NOTIFICATION).

## Behavior Change
Wire-visible only for peers that send a message before our OPEN: they now get 5/0 (was 2/0) for non-OPEN messages, and silence (was 2/0) for a NOTIFICATION.

## Deviation from Issue Proposal
None.