### PR TITLE
fix(protocol): reject a zero-length AS_PATH at the eBGP policy layer (#486)

### DIFF
--- a/BGPLite.Protocol/UpdateCodec.cs
+++ b/BGPLite.Protocol/UpdateCodec.cs
@@ -358,6 +358,16 @@ public static class UpdateCodec
                         originSeen = true;
                         break;
                     case BgpConstants.Attribute.AsPath:
+                        // #486 (D25): a zero-length AS_PATH is a legal ENCODING (RFC 4271 §5.1.2
+                        // lets an originator send an empty path toward INTERNAL peers) but never a
+                        // valid eBGP path — BGPLite serves eBGP only, where the sender's own ASN
+                        // must be present. Rejected at the policy layer as Malformed AS_PATH
+                        // (treat-as-withdraw); the codec stays encoding-neutral so the writer's
+                        // empty-path roundtrip (#248 review) stands.
+                        if (attr.Data.Length == 0)
+                            throw new BgpNotificationException(
+                                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAsPath,
+                                "Invalid AS_PATH: an empty path is only valid toward internal peers (RFC 4271 §5.1.2)");
                         asPath = AttributeHelper.ReadAsPath(attr, fourByteAsnSession);
                         asPathSeen = true;
                         break;

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -654,6 +654,33 @@ public class BgpMessageTests
     }
 
     [Fact]
+    public void AsPath_ZeroLengthAttribute_IsMalformedOnEbgp_PolicyLayer()
+    {
+        // #486 (D25): a zero-length AS_PATH is the on-wire form of an EMPTY path — legal only
+        // toward internal peers (RFC 4271 §5.1.2). BGPLite is eBGP-only, so the inbound policy
+        // layer rejects it as Malformed AS_PATH (treat-as-withdraw); the codec itself stays
+        // encoding-neutral (see AsPath_Empty_RoundtripsAsZeroLengthAttribute).
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                new PathAttribute { Flags = BgpConstants.Attribute.FlagTransitive, TypeCode = BgpConstants.Attribute.AsPath, Data = [] },
+                new PathAttribute { Flags = BgpConstants.Attribute.FlagTransitive, TypeCode = BgpConstants.Attribute.Origin, Data = [0] },
+                new PathAttribute { Flags = BgpConstants.Attribute.FlagTransitive, TypeCode = BgpConstants.Attribute.NextHop, Data = [0xC0, 0x00, 0x02, 0x01] }
+            ],
+            Nlri = [new IpPrefix(0xC0000200, 24)]
+        };
+
+        var ex = Assert.Throws<BgpNotificationException>(() =>
+            UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: false, localRouterId: 0x0A000001));
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.MalformedAsPath, ex.SubErrorCode);
+
+        // The codec layer is untouched: the zero-length attribute still decodes (as an empty path).
+        Assert.Empty(AttributeHelper.ReadAsPath(update.PathAttributes[0], fourByteAsn: false));
+    }
+
+    [Fact]
     public void As4Path_WithAsTrans_Throws()
     {
         // AS_TRANS (23456) is the 2-octet placeholder for a non-mappable 4-octet AS — meaningless

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -335,3 +335,19 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
   conditional on the peer's offer (its receiving half has existed since #14).
 - **Tracker:** #466 (echo removed 2026-09-03, receive implemented same day after the
   `compose-integration` finding).
+
+### D25. A zero-length AS_PATH is rejected at the eBGP policy layer (Malformed AS_PATH)
+- **Decision:** an inbound UPDATE whose AS_PATH attribute has a zero-length value is rejected as
+  Malformed AS_PATH (subcode 11, treat-as-withdraw) in `UpdateCodec.ParseRouteAttributes`. The
+  codec (`AttributeHelper.ReadAsPath`/`WriteAsPath`) stays encoding-neutral — a zero-length
+  attribute is the on-wire form of an empty path, and the writer's empty-path roundtrip stands
+  (#248 review). AS4_PATH stays lenient: RFC 6793 leaves an empty one to the merge, which ignores it.
+- **Context:** RFC 4271 §5.1.2 defines a path segment as carrying "one or more AS numbers" and
+  permits an empty path only toward INTERNAL peers (iBGP); BGPLite serves eBGP exclusively, where
+  the sender's own ASN must be present — an empty path is malformed in practice (major
+  implementations reject it), though the RFC does not state it verbatim. #238 settled the
+  empty-SEGMENT case; #486 settled the empty-ATTRIBUTE case.
+- **Consequence:** an UPDATE a maximally lenient implementation might accept is
+  treated-as-withdraw; routes never install with an empty path (which the AS-loop exclusion,
+  RFC 4271 §9.1.2, could never match anyway — D23).
+- **Tracker:** #486.


### PR DESCRIPTION
Closes #486   # linkage only — the integration PR aggregates the closing keywords

## Problem
`UpdateCodec.ParseRouteAttributes` accepted a zero-length AS_PATH: `ReadPathData`'s segment loop never ran, `asPathSeen` was set, and routes installed with an empty path — which the AS-loop exclusion (RFC 4271 §9.1.2) can never match (D23), and which no conformant eBGP sender produces.

## Root Cause
#238 rejected the empty-SEGMENT case; the empty-ATTRIBUTE case (the segment loop's zero-iteration path) was never covered.

## Fix
Policy-layer rejection in `ParseRouteAttributes` (`3/11` Malformed AS Path → the caller's treat-as-withdraw). The CODEC stays encoding-neutral: a zero-length attribute is the legal on-wire form of an empty path (RFC 4271 §5.1.2, iBGP), the writer's empty-path roundtrip (#248 review: "the writer must not emit what the reader rejects") stands, and AS4_PATH stays lenient (the RFC 6793 merge ignores an empty one). Decision recorded as **D25** in DESIGN_DECISIONS.md.

## RFC
- RFC 4271 §5.1.2 (path segments carry "one or more AS numbers"; empty path only toward internal peers), §9.1.2 (loop detection over the path), §6.3 (Malformed AS_PATH). The verbatim eBGP prohibition is interpretation + implementation practice — recorded as a decision (D25), exactly what #486 asked ("settle the policy").

## Regression Test
`BgpMessageTests.AsPath_ZeroLengthAttribute_IsMalformedOnEbgp_PolicyLayer` — asserts `ParseRouteAttributes` throws 3/11 for a zero-length AS_PATH and, in the same test, that the codec layer still decodes it (policy/codec split pinned). **Red/green proven.**

## Verification
- `dotnet format` clean; `dotnet build BGPLite.sln` 0 warnings/0 errors
- `dotnet test BGPLite.sln`: 1087/1087 (baseline 1086 + the new test)

## Behavior Change
An UPDATE carrying a zero-length AS_PATH is now treated-as-withdraw (session stays up, UpdateRejected counted) instead of installing routes with an empty path.

## Deviation from Issue Proposal
The issue suggested rejecting inside `ReadAsPath`; analysis showed that would break the writer/reader symmetry pinned by `AsPath_Empty_RoundtripsAsZeroLengthAttribute` (#248) — the rejection belongs at the eBGP policy layer, not the codec.