### PR TITLE
fix(server): apply the MP_UNREACH_NLRI half of an UPDATE during treat-as-withdraw (#484)

### DIFF
--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -1135,6 +1135,9 @@ public sealed class BgpSession : IDisposable
                 // the parse; this closes the asymmetry on the NLRI side.
                 // Same ownership rule as an explicit withdrawal (#289): treat-as-withdraw removes
                 // what this peer installed, not whatever is at that prefix.
+                // #484 (RFC 7606 §2): the MP_UNREACH_NLRI half of the SAME message is applied too —
+                // the classic WITHDRAWN field is honored even when the parse fails (it ran before
+                // the parse), so the MP withdrawal must not be lost to the same failure.
                 foreach (var nlri in update.Nlri)
                     WithdrawIfOwned(nlri, "Route withdrawn (treat-as-withdraw)");
                 if (mpReach is { } failedReach)
@@ -1143,6 +1146,12 @@ public sealed class BgpSession : IDisposable
                 if (mpReachV4 is { } failedReach4)
                     foreach (var p in failedReach4.Prefixes)
                         WithdrawIfOwned(p, "Route withdrawn (treat-as-withdraw, MP_REACH IPv4)");
+                if (update.MpUnreachV6 is { Count: > 0 } failedUnreach)
+                    foreach (var p in failedUnreach)
+                        WithdrawIfOwned(p, "Route withdrawn (treat-as-withdraw, MP_UNREACH)");
+                if (update.MpUnreachV4 is { Count: > 0 } failedUnreach4)
+                    foreach (var p in failedUnreach4)
+                        WithdrawIfOwned(p, "Route withdrawn (treat-as-withdraw, MP_UNREACH IPv4)");
                 _metrics.SetRouteCount(_routeTable.Count);
                 throw;
             }

--- a/BGPLite.Tests/MpAttributeErrorPolicyTests.cs
+++ b/BGPLite.Tests/MpAttributeErrorPolicyTests.cs
@@ -288,6 +288,47 @@ public class MpAttributeErrorPolicyTests
     }
 
     [Fact]
+    public async Task TreatAsWithdraw_AppliesTheSameUpdatesMpUnreach()
+    {
+        // #484 (RFC 7606 §2): an UPDATE is treated as withdrawn AS A WHOLE. The classic WITHDRAWN
+        // half is applied before the attribute parse and survives a parse failure; the
+        // MP_UNREACH_NLRI half of the same message must not be lost to that failure — pre-fix it
+        // was skipped (its block runs after the announcement block, which the failure unwinds),
+        // leaving a stale IPv6 route alive until session teardown.
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        // Install one IPv6 route via a valid MP_REACH announcement.
+        conn.EnqueueFrame(UpdateFrame(
+            OriginAsPathAttributes,
+            MpReachAttribute(MpOptionalNonTransitive, ReachValue(GlobalNextHop, 32, 0x20, 0x01, 0x0D, 0xB8))));
+        await SettleAsync(conn, () => routeTable.Count == 1);
+        Assert.NotNull(routeTable.Get(DocumentedPrefix, 32, isIpv4: false));
+
+        // An UPDATE with classic NLRI + a malformed ORIGIN (length 2 — Attribute Length Error →
+        // treat-as-withdraw) whose MP_UNREACH withdraws exactly that v6 prefix. The NLRI is what
+        // drives the announcement block into the failing parse — without it the whole block is
+        // skipped and the bug cannot show.
+        var attrs = new List<byte[]>
+        {
+            new byte[] { 0x40, 0x01, 0x02, 0x00, 0x00 },   // ORIGIN with length 2 — malformed per RFC 7606 §7.1
+            MpUnreachAttribute(MpOptionalNonTransitive, new byte[] { 0x00, 0x02, 0x01, 0x20, 0x20, 0x01, 0x0D, 0xB8 }),
+        };
+        var attrsLen = attrs.Sum(a => a.Length);
+        var payload = new List<byte> { 0x00, 0x00, (byte)(attrsLen >> 8), (byte)attrsLen };
+        foreach (var a in attrs) payload.AddRange(a);
+        payload.Add(24);                       // classic NLRI: 192.0.2.0/24
+        payload.AddRange([0xC0, 0x00, 0x02]);
+        conn.EnqueueFrame(Frame(BgpMessageType.Update, [.. payload]));
+        await SettleAsync(conn, () => routeTable.Count == 0);
+
+        Assert.Null(routeTable.Get(DocumentedPrefix, 32, isIpv4: false));   // RED pre-fix: stale route survived
+        Assert.True(session.IsEstablished, "treat-as-withdraw keeps the session up");
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
     public async Task MalformedMpReachV4_ResetsSession_ScopedFallback()
     {
         // #472 review, IPv4 half: a supported IPv4/Unicast tuple whose value cannot be decoded


### PR DESCRIPTION
Closes #484   # linkage only — the integration PR aggregates the closing keywords

## Problem
`HandleUpdateAsync` applies the classic WITHDRAWN ROUTES of an UPDATE **before** the attribute parse (`:1038`), so those withdrawals survive a treat-as-withdraw failure. The MP_UNREACH_NLRI half is processed **after** the announcement block (`:1264-1276`) — when `ParseRouteAttributes` throws, the catch withdraws the classic NLRI and MP_REACH prefixes and rethrows, and the MP_UNREACH prefixes named in the SAME message are never withdrawn. A stale IPv6 route lives until session teardown or a repeat withdrawal.

## Root Cause
Ordering asymmetry: one half of the message's withdrawals runs pre-parse, the other post-parse; nothing in D17/D2 records dropping it.

## Fix
In the treat-as-withdraw catch, also `WithdrawIfOwned` every prefix of `update.MpUnreachV6` / `update.MpUnreachV4` before the rethrow — the same ownership-scoped, idempotent helper every withdrawal path uses (a disabled family's routes were already flushed by `DisablePeerMpV6`, and the owner check makes re-withdrawing a no-op).

## Correctness
- The non-throwing path is unchanged (the trailing MP_UNREACH block still runs).
- Ownership semantics unchanged (only this session's own routes are removed).
- RFC 7606 §2: "the UPDATE message … MUST be treated as though all contained routes had been withdrawn" — the message is now applied as a whole, matching the codebase's own pre-parse treatment of the classic WITHDRAWN field.

## Regression Test
`MpAttributeErrorPolicyTests.TreatAsWithdraw_AppliesTheSameUpdatesMpUnreach` — installs an IPv6 route via a valid MP_REACH, then sends one UPDATE carrying classic NLRI + a malformed ORIGIN (length 2 → Attribute Length Error → treat-as-withdraw) + an MP_UNREACH naming that prefix. Asserts the v6 route is withdrawn and the session stays up. **Red/green proven** (pre-fix: the stale route survived). Note the classic NLRI is required to drive the announcement block into the failing parse — an MP_UNREACH-only malformed UPDATE never reaches the bug (the block is skipped and the withdrawal applies normally); the test documents this.

## Verification
- `dotnet format` clean; `dotnet build BGPLite.sln` 0 warnings/0 errors
- `dotnet test BGPLite.sln`: 1083/1083 (baseline 1082 + the new test); full MpAttributeErrorPolicyTests green

## RFC
- RFC 7606 §2 (treat-as-withdraw: the message is treated as a whole).

## Behavior Change
None beyond the fix: stale routes named in a failing message's MP_UNREACH are now withdrawn.

## Deviation from Issue Proposal
None.