### PR TITLE
fix(routing): fail closed on total source failure, warn on unknown subscriptions (#488)

### DIFF
--- a/BGPLite.Server/RouteAssembler.cs
+++ b/BGPLite.Server/RouteAssembler.cs
@@ -95,6 +95,10 @@ public sealed class RouteAssembler : IRouteAssembler
 
             _logger.LogInformation("Peer {Peer} subscriptions: [{Subs}]", peerLabel, string.Join(", ", subscriptionIds));
 
+            // #488 (D26): tracks whether any configured fetch FAILED (vs legitimately resolved to
+            // nothing). The RU fallback below must not fire on total failure — see the gate there.
+            var anyFetchFailed = false;
+
             var subscribedLists = _appConfig.RipeStat?.AsnLists
                 .Where(l => subscriptionIds.Contains(l.Name))
                 .ToList() ?? [];
@@ -124,6 +128,7 @@ public sealed class RouteAssembler : IRouteAssembler
                     catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#330
                     catch (Exception ex)
                     {
+                        anyFetchFailed = true;   // #488
                         _logger.LogError(ex, "Failed to fetch prefixes for {Peer} (list '{List}')", peerLabel, list.Name);
                     }
                 }
@@ -147,6 +152,7 @@ public sealed class RouteAssembler : IRouteAssembler
                 catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#330
                 catch (Exception ex)
                 {
+                    anyFetchFailed = true;   // #488
                     _logger.LogError(ex, "Failed to fetch RU prefixes for {Peer}", peerLabel);
                 }
             }
@@ -157,6 +163,16 @@ public sealed class RouteAssembler : IRouteAssembler
             var sourceNames = subscriptionIds
                 .Where(n => !resolvedAsRipe.Contains(n) && prefixSources.Any(s => s.Name == n))
                 .ToList();
+
+            // #488: a subscription matching no AsnLists entry and no PrefixSource is a config
+            // typo — invisible until now (silently ignored on every build). Name it so the row
+            // can be fixed.
+            foreach (var unknown in subscriptionIds.Where(n =>
+                         !resolvedAsRipe.Contains(n) && !prefixSources.Any(s => s.Name == n)))
+                _logger.LogWarning(
+                    "Subscription '{Name}' on {Peer} matches no RipeStat.AsnLists entry and no PrefixSource — ignored (fix the peer's subscription)",
+                    unknown, peerLabel);
+
             foreach (var name in sourceNames)
             {
                 try
@@ -171,6 +187,7 @@ public sealed class RouteAssembler : IRouteAssembler
                 catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#330
                 catch (Exception ex)
                 {
+                    anyFetchFailed = true;   // #488
                     _logger.LogError(ex, "Failed to fetch source '{Source}' for {Peer}", name, peerLabel);
                 }
             }
@@ -211,6 +228,7 @@ public sealed class RouteAssembler : IRouteAssembler
                 catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#330
                 catch (Exception ex)
                 {
+                    anyFetchFailed = true;   // #488
                     _logger.LogError(ex, "Failed to fetch custom AS prefixes for {Peer}", peerLabel);
                 }
             }
@@ -218,7 +236,7 @@ public sealed class RouteAssembler : IRouteAssembler
             // Per-peer user URL sources (#143/#147): each Active source fetched + community-stamped.
             foreach (var source in peer.UserSources)
             {
-                await AddUserSourceRoutesAsync(
+                anyFetchFailed |= !await AddUserSourceRoutesAsync(
                     routes, source, nextHop, _prefixService, _communityResolver, _logger, peerLabel, ct);
             }
 
@@ -237,8 +255,19 @@ public sealed class RouteAssembler : IRouteAssembler
 
             _logger.LogInformation("Sending {Count} total routes to {Peer}", routes.Count, peerLabel);
 
-            // Configured peer resolved 0 prefixes — fall back to RU.
-            if (routes.Count == 0)
+            // Configured peer resolved 0 prefixes — fall back to RU. #488 (D26): ONLY when the
+            // peer's configured sources legitimately resolved to nothing. When every fetch FAILED
+            // (RIPEstat outage / network partition), substituting the full RU dump would advertise
+            // hundreds of thousands of prefixes the peer never asked for — total-source failure
+            // fails CLOSED: the peer keeps an empty set and the per-source errors above carry the
+            // cause.
+            if (routes.Count == 0 && anyFetchFailed)
+            {
+                _logger.LogWarning(
+                    "Peer {Peer} resolved 0 prefixes WITH fetch failures — NOT falling back to RU defaults (total-source failure fails closed)",
+                    peerLabel);
+            }
+            else if (routes.Count == 0)
             {
                 _logger.LogInformation("Peer {Peer} resolved 0 prefixes, falling back to RU defaults", peerLabel);
                 try
@@ -378,7 +407,9 @@ public sealed class RouteAssembler : IRouteAssembler
     /// e.g. #320's linked CTS in HttpPrefixProvider) is a fetch failure like any other, so one
     /// slow URL skips its source instead of aborting the whole dump.
     /// </summary>
-    internal static async Task AddUserSourceRoutesAsync(
+    /// <returns><c>true</c> when the source loaded (even to an empty list); <c>false</c> when the
+    /// fetch failed — the #488 fail-closed fallback gate consumes the failure signal.</returns>
+    internal static async Task<bool> AddUserSourceRoutesAsync(
         List<Route> routes, CustomSourceView source, uint nextHop,
         IPrefixService prefixService, ICommunityResolver communityResolver,
         ILogger logger, string peerLabel, CancellationToken ct)
@@ -391,11 +422,13 @@ public sealed class RouteAssembler : IRouteAssembler
             foreach (var p in prefixes)
                 routes.Add(MakeRoute(p.Prefix, p.Length, p.IsIpv4, nextHop, null, comms));
             logger.LogInformation("User-source '{Name}': {Count} prefixes for {Peer}", source.Name, prefixes.Count, peerLabel);
+            return true;
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#342: only CALLER cancellation — a per-source timeout OCE (#320's linked CTS, live ct) must stay a fetch failure below
         catch (Exception ex)
         {
             logger.LogWarning(ex, "User-source '{Name}' failed for {Peer}; skipped", source.Name, peerLabel);
+            return false;
         }
     }
 

--- a/BGPLite.Tests/RouteAssemblerPolicyTests.cs
+++ b/BGPLite.Tests/RouteAssemblerPolicyTests.cs
@@ -1,0 +1,131 @@
+using BGPLite.Configuration;
+using BGPLite.Contracts;
+using BGPLite.Routing;
+using BGPLite.Server;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using BGPLite.Protocol;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #488 (D26): the outbound policy under failure. A CONFIGURED peer that resolves zero routes falls
+/// back to the RU default list only when its sources legitimately resolved to nothing — a TOTAL
+/// fetch failure (RIPEstat outage / network partition) fails CLOSED, because substituting the full
+/// RU dump would advertise hundreds of thousands of prefixes the peer never asked for. An unknown
+/// subscription name is a config typo and must be logged, not silently ignored.
+/// </summary>
+public sealed class RouteAssemblerPolicyTests
+{
+    private static readonly UInt128 RuPrefix = 0x0A000000;
+
+    private static RouteAssembler NewAssembler(IPrefixService prefixService, AppConfig config, ILogger<RouteAssembler>? logger = null)
+        => new(
+            prefixService,
+            new ConfiguredPeerStore(),
+            new ConfigCommunityResolver(config, config.Bgp),
+            AllowAllFilter.Instance,
+            config,
+            config.Bgp,
+            logger ?? NullLogger<RouteAssembler>.Instance);
+
+    private static AppConfig Config() => new()
+    {
+        Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" },
+        RipeStat = new RipeStatConfig
+        {
+            AsnLists = [new AsnList { Name = "tier1", Asns = [65010], Community = "65001:200" }]
+        }
+    };
+
+    /// <summary>Every fetch succeeds with EMPTY lists except where a test overrides one member.</summary>
+    private class StubPrefixService : IPrefixService
+    {
+        public Func<IEnumerable<uint>, CancellationToken, Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>>>? OnGetPrefixesForAsns { get; set; }
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
+            => OnGetPrefixesForAsns?.Invoke(asns, ct) ?? Task.FromResult(new List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>());
+        public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
+            => Task.FromResult(new List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)> { (RuPrefix, 8, true, 0u) });
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    /// <summary>An existing peer subscribed to "tier1" — the configured-peer branch.</summary>
+    private sealed class ConfiguredPeerStore : IPeerStore
+    {
+        public List<string> Subscriptions { get; set; } = ["tier1"];
+        public Task<string> CreatePeerAsync(string ip, uint asn, string? description, CancellationToken ct = default) => Task.FromResult("id");
+        public Task UpsertPeerAsync(string ip, uint asn, CancellationToken ct = default) => Task.CompletedTask;
+        public Task UpdateSessionStatusAsync(string ip, uint asn, bool active, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<int?> GetPeerMaxPrefixAsync(string ip, uint asn, CancellationToken ct = default) => Task.FromResult<int?>(null);
+        public Task<PeerRoutingView?> LoadPeerRoutingViewAsync(string ip, uint asn, CancellationToken ct = default)
+            => Task.FromResult<PeerRoutingView?>(new("id", Subscriptions, [], [], []));
+    }
+
+    [Fact]
+    public async Task TotalSourceFailure_FailsClosed_NoRuDump()
+    {
+        // #488 (D26): the only configured fetch THROWS (outage) — the RU fallback must NOT fire;
+        // the peer keeps an empty set instead of the whole RU table.
+        var logger = new CapturingLogger();
+        var service = new StubPrefixService
+        {
+            OnGetPrefixesForAsns = (_, _) => throw new InvalidOperationException("simulated outage")
+        };
+        var assembler = NewAssembler(service, Config(), logger);
+
+        var routes = await assembler.BuildOutboundRoutesAsync(
+            "203.0.113.7", 65002, new PeerConfig { Address = "203.0.113.7" }, "203.0.113.7", CancellationToken.None);
+
+        Assert.Empty(routes);   // RED pre-fix: the RU fallback fired and added the RU prefix
+        Assert.Contains(logger.Entries, e => e.Message.Contains("NOT falling back"));
+    }
+
+    [Fact]
+    public async Task LegitimatelyEmptySources_StillFallBackToRu()
+    {
+        // Control for the same gate: the sources RESOLVED (to an empty list — the operator emptied
+        // them) — the documented "configured peer resolved 0 prefixes" fallback still applies.
+        var assembler = NewAssembler(new StubPrefixService(), Config());
+
+        var routes = await assembler.BuildOutboundRoutesAsync(
+            "203.0.113.7", 65002, new PeerConfig { Address = "203.0.113.7" }, "203.0.113.7", CancellationToken.None);
+
+        var route = Assert.Single(routes);
+        Assert.Equal((RuPrefix, (byte)8), (route.Prefix, route.PrefixLength));
+    }
+
+    [Fact]
+    public async Task UnknownSubscriptionName_IsWarned_NotSilentlyIgnored()
+    {
+        // #488: a subscription matching no AsnLists entry and no PrefixSource is a config typo —
+        // it was silently ignored on every build. Name it in the log.
+        var logger = new CapturingLogger();
+        var store = new ConfiguredPeerStore { Subscriptions = ["no-such-list"] };
+        var config = Config();
+        var assembler = new RouteAssembler(
+            new StubPrefixService(), store,
+            new ConfigCommunityResolver(config, config.Bgp),
+            AllowAllFilter.Instance, config, config.Bgp, logger);
+
+        await assembler.BuildOutboundRoutesAsync(
+            "203.0.113.7", 65002, new PeerConfig { Address = "203.0.113.7" }, "203.0.113.7", CancellationToken.None);
+
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("no-such-list"));
+    }
+
+    private sealed class CapturingLogger : ILogger<RouteAssembler>
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            => Entries.Add((logLevel, formatter(state, exception)));
+    }
+}

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -351,3 +351,22 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
   treated-as-withdraw; routes never install with an empty path (which the AS-loop exclusion,
   RFC 4271 §9.1.2, could never match anyway — D23).
 - **Tracker:** #486.
+
+### D26. Outbound policy under failure — total-source failure fails CLOSED; seed-takeover loss is accepted
+- **Decision (RU fallback):** a CONFIGURED peer whose routes resolve to zero falls back to the RU
+  default list ONLY when its sources legitimately resolved to nothing. When every configured fetch
+  FAILED (RIPEstat outage / network partition), the fallback is suppressed — the peer keeps an
+  empty set (fail closed) instead of receiving the entire RU table it never asked for.
+  Implemented via a per-build failure flag in `RouteAssembler` (`#488`).
+- **Decision (seed takeover):** a peer's announcement of a seeded prefix takes over the shared-table
+  entry (D12), and that session's teardown then removes the entry WITHOUT restoring the seed value.
+  Accepted: in the production composition the outbound path reads sources, never the shared table
+  (D13), so only `GET /api/routes` / LPM lose the prefix until restart; the degraded composition is
+  a named error mode of its own. Restoring seeds would require retaining seed data in `RouteTable`
+  — revisit only if the degraded composition ever becomes supported.
+- **Context:** both behaviors were silent policy gaps found by the 2026-09-04 audit (#488); neither
+  corrupted state — one substituted a huge unintended set on failure, the other lost an API-view row.
+- **Consequence:** during a total source outage, subscribed peers keep an empty advertisement (they
+  were withdrawn at refresh start anyway); an unknown subscription name now logs a Warning per build
+  instead of being silently ignored.
+- **Tracker:** #488.


### PR DESCRIPTION
Closes #488   # linkage only — the integration PR aggregates the closing keywords

## Problem
Three policy gaps from the audit (#488):
1. **Total-source-failure RU fallback:** a configured peer resolving 0 routes fell back to the full RU default list even when the cause was that every configured fetch FAILED — during a RIPEstat/network outage each subscribed peer received the entire RU table it never asked for (initial send after reconnect included).
2. **Unknown subscription names** (a config typo) were silently ignored on every build.
3. **Seed-takeover loss** (a peer announces a seeded prefix, takes over the entry per D12, and its teardown removes the entry without restoring the seed) was undocumented.

## Fix
1. A per-build `anyFetchFailed` flag in `RouteAssembler` (set in every per-fetch catch; `AddUserSourceRoutesAsync` now returns success) gates the RU fallback: total failure → **fail closed** — the peer keeps an empty set, a Warning explains why, and the per-source ERRORs carry the cause. Legitimate zero (sources resolved to nothing, e.g. the operator emptied a list) still falls back — the documented #220-era behavior.
2. A Warning per unknown subscription name ("matches no RipeStat.AsnLists entry and no PrefixSource — ignored").
3. Recorded as **D26** in DESIGN_DECISIONS.md: the fail-closed fallback, the accepted seed-takeover loss (production composition reads sources, never the shared table — D13; only API-view/LPM and the named degraded mode are affected), and the new warning.

## Correctness
- Unconfigured peers (no subscriptions at all) are untouched — their RU-defaults path is a separate branch.
- Caller cancellation still propagates everywhere (the flag is set only in the generic catches, never the OCE filters).
- The refresh flow already withdrew everything before the rebuild, so fail-closed yields "keeps withdrawn", not a new withdrawal.

## Regression Tests
`RouteAssemblerPolicyTests` (new):
- `TotalSourceFailure_FailsClosed_NoRuDump` — the only configured fetch throws → zero routes + the NOT-falling-back Warning. **Red/green proven** (pre-fix: the RU prefix was added).
- `LegitimatelyEmptySources_StillFallBackToRu` — control: sources resolve to empty → the RU fallback still fires.
- `UnknownSubscriptionName_IsWarned_NotSilentlyIgnored` — the typo name appears in a Warning.

## Verification
- `dotnet format` clean; `dotnet build BGPLite.sln` 0 warnings/0 errors
- `dotnet test BGPLite.sln`: 1092/1092 (baseline 1089 + the three new tests)

## RFC
- none directly; RFC 4486 context unchanged (this is provisioning policy, not peering policy).

## Behavior Change
**Yes (the point):** during a total source outage, subscribed peers now keep an empty advertisement instead of receiving the full RU default table. Unknown subscription names log a Warning per build.

## Deviation from Issue Proposal
The seed-restore option was considered and declined with rationale in D26 (restoring seeds requires retaining seed data in RouteTable; production composition is unaffected — the loss is API-view-only). The issue offered both choices.