### PR TITLE
chore: minor-batch from the 2026-09-04 audit (#487)

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -68,6 +68,12 @@ public sealed class ManagementApi : IHostedService, IDisposable
     /// their PARTIAL result with a warning; shutdown still propagates. internal settable for tests.
     /// </summary>
     internal TimeSpan ExternalFetchBudget { get; set; } = TimeSpan.FromSeconds(30);
+
+    // #487: bounds for peer-supplied custom sources — generous ceilings that only reject abuse
+    // (repeated POSTs growing the DB without limit; megabyte-scale names/URLs in logs and rows).
+    internal const int MaxSourceNameLength = 200;
+    internal const int MaxSourceUrlLength = 2048;
+    internal const int MaxSourcesPerPeer = 64;
     // #258: in-flight tracking is a COUNT plus an idle Task (completed whenever the count is 0),
     // not a List<Task> — the #248 design appended every handler and never removed it, so each
     // completed request leaked its Task (and its exception, if faulted) for the process lifetime
@@ -721,7 +727,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         {
             asn = bgp.Asn,
             routerId = bgp.RouterId,
-            bgpPort = 179,
+            bgpPort = BgpConstants.BgpPort,
             apiPort = _port,
             holdTime = bgp.HoldTime,
             keepalive = bgp.KeepAlive,
@@ -1115,13 +1121,18 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         await _store.UpdatePeerConfigurationAsync(peerId, data.Description, data.Lists, parsedPrefixes, data.CustomAsns, data.MaxPrefix,
             md5Password: data.Md5Password);
+        // #487: a concurrent DELETE between the top-of-handler GET and this UPDATE left the
+        // ExecuteUpdates touching 0 rows while the handler still logged "Updated peer", answered
+        // 200 and fired a refresh — the follow-up GET then 404ed. Re-check the row and answer 404
+        // directly (the write itself is harmless: transaction-scoped, 0 rows affected).
+        var surviving = await _store.GetDbPeerByIdAsync(peerId);
+        if (surviving is null)
+            return ApiResponse.Error("Peer not found", 404);
         if (data.Md5Password is not null)
         {
             // #418: re-arm from ALL surviving rows for this IP — clearing this peer's key must
             // fall back to a sibling's, not silently disarm the address for every peer on it.
-            var md5Peer = await _store.GetDbPeerByIdAsync(peerId);
-            if (md5Peer is not null)
-                await RearmPeerIpMd5KeyAsync(md5Peer.Ip);
+            await RearmPeerIpMd5KeyAsync(surviving.Ip);
         }
 
         _logger.LogInformation("Updated peer {Id}", SanitizeForLog(peerId));
@@ -1216,6 +1227,16 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         if (data is null || string.IsNullOrWhiteSpace(data.Name) || string.IsNullOrWhiteSpace(data.Url))
             return ApiResponse.Error("Name and Url are required", 400);
+
+        // #487: bound the peer-supplied fields and the per-peer source count. The 1 MiB body cap
+        // bounds ONE request; nothing bounded repeated posts, and the DB rows outlive the request.
+        // Generous limits: a longer name/URL is never legitimate, and a peer needs far fewer
+        // sources than the user-source cache's 1024-URL entry cap.
+        if (data.Name.Length > MaxSourceNameLength || data.Url.Length > MaxSourceUrlLength)
+            return ApiResponse.Error(
+                $"Name must be at most {MaxSourceNameLength} characters and Url at most {MaxSourceUrlLength}.", 400);
+        if ((await _store.GetCustomSourcesAsync(peerId)).Count >= MaxSourcesPerPeer)
+            return ApiResponse.Error($"Peer already has the maximum of {MaxSourcesPerPeer} custom sources.", 400);
 
         // #266 item 3: the community is peer-supplied and reaches the wire through
         // CommunityCodec at send time — validate the SAME contract at the API boundary (#255

--- a/BGPLite.Protocol/UpdateCodec.cs
+++ b/BGPLite.Protocol/UpdateCodec.cs
@@ -310,9 +310,11 @@ public static class UpdateCodec
             // one, so anything reading the first (a collector, a looking glass, an operator's packet
             // capture) disagreed with what actually landed in the route table (#287).
             //
-            // The MP_REACH_NLRI/MP_UNREACH_NLRI half of that paragraph — duplicate → NOTIFICATION,
-            // session reset — is deliberately not implemented: BGPLite is IPv4-unicast only and never
-            // parses those attributes. It belongs with MP-BGP support (#14).
+            // The MP_REACH_NLRI/MP_UNREACH_NLRI half of that paragraph is handled UPSTREAM, in
+            // BgpMessageReader.ParseUpdate: those attributes are extracted into typed fields
+            // before this generic list is built, and a duplicate takes the RFC 7606 §3(g)
+            // NOTIFICATION + session reset there (#467). The first-wins guard below therefore
+            // never sees them.
             //
             // Clear() is not redundant despite `localsinit` zeroing stackalloc by default: adding
             // [SkipLocalsInit] (or <SkipLocalsInit> in the csproj) is an ordinary perf tweak for a

--- a/BGPLite.Providers/FilePrefixProvider.cs
+++ b/BGPLite.Providers/FilePrefixProvider.cs
@@ -41,6 +41,13 @@ public sealed class FilePrefixProvider(ILogger<FilePrefixProvider> logger) : IPr
         // #321 item 5: async read with the caller's token — the sync ReadAllText held a threadpool
         // thread under the per-source gate for the whole file. The metadata probes above stay
         // sync: they are single stat calls, not reads.
+        // #487: cap parity with the HTTP paths (HttpPrefixProvider.MaxResponseBytes) — the file is
+        // operator-controlled, but a multi-GB "prefix list" is never legitimate and the uncapped
+        // read was an asymmetric memory-amplification footgun.
+        var length = new FileInfo(fullPath).Length;
+        if (length > HttpPrefixProvider.MaxResponseBytes)
+            throw new InvalidOperationException(
+                $"Prefix file for source '{source.Name}' is {length} bytes — over the {HttpPrefixProvider.MaxResponseBytes}-byte cap.");
         var text = await File.ReadAllTextAsync(fullPath, ct);
         var prefixes = PrefixListParser.Parse(text);
         logger.LogInformation("Source '{Name}' (file): loaded {Count} prefixes from {Path}", source.Name, prefixes.Count, fullPath);

--- a/BGPLite.Providers/UserSourceCache.cs
+++ b/BGPLite.Providers/UserSourceCache.cs
@@ -216,7 +216,9 @@ internal sealed class UserSourceCache
         if (_cache.ContainsKey(insertingUrl)) return; // already present, no insert coming
 
         var now = _timeProvider.GetUtcNow().UtcDateTime;
-        var toEvict = new List<string>();
+        // #487: HashSet — the Contains in the oldest-selection loop below made eviction O(n²) at
+        // the 1024-entry cap.
+        var toEvict = new HashSet<string>();
         foreach (var (key, entry) in _cache)
         {
             var ttl = entry.Negative ? _negativeTtl : _positiveTtl;
@@ -280,7 +282,7 @@ internal sealed class UserSourceCache
         Volatile.Write(ref _callsSinceSweep, 0);
 
         var now = _timeProvider.GetUtcNow().UtcDateTime;
-        var toEvict = new List<string>();
+        var toEvict = new HashSet<string>();   // #487: O(1) Contains for the budget loop below
         long total = 0;
         foreach (var (key, entry) in _cache)
         {

--- a/BGPLite.Server/BgpServer.cs
+++ b/BGPLite.Server/BgpServer.cs
@@ -573,6 +573,7 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
         _listener?.Close();
         _cts.Cancel();
         _cts.Dispose();  // #105: dispose the CTS (StopAsync's graceful path doesn't reach here)
+        _statusTimer?.Dispose();  // #487: the abort path never runs StopAsync — don't leak the timer to GC
         foreach (var session in _sessions.Values)
             session.Dispose();
     }

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -31,8 +31,9 @@ public sealed class BgpSession : IDisposable
     private readonly ILogger<BgpSession> _logger;
     private readonly CancellationTokenSource _cts = new();
     private readonly Func<string, uint, CancellationToken, Task>? _onPeerIdentified;
-    // #15 phase 2: the peer advertised MP-BGP IPv6/Unicast.
-    private bool _peerMpIpv6Unicast;
+    // #15 phase 2: the peer advertised MP-BGP IPv6/Unicast. Written once on the session thread
+    // (ValidateOpenAsync); read cross-thread on the API-refresh/send paths — volatile (#487).
+    private volatile bool _peerMpIpv6Unicast;
     // #467 (RFC 7606 §3(j) "AFI/SAFI disable"): set when an unparseable MP attribute withdraws
     // the family — subsequent MP_REACH/MP_UNREACH payloads from this peer are ignored and its
     // accepted IPv6 routes are gone. Volatile: written on the read loop, read on send paths.
@@ -72,7 +73,10 @@ public sealed class BgpSession : IDisposable
     // StopAsync/replace path), read by the RunAsync finally-block on a different thread.
     private int _teardownReason = (int)TeardownReason.None;
     private int _disposed;
-    private uint _remoteAsn;
+    // Negotiated from the peer's OPEN (OpenNegotiator). Written on the session thread before
+    // Established; read cross-thread by BgpServer's (Ip, Asn) filters and the refresh/send paths
+    // — volatile for guaranteed visibility (#487, matching _peerMpV6Disabled).
+    private volatile uint _remoteAsn;
     private bool _remoteFourByteAsn;
     private bool _remoteRouteRefresh;
     private bool _localFourByteAsn; // derived from negotiated OPEN capability (RFC 6793)

--- a/BGPLite.Tests/ApiHandlerBehaviorTests.cs
+++ b/BGPLite.Tests/ApiHandlerBehaviorTests.cs
@@ -382,6 +382,34 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
     }
 
     [Fact]
+    public async Task AddSource_FieldLimits_And_PerPeerCap_AreEnforced()
+    {
+        // #487: repeated POSTs bounded — name/URL length ceilings and a per-peer source-count cap
+        // (the 1 MiB body cap bounds ONE request; the DB rows outlive it).
+        var store = new PeerStore(new StaticOptionsFactory(new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(_connection).Options));
+        var id = (await store.SavePeerConfigurationAsync("198.51.100.8", 65091, null, [], [], [])).Id;
+        _port = await StartAsync(new AppConfig { Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" } });
+        _client = new HttpClient();
+
+        var longName = new string('n', ManagementApi.MaxSourceNameLength + 1);
+        using var badName = await _client.PostAsync($"http://127.0.0.1:{_port}/api/peers/{id}/sources",
+            new StringContent(JsonSerializer.Serialize(new { name = longName, url = "https://example.com/l" }), Encoding.UTF8, "application/json"));
+        Assert.Equal(HttpStatusCode.BadRequest, badName.StatusCode);
+
+        var longUrl = "https://example.com/" + new string('u', ManagementApi.MaxSourceUrlLength);
+        using var badUrl = await _client.PostAsync($"http://127.0.0.1:{_port}/api/peers/{id}/sources",
+            new StringContent(JsonSerializer.Serialize(new { name = "ok", url = longUrl }), Encoding.UTF8, "application/json"));
+        Assert.Equal(HttpStatusCode.BadRequest, badUrl.StatusCode);
+
+        // Seed the per-peer cap directly through the store, then POST one more → 400.
+        for (var i = 0; i < ManagementApi.MaxSourcesPerPeer; i++)
+            await store.AddCustomSourceAsync(id, $"s{i}", $"https://example.com/{i}", null);
+        using var capped = await _client.PostAsync($"http://127.0.0.1:{_port}/api/peers/{id}/sources",
+            new StringContent(JsonSerializer.Serialize(new { name = "one-too-many", url = "https://example.com/x" }), Encoding.UTF8, "application/json"));
+        Assert.Equal(HttpStatusCode.BadRequest, capped.StatusCode);
+    }
+
+    [Fact]
     public async Task AsnLists_BudgetExpiryMidSources_ServesPartialJson()
     {
         // #480: the budget token firing during LoadAllAsync must degrade to the partial response

--- a/BGPLite.Tests/FilePrefixProviderTests.cs
+++ b/BGPLite.Tests/FilePrefixProviderTests.cs
@@ -35,4 +35,22 @@ public class FilePrefixProviderTests
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
             provider.LoadAsync(new PrefixSourceConfig { Name = "t", Kind = "file", Path = null }));
     }
+
+    [Fact]
+    public async Task OversizedFileThrows()
+    {
+        // #487: cap parity with the HTTP paths — a file over HttpPrefixProvider.MaxResponseBytes
+        // is never a legitimate prefix list and must not be read into memory whole.
+        var path = Path.GetTempFileName();
+        await using (var fs = new FileStream(path, FileMode.Create, FileAccess.Write))
+            await fs.WriteAsync(new byte[HttpPrefixProvider.MaxResponseBytes + 1]);
+        try
+        {
+            var provider = new FilePrefixProvider(NullLogger<FilePrefixProvider>.Instance);
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                provider.LoadAsync(new PrefixSourceConfig { Name = "t", Kind = "file", Path = path }));
+            Assert.Contains("cap", ex.Message);
+        }
+        finally { File.Delete(path); }
+    }
 }

--- a/BGPLite/ConfigReloader.cs
+++ b/BGPLite/ConfigReloader.cs
@@ -71,6 +71,11 @@ public sealed class ConfigReloader : IHostedService, IDisposable
         _watcher.Changed += OnFileChanged;
         _watcher.Created += OnFileChanged;
         _watcher.Renamed += OnFileChanged;
+        // #487: an internal-buffer overflow (busy save storms) drops events SILENTLY — hot reload
+        // would quietly stop working until the next successful save. Surface it; the operator can
+        // then touch the file or restart.
+        _watcher.Error += (_, e) => _logger.LogWarning(e.GetException(),
+            "Config hot-reload watcher error (buffer overflow?) — change events may have been LOST; touch the config file to force a reload.");
         _watcher.EnableRaisingEvents = true;
 
         // One debounce timer, rearmed (never auto-recurring): fires exactly once, DebounceMs after


### PR DESCRIPTION
Closes #487   # linkage only — the integration PR aggregates the closing keywords

## Problem / Fix
The nine verified minor items from the audit, one sweep PR (per-item details in the issue):
1. `BgpServer.Dispose` disposes `_statusTimer` (abort path never runs StopAsync).
2. `/api/me` `bgpPort` references `BgpConstants.BgpPort` (was a hardcoded 179 — AGENTS.md rule).
3. `ConfigReloader` subscribes `FileSystemWatcher.Error` — buffer-overflow event loss is now visible instead of silently disabling hot reload.
4. `PATCH /api/peers/{id}` re-checks the row post-update and answers 404 on a concurrent DELETE (was: "Updated peer" log + 200, then a 404 from the follow-up GET; the write itself is transaction-scoped and touched 0 rows).
5. `FilePrefixProvider` caps the read at `HttpPrefixProvider.MaxResponseBytes` (parity with every HTTP path).
6. `HandleAddSource` enforces Name ≤ 200 / Url ≤ 2048 and a 64-source per-peer cap (the 1 MiB body cap bounds one request, not the DB).
7. `UserSourceCache` eviction uses `HashSet` (O(n²) → O(n) oldest-selection at the cap).
8. `UpdateCodec` MP-duplicate comment updated (#467 moved that handling upstream).
9. `_remoteAsn` / `_peerMpIpv6Unicast` volatile (cross-thread reads from BgpServer filters and refresh/send paths).

## Regression Tests
- `ApiHandlerBehaviorTests.AddSource_FieldLimits_And_PerPeerCap_AreEnforced` — 201-char name → 400; oversized URL → 400; store seeded to the cap → one more POST → 400.
- `FilePrefixProviderTests.OversizedFileThrows` — a MaxResponseBytes+1 file → InvalidOperationException naming the cap.
(The remaining items are mechanical/comment-level; no meaningful invariant to pin.)

## Verification
- `dotnet format` clean; `dotnet build BGPLite.sln` 0 warnings/0 errors
- `dotnet test BGPLite.sln`: 1089/1089 (baseline 1087 + the two new tests)

## RFC
- none.

## Behavior Change
Over-long source names/URLs, the 65th source per peer, and >10 MB prefix files are now rejected; PATCH racing a DELETE answers 404 instead of 200-then-404. All are abuse/misconfiguration bounds, not legitimate-workflow changes.

## Deviation from Issue Proposal
Item 4 is fixed at the handler level (post-update existence re-check) rather than threading rows-affected through `IPeerStore.UpdatePeerConfigurationAsync` — same observable outcome, no public contract change.