### PR TITLE
fix(providers): apply the caller-vs-foreign OCE contract at three stragglers (#485)

### DIFF
--- a/BGPLite.Providers/PrefixService.cs
+++ b/BGPLite.Providers/PrefixService.cs
@@ -250,7 +250,10 @@ public sealed class PrefixService : IPrefixService
                 projected = prefixes.Select(p => (p.Address, p.Length, p.IsIpv4, 0u)).ToList();
                 changed = loadChanged;
             }
-            catch (OperationCanceledException) { throw; }
+            // #485 (#320/#324 contract): only CALLER cancellation propagates. A foreign-token OCE
+            // (the default source's fetch budget firing on a live ct) is a load FAILURE and takes
+            // the stale-on-failure branch below instead of escaping as "cancellation".
+            catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
             catch (Exception ex)
             {
                 // Stale-on-failure (#163 parity): serve the last good copy regardless of its age so
@@ -324,6 +327,7 @@ public sealed class PrefixService : IPrefixService
                 await GetPrefixesAsync(asn, ct);
                 _logger?.LogInformation("WarmUp: AS{Asn} cached", asn);
             }
+            catch (OperationCanceledException) { throw; }   // #485: host shutdown unwinds the loop, not a WARN per remaining ASN
             catch (Exception ex)
             {
                 _logger?.LogWarning(ex, "WarmUp: AS{Asn} failed", asn);

--- a/BGPLite.Providers/RipeStatPrefixCache.cs
+++ b/BGPLite.Providers/RipeStatPrefixCache.cs
@@ -134,7 +134,12 @@ public sealed class RipeStatPrefixCache
             {
                 prefixes = await _ripe.GetPrefixesAsync(asn, ct);
             }
-            catch (OperationCanceledException) { throw; }
+            // #485 (#320/#324 contract): only CALLER cancellation propagates. A foreign-token OCE
+            // (the per-attempt/body deadline inside RipeStatProvider, fired on a live ct) is a
+            // load FAILURE and takes the stale-on-failure / negative-cache branches below — the
+            // unfiltered rethrow meant every retry re-paid the full fetch budget with no backoff
+            // ever recorded.
+            catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
             catch (Exception ex)
             {
                 // Stale-on-failure (#163): serve the last good copy regardless of its age so a

--- a/BGPLite.Tests/AsnPrefixProviderTests.cs
+++ b/BGPLite.Tests/AsnPrefixProviderTests.cs
@@ -133,4 +133,42 @@ public class AsnPrefixProviderTests
 
         Assert.Equal(1, cache.TrackedCount);
     }
+
+    /// <summary>Succeeds on the first call, throws a foreign-token OCE (live ct) afterwards —
+    /// the deterministic stand-in for the #324 body deadline firing mid-response (#485).</summary>
+    private sealed class OceAfterFirstHandler : HttpMessageHandler
+    {
+        public int Calls { get; private set; }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Calls++;
+            return Calls > 1
+                ? Task.FromException<HttpResponseMessage>(new OperationCanceledException())
+                : Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        """{"status":"ok","data":{"resource":"65010","prefixes":{"v4":{"originating":["10.1.10.1/32"]},"v6":{"originating":[]}}}}""")
+                });
+        }
+    }
+
+    [Fact]
+    public async Task ForeignOceFromRipeStat_IsAFailure_StaleIsServed()
+    {
+        // #485 (#320/#324 contract): a foreign-token OCE (live ct) is a load FAILURE — the
+        // stale-on-failure copy must be served. The unfiltered rethrow escaped the cache instead,
+        // so every retry re-paid the full fetch budget with no backoff ever recorded.
+        var handler = new OceAfterFirstHandler();
+        var cache = new RipeStatPrefixCache(
+            new RipeStatProvider(new StubFactory(handler), NullLogger<RipeStatProvider>.Instance,
+                new RipeStatConfig { RetryAttempts = 0, RetryDelaySeconds = 0 }),
+            cacheTtl: TimeSpan.Zero);   // every call past the first refetches
+
+        var first = await cache.GetPrefixesAsync(65010);
+        Assert.Single(first);
+
+        var second = await cache.GetPrefixesAsync(65010);   // RED pre-fix: OperationCanceledException escapes
+        Assert.Single(second);                              // the stale copy is served as the failure remedy
+        Assert.Equal(2, handler.Calls);
+    }
 }

--- a/BGPLite.Tests/PrefixCacheFailureTests.cs
+++ b/BGPLite.Tests/PrefixCacheFailureTests.cs
@@ -1,3 +1,4 @@
+using System.Net.Http;
 using BGPLite.Configuration;
 using BGPLite.Providers;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -134,5 +135,48 @@ public class PrefixCacheFailureTests
         public bool SupportsConditionalRequests => true;
         public Task<SourceLoadResult> LoadAsync(PrefixSourceConfig source, string? etag = null, DateTimeOffset? lastModified = null, CancellationToken ct = default)
             => Task.FromResult(SourceLoadResult.Ok(new List<IpPrefix>()));
+    }
+
+    /// <summary>Succeeds normally; throws the CALLER's OCE once the token is cancelled — how
+    /// RipeStatProvider surfaces host shutdown to the cache (#485).</summary>
+    private sealed class OceWhenCancelledHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            => ct.IsCancellationRequested
+                ? Task.FromException<HttpResponseMessage>(new OperationCanceledException(ct))
+                : Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        """{"status":"ok","data":{"resource":"65010","prefixes":{"v4":{"originating":["10.1.10.1/32"]},"v6":{"originating":[]}}}}""")
+                });
+    }
+
+    private sealed class HttpClientFactoryStub(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(handler, disposeHandler: false);
+    }
+
+    [Fact]
+    public async Task WarmUp_CancelledToken_UnwindsTheLoop_NotAWarnPerAsn()
+    {
+        // #485: the per-ASN catch (Exception) swallowed the shutdown OCE once per remaining ASN —
+        // a "WarmUp failed" WARN storm on every stop. Caller cancellation must unwind the loop.
+        var yaml = "Bgp:\n  Asn: 65444\n  RouterId: 10.0.0.1\n" +
+                   "RipeStat:\n  AsnLists:\n    - Name: ru\n      Asns: [65010, 65011]\n";
+        var config = ConfigLoader.LoadFromText(yaml);
+        var cache = new RipeStatPrefixCache(new RipeStatProvider(
+            new HttpClientFactoryStub(new OceWhenCancelledHandler()),
+            NullLogger<RipeStatProvider>.Instance,
+            new RipeStatConfig { RetryAttempts = 0, RetryDelaySeconds = 0 }));
+        var sources = new PrefixSourceService(
+            config,
+            new PrefixSourceProviderFactory([]),
+            NullLogger<PrefixSourceService>.Instance);
+        var service = new PrefixService(config, cache, sources, null!);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        // RED pre-fix: both per-ASN OCEs were swallowed (a WARN each) and WarmUp completed normally.
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => service.WarmUpAsync(cts.Token));
     }
 }


### PR DESCRIPTION
Closes #485   # linkage only — the integration PR aggregates the closing keywords

## Problem
Three sites diverge from the repo's #114/#225/#320/#324 contract (caller-OCE propagates; foreign-OCE on a live token is a load FAILURE → stale-serve / negative-cache):
1. `RipeStatPrefixCache` (`:137`): `catch (OperationCanceledException) { throw; }` unfiltered — a body-deadline OCE from `RipeStatProvider` (foreign token, live ct) escaped the stale-on-failure/negative-cache handling, so every retry re-paid the full fetch budget and no backoff was ever recorded.
2. `PrefixService.GetRuPrefixesAsync` (`:253`): same unfiltered rethrow — a budget OCE surfaced as "cancellation" with a live ct (the latent #225 pattern).
3. `PrefixService.WarmUpAsync` per-ASN loop (`:327`): the inverse defect — `catch (Exception)` swallowed the host-shutdown OCE per ASN, producing a "WarmUp failed" WARN per remaining ASN on every stop instead of unwinding.

## Root Cause
The filtered-catch pattern was established at the neighboring sites (`PrefixSourceService` :78/:129/:172, `UserSourceCache` :127) but not applied here.

## Fix
1+2: `catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }` — the foreign OCE falls through to the existing stale/negative branches, byte-identical to the reference sites.
3: `catch (OperationCanceledException) { throw; }` before the generic catch inside the loop.

## Correctness
- Real caller cancellation still propagates everywhere (the `when` filters).
- Site 2 is contract hardening: through the normal path `PrefixSourceService.LoadCachedAsync` already converts a foreign OCE to stale-serve/negative; the OCE reaches `PrefixService`'s catch only after a source-cache eviction — narrow but real, and the filter makes the site obey the same rule as its neighbors.

## Regression Tests
- `AsnPrefixProviderTests.ForeignOceFromRipeStat_IsAFailure_StaleIsServed` — a handler that succeeds once then throws a foreign-token OCE; asserts the second `GetPrefixesAsync` serves the stale copy instead of throwing. **Red/green proven.**
- `PrefixCacheFailureTests.WarmUp_CancelledToken_UnwindsTheLoop_NotAWarnPerAsn` — two configured ASNs + a cancelled token; asserts `WarmUpAsync` throws OCE (pre-fix it completed normally after two WARN-swallowed failures). **Red/green proven.**
- Site 2 has no deterministic public-seam repro (requires a source-cache eviction between loads); the fix is a one-token alignment with the adjacent reference sites, documented here.

## Verification
- `dotnet format` clean; `dotnet build BGPLite.sln` 0 warnings/0 errors
- `dotnet test BGPLite.sln`: 1086/1086 (baseline 1084 + the two new tests)

## RFC
- none.

## Behavior Change
WarmUp on shutdown no longer logs a WARN per remaining ASN; RIPEstat budget cancels now back off via the negative cache instead of hammering.

## Deviation from Issue Proposal
None — exactly the three sites.