### PR TITLE
chore: integrate dev — 2026-09-04 audit fixes #476–#488

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -1445,20 +1445,31 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         // Append configured PrefixSources (file/http) alongside the legacy RipeStat ASN-lists,
         // reusing the same response shape. "Kind" is intentionally not exposed.
+        // #480: the budget token firing mid-LoadAllAsync surfaces as a foreign-token OCE (live
+        // shutdown token) — without this catch it escaped the handler and closed the connection
+        // without a body, discarding the partial result assembled above. Degrade like the
+        // per-source loops above; the tail warning below reports the budget expiry (both paths).
         var seen = lists.Select(l => l.Name).ToHashSet();
-        foreach (var (source, prefixes) in await _prefixSources.LoadAllAsync(ct))
+        try
         {
-            if (!seen.Add(source.Name)) continue; // skip names already present (e.g. shared "ru")
-            result.Add(new
+            foreach (var (source, prefixes) in await _prefixSources.LoadAllAsync(ct))
             {
-                id = source.Name,
-                Name = source.Name,
-                Description = source.Description,
-                Country = (string?)null,
-                Community = source.Community,
-                prefixCount = prefixes.Count,
-                type = source.Kind == "asn" ? "asn" : "list"
-            });
+                if (!seen.Add(source.Name)) continue; // skip names already present (e.g. shared "ru")
+                result.Add(new
+                {
+                    id = source.Name,
+                    Name = source.Name,
+                    Description = source.Description,
+                    Country = (string?)null,
+                    Community = source.Community,
+                    prefixCount = prefixes.Count,
+                    type = source.Kind == "asn" ? "asn" : "list"
+                });
+            }
+        }
+        catch (OperationCanceledException) when (!_shutdownCts.IsCancellationRequested)
+        {
+            // Budget expiry, not shutdown — serve the partial result (see above).
         }
 
         if (ct.IsCancellationRequested && !_shutdownCts.IsCancellationRequested)

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -68,6 +68,12 @@ public sealed class ManagementApi : IHostedService, IDisposable
     /// their PARTIAL result with a warning; shutdown still propagates. internal settable for tests.
     /// </summary>
     internal TimeSpan ExternalFetchBudget { get; set; } = TimeSpan.FromSeconds(30);
+
+    // #487: bounds for peer-supplied custom sources — generous ceilings that only reject abuse
+    // (repeated POSTs growing the DB without limit; megabyte-scale names/URLs in logs and rows).
+    internal const int MaxSourceNameLength = 200;
+    internal const int MaxSourceUrlLength = 2048;
+    internal const int MaxSourcesPerPeer = 64;
     // #258: in-flight tracking is a COUNT plus an idle Task (completed whenever the count is 0),
     // not a List<Task> — the #248 design appended every handler and never removed it, so each
     // completed request leaked its Task (and its exception, if faulted) for the process lifetime
@@ -721,7 +727,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         {
             asn = bgp.Asn,
             routerId = bgp.RouterId,
-            bgpPort = 179,
+            bgpPort = BgpConstants.BgpPort,
             apiPort = _port,
             holdTime = bgp.HoldTime,
             keepalive = bgp.KeepAlive,
@@ -1115,13 +1121,18 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         await _store.UpdatePeerConfigurationAsync(peerId, data.Description, data.Lists, parsedPrefixes, data.CustomAsns, data.MaxPrefix,
             md5Password: data.Md5Password);
+        // #487: a concurrent DELETE between the top-of-handler GET and this UPDATE left the
+        // ExecuteUpdates touching 0 rows while the handler still logged "Updated peer", answered
+        // 200 and fired a refresh — the follow-up GET then 404ed. Re-check the row and answer 404
+        // directly (the write itself is harmless: transaction-scoped, 0 rows affected).
+        var surviving = await _store.GetDbPeerByIdAsync(peerId);
+        if (surviving is null)
+            return ApiResponse.Error("Peer not found", 404);
         if (data.Md5Password is not null)
         {
             // #418: re-arm from ALL surviving rows for this IP — clearing this peer's key must
             // fall back to a sibling's, not silently disarm the address for every peer on it.
-            var md5Peer = await _store.GetDbPeerByIdAsync(peerId);
-            if (md5Peer is not null)
-                await RearmPeerIpMd5KeyAsync(md5Peer.Ip);
+            await RearmPeerIpMd5KeyAsync(surviving.Ip);
         }
 
         _logger.LogInformation("Updated peer {Id}", SanitizeForLog(peerId));
@@ -1216,6 +1227,16 @@ public sealed class ManagementApi : IHostedService, IDisposable
 
         if (data is null || string.IsNullOrWhiteSpace(data.Name) || string.IsNullOrWhiteSpace(data.Url))
             return ApiResponse.Error("Name and Url are required", 400);
+
+        // #487: bound the peer-supplied fields and the per-peer source count. The 1 MiB body cap
+        // bounds ONE request; nothing bounded repeated posts, and the DB rows outlive the request.
+        // Generous limits: a longer name/URL is never legitimate, and a peer needs far fewer
+        // sources than the user-source cache's 1024-URL entry cap.
+        if (data.Name.Length > MaxSourceNameLength || data.Url.Length > MaxSourceUrlLength)
+            return ApiResponse.Error(
+                $"Name must be at most {MaxSourceNameLength} characters and Url at most {MaxSourceUrlLength}.", 400);
+        if ((await _store.GetCustomSourcesAsync(peerId)).Count >= MaxSourcesPerPeer)
+            return ApiResponse.Error($"Peer already has the maximum of {MaxSourcesPerPeer} custom sources.", 400);
 
         // #266 item 3: the community is peer-supplied and reaches the wire through
         // CommunityCodec at send time — validate the SAME contract at the API boundary (#255

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -1250,14 +1250,19 @@ public sealed class ManagementApi : IHostedService, IDisposable
         }
         catch (OperationCanceledException) when (validationCts.IsCancellationRequested)
         {
-            // DNS-resolution timeout (5s).
-            _logger.LogWarning("Save-time URL validation timed out for '{Url}'", SanitizeForLog(data.Url));
+            // DNS-resolution timeout (5s). #479 (#149): source URLs may carry query-string tokens —
+            // the log names the source, never the URL.
+            _logger.LogWarning("Save-time URL validation timed out for source '{Name}'", SanitizeForLog(data.Name));
             return ApiResponse.Error("URL validation timed out (DNS resolution took too long)", 400);
         }
         if (!isValid)
         {
-            _logger.LogWarning("Save-time URL validation rejected '{Url}': {Error}", SanitizeForLog(data.Url), validationError);
-            return ApiResponse.Error($"Invalid URL: the host could not be reached or is not allowed", 400);
+            // #479 (#149): neither the URL nor the validator's message (which embeds it) belongs in
+            // the log. The reason goes to the RESPONSE instead — the operator just submitted this
+            // URL, so echoing it there leaks nothing.
+            _logger.LogWarning("Save-time URL validation rejected source '{Name}' for peer {PeerId}",
+                SanitizeForLog(data.Name), SanitizeForLog(peerId));
+            return ApiResponse.Error($"Invalid URL: {validationError ?? "the host could not be reached or is not allowed"}", 400);
         }
 
         var source = await _store.AddCustomSourceAsync(peerId, data.Name, data.Url, data.Community);
@@ -1266,8 +1271,9 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // same pattern as CreatePeer/UpdatePeer. Pass ASN so shared-IP peers aren't refreshed (#200).
         RequestPeerRefresh(peerId, peer);
 
-        _logger.LogInformation("Added source '{Name}' ({Url}) to peer {PeerId}",
-            SanitizeForLog(data.Name), SanitizeForLog(data.Url), SanitizeForLog(peerId));
+        // #479 (#149): log the source Name, not the URL (query-string tokens are secrets).
+        _logger.LogInformation("Added source '{Name}' to peer {PeerId}",
+            SanitizeForLog(data.Name), SanitizeForLog(peerId));
         return ApiResponse.Ok(new { id = source.Id, name = source.Name, url = source.Url, community = source.Community, active = source.Active });
     }
 

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -1712,7 +1712,7 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (config.RipeStat?.AsnLists is { } lists)
             foreach (var l in lists)
                 known.Add(l.Name);
-        foreach (var source in config.PrefixSources)
+        foreach (var source in config.PrefixSources ?? []) // #477: YAML null = no sources
             known.Add(source.Name);
         return names.Where(n => !known.Contains(n)).Distinct(StringComparer.Ordinal).ToList();
     }

--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -1264,10 +1264,11 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // (unlike ASP.NET Core's RequestAborted), so the timeout is purely time-bounded.
         using var validationCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         bool isValid;
-        string? validationError;
         try
         {
-            (isValid, validationError) = await PrefixSourceUrlValidator.ValidateUrlAsync(data.Url, ct: validationCts.Token);
+            // #503 review: the validator's reason string embeds the URL and DNS internals —
+            // discarded; the log names the source and the response carries a fixed classification.
+            (isValid, _) = await PrefixSourceUrlValidator.ValidateUrlAsync(data.Url, ct: validationCts.Token);
         }
         catch (OperationCanceledException) when (validationCts.IsCancellationRequested)
         {
@@ -1279,11 +1280,13 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (!isValid)
         {
             // #479 (#149): neither the URL nor the validator's message (which embeds it) belongs in
-            // the log. The reason goes to the RESPONSE instead — the operator just submitted this
-            // URL, so echoing it there leaks nothing.
+            // the log. #503 review (CWE-209): the validator's message ALSO embeds resolved
+            // addresses and raw DNS exception text — classify for the response instead of echoing
+            // server-side resolution internals back to the caller.
             _logger.LogWarning("Save-time URL validation rejected source '{Name}' for peer {PeerId}",
                 SanitizeForLog(data.Name), SanitizeForLog(peerId));
-            return ApiResponse.Error($"Invalid URL: {validationError ?? "the host could not be reached or is not allowed"}", 400);
+            return ApiResponse.Error(
+                "Invalid URL: the scheme must be http/https on port 80/443 and the host must resolve to a reachable public address", 400);
         }
 
         var source = await _store.AddCustomSourceAsync(peerId, data.Name, data.Url, data.Community);

--- a/BGPLite.Configuration/BgpConfig.cs
+++ b/BGPLite.Configuration/BgpConfig.cs
@@ -88,9 +88,12 @@ public sealed class BgpConfig
     /// <summary>#304: per-peer ceiling on prefixes installed from one session (distinct
     /// NLRI this session currently owns); exceeding it tears the session down with
     /// NOTIFICATION(Cease, MaxPrefixesExceeded) per RFC 4271 §6.7 / RFC 4486 §2.
-    /// 0 = unlimited (the convention of OpenTimeoutSeconds / MaxAcceptsPerIpPerMinute).</summary>
+    /// #481: the shipped default is bounded (1,000,000 — above any legitimate provisioning
+    /// peer, far below memory exhaustion) so the RFC 4486 defense is on out of the box;
+    /// 0 = unlimited remains available as an explicit opt-out (the convention of
+    /// OpenTimeoutSeconds / MaxAcceptsPerIpPerMinute).</summary>
     [YamlMember(Alias = "MaxPrefixesPerPeer")]
-    public int MaxPrefixesPerPeer { get; init; } = 0;
+    public int MaxPrefixesPerPeer { get; init; } = 1_000_000;
 
     public IPAddress GetRouterIdAddress() => IPAddress.Parse(RouterId);
 

--- a/BGPLite.Protocol/UpdateCodec.cs
+++ b/BGPLite.Protocol/UpdateCodec.cs
@@ -310,9 +310,11 @@ public static class UpdateCodec
             // one, so anything reading the first (a collector, a looking glass, an operator's packet
             // capture) disagreed with what actually landed in the route table (#287).
             //
-            // The MP_REACH_NLRI/MP_UNREACH_NLRI half of that paragraph — duplicate → NOTIFICATION,
-            // session reset — is deliberately not implemented: BGPLite is IPv4-unicast only and never
-            // parses those attributes. It belongs with MP-BGP support (#14).
+            // The MP_REACH_NLRI/MP_UNREACH_NLRI half of that paragraph is handled UPSTREAM, in
+            // BgpMessageReader.ParseUpdate: those attributes are extracted into typed fields
+            // before this generic list is built, and a duplicate takes the RFC 7606 §3(g)
+            // NOTIFICATION + session reset there (#467). The first-wins guard below therefore
+            // never sees them.
             //
             // Clear() is not redundant despite `localsinit` zeroing stackalloc by default: adding
             // [SkipLocalsInit] (or <SkipLocalsInit> in the csproj) is an ordinary perf tweak for a

--- a/BGPLite.Protocol/UpdateCodec.cs
+++ b/BGPLite.Protocol/UpdateCodec.cs
@@ -358,6 +358,16 @@ public static class UpdateCodec
                         originSeen = true;
                         break;
                     case BgpConstants.Attribute.AsPath:
+                        // #486 (D25): a zero-length AS_PATH is a legal ENCODING (RFC 4271 §5.1.2
+                        // lets an originator send an empty path toward INTERNAL peers) but never a
+                        // valid eBGP path — BGPLite serves eBGP only, where the sender's own ASN
+                        // must be present. Rejected at the policy layer as Malformed AS_PATH
+                        // (treat-as-withdraw); the codec stays encoding-neutral so the writer's
+                        // empty-path roundtrip (#248 review) stands.
+                        if (attr.Data.Length == 0)
+                            throw new BgpNotificationException(
+                                BgpConstants.Error.UpdateMessageError, BgpConstants.SubError.MalformedAsPath,
+                                "Invalid AS_PATH: an empty path is only valid toward internal peers (RFC 4271 §5.1.2)");
                         asPath = AttributeHelper.ReadAsPath(attr, fourByteAsnSession);
                         asPathSeen = true;
                         break;

--- a/BGPLite.Providers/FilePrefixProvider.cs
+++ b/BGPLite.Providers/FilePrefixProvider.cs
@@ -41,14 +41,29 @@ public sealed class FilePrefixProvider(ILogger<FilePrefixProvider> logger) : IPr
         // #321 item 5: async read with the caller's token — the sync ReadAllText held a threadpool
         // thread under the per-source gate for the whole file. The metadata probes above stay
         // sync: they are single stat calls, not reads.
-        // #487: cap parity with the HTTP paths (HttpPrefixProvider.MaxResponseBytes) — the file is
-        // operator-controlled, but a multi-GB "prefix list" is never legitimate and the uncapped
-        // read was an asymmetric memory-amplification footgun.
-        var length = new FileInfo(fullPath).Length;
-        if (length > HttpPrefixProvider.MaxResponseBytes)
-            throw new InvalidOperationException(
-                $"Prefix file for source '{source.Name}' is {length} bytes — over the {HttpPrefixProvider.MaxResponseBytes}-byte cap.");
-        var text = await File.ReadAllTextAsync(fullPath, ct);
+        // #487 + #503 review: cap parity with the HTTP paths (HttpPrefixProvider.MaxResponseBytes),
+        // enforced WHILE reading — a length probe alone races a concurrent writer extending the
+        // file between the stat and the read.
+        string text;
+        await using (var fs = File.OpenRead(fullPath))
+        {
+            if (fs.Length > HttpPrefixProvider.MaxResponseBytes)
+                throw new InvalidOperationException(
+                    $"Prefix file for source '{source.Name}' is {fs.Length} bytes — over the {HttpPrefixProvider.MaxResponseBytes}-byte cap.");
+            using var ms = new MemoryStream(capacity: (int)Math.Min(fs.Length, HttpPrefixProvider.MaxResponseBytes));
+            var buffer = new byte[81920];
+            int read;
+            long total = 0;
+            while ((read = await fs.ReadAsync(buffer, ct)) > 0)
+            {
+                total += read;
+                if (total > HttpPrefixProvider.MaxResponseBytes)
+                    throw new InvalidOperationException(
+                        $"Prefix file for source '{source.Name}' grew past the {HttpPrefixProvider.MaxResponseBytes}-byte cap while reading.");
+                ms.Write(buffer, 0, read);
+            }
+            text = System.Text.Encoding.UTF8.GetString(ms.ToArray());
+        }
         var prefixes = PrefixListParser.Parse(text);
         logger.LogInformation("Source '{Name}' (file): loaded {Count} prefixes from {Path}", source.Name, prefixes.Count, fullPath);
         return SourceLoadResult.Ok(prefixes, lastModified: fileMtime);

--- a/BGPLite.Providers/FilePrefixProvider.cs
+++ b/BGPLite.Providers/FilePrefixProvider.cs
@@ -41,6 +41,13 @@ public sealed class FilePrefixProvider(ILogger<FilePrefixProvider> logger) : IPr
         // #321 item 5: async read with the caller's token — the sync ReadAllText held a threadpool
         // thread under the per-source gate for the whole file. The metadata probes above stay
         // sync: they are single stat calls, not reads.
+        // #487: cap parity with the HTTP paths (HttpPrefixProvider.MaxResponseBytes) — the file is
+        // operator-controlled, but a multi-GB "prefix list" is never legitimate and the uncapped
+        // read was an asymmetric memory-amplification footgun.
+        var length = new FileInfo(fullPath).Length;
+        if (length > HttpPrefixProvider.MaxResponseBytes)
+            throw new InvalidOperationException(
+                $"Prefix file for source '{source.Name}' is {length} bytes — over the {HttpPrefixProvider.MaxResponseBytes}-byte cap.");
         var text = await File.ReadAllTextAsync(fullPath, ct);
         var prefixes = PrefixListParser.Parse(text);
         logger.LogInformation("Source '{Name}' (file): loaded {Count} prefixes from {Path}", source.Name, prefixes.Count, fullPath);

--- a/BGPLite.Providers/PrefixService.cs
+++ b/BGPLite.Providers/PrefixService.cs
@@ -250,7 +250,10 @@ public sealed class PrefixService : IPrefixService
                 projected = prefixes.Select(p => (p.Address, p.Length, p.IsIpv4, 0u)).ToList();
                 changed = loadChanged;
             }
-            catch (OperationCanceledException) { throw; }
+            // #485 (#320/#324 contract): only CALLER cancellation propagates. A foreign-token OCE
+            // (the default source's fetch budget firing on a live ct) is a load FAILURE and takes
+            // the stale-on-failure branch below instead of escaping as "cancellation".
+            catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
             catch (Exception ex)
             {
                 // Stale-on-failure (#163 parity): serve the last good copy regardless of its age so
@@ -324,6 +327,7 @@ public sealed class PrefixService : IPrefixService
                 await GetPrefixesAsync(asn, ct);
                 _logger?.LogInformation("WarmUp: AS{Asn} cached", asn);
             }
+            catch (OperationCanceledException) { throw; }   // #485: host shutdown unwinds the loop, not a WARN per remaining ASN
             catch (Exception ex)
             {
                 _logger?.LogWarning(ex, "WarmUp: AS{Asn} failed", asn);

--- a/BGPLite.Providers/PrefixService.cs
+++ b/BGPLite.Providers/PrefixService.cs
@@ -327,7 +327,11 @@ public sealed class PrefixService : IPrefixService
                 await GetPrefixesAsync(asn, ct);
                 _logger?.LogInformation("WarmUp: AS{Asn} cached", asn);
             }
-            catch (OperationCanceledException) { throw; }   // #485: host shutdown unwinds the loop, not a WARN per remaining ASN
+            // #485: host shutdown unwinds the loop, not a WARN per remaining ASN.
+            // #503 review: filter CALLER cancellation — a foreign-token OCE (body deadline on a
+            // cold ASN, escaping RipeStatPrefixCache's no-stale rethrow) is a per-ASN fetch
+            // failure like any other; unfiltered, one cold timeout aborted the whole warm-up.
+            catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
             catch (Exception ex)
             {
                 _logger?.LogWarning(ex, "WarmUp: AS{Asn} failed", asn);

--- a/BGPLite.Providers/PrefixSourceService.cs
+++ b/BGPLite.Providers/PrefixSourceService.cs
@@ -48,7 +48,8 @@ public sealed class PrefixSourceService : IPrefixSourceService
         TimeProvider? timeProvider = null,
         Func<string, Task>? onSourceChanged = null)
     {
-        var duplicate = config.PrefixSources
+        // #477: "PrefixSources:" (YAML null) is a documented-valid "no sources" config.
+        var duplicate = (config.PrefixSources ?? [])
             .GroupBy(s => s.Name)
             .FirstOrDefault(g => g.Count() > 1);
         if (duplicate != null)
@@ -62,7 +63,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
         _negativeTtl = negativeTtl ?? TimeSpan.FromSeconds(30);
         _timeProvider = timeProvider ?? TimeProvider.System;
         _onSourceChanged = onSourceChanged;
-        _sourcesByName = config.PrefixSources.ToDictionary(s => s.Name);
+        _sourcesByName = (config.PrefixSources ?? []).ToDictionary(s => s.Name);
     }
 
     public async Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default)
@@ -122,7 +123,7 @@ public sealed class PrefixSourceService : IPrefixSourceService
     public async Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
     {
         var result = new List<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>();
-        foreach (var source in _config.PrefixSources)
+        foreach (var source in _config.PrefixSources ?? [])
         {
             IReadOnlyList<IpPrefix> prefixes;
             try { prefixes = (await LoadCachedAsync(source, ct)).Prefixes; }

--- a/BGPLite.Providers/RipeStatPrefixCache.cs
+++ b/BGPLite.Providers/RipeStatPrefixCache.cs
@@ -134,7 +134,12 @@ public sealed class RipeStatPrefixCache
             {
                 prefixes = await _ripe.GetPrefixesAsync(asn, ct);
             }
-            catch (OperationCanceledException) { throw; }
+            // #485 (#320/#324 contract): only CALLER cancellation propagates. A foreign-token OCE
+            // (the per-attempt/body deadline inside RipeStatProvider, fired on a live ct) is a
+            // load FAILURE and takes the stale-on-failure / negative-cache branches below — the
+            // unfiltered rethrow meant every retry re-paid the full fetch budget with no backoff
+            // ever recorded.
+            catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
             catch (Exception ex)
             {
                 // Stale-on-failure (#163): serve the last good copy regardless of its age so a

--- a/BGPLite.Providers/UserSourceCache.cs
+++ b/BGPLite.Providers/UserSourceCache.cs
@@ -216,7 +216,9 @@ internal sealed class UserSourceCache
         if (_cache.ContainsKey(insertingUrl)) return; // already present, no insert coming
 
         var now = _timeProvider.GetUtcNow().UtcDateTime;
-        var toEvict = new List<string>();
+        // #487: HashSet — the Contains in the oldest-selection loop below made eviction O(n²) at
+        // the 1024-entry cap.
+        var toEvict = new HashSet<string>();
         foreach (var (key, entry) in _cache)
         {
             var ttl = entry.Negative ? _negativeTtl : _positiveTtl;
@@ -280,7 +282,7 @@ internal sealed class UserSourceCache
         Volatile.Write(ref _callsSinceSweep, 0);
 
         var now = _timeProvider.GetUtcNow().UtcDateTime;
-        var toEvict = new List<string>();
+        var toEvict = new HashSet<string>();   // #487: O(1) Contains for the budget loop below
         long total = 0;
         foreach (var (key, entry) in _cache)
         {

--- a/BGPLite.Providers/UserSourceCache.cs
+++ b/BGPLite.Providers/UserSourceCache.cs
@@ -58,6 +58,13 @@ internal sealed class UserSourceCache
     // still inside or queued — otherwise two gates coexist and two loaders race one URL, with the
     // older response able to overwrite the newer (RipeStatPrefixCache's #267-item-3 invariant).
     private readonly ConcurrentDictionary<string, int> _inflight = new();
+    // #478: serializes the COMPOUND bookkeeping over _inflight and _locks — registration,
+    // last-leaver gate removal, and the sweeps' inflight-check-then-remove. Without it the
+    // decrement→zero-check→gate-removal sequence in ExitInflight could interleave with a fresh
+    // registration, pair-removing a gate its loader still held (duplicate concurrent fetch — the
+    // #468 consequence in a nanosecond window). Never held across an await: the gate Wait/Release
+    // stay outside.
+    private readonly object _gateSync = new();
 
     public UserSourceCache(TimeSpan? positiveTtl = null, TimeSpan? negativeTtl = null, ILogger? logger = null, TimeProvider? timeProvider = null, int? maxCacheEntries = null, long? maxTotalPrefixes = null, int? sweepEvery = null)
     {
@@ -102,9 +109,15 @@ internal sealed class UserSourceCache
         // (now-removed) gate instance but not yet registered, parking it on an orphaned
         // semaphore while the next caller minted a second gate. With this order every
         // participant is counted in _inflight before it can touch _locks, so ExitInflight only
-        // ever removes a gate that nobody holds or queues on.
-        _inflight.AddOrUpdate(url, 1, (_, c) => c + 1);
-        var gate = _locks.GetOrAdd(url, _ => new SemaphoreSlim(1, 1));
+        // ever removes a gate that nobody holds or queues on. #478: register+take run as one
+        // atomic section under _gateSync — the counter bump and the gate lookup must not be
+        // split by a concurrent last-leaver removal.
+        SemaphoreSlim gate;
+        lock (_gateSync)
+        {
+            _inflight.AddOrUpdate(url, 1, (_, c) => c + 1);
+            gate = _locks.GetOrAdd(url, _ => new SemaphoreSlim(1, 1));
+        }
         var entered = false;
         try
         {
@@ -172,17 +185,21 @@ internal sealed class UserSourceCache
     /// hygiene). #468: a cancelled waiter no longer removes the gate directly — that pair-
     /// removed the shared instance out from under the still-running first loader, minted a
     /// second gate for the next caller, and raced a newer load against an older snapshot.
-    /// Removal here can only run when nobody holds or queues on the gate: every participant
-    /// registers in <see cref="_inflight"/> BEFORE taking the gate from <see cref="_locks"/>,
-    /// so a non-zero remaining count means someone else is inside or queued and the gate must
-    /// stay. The sweeps keep their own <c>_inflight &gt; 0</c> guards for the entry-backed path.
+    /// #478: the whole sequence runs as one atomic section under <see cref="_gateSync"/>, with
+    /// registration taking the same lock — the previous unlocked decrement→zero-check→gate-
+    /// removal could interleave with a fresh registration landing between the check and the
+    /// pair-removal, deleting a gate its loader still held (duplicate concurrent fetch,
+    /// last-writer-wins on the cache entry).
     /// </summary>
     private void ExitInflight(string url, SemaphoreSlim gate)
     {
-        var remaining = _inflight.AddOrUpdate(url, 0, (_, c) => c - 1);
-        if (remaining > 0) return;
-        _inflight.TryRemove(new KeyValuePair<string, int>(url, 0));
-        ((ICollection<KeyValuePair<string, SemaphoreSlim>>)_locks).Remove(new KeyValuePair<string, SemaphoreSlim>(url, gate));
+        lock (_gateSync)
+        {
+            var remaining = _inflight.AddOrUpdate(url, 0, (_, c) => c - 1);
+            if (remaining > 0) return;
+            _inflight.TryRemove(new KeyValuePair<string, int>(url, 0));
+            ((ICollection<KeyValuePair<string, SemaphoreSlim>>)_locks).Remove(new KeyValuePair<string, SemaphoreSlim>(url, gate));
+        }
     }
 
     /// <summary>
@@ -223,9 +240,14 @@ internal sealed class UserSourceCache
         foreach (var key in toEvict)
         {
             // #450 review: a URL with active loaders keeps its gate (see SweepIfNeeded).
-            if (_inflight.TryGetValue(key, out var active) && active > 0) continue;
-            if (_cache.TryRemove(key, out _))
-                _locks.TryRemove(key, out _);
+            // #478: inflight-check and gate removal run under _gateSync so a loader registering
+            // between the check and the removal cannot lose its gate to the eviction.
+            lock (_gateSync)
+            {
+                if (_inflight.TryGetValue(key, out var active) && active > 0) continue;
+                if (_cache.TryRemove(key, out _))
+                    _locks.TryRemove(key, out _);
+            }
         }
     }
 
@@ -285,9 +307,13 @@ internal sealed class UserSourceCache
         {
             // #450 review: a URL with active loaders keeps its gate (its loader writes the entry
             // on its own reference) — removing the gate would mint a duplicate concurrent fetch.
-            if (_inflight.TryGetValue(key, out var active) && active > 0) continue;
-            if (_cache.TryRemove(key, out _))
-                _locks.TryRemove(key, out _);
+            // #478: same _gateSync atomicity as EvictIfAtCapacity's removal loop.
+            lock (_gateSync)
+            {
+                if (_inflight.TryGetValue(key, out var active) && active > 0) continue;
+                if (_cache.TryRemove(key, out _))
+                    _locks.TryRemove(key, out _);
+            }
         }
     }
 }

--- a/BGPLite.Server/BgpServer.cs
+++ b/BGPLite.Server/BgpServer.cs
@@ -573,6 +573,7 @@ public sealed class BgpServer : IHostedService, ISessionManager, IDisposable
         _listener?.Close();
         _cts.Cancel();
         _cts.Dispose();  // #105: dispose the CTS (StopAsync's graceful path doesn't reach here)
+        _statusTimer?.Dispose();  // #487: the abort path never runs StopAsync — don't leak the timer to GC
         foreach (var session in _sessions.Values)
             session.Dispose();
     }

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -31,8 +31,9 @@ public sealed class BgpSession : IDisposable
     private readonly ILogger<BgpSession> _logger;
     private readonly CancellationTokenSource _cts = new();
     private readonly Func<string, uint, CancellationToken, Task>? _onPeerIdentified;
-    // #15 phase 2: the peer advertised MP-BGP IPv6/Unicast.
-    private bool _peerMpIpv6Unicast;
+    // #15 phase 2: the peer advertised MP-BGP IPv6/Unicast. Written once on the session thread
+    // (ValidateOpenAsync); read cross-thread on the API-refresh/send paths — volatile (#487).
+    private volatile bool _peerMpIpv6Unicast;
     // #467 (RFC 7606 §3(j) "AFI/SAFI disable"): set when an unparseable MP attribute withdraws
     // the family — subsequent MP_REACH/MP_UNREACH payloads from this peer are ignored and its
     // accepted IPv6 routes are gone. Volatile: written on the read loop, read on send paths.
@@ -72,7 +73,10 @@ public sealed class BgpSession : IDisposable
     // StopAsync/replace path), read by the RunAsync finally-block on a different thread.
     private int _teardownReason = (int)TeardownReason.None;
     private int _disposed;
-    private uint _remoteAsn;
+    // Negotiated from the peer's OPEN (OpenNegotiator). Written on the session thread before
+    // Established; read cross-thread by BgpServer's (Ip, Asn) filters and the refresh/send paths
+    // — volatile for guaranteed visibility (#487, matching _peerMpV6Disabled).
+    private volatile uint _remoteAsn;
     private bool _remoteFourByteAsn;
     private bool _remoteRouteRefresh;
     private bool _localFourByteAsn; // derived from negotiated OPEN capability (RFC 6793)

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -1135,6 +1135,9 @@ public sealed class BgpSession : IDisposable
                 // the parse; this closes the asymmetry on the NLRI side.
                 // Same ownership rule as an explicit withdrawal (#289): treat-as-withdraw removes
                 // what this peer installed, not whatever is at that prefix.
+                // #484 (RFC 7606 §2): the MP_UNREACH_NLRI half of the SAME message is applied too —
+                // the classic WITHDRAWN field is honored even when the parse fails (it ran before
+                // the parse), so the MP withdrawal must not be lost to the same failure.
                 foreach (var nlri in update.Nlri)
                     WithdrawIfOwned(nlri, "Route withdrawn (treat-as-withdraw)");
                 if (mpReach is { } failedReach)
@@ -1143,6 +1146,12 @@ public sealed class BgpSession : IDisposable
                 if (mpReachV4 is { } failedReach4)
                     foreach (var p in failedReach4.Prefixes)
                         WithdrawIfOwned(p, "Route withdrawn (treat-as-withdraw, MP_REACH IPv4)");
+                if (update.MpUnreachV6 is { Count: > 0 } failedUnreach)
+                    foreach (var p in failedUnreach)
+                        WithdrawIfOwned(p, "Route withdrawn (treat-as-withdraw, MP_UNREACH)");
+                if (update.MpUnreachV4 is { Count: > 0 } failedUnreach4)
+                    foreach (var p in failedUnreach4)
+                        WithdrawIfOwned(p, "Route withdrawn (treat-as-withdraw, MP_UNREACH IPv4)");
                 _metrics.SetRouteCount(_routeTable.Count);
                 throw;
             }

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -478,7 +478,15 @@ public sealed class BgpSession : IDisposable
             // Send initial routes. _sendLock is acquired inside SendMessageAsync for byte-level
             // ordering; _advertisedPrefixesLock guards the list across the initial-send vs. a
             // RefreshRoutesAsync fired from the API the instant IsEstablished became true.
-            await _advertisedPrefixesLock.WaitAsync(linkedCts.Token);
+            // #482: the acquire/release are OCE/ODE-guarded exactly like RefreshCycleAsync's —
+            // an external Dispose during the dump otherwise surfaced as an ERROR-logged
+            // "Session error" (WaitAsync on a disposed semaphore / Release after dispose)
+            // instead of a clean unwind.
+            try
+            {
+                await _advertisedPrefixesLock.WaitAsync(linkedCts.Token);
+            }
+            catch (ObjectDisposedException) { return; } // session disposed mid-dump — nothing to send
             try
             {
                 await SendAllRoutesAsync();
@@ -487,7 +495,12 @@ public sealed class BgpSession : IDisposable
                 if (_bgpConfig.GracefulRestart)
                     await SendEndOfRibAsync();
             }
-            finally { _advertisedPrefixesLock.Release(); }
+            finally
+            {
+                try { _advertisedPrefixesLock.Release(); }
+                catch (ObjectDisposedException) { /* session disposed — fine */ }
+                catch (SemaphoreFullException) { /* double-release guard, shouldn't happen */ }
+            }
 
             // Run main loop: read messages + send keepalives
             await RunEstablishedAsync(linkedCts.Token);
@@ -666,7 +679,7 @@ public sealed class BgpSession : IDisposable
         if (_negotiatedHoldTime == 0)
         {
             await ReadLoopAsync(cancellationToken);
-            await _cts.CancelAsync();
+            await CancelSessionCtsAsync();
             return;
         }
 
@@ -677,10 +690,24 @@ public sealed class BgpSession : IDisposable
         var keepaliveTask = HoldTimerLoopAsync(keepaliveTimer, cancellationToken);
 
         await Task.WhenAny(readTask, keepaliveTask);
-        await _cts.CancelAsync();
+        await CancelSessionCtsAsync();
 
         await AwaitLoopTaskAsync(readTask, "read");
         await AwaitLoopTaskAsync(keepaliveTask, "keepalive");
+    }
+
+    /// <summary>
+    /// #482: an external Dispose (API peer deletion / server shutdown) can complete
+    /// <c>_cts.Cancel()</c> + <c>_cts.Dispose()</c> while this session task is still parked on
+    /// <c>Task.WhenAny</c> — <c>CancelAsync</c> on the disposed CTS then throws ObjectDisposedException,
+    /// which escaped to RunAsync's generic catch as an ERROR-logged "Session error" on a routine
+    /// teardown and skipped the loop-task drains. MarkSilentClose/FaultSession already guard the
+    /// synchronous Cancel the same way; unwinding is the goal either way, so the ODE is swallowed.
+    /// </summary>
+    private async Task CancelSessionCtsAsync()
+    {
+        try { await _cts.CancelAsync(); }
+        catch (ObjectDisposedException) { /* session disposed mid-unwind — nothing left to cancel */ }
     }
 
     private async Task AwaitLoopTaskAsync(Task task, string label)
@@ -1368,6 +1395,14 @@ public sealed class BgpSession : IDisposable
     /// </summary>
     private async Task SendAllRoutesAsync()
     {
+        // #482: _cts.Token throws ObjectDisposedException once Dispose has run — a send cycle that
+        // outlives its session otherwise logs a misleading MaxPrefix/refresh failure (a normal
+        // unwind reads as an ERROR). RefreshRoutesAsync guards the same read; capture the token
+        // once and bail quietly on a disposed session.
+        CancellationToken sessionToken;
+        try { sessionToken = _cts.Token; }
+        catch (ObjectDisposedException) { return; }
+
         // #391: refresh the effective per-peer prefix ceiling once per cycle — the peer row's
         // MaxPrefix override when the peer is configured (operator edits apply on the next
         // refresh), else the global default. Unknown peers (auto-register path) read null here
@@ -1379,7 +1414,7 @@ public sealed class BgpSession : IDisposable
             // until some later successful refresh. Keep the last known cap instead.
             try
             {
-                var overrideCap = await _peerStore.GetPeerMaxPrefixAsync(_peerConfig.Address, _remoteAsn, _cts.Token);
+                var overrideCap = await _peerStore.GetPeerMaxPrefixAsync(_peerConfig.Address, _remoteAsn, sessionToken);
                 Volatile.Write(ref _effectiveMaxPrefix, overrideCap ?? _bgpConfig.MaxPrefixesPerPeer);
             }
             catch (OperationCanceledException) when (_cts.IsCancellationRequested) { throw; }
@@ -1393,7 +1428,7 @@ public sealed class BgpSession : IDisposable
 
         var nextHop = BgpConstants.IPAddressToUint(_bgpConfig.GetRouterIdAddress());
         var routes = await _routeAssembler.BuildOutboundRoutesAsync(
-            _peerConfig.Address, _remoteAsn, GetFilterPeerConfig(), _peer, _cts.Token);
+            _peerConfig.Address, _remoteAsn, GetFilterPeerConfig(), _peer, sessionToken);
         if (routes.Count > 0)
             await SendRoutesAsync(nextHop, routes);
     }
@@ -1645,7 +1680,13 @@ public sealed class BgpSession : IDisposable
             return false;
         }
 
-        await SendMessageAsync(update);
+        // #482: a false here means the send was abandoned (session disposed mid-send — the
+        // #341 dispose-wake or a disposed connection), so NOTHING reached the wire: skip the
+        // mirror commit and report unsent, keeping _advertisedPrefixes/_advertisedCount at wire
+        // truth (#212/#457). A truncated-frame abort still throws IOException from the transport
+        // (#285 latch) and never returns false.
+        if (!await SendMessageAsync(update))
+            return false;
         // #430 + #450 review: per-UPDATE mirror commit — SendRouteBatchAsync/SendV6RouteBatchAsync
         // emit one UPDATE per community group, so a group that throws after an earlier group
         // succeeded must not drag the earlier group's mirror entries down (they ARE on the wire)

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -368,9 +368,31 @@ public sealed class BgpSession : IDisposable
                 openMessage = await ReceiveMessageAsync(linkedCts.Token);
             }
 
+            if (openMessage is BgpNotificationMessage earlyNotification)
+            {
+                // #483 (RFC 4271 §6.3/§4.5, D8): on receiving a NOTIFICATION, release resources and
+                // close — NEVER reply. Previously this fell into the not-OPEN branch below and
+                // answered 2/0, violating the no-reply rule the OpenConfirm and Established arms
+                // follow. Latch RemoteNotification so the finally-block stays silent too.
+                _logger.LogWarning("NotificationReceived from {Peer} before OPEN: {Error}/{SubError}",
+                    _peer, earlyNotification.ErrorCode, earlyNotification.SubErrorCode);
+                Interlocked.CompareExchange(ref _teardownReason, (int)TeardownReason.RemoteNotification, (int)TeardownReason.None);
+                return;
+            }
+
             if (openMessage is not BgpOpenMessage remoteOpen)
             {
-                await SendNotificationAsync(BgpConstants.Error.OpenMessageError, BgpConstants.SubError.Unspecific);
+                // #483 (RFC 4271 §8.2.2, the #427/#453 class): the handshake phase accepts only
+                // OPEN and NOTIFICATION — any other first message is an FSM error, not an OPEN-body
+                // problem (the previous 2/0 misreported "your OPEN body was malformed"). CAS-latch
+                // the teardown before sending, like every other pre-close NOTIFICATION send.
+                _logger.LogWarning("Unexpected message {Type} from {Peer} before OPEN — FSM error (RFC 4271 §8.2.2)",
+                    openMessage.Type, _peer);
+                if (Interlocked.CompareExchange(ref _teardownReason, (int)TeardownReason.LocalCease, (int)TeardownReason.None) == (int)TeardownReason.None)
+                {
+                    try { await SendNotificationAsync(BgpConstants.Error.FiniteStateMachineError, BgpConstants.SubError.Unspecific); }
+                    catch { /* best-effort — partial write counts, see RFC 4271 §8.1 */ }
+                }
                 return;
             }
 
@@ -464,8 +486,15 @@ public sealed class BgpSession : IDisposable
                         _peer, notif.ErrorCode, notif.SubErrorCode, dataHex);
                     return;
                 default:
-                    _logger.LogError("Unexpected message {Type} from {Peer} in OpenConfirm", response.Type, _peer);
-                    await SendNotificationAsync(BgpConstants.Error.FiniteStateMachineError, BgpConstants.SubError.Unspecific);
+                    // #483: CAS-latch before sending (the #453/#427 shape) — the un-latched send
+                    // let a concurrent replacement's SilentClose be answered with a 5/0.
+                    _logger.LogWarning("Unexpected message {Type} from {Peer} in OpenConfirm — FSM error (RFC 4271 §8.2.2)",
+                        response.Type, _peer);
+                    if (Interlocked.CompareExchange(ref _teardownReason, (int)TeardownReason.LocalCease, (int)TeardownReason.None) == (int)TeardownReason.None)
+                    {
+                        try { await SendNotificationAsync(BgpConstants.Error.FiniteStateMachineError, BgpConstants.SubError.Unspecific); }
+                        catch { /* best-effort — partial write counts, see RFC 4271 §8.1 */ }
+                    }
                     return;
             }
 

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -1555,9 +1555,13 @@ public sealed class BgpSession : IDisposable
                 var comms = existing.Communities.Concat(route.Communities).Distinct().OrderBy(c => c).ToArray();
                 var large = existing.LargeCommunities.Concat(route.LargeCommunities).Distinct().ToArray();
                 // Route is a class (init-only props), not a record — mutate via reassignment.
+                // #476: IsIpv4 must be carried over explicitly — the property defaults to true,
+                // and a merged IPv6 duplicate that lost its family bit landed in the IPv4 batch,
+                // where its >32 length crashed the send (or masked down to a bogus 0.0.0.0/N NLRI).
                 merged[key] = new Route
                 {
                     Prefix = existing.Prefix,
+                    IsIpv4 = existing.IsIpv4,
                     PrefixLength = existing.PrefixLength,
                     NextHop = existing.NextHop,
                     AsPath = existing.AsPath,

--- a/BGPLite.Server/ConfigCommunityResolver.cs
+++ b/BGPLite.Server/ConfigCommunityResolver.cs
@@ -49,7 +49,9 @@ public sealed class ConfigCommunityResolver : ICommunityResolver
         _asnListCommunities = (config.RipeStat?.AsnLists ?? [])
             .GroupBy(l => l.Name)
             .ToDictionary(g => g.Key, g => g.Last().Community);
-        _prefixSourceCommunities = config.PrefixSources
+        // #477: "PrefixSources:" (YAML null) is a documented-valid "no sources" config — treat it
+        // as empty instead of crashing DI resolution (same idiom as the AsnLists line above).
+        _prefixSourceCommunities = (config.PrefixSources ?? [])
             .ToDictionary(s => s.Name, s => s.Community);
     }
 

--- a/BGPLite.Server/RouteAssembler.cs
+++ b/BGPLite.Server/RouteAssembler.cs
@@ -95,9 +95,12 @@ public sealed class RouteAssembler : IRouteAssembler
 
             _logger.LogInformation("Peer {Peer} subscriptions: [{Subs}]", peerLabel, string.Join(", ", subscriptionIds));
 
-            // #488 (D26): tracks whether any configured fetch FAILED (vs legitimately resolved to
-            // nothing). The RU fallback below must not fire on total failure — see the gate there.
-            var anyFetchFailed = false;
+            // #488 (D26): fetch outcome counters — the RU fallback below is suppressed only on a
+            // TOTAL failure (every attempted fetch failed). A mixed build (one source failed,
+            // another resolved — even to an empty list) is not total: the fallback keeps the
+            // documented "configured peer resolved 0 prefixes" behavior.
+            var fetchAttempts = 0;
+            var fetchFailures = 0;
 
             var subscribedLists = _appConfig.RipeStat?.AsnLists
                 .Where(l => subscriptionIds.Contains(l.Name))
@@ -114,6 +117,7 @@ public sealed class RouteAssembler : IRouteAssembler
                 var before = routes.Count;
                 foreach (var list in asnLists)
                 {
+                    fetchAttempts++;
                     try
                     {
                         var comms = _communityResolver.Resolve(
@@ -128,7 +132,7 @@ public sealed class RouteAssembler : IRouteAssembler
                     catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#330
                     catch (Exception ex)
                     {
-                        anyFetchFailed = true;   // #488
+                        fetchFailures++;   // #488
                         _logger.LogError(ex, "Failed to fetch prefixes for {Peer} (list '{List}')", peerLabel, list.Name);
                     }
                 }
@@ -140,6 +144,7 @@ public sealed class RouteAssembler : IRouteAssembler
             var countryLists = subscribedLists.Where(l => l.Asns.Count == 0 && l.Country is not null).ToList();
             if (countryLists.Count > 0)
             {
+                fetchAttempts++;
                 try
                 {
                     var comms = _communityResolver.Resolve(
@@ -152,7 +157,7 @@ public sealed class RouteAssembler : IRouteAssembler
                 catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#330
                 catch (Exception ex)
                 {
-                    anyFetchFailed = true;   // #488
+                    fetchFailures++;   // #488
                     _logger.LogError(ex, "Failed to fetch RU prefixes for {Peer}", peerLabel);
                 }
             }
@@ -175,6 +180,7 @@ public sealed class RouteAssembler : IRouteAssembler
 
             foreach (var name in sourceNames)
             {
+                fetchAttempts++;
                 try
                 {
                     var comms = _communityResolver.Resolve(new CommunitySource(CommunitySourceKind.PrefixSource, name));
@@ -187,7 +193,7 @@ public sealed class RouteAssembler : IRouteAssembler
                 catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#330
                 catch (Exception ex)
                 {
-                    anyFetchFailed = true;   // #488
+                    fetchFailures++;   // #488
                     _logger.LogError(ex, "Failed to fetch source '{Source}' for {Peer}", name, peerLabel);
                 }
             }
@@ -216,6 +222,7 @@ public sealed class RouteAssembler : IRouteAssembler
             // Add custom AS prefixes. Custom-AS routes carry the static "custom AS" community.
             if (customAsns.Count > 0)
             {
+                fetchAttempts++;
                 try
                 {
                     var customAsnComms = _communityResolver.Resolve(new CommunitySource(CommunitySourceKind.CustomAsn));
@@ -228,7 +235,7 @@ public sealed class RouteAssembler : IRouteAssembler
                 catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#330
                 catch (Exception ex)
                 {
-                    anyFetchFailed = true;   // #488
+                    fetchFailures++;   // #488
                     _logger.LogError(ex, "Failed to fetch custom AS prefixes for {Peer}", peerLabel);
                 }
             }
@@ -236,8 +243,10 @@ public sealed class RouteAssembler : IRouteAssembler
             // Per-peer user URL sources (#143/#147): each Active source fetched + community-stamped.
             foreach (var source in peer.UserSources)
             {
-                anyFetchFailed |= !await AddUserSourceRoutesAsync(
-                    routes, source, nextHop, _prefixService, _communityResolver, _logger, peerLabel, ct);
+                fetchAttempts++;
+                if (!await AddUserSourceRoutesAsync(
+                        routes, source, nextHop, _prefixService, _communityResolver, _logger, peerLabel, ct))
+                    fetchFailures++;
             }
 
             // #220 "suppress more-specifics": a custom prefix is an explicit operator override, so
@@ -255,13 +264,13 @@ public sealed class RouteAssembler : IRouteAssembler
 
             _logger.LogInformation("Sending {Count} total routes to {Peer}", routes.Count, peerLabel);
 
-            // Configured peer resolved 0 prefixes — fall back to RU. #488 (D26): ONLY when the
-            // peer's configured sources legitimately resolved to nothing. When every fetch FAILED
-            // (RIPEstat outage / network partition), substituting the full RU dump would advertise
-            // hundreds of thousands of prefixes the peer never asked for — total-source failure
-            // fails CLOSED: the peer keeps an empty set and the per-source errors above carry the
-            // cause.
-            if (routes.Count == 0 && anyFetchFailed)
+            // Configured peer resolved 0 prefixes — fall back to RU. #488 (D26): suppressed only
+            // on a TOTAL failure — every attempted fetch failed (RIPEstat outage / network
+            // partition). Substituting the full RU dump then would advertise hundreds of thousands
+            // of prefixes the peer never asked for — fail CLOSED: the peer keeps an empty set and
+            // the per-source errors above carry the cause. A MIXED build (some failed, some
+            // resolved to empty) is not total and keeps the documented fallback.
+            if (routes.Count == 0 && fetchAttempts > 0 && fetchFailures == fetchAttempts)
             {
                 _logger.LogWarning(
                     "Peer {Peer} resolved 0 prefixes WITH fetch failures — NOT falling back to RU defaults (total-source failure fails closed)",

--- a/BGPLite.Server/RouteAssembler.cs
+++ b/BGPLite.Server/RouteAssembler.cs
@@ -153,7 +153,7 @@ public sealed class RouteAssembler : IRouteAssembler
 
             // Prefix-source subscriptions: subscribed names that match a configured PrefixSource.
             var resolvedAsRipe = subscribedLists.Select(l => l.Name).ToHashSet();
-            var prefixSources = _appConfig.PrefixSources;
+            var prefixSources = _appConfig.PrefixSources ?? []; // #477: YAML null = no sources
             var sourceNames = subscriptionIds
                 .Where(n => !resolvedAsRipe.Contains(n) && prefixSources.Any(s => s.Name == n))
                 .ToList();

--- a/BGPLite.Server/RouteAssembler.cs
+++ b/BGPLite.Server/RouteAssembler.cs
@@ -95,6 +95,10 @@ public sealed class RouteAssembler : IRouteAssembler
 
             _logger.LogInformation("Peer {Peer} subscriptions: [{Subs}]", peerLabel, string.Join(", ", subscriptionIds));
 
+            // #488 (D26): tracks whether any configured fetch FAILED (vs legitimately resolved to
+            // nothing). The RU fallback below must not fire on total failure — see the gate there.
+            var anyFetchFailed = false;
+
             var subscribedLists = _appConfig.RipeStat?.AsnLists
                 .Where(l => subscriptionIds.Contains(l.Name))
                 .ToList() ?? [];
@@ -124,6 +128,7 @@ public sealed class RouteAssembler : IRouteAssembler
                     catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#330
                     catch (Exception ex)
                     {
+                        anyFetchFailed = true;   // #488
                         _logger.LogError(ex, "Failed to fetch prefixes for {Peer} (list '{List}')", peerLabel, list.Name);
                     }
                 }
@@ -147,6 +152,7 @@ public sealed class RouteAssembler : IRouteAssembler
                 catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#330
                 catch (Exception ex)
                 {
+                    anyFetchFailed = true;   // #488
                     _logger.LogError(ex, "Failed to fetch RU prefixes for {Peer}", peerLabel);
                 }
             }
@@ -157,6 +163,16 @@ public sealed class RouteAssembler : IRouteAssembler
             var sourceNames = subscriptionIds
                 .Where(n => !resolvedAsRipe.Contains(n) && prefixSources.Any(s => s.Name == n))
                 .ToList();
+
+            // #488: a subscription matching no AsnLists entry and no PrefixSource is a config
+            // typo — invisible until now (silently ignored on every build). Name it so the row
+            // can be fixed.
+            foreach (var unknown in subscriptionIds.Where(n =>
+                         !resolvedAsRipe.Contains(n) && !prefixSources.Any(s => s.Name == n)))
+                _logger.LogWarning(
+                    "Subscription '{Name}' on {Peer} matches no RipeStat.AsnLists entry and no PrefixSource — ignored (fix the peer's subscription)",
+                    unknown, peerLabel);
+
             foreach (var name in sourceNames)
             {
                 try
@@ -171,6 +187,7 @@ public sealed class RouteAssembler : IRouteAssembler
                 catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#330
                 catch (Exception ex)
                 {
+                    anyFetchFailed = true;   // #488
                     _logger.LogError(ex, "Failed to fetch source '{Source}' for {Peer}", name, peerLabel);
                 }
             }
@@ -211,6 +228,7 @@ public sealed class RouteAssembler : IRouteAssembler
                 catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#330
                 catch (Exception ex)
                 {
+                    anyFetchFailed = true;   // #488
                     _logger.LogError(ex, "Failed to fetch custom AS prefixes for {Peer}", peerLabel);
                 }
             }
@@ -218,7 +236,7 @@ public sealed class RouteAssembler : IRouteAssembler
             // Per-peer user URL sources (#143/#147): each Active source fetched + community-stamped.
             foreach (var source in peer.UserSources)
             {
-                await AddUserSourceRoutesAsync(
+                anyFetchFailed |= !await AddUserSourceRoutesAsync(
                     routes, source, nextHop, _prefixService, _communityResolver, _logger, peerLabel, ct);
             }
 
@@ -237,8 +255,19 @@ public sealed class RouteAssembler : IRouteAssembler
 
             _logger.LogInformation("Sending {Count} total routes to {Peer}", routes.Count, peerLabel);
 
-            // Configured peer resolved 0 prefixes — fall back to RU.
-            if (routes.Count == 0)
+            // Configured peer resolved 0 prefixes — fall back to RU. #488 (D26): ONLY when the
+            // peer's configured sources legitimately resolved to nothing. When every fetch FAILED
+            // (RIPEstat outage / network partition), substituting the full RU dump would advertise
+            // hundreds of thousands of prefixes the peer never asked for — total-source failure
+            // fails CLOSED: the peer keeps an empty set and the per-source errors above carry the
+            // cause.
+            if (routes.Count == 0 && anyFetchFailed)
+            {
+                _logger.LogWarning(
+                    "Peer {Peer} resolved 0 prefixes WITH fetch failures — NOT falling back to RU defaults (total-source failure fails closed)",
+                    peerLabel);
+            }
+            else if (routes.Count == 0)
             {
                 _logger.LogInformation("Peer {Peer} resolved 0 prefixes, falling back to RU defaults", peerLabel);
                 try
@@ -378,7 +407,9 @@ public sealed class RouteAssembler : IRouteAssembler
     /// e.g. #320's linked CTS in HttpPrefixProvider) is a fetch failure like any other, so one
     /// slow URL skips its source instead of aborting the whole dump.
     /// </summary>
-    internal static async Task AddUserSourceRoutesAsync(
+    /// <returns><c>true</c> when the source loaded (even to an empty list); <c>false</c> when the
+    /// fetch failed — the #488 fail-closed fallback gate consumes the failure signal.</returns>
+    internal static async Task<bool> AddUserSourceRoutesAsync(
         List<Route> routes, CustomSourceView source, uint nextHop,
         IPrefixService prefixService, ICommunityResolver communityResolver,
         ILogger logger, string peerLabel, CancellationToken ct)
@@ -391,11 +422,13 @@ public sealed class RouteAssembler : IRouteAssembler
             foreach (var p in prefixes)
                 routes.Add(MakeRoute(p.Prefix, p.Length, p.IsIpv4, nextHop, null, comms));
             logger.LogInformation("User-source '{Name}': {Count} prefixes for {Peer}", source.Name, prefixes.Count, peerLabel);
+            return true;
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#342: only CALLER cancellation — a per-source timeout OCE (#320's linked CTS, live ct) must stay a fetch failure below
         catch (Exception ex)
         {
             logger.LogWarning(ex, "User-source '{Name}' failed for {Peer}; skipped", source.Name, peerLabel);
+            return false;
         }
     }
 

--- a/BGPLite.Tests/ApiHandlerBehaviorTests.cs
+++ b/BGPLite.Tests/ApiHandlerBehaviorTests.cs
@@ -8,6 +8,7 @@ using BGPLite.Providers;
 using BGPLite.Routing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 using BGPLite.Protocol;
@@ -43,7 +44,7 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
         _connection.Dispose();
     }
 
-    private async Task<int> StartAsync(AppConfig template, ISessionManager? sessions = null)
+    private async Task<int> StartAsync(AppConfig template, ISessionManager? sessions = null, ILogger<ManagementApi>? logger = null)
     {
         for (var attempt = 0; ; attempt++)
         {
@@ -61,7 +62,7 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
                 new RouteTable(),
                 config,
                 new BgpMetrics(),
-                NullLogger<ManagementApi>.Instance,
+                logger ?? NullLogger<ManagementApi>.Instance,
                 new InertPrefixService(),
                 new InertPrefixSources(),
                 sessions ?? new InertSessions());
@@ -333,5 +334,35 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
         public void SetPeerMd5Key(string peerIp, string? password) => Md5Keys.Add((peerIp, password));
         public int GetAdvertisedPrefixCount(string peerIp, uint asn) => 0;
         public Task RefreshAllEstablishedAsync() => Task.CompletedTask;
+    }
+
+    /// <summary>Captures formatted log messages so a test can assert what must NEVER be logged (#479).</summary>
+    private sealed class RecordingLogger : ILogger<ManagementApi>
+    {
+        public List<string> Messages { get; } = [];
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            => Messages.Add(formatter(state, exception));
+    }
+
+    [Fact]
+    public async Task AddSource_RejectedUrl_IsNeverLogged()
+    {
+        // #479 (#149): peer-source URLs may carry query-string tokens — the log events around
+        // save-time validation must name the source, never the URL. The loopback host is blocked
+        // by the SSRF validator without any network access, so the rejected path fires offline.
+        var store = new PeerStore(new StaticOptionsFactory(new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(_connection).Options));
+        var id = (await store.SavePeerConfigurationAsync("198.51.100.7", 65090, null, [], [], [])).Id;
+        var logger = new RecordingLogger();
+        _port = await StartAsync(new AppConfig { Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" } }, logger: logger);
+        _client = new HttpClient();
+
+        var body = JsonSerializer.Serialize(new { name = "leaky", url = "http://127.0.0.1:9/list?token=SECRET123" });
+        using var response = await _client.PostAsync($"http://127.0.0.1:{_port}/api/peers/{id}/sources",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);   // the loopback host is rejected
+        Assert.DoesNotContain(logger.Messages, m => m.Contains("SECRET123") || m.Contains("token="));
     }
 }

--- a/BGPLite.Tests/ApiHandlerBehaviorTests.cs
+++ b/BGPLite.Tests/ApiHandlerBehaviorTests.cs
@@ -382,6 +382,34 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
     }
 
     [Fact]
+    public async Task AddSource_FieldLimits_And_PerPeerCap_AreEnforced()
+    {
+        // #487: repeated POSTs bounded — name/URL length ceilings and a per-peer source-count cap
+        // (the 1 MiB body cap bounds ONE request; the DB rows outlive it).
+        var store = new PeerStore(new StaticOptionsFactory(new DbContextOptionsBuilder<BgpDbContext>().UseSqlite(_connection).Options));
+        var id = (await store.SavePeerConfigurationAsync("198.51.100.8", 65091, null, [], [], [])).Id;
+        _port = await StartAsync(new AppConfig { Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" } });
+        _client = new HttpClient();
+
+        var longName = new string('n', ManagementApi.MaxSourceNameLength + 1);
+        using var badName = await _client.PostAsync($"http://127.0.0.1:{_port}/api/peers/{id}/sources",
+            new StringContent(JsonSerializer.Serialize(new { name = longName, url = "https://example.com/l" }), Encoding.UTF8, "application/json"));
+        Assert.Equal(HttpStatusCode.BadRequest, badName.StatusCode);
+
+        var longUrl = "https://example.com/" + new string('u', ManagementApi.MaxSourceUrlLength);
+        using var badUrl = await _client.PostAsync($"http://127.0.0.1:{_port}/api/peers/{id}/sources",
+            new StringContent(JsonSerializer.Serialize(new { name = "ok", url = longUrl }), Encoding.UTF8, "application/json"));
+        Assert.Equal(HttpStatusCode.BadRequest, badUrl.StatusCode);
+
+        // Seed the per-peer cap directly through the store, then POST one more → 400.
+        for (var i = 0; i < ManagementApi.MaxSourcesPerPeer; i++)
+            await store.AddCustomSourceAsync(id, $"s{i}", $"https://example.com/{i}", null);
+        using var capped = await _client.PostAsync($"http://127.0.0.1:{_port}/api/peers/{id}/sources",
+            new StringContent(JsonSerializer.Serialize(new { name = "one-too-many", url = "https://example.com/x" }), Encoding.UTF8, "application/json"));
+        Assert.Equal(HttpStatusCode.BadRequest, capped.StatusCode);
+    }
+
+    [Fact]
     public async Task AsnLists_BudgetExpiryMidSources_ServesPartialJson()
     {
         // #480: the budget token firing during LoadAllAsync must degrade to the partial response

--- a/BGPLite.Tests/ApiHandlerBehaviorTests.cs
+++ b/BGPLite.Tests/ApiHandlerBehaviorTests.cs
@@ -44,7 +44,7 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
         _connection.Dispose();
     }
 
-    private async Task<int> StartAsync(AppConfig template, ISessionManager? sessions = null, ILogger<ManagementApi>? logger = null)
+    private async Task<int> StartAsync(AppConfig template, ISessionManager? sessions = null, ILogger<ManagementApi>? logger = null, IPrefixSourceService? prefixSources = null)
     {
         for (var attempt = 0; ; attempt++)
         {
@@ -54,6 +54,7 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
                 Bgp = template.Bgp,
                 CorsAllowedOrigins = template.CorsAllowedOrigins,
                 ApiRateLimit = template.ApiRateLimit,
+                RipeStat = template.RipeStat,
                 ApiListen = "127.0.0.1",
                 ApiPort = port,
             };
@@ -64,7 +65,7 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
                 new BgpMetrics(),
                 logger ?? NullLogger<ManagementApi>.Instance,
                 new InertPrefixService(),
-                new InertPrefixSources(),
+                prefixSources ?? new InertPrefixSources(),
                 sessions ?? new InertSessions());
             try
             {
@@ -364,5 +365,41 @@ public sealed class ApiHandlerBehaviorTests : IDisposable
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);   // the loopback host is rejected
         Assert.DoesNotContain(logger.Messages, m => m.Contains("SECRET123") || m.Contains("token="));
+    }
+
+    /// <summary>LoadAllAsync throws a foreign-token OCE — the deterministic stand-in for the
+    /// #424 external-fetch budget firing mid-load (live shutdown token, cancelled budget token).</summary>
+    private sealed class BudgetExhaustedSources : IPrefixSourceService
+    {
+        public event Action<string>? ContentCommitted;
+        public Task<IReadOnlyList<(PrefixSourceConfig Source, IReadOnlyList<IpPrefix> Prefixes)>> LoadAllAsync(CancellationToken ct = default)
+            => throw new OperationCanceledException();
+        public Task<IReadOnlyList<IpPrefix>> GetAsync(string name, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<IpPrefix>>([]);
+        public Task<(IReadOnlyList<IpPrefix> Prefixes, bool Changed)> LoadDefaultAsync(CancellationToken ct = default) => Task.FromResult<(IReadOnlyList<IpPrefix>, bool)>(([], false));
+        public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default) => Task.FromResult(false);
+        public bool SourceSupportsConditional(string sourceName) => false;
+    }
+
+    [Fact]
+    public async Task AsnLists_BudgetExpiryMidSources_ServesPartialJson()
+    {
+        // #480: the budget token firing during LoadAllAsync must degrade to the partial response
+        // (the ASN-list entries collected above), not escape the handler and abort the connection
+        // without a body.
+        _port = await StartAsync(
+            new AppConfig
+            {
+                Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" },
+                RipeStat = new RipeStatConfig { AsnLists = [new AsnList { Name = "ru", Country = "RU", Community = "65000:100" }] }
+            },
+            prefixSources: new BudgetExhaustedSources());
+        _client = new HttpClient();
+
+        using var response = await _client.GetAsync($"http://127.0.0.1:{_port}/api/asn-lists");
+        var body = await response.Content.ReadAsStringAsync();
+
+        Assert.True(response.IsSuccessStatusCode, $"expected a partial response, got {(int)response.StatusCode}");   // RED pre-fix: the connection was aborted (HttpRequestException)
+        Assert.Contains("\"ru\"", body);   // the ASN-list half of the response survived
     }
 }

--- a/BGPLite.Tests/AsnPrefixProviderTests.cs
+++ b/BGPLite.Tests/AsnPrefixProviderTests.cs
@@ -133,4 +133,42 @@ public class AsnPrefixProviderTests
 
         Assert.Equal(1, cache.TrackedCount);
     }
+
+    /// <summary>Succeeds on the first call, throws a foreign-token OCE (live ct) afterwards —
+    /// the deterministic stand-in for the #324 body deadline firing mid-response (#485).</summary>
+    private sealed class OceAfterFirstHandler : HttpMessageHandler
+    {
+        public int Calls { get; private set; }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Calls++;
+            return Calls > 1
+                ? Task.FromException<HttpResponseMessage>(new OperationCanceledException())
+                : Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        """{"status":"ok","data":{"resource":"65010","prefixes":{"v4":{"originating":["10.1.10.1/32"]},"v6":{"originating":[]}}}}""")
+                });
+        }
+    }
+
+    [Fact]
+    public async Task ForeignOceFromRipeStat_IsAFailure_StaleIsServed()
+    {
+        // #485 (#320/#324 contract): a foreign-token OCE (live ct) is a load FAILURE — the
+        // stale-on-failure copy must be served. The unfiltered rethrow escaped the cache instead,
+        // so every retry re-paid the full fetch budget with no backoff ever recorded.
+        var handler = new OceAfterFirstHandler();
+        var cache = new RipeStatPrefixCache(
+            new RipeStatProvider(new StubFactory(handler), NullLogger<RipeStatProvider>.Instance,
+                new RipeStatConfig { RetryAttempts = 0, RetryDelaySeconds = 0 }),
+            cacheTtl: TimeSpan.Zero);   // every call past the first refetches
+
+        var first = await cache.GetPrefixesAsync(65010);
+        Assert.Single(first);
+
+        var second = await cache.GetPrefixesAsync(65010);   // RED pre-fix: OperationCanceledException escapes
+        Assert.Single(second);                              // the stale copy is served as the failure remedy
+        Assert.Equal(2, handler.Calls);
+    }
 }

--- a/BGPLite.Tests/BgpMessageTests.cs
+++ b/BGPLite.Tests/BgpMessageTests.cs
@@ -654,6 +654,33 @@ public class BgpMessageTests
     }
 
     [Fact]
+    public void AsPath_ZeroLengthAttribute_IsMalformedOnEbgp_PolicyLayer()
+    {
+        // #486 (D25): a zero-length AS_PATH is the on-wire form of an EMPTY path — legal only
+        // toward internal peers (RFC 4271 §5.1.2). BGPLite is eBGP-only, so the inbound policy
+        // layer rejects it as Malformed AS_PATH (treat-as-withdraw); the codec itself stays
+        // encoding-neutral (see AsPath_Empty_RoundtripsAsZeroLengthAttribute).
+        var update = new BgpUpdateMessage
+        {
+            PathAttributes =
+            [
+                new PathAttribute { Flags = BgpConstants.Attribute.FlagTransitive, TypeCode = BgpConstants.Attribute.AsPath, Data = [] },
+                new PathAttribute { Flags = BgpConstants.Attribute.FlagTransitive, TypeCode = BgpConstants.Attribute.Origin, Data = [0] },
+                new PathAttribute { Flags = BgpConstants.Attribute.FlagTransitive, TypeCode = BgpConstants.Attribute.NextHop, Data = [0xC0, 0x00, 0x02, 0x01] }
+            ],
+            Nlri = [new IpPrefix(0xC0000200, 24)]
+        };
+
+        var ex = Assert.Throws<BgpNotificationException>(() =>
+            UpdateCodec.ParseRouteAttributes(update, fourByteAsnSession: false, localRouterId: 0x0A000001));
+        Assert.Equal(BgpConstants.Error.UpdateMessageError, ex.ErrorCode);
+        Assert.Equal(BgpConstants.SubError.MalformedAsPath, ex.SubErrorCode);
+
+        // The codec layer is untouched: the zero-length attribute still decodes (as an empty path).
+        Assert.Empty(AttributeHelper.ReadAsPath(update.PathAttributes[0], fourByteAsn: false));
+    }
+
+    [Fact]
     public void As4Path_WithAsTrans_Throws()
     {
         // AS_TRANS (23456) is the 2-octet placeholder for a non-mappable 4-octet AS — meaningless

--- a/BGPLite.Tests/BgpSessionShutdownTests.cs
+++ b/BGPLite.Tests/BgpSessionShutdownTests.cs
@@ -768,4 +768,53 @@ public class BgpSessionShutdownTests
         Assert.True(sw.Elapsed < TimeSpan.FromSeconds(2),
             $"RefreshRoutesAsync with a cancelled token took {sw.ElapsedMilliseconds}ms — token not honored");
     }
+
+    /// <summary>Captures log events so a test can assert what must never surface at ERROR (#482).</summary>
+    private sealed class RecordingLogger : ILogger<BgpSession>
+    {
+        public List<(LogLevel Level, string Message)> Events { get; } = [];
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            => Events.Add((logLevel, formatter(state, exception)));
+    }
+
+    [Fact]
+    public async Task ExternalDisposeDuringEstablished_TearsDownQuietly_NoErrorLog()
+    {
+        // #482: an external Dispose (the API peer-deletion shape) racing the session task's
+        // Task.WhenAny unwind could make CancelAsync throw ObjectDisposedException, which surfaced
+        // as an ERROR-logged "Session error" on a routine teardown and skipped the loop drains.
+        // The ODE window itself is scheduling-dependent (the WhenAny continuation may run inline
+        // inside Cancel() before Dispose reaches _cts.Dispose()), so this test pins the whole
+        // path instead: dispose during Established must complete RunAsync with zero ERROR events.
+        var logger = new RecordingLogger();
+        var conn = new ScriptedConnection();
+        var session = new BgpSession(
+            conn,
+            new PeerConfig { Address = "127.0.0.1" },
+            new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 30, KeepAlive = 10 },
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            logger);
+        var run = session.RunAsync();
+        conn.EnqueueMessage(new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = 30,
+            RouterId = 0x0A000002,
+            Capabilities = []
+        });
+        conn.EnqueueMessage(BgpKeepaliveMessage.Instance);
+        for (var i = 0; i < 200 && !session.IsEstablished; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        Assert.True(session.IsEstablished, "session must reach Established");
+
+        session.Dispose();
+        await run.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.DoesNotContain(logger.Events, e => e.Level == LogLevel.Error);
+    }
 }

--- a/BGPLite.Tests/BgpSessionV6AdvertiseTests.cs
+++ b/BGPLite.Tests/BgpSessionV6AdvertiseTests.cs
@@ -136,6 +136,15 @@ public class BgpSessionV6AdvertiseTests
         await TeardownAsync(session, run);
     }
 
+    /// <summary>Serves a fixed outbound route list — the seam for driving SendRoutesAsync with
+    /// inputs the shared RouteTable cannot hold (e.g. cross-community duplicates, #476).</summary>
+    private sealed class StubRouteAssembler(List<Route> routes) : IRouteAssembler
+    {
+        public Task<List<Route>> BuildOutboundRoutesAsync(
+            string peerIp, uint remoteAsn, PeerConfig filterPeerConfig, string peerLabel, CancellationToken ct)
+            => Task.FromResult(routes);
+    }
+
     private static int CountUpdates(ScriptedConnection conn) =>
         conn.Sent.Select(f => BgpMessageReader.ReadMessage(f)).OfType<BgpUpdateMessage>().Count();
 
@@ -281,6 +290,55 @@ public class BgpSessionV6AdvertiseTests
         var eor = await SentUpdatesAsync(conn, u => u.MpUnreachV6 is { Count: 0 });
         var mpEor = Assert.Single(eor, u => u.MpUnreachV6 is { Count: 0 });
         Assert.Empty(mpEor.Nlri);
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
+    public async Task DuplicateV6Prefixes_AcrossCommunitySets_MergeKeepsTheFamily()
+    {
+        // #476: two sources can announce the SAME IPv6 prefix with different community sets (the
+        // aggregator keeps them in separate groups); MergeDuplicatePrefixes then unions them. The
+        // merged route must stay IPv6 — before the fix the family bit was lost, the route landed in
+        // the IPv4 batch and its /48 length crashed the send (AOORE → Cease → teardown on every
+        // connect). The union must ride ONE MP_REACH UPDATE carrying both communities.
+        var routes = new List<Route>
+        {
+            new() { Prefix = V6PrefixNet, IsIpv4 = false, PrefixLength = 48, NextHop = V6NextHop, Communities = [200u] },
+            new() { Prefix = V6PrefixNet, IsIpv4 = false, PrefixLength = 48, NextHop = V6NextHop, Communities = [100u] }
+        };
+        var conn = new ScriptedConnection();
+        var session = new BgpSession(
+            conn,
+            new PeerConfig { Address = "127.0.0.1" },
+            Config(),
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            NullLogger<BgpSession>.Instance,
+            routeAssembler: new StubRouteAssembler(routes));
+        var run = session.RunAsync();
+        conn.EnqueueMessage(new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = 0,
+            RouterId = 0x0A000002,
+            Capabilities = [BgpCapabilityInfo.FourOctetAsn(65002), BgpCapabilityInfo.MultiprotocolIpv6Unicast()]
+        });
+        conn.EnqueueMessage(BgpKeepaliveMessage.Instance);
+        for (var i = 0; i < 200 && !session.IsEstablished; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+
+        var updates = await SentUpdatesAsync(conn, u => u.MpReachV6 is not null);
+        var v6Update = Assert.Single(updates, u => u.MpReachV6 is not null);
+        var pfx = Assert.Single(v6Update.MpReachV6!.Value.Prefixes);
+        Assert.False(pfx.IsIpv4, "the merged duplicate must stay IPv6");
+        Assert.Equal((V6PrefixNet, (byte)48), (pfx.Address, pfx.Length));
+        Assert.Empty(v6Update.Nlri); // never a bogus classic-IPv4 NLRI for a v6 prefix
+        var communityAttr = Assert.Single(v6Update.PathAttributes, a => a.TypeCode == BgpConstants.Attribute.Community);
+        Assert.Equal(new[] { 100u, 200u }, AttributeHelper.ReadCommunities(communityAttr));
+        Assert.True(session.IsEstablished, "the duplicate merge must not tear the session down");
 
         await TeardownAsync(session, run);
     }

--- a/BGPLite.Tests/ConfigValidationTests.cs
+++ b/BGPLite.Tests/ConfigValidationTests.cs
@@ -344,6 +344,15 @@ public class ConfigValidationTests
 
     /// <summary>#304: the per-peer prefix cap validates like the other 0=unlimited knobs.</summary>
     [Fact]
+    public void ShippedMaxPrefixesPerPeerDefault_IsBounded()
+    {
+        // #481: the RFC 4486 defense must be on out of the box — the shipped default is a
+        // generous bound (1M prefixes, above any legitimate provisioning peer, far below memory
+        // exhaustion), not unlimited; 0 remains available as an explicit opt-out.
+        Assert.Equal(1_000_000, new BgpConfig().MaxPrefixesPerPeer);
+    }
+
+    [Fact]
     public void Validate_RejectsNegativeMaxPrefixesPerPeer()
     {
         var config = Config(Bgp(maxPrefixesPerPeer: -1));

--- a/BGPLite.Tests/FilePrefixProviderTests.cs
+++ b/BGPLite.Tests/FilePrefixProviderTests.cs
@@ -35,4 +35,22 @@ public class FilePrefixProviderTests
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
             provider.LoadAsync(new PrefixSourceConfig { Name = "t", Kind = "file", Path = null }));
     }
+
+    [Fact]
+    public async Task OversizedFileThrows()
+    {
+        // #487: cap parity with the HTTP paths — a file over HttpPrefixProvider.MaxResponseBytes
+        // is never a legitimate prefix list and must not be read into memory whole.
+        var path = Path.GetTempFileName();
+        await using (var fs = new FileStream(path, FileMode.Create, FileAccess.Write))
+            await fs.WriteAsync(new byte[HttpPrefixProvider.MaxResponseBytes + 1]);
+        try
+        {
+            var provider = new FilePrefixProvider(NullLogger<FilePrefixProvider>.Instance);
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                provider.LoadAsync(new PrefixSourceConfig { Name = "t", Kind = "file", Path = path }));
+            Assert.Contains("cap", ex.Message);
+        }
+        finally { File.Delete(path); }
+    }
 }

--- a/BGPLite.Tests/MpAttributeErrorPolicyTests.cs
+++ b/BGPLite.Tests/MpAttributeErrorPolicyTests.cs
@@ -288,6 +288,47 @@ public class MpAttributeErrorPolicyTests
     }
 
     [Fact]
+    public async Task TreatAsWithdraw_AppliesTheSameUpdatesMpUnreach()
+    {
+        // #484 (RFC 7606 §2): an UPDATE is treated as withdrawn AS A WHOLE. The classic WITHDRAWN
+        // half is applied before the attribute parse and survives a parse failure; the
+        // MP_UNREACH_NLRI half of the same message must not be lost to that failure — pre-fix it
+        // was skipped (its block runs after the announcement block, which the failure unwinds),
+        // leaving a stale IPv6 route alive until session teardown.
+        var routeTable = new RouteTable();
+        var (session, run, conn) = await EstablishAsync(routeTable);
+
+        // Install one IPv6 route via a valid MP_REACH announcement.
+        conn.EnqueueFrame(UpdateFrame(
+            OriginAsPathAttributes,
+            MpReachAttribute(MpOptionalNonTransitive, ReachValue(GlobalNextHop, 32, 0x20, 0x01, 0x0D, 0xB8))));
+        await SettleAsync(conn, () => routeTable.Count == 1);
+        Assert.NotNull(routeTable.Get(DocumentedPrefix, 32, isIpv4: false));
+
+        // An UPDATE with classic NLRI + a malformed ORIGIN (length 2 — Attribute Length Error →
+        // treat-as-withdraw) whose MP_UNREACH withdraws exactly that v6 prefix. The NLRI is what
+        // drives the announcement block into the failing parse — without it the whole block is
+        // skipped and the bug cannot show.
+        var attrs = new List<byte[]>
+        {
+            new byte[] { 0x40, 0x01, 0x02, 0x00, 0x00 },   // ORIGIN with length 2 — malformed per RFC 7606 §7.1
+            MpUnreachAttribute(MpOptionalNonTransitive, new byte[] { 0x00, 0x02, 0x01, 0x20, 0x20, 0x01, 0x0D, 0xB8 }),
+        };
+        var attrsLen = attrs.Sum(a => a.Length);
+        var payload = new List<byte> { 0x00, 0x00, (byte)(attrsLen >> 8), (byte)attrsLen };
+        foreach (var a in attrs) payload.AddRange(a);
+        payload.Add(24);                       // classic NLRI: 192.0.2.0/24
+        payload.AddRange([0xC0, 0x00, 0x02]);
+        conn.EnqueueFrame(Frame(BgpMessageType.Update, [.. payload]));
+        await SettleAsync(conn, () => routeTable.Count == 0);
+
+        Assert.Null(routeTable.Get(DocumentedPrefix, 32, isIpv4: false));   // RED pre-fix: stale route survived
+        Assert.True(session.IsEstablished, "treat-as-withdraw keeps the session up");
+
+        await TeardownAsync(session, run);
+    }
+
+    [Fact]
     public async Task MalformedMpReachV4_ResetsSession_ScopedFallback()
     {
         // #472 review, IPv4 half: a supported IPv4/Unicast tuple whose value cannot be decoded

--- a/BGPLite.Tests/OpenConfirmFsmErrorTests.cs
+++ b/BGPLite.Tests/OpenConfirmFsmErrorTests.cs
@@ -68,6 +68,64 @@ public sealed class OpenConfirmFsmErrorTests
         await runTask.WaitAsync(TimeSpan.FromSeconds(5));
     }
 
+    [Fact]
+    public async Task NotificationBeforeOpen_IsNeverRepliedTo()
+    {
+        // #483 (RFC 4271 §6.3/§4.5, D8): a peer NOTIFICATION as the FIRST message must close the
+        // session silently. Pre-fix, it fell into the not-OPEN branch and was answered with
+        // NOTIFICATION 2/0 — replying to a NOTIFICATION.
+        var (server, client) = ConnectedPair();
+        using var clientSock = client;
+        using var session = new BgpSession(
+            new SocketBgpConnection(server),
+            new PeerConfig { Address = "127.0.0.1" },
+            new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 },
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            new NopLogger<BgpSession>());
+        var runTask = session.RunAsync();
+
+        Send(client, new BgpNotificationMessage
+        {
+            ErrorCode = BgpConstants.Error.Cease,
+            SubErrorCode = BgpConstants.SubError.Unspecific
+        });
+
+        await runTask.WaitAsync(TimeSpan.FromSeconds(5));
+        var sent = await DrainAsync(client, TimeSpan.FromSeconds(1));
+        Assert.Empty(sent.OfType<BgpNotificationMessage>());   // RED pre-fix: exactly one 2/0 reply
+        Assert.Empty(sent.OfType<BgpOpenMessage>());           // no OPEN is sent after a NOTIFICATION
+    }
+
+    [Fact]
+    public async Task KeepaliveBeforeOpen_IsFsmError_5_0_NotOpenMessageError()
+    {
+        // #483 (RFC 4271 §8.2.2, the #427/#453 class): the handshake accepts only OPEN and
+        // NOTIFICATION — a KEEPALIVE as the first message is an FSM error (5/0), not an
+        // Open Message Error (the previous 2/0 misreported an OPEN-body problem).
+        var (server, client) = ConnectedPair();
+        using var clientSock = client;
+        using var session = new BgpSession(
+            new SocketBgpConnection(server),
+            new PeerConfig { Address = "127.0.0.1" },
+            new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 0, KeepAlive = 0 },
+            new RouteTable(),
+            AllowAllFilter.Instance,
+            new BgpMetrics(),
+            new NopLogger<BgpSession>());
+        var runTask = session.RunAsync();
+
+        Send(client, BgpKeepaliveMessage.Instance);
+
+        await runTask.WaitAsync(TimeSpan.FromSeconds(5));
+        var sent = await DrainAsync(client, TimeSpan.FromSeconds(1));
+        var notification = Assert.Single(sent.OfType<BgpNotificationMessage>());
+        Assert.Equal(BgpConstants.Error.FiniteStateMachineError, notification.ErrorCode);   // RED pre-fix: OpenMessageError
+        Assert.Equal(BgpConstants.SubError.Unspecific, notification.SubErrorCode);
+        Assert.False(session.IsEstablished);
+    }
+
     private static (Socket server, Socket client) ConnectedPair()
     {
         using var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);

--- a/BGPLite.Tests/PrefixCacheFailureTests.cs
+++ b/BGPLite.Tests/PrefixCacheFailureTests.cs
@@ -1,3 +1,4 @@
+using System.Net.Http;
 using BGPLite.Configuration;
 using BGPLite.Providers;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -134,5 +135,48 @@ public class PrefixCacheFailureTests
         public bool SupportsConditionalRequests => true;
         public Task<SourceLoadResult> LoadAsync(PrefixSourceConfig source, string? etag = null, DateTimeOffset? lastModified = null, CancellationToken ct = default)
             => Task.FromResult(SourceLoadResult.Ok(new List<IpPrefix>()));
+    }
+
+    /// <summary>Succeeds normally; throws the CALLER's OCE once the token is cancelled — how
+    /// RipeStatProvider surfaces host shutdown to the cache (#485).</summary>
+    private sealed class OceWhenCancelledHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            => ct.IsCancellationRequested
+                ? Task.FromException<HttpResponseMessage>(new OperationCanceledException(ct))
+                : Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        """{"status":"ok","data":{"resource":"65010","prefixes":{"v4":{"originating":["10.1.10.1/32"]},"v6":{"originating":[]}}}}""")
+                });
+    }
+
+    private sealed class HttpClientFactoryStub(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(handler, disposeHandler: false);
+    }
+
+    [Fact]
+    public async Task WarmUp_CancelledToken_UnwindsTheLoop_NotAWarnPerAsn()
+    {
+        // #485: the per-ASN catch (Exception) swallowed the shutdown OCE once per remaining ASN —
+        // a "WarmUp failed" WARN storm on every stop. Caller cancellation must unwind the loop.
+        var yaml = "Bgp:\n  Asn: 65444\n  RouterId: 10.0.0.1\n" +
+                   "RipeStat:\n  AsnLists:\n    - Name: ru\n      Asns: [65010, 65011]\n";
+        var config = ConfigLoader.LoadFromText(yaml);
+        var cache = new RipeStatPrefixCache(new RipeStatProvider(
+            new HttpClientFactoryStub(new OceWhenCancelledHandler()),
+            NullLogger<RipeStatProvider>.Instance,
+            new RipeStatConfig { RetryAttempts = 0, RetryDelaySeconds = 0 }));
+        var sources = new PrefixSourceService(
+            config,
+            new PrefixSourceProviderFactory([]),
+            NullLogger<PrefixSourceService>.Instance);
+        var service = new PrefixService(config, cache, sources, null!);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        // RED pre-fix: both per-ASN OCEs were swallowed (a WARN each) and WarmUp completed normally.
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => service.WarmUpAsync(cts.Token));
     }
 }

--- a/BGPLite.Tests/PrefixSourceServiceTests.cs
+++ b/BGPLite.Tests/PrefixSourceServiceTests.cs
@@ -1,5 +1,6 @@
 using BGPLite.Configuration;
 using BGPLite.Providers;
+using BGPLite.Server;
 using Microsoft.Extensions.Logging.Abstractions;
 using BGPLite.Protocol;
 
@@ -36,6 +37,22 @@ public class PrefixSourceServiceTests
         foreach (var name in names)
             yaml += $"  - Name: {name}\n    Kind: stub\n";
         return ConfigLoader.LoadFromText(yaml);
+    }
+
+    [Fact]
+    public async Task PrefixSources_YamlNull_ConsumersTolerateTheDocumentedEmpty()
+    {
+        // #477: "PrefixSources:" (YAML null) deserializes as a null list — Validate and
+        // ConfigValidationTests bless it as "no sources", so the startup consumers must treat it
+        // as empty instead of crashing with NRE/ANE (ConfigCommunityResolver previously threw
+        // ArgumentNullException at DI resolution → startup failure on a documented-valid config).
+        var config = ConfigWith();
+
+        var resolver = new ConfigCommunityResolver(config, config.Bgp, logger: null);
+        var service = new PrefixSourceService(
+            config, new PrefixSourceProviderFactory([]), NullLogger<PrefixSourceService>.Instance);
+
+        Assert.Empty(await service.LoadAllAsync());
     }
 
     [Fact]

--- a/BGPLite.Tests/RouteAssemblerPolicyTests.cs
+++ b/BGPLite.Tests/RouteAssemblerPolicyTests.cs
@@ -1,0 +1,131 @@
+using BGPLite.Configuration;
+using BGPLite.Contracts;
+using BGPLite.Routing;
+using BGPLite.Server;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using BGPLite.Protocol;
+
+namespace BGPLite.Tests;
+
+/// <summary>
+/// #488 (D26): the outbound policy under failure. A CONFIGURED peer that resolves zero routes falls
+/// back to the RU default list only when its sources legitimately resolved to nothing — a TOTAL
+/// fetch failure (RIPEstat outage / network partition) fails CLOSED, because substituting the full
+/// RU dump would advertise hundreds of thousands of prefixes the peer never asked for. An unknown
+/// subscription name is a config typo and must be logged, not silently ignored.
+/// </summary>
+public sealed class RouteAssemblerPolicyTests
+{
+    private static readonly UInt128 RuPrefix = 0x0A000000;
+
+    private static RouteAssembler NewAssembler(IPrefixService prefixService, AppConfig config, ILogger<RouteAssembler>? logger = null)
+        => new(
+            prefixService,
+            new ConfiguredPeerStore(),
+            new ConfigCommunityResolver(config, config.Bgp),
+            AllowAllFilter.Instance,
+            config,
+            config.Bgp,
+            logger ?? NullLogger<RouteAssembler>.Instance);
+
+    private static AppConfig Config() => new()
+    {
+        Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" },
+        RipeStat = new RipeStatConfig
+        {
+            AsnLists = [new AsnList { Name = "tier1", Asns = [65010], Community = "65001:200" }]
+        }
+    };
+
+    /// <summary>Every fetch succeeds with EMPTY lists except where a test overrides one member.</summary>
+    private class StubPrefixService : IPrefixService
+    {
+        public Func<IEnumerable<uint>, CancellationToken, Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>>>? OnGetPrefixesForAsns { get; set; }
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetPrefixesAsync(uint asn, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetPrefixesForAsns(IEnumerable<uint> asns, CancellationToken ct = default)
+            => OnGetPrefixesForAsns?.Invoke(asns, ct) ?? Task.FromResult(new List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>());
+        public Task<int> GetPrefixCountAsync(uint asn, CancellationToken ct = default) => Task.FromResult(0);
+        public Task<List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>> GetRuPrefixesAsync(CancellationToken ct = default)
+            => Task.FromResult(new List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)> { (RuPrefix, 8, true, 0u) });
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetSourcePrefixesAsync(string name, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>> GetUserSourcePrefixesAsync(string name, string url, string? community, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<(UInt128 Prefix, byte Length, bool IsIpv4)>>([]);
+        public Task WarmUpAsync(CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    /// <summary>An existing peer subscribed to "tier1" — the configured-peer branch.</summary>
+    private sealed class ConfiguredPeerStore : IPeerStore
+    {
+        public List<string> Subscriptions { get; set; } = ["tier1"];
+        public Task<string> CreatePeerAsync(string ip, uint asn, string? description, CancellationToken ct = default) => Task.FromResult("id");
+        public Task UpsertPeerAsync(string ip, uint asn, CancellationToken ct = default) => Task.CompletedTask;
+        public Task UpdateSessionStatusAsync(string ip, uint asn, bool active, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<int?> GetPeerMaxPrefixAsync(string ip, uint asn, CancellationToken ct = default) => Task.FromResult<int?>(null);
+        public Task<PeerRoutingView?> LoadPeerRoutingViewAsync(string ip, uint asn, CancellationToken ct = default)
+            => Task.FromResult<PeerRoutingView?>(new("id", Subscriptions, [], [], []));
+    }
+
+    [Fact]
+    public async Task TotalSourceFailure_FailsClosed_NoRuDump()
+    {
+        // #488 (D26): the only configured fetch THROWS (outage) — the RU fallback must NOT fire;
+        // the peer keeps an empty set instead of the whole RU table.
+        var logger = new CapturingLogger();
+        var service = new StubPrefixService
+        {
+            OnGetPrefixesForAsns = (_, _) => throw new InvalidOperationException("simulated outage")
+        };
+        var assembler = NewAssembler(service, Config(), logger);
+
+        var routes = await assembler.BuildOutboundRoutesAsync(
+            "203.0.113.7", 65002, new PeerConfig { Address = "203.0.113.7" }, "203.0.113.7", CancellationToken.None);
+
+        Assert.Empty(routes);   // RED pre-fix: the RU fallback fired and added the RU prefix
+        Assert.Contains(logger.Entries, e => e.Message.Contains("NOT falling back"));
+    }
+
+    [Fact]
+    public async Task LegitimatelyEmptySources_StillFallBackToRu()
+    {
+        // Control for the same gate: the sources RESOLVED (to an empty list — the operator emptied
+        // them) — the documented "configured peer resolved 0 prefixes" fallback still applies.
+        var assembler = NewAssembler(new StubPrefixService(), Config());
+
+        var routes = await assembler.BuildOutboundRoutesAsync(
+            "203.0.113.7", 65002, new PeerConfig { Address = "203.0.113.7" }, "203.0.113.7", CancellationToken.None);
+
+        var route = Assert.Single(routes);
+        Assert.Equal((RuPrefix, (byte)8), (route.Prefix, route.PrefixLength));
+    }
+
+    [Fact]
+    public async Task UnknownSubscriptionName_IsWarned_NotSilentlyIgnored()
+    {
+        // #488: a subscription matching no AsnLists entry and no PrefixSource is a config typo —
+        // it was silently ignored on every build. Name it in the log.
+        var logger = new CapturingLogger();
+        var store = new ConfiguredPeerStore { Subscriptions = ["no-such-list"] };
+        var config = Config();
+        var assembler = new RouteAssembler(
+            new StubPrefixService(), store,
+            new ConfigCommunityResolver(config, config.Bgp),
+            AllowAllFilter.Instance, config, config.Bgp, logger);
+
+        await assembler.BuildOutboundRoutesAsync(
+            "203.0.113.7", 65002, new PeerConfig { Address = "203.0.113.7" }, "203.0.113.7", CancellationToken.None);
+
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("no-such-list"));
+    }
+
+    private sealed class CapturingLogger : ILogger<RouteAssembler>
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            => Entries.Add((logLevel, formatter(state, exception)));
+    }
+}

--- a/BGPLite.Tests/RouteAssemblerPolicyTests.cs
+++ b/BGPLite.Tests/RouteAssemblerPolicyTests.cs
@@ -34,7 +34,11 @@ public sealed class RouteAssemblerPolicyTests
         Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" },
         RipeStat = new RipeStatConfig
         {
-            AsnLists = [new AsnList { Name = "tier1", Asns = [65010], Community = "65001:200" }]
+            AsnLists =
+            [
+                new AsnList { Name = "tier1", Asns = [65010], Community = "65001:200" },
+                new AsnList { Name = "tier2", Asns = [65020], Community = "65001:201" }
+            ]
         }
     };
 
@@ -59,8 +63,7 @@ public sealed class RouteAssemblerPolicyTests
     /// <summary>An existing peer subscribed to "tier1" — the configured-peer branch.</summary>
     private sealed class ConfiguredPeerStore : IPeerStore
     {
-        public List<string> Subscriptions { get; set; } = ["tier1"];
-        public Task<string> CreatePeerAsync(string ip, uint asn, string? description, CancellationToken ct = default) => Task.FromResult("id");
+        public List<string> Subscriptions { get; set; } = ["tier1"]; public Task<string> CreatePeerAsync(string ip, uint asn, string? description, CancellationToken ct = default) => Task.FromResult("id");
         public Task UpsertPeerAsync(string ip, uint asn, CancellationToken ct = default) => Task.CompletedTask;
         public Task UpdateSessionStatusAsync(string ip, uint asn, bool active, CancellationToken ct = default) => Task.CompletedTask;
         public Task<int?> GetPeerMaxPrefixAsync(string ip, uint asn, CancellationToken ct = default) => Task.FromResult<int?>(null);
@@ -99,6 +102,32 @@ public sealed class RouteAssemblerPolicyTests
 
         var route = Assert.Single(routes);
         Assert.Equal((RuPrefix, (byte)8), (route.Prefix, route.PrefixLength));
+    }
+
+    [Fact]
+    public async Task MixedFailureAndEmptyResolution_StillFallsBackToRu()
+    {
+        // #503 review (D26 refinement): fail-closed is for TOTAL failure only. tier1 fails
+        // (outage), tier2 RESOLVES to an empty list — a source answered, so the build is not a
+        // total failure and the documented "configured peer resolved 0 prefixes" fallback applies.
+        var store = new ConfiguredPeerStore { Subscriptions = ["tier1", "tier2"] };
+        var config = Config();
+        var service = new StubPrefixService
+        {
+            OnGetPrefixesForAsns = (asns, _) => asns.Contains(65010u)
+                ? throw new InvalidOperationException("simulated outage")
+                : Task.FromResult(new List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>())
+        };
+        var assembler = new RouteAssembler(
+            service, store,
+            new ConfigCommunityResolver(config, config.Bgp),
+            AllowAllFilter.Instance, config, config.Bgp, NullLogger<RouteAssembler>.Instance);
+
+        var routes = await assembler.BuildOutboundRoutesAsync(
+            "203.0.113.7", 65002, new PeerConfig { Address = "203.0.113.7" }, "203.0.113.7", CancellationToken.None);
+
+        var route = Assert.Single(routes);
+        Assert.Equal((RuPrefix, (byte)8), (route.Prefix, route.PrefixLength));   // the RU fallback fired
     }
 
     [Fact]

--- a/BGPLite.Tests/UserSourceCacheTests.cs
+++ b/BGPLite.Tests/UserSourceCacheTests.cs
@@ -354,11 +354,61 @@ public class UserSourceCacheTests
         holder.TrySetResult();
         await holding.WaitAsync(TimeSpan.FromSeconds(5));
 
-        // The cancelled caller's pair-remove took the SHARED gate instance (the holder kept
-        // running on its own reference — the accepted duplicate-fetch tradeoff), and nothing
-        // re-adds a gate until the next call: zero gates, one cached entry, no orphan.
+        // The holder is the last participant out, so ExitInflight pair-removes the shared gate
+        // (the cancelled waiter no longer touches it — #468): zero gates, one cached entry,
+        // no orphan.
         Assert.Equal(0, cache.TrackedGateCount);
         Assert.Equal(1, cache.TrackedCount);
+    }
+
+    /// <summary>
+    /// #478: the #468 single-fetch invariant, end-to-end — across a waiter cancelled mid-queue AND
+    /// a caller arriving after it, exactly one loadAsync may run for the URL. Any gate split (the
+    /// cancelled waiter removing the shared gate, or a registration racing the first loader's
+    /// last-leaver exit) manifests as a second concurrent load, which the counting fetcher records
+    /// deterministically: every load blocks on the same release signal, so nobody finishes before
+    /// the assertion point. (The pre-#478 lock-free window between the decrement and the gate
+    /// pair-removal is nanosecond-narrow and cannot be forced from outside; this test pins the
+    /// invariant class, the lock closes the window by construction.)
+    /// </summary>
+    [Fact]
+    public async Task CancelledWaiterThenNewCaller_StillExactlyOneLoad()
+    {
+        var cache = new UserSourceCache();
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource<IReadOnlyList<IpPrefix>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var loads = 0;
+
+        Task<IReadOnlyList<IpPrefix>> BlockingLoad(CancellationToken ct)
+        {
+            Interlocked.Increment(ref loads);
+            entered.TrySetResult();
+            return release.Task.WaitAsync(ct);
+        }
+
+        // Loader A holds the gate.
+        var a = cache.GetOrLoadAsync("https://example.com/l", "src", BlockingLoad, CancellationToken.None);
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Waiter B queues behind A and is cancelled while queued (the #468 trigger).
+        var queuedCts = new CancellationTokenSource();
+        var queued = Task.Run(() => cache.GetOrLoadAsync("https://example.com/l", "src", BlockingLoad, queuedCts.Token));
+        await Task.Delay(50);            // let it queue behind the holder
+        queuedCts.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => queued);
+
+        // Caller C arrives while A is still inside — it must wait on A's gate (or hit the fresh
+        // cache entry after A completes), never start a second load.
+        var c = cache.GetOrLoadAsync("https://example.com/l", "src", BlockingLoad, CancellationToken.None);
+
+        release.TrySetResult(P((0x0A000000, 8, true)));
+        await a.WaitAsync(TimeSpan.FromSeconds(5));
+        var fromC = await c.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(1, loads);
+        Assert.Single(fromC);
+        Assert.Equal(1, cache.TrackedCount);
+        Assert.Equal(0, cache.TrackedGateCount);   // last leaver reclaimed the gate
     }
 
     /// <summary>

--- a/BGPLite/ConfigReloader.cs
+++ b/BGPLite/ConfigReloader.cs
@@ -71,6 +71,11 @@ public sealed class ConfigReloader : IHostedService, IDisposable
         _watcher.Changed += OnFileChanged;
         _watcher.Created += OnFileChanged;
         _watcher.Renamed += OnFileChanged;
+        // #487: an internal-buffer overflow (busy save storms) drops events SILENTLY — hot reload
+        // would quietly stop working until the next successful save. Surface it; the operator can
+        // then touch the file or restart.
+        _watcher.Error += (_, e) => _logger.LogWarning(e.GetException(),
+            "Config hot-reload watcher error (buffer overflow?) — change events may have been LOST; touch the config file to force a reload.");
         _watcher.EnableRaisingEvents = true;
 
         // One debounce timer, rearmed (never auto-recurring): fires exactly once, DebounceMs after

--- a/BGPLite/PrefixAutoRefreshService.cs
+++ b/BGPLite/PrefixAutoRefreshService.cs
@@ -58,7 +58,7 @@ internal sealed class PrefixAutoRefreshService : IHostedService, IDisposable
         _logger = logger;
         _timeProvider = timeProvider ?? TimeProvider.System;
         _jitterRandom = jitterRandom ?? new Random();
-        _sourceNames = [.. appConfig.PrefixSources.Select(s => s.Name)];
+        _sourceNames = [.. (appConfig.PrefixSources ?? []).Select(s => s.Name)]; // #477: YAML null = no sources
     }
 
     public Task StartAsync(CancellationToken cancellationToken)

--- a/appsettings.Example.yml
+++ b/appsettings.Example.yml
@@ -11,6 +11,8 @@ Bgp:
   # accept throttle. Both have secure, generous defaults; set to 0 to disable either.
   # OpenTimeoutSeconds: 30                 # drop a peer that connects but never sends OPEN (default 30, 0 = off)
   # MaxAcceptsPerIpPerMinute: 60           # per-source-IP accept flood limit (default 60, 0 = off)
+  # MaxPrefixesPerPeer: 1000000            # per-peer prefix ceiling (default 1M; exceeding it resets the
+                                           # session per RFC 4486; 0 = unlimited opt-out)
 
 Peers:
   - Address: 10.0.0.1

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -351,3 +351,22 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
   treated-as-withdraw; routes never install with an empty path (which the AS-loop exclusion,
   RFC 4271 §9.1.2, could never match anyway — D23).
 - **Tracker:** #486.
+
+### D26. Outbound policy under failure — total-source failure fails CLOSED; seed-takeover loss is accepted
+- **Decision (RU fallback):** a CONFIGURED peer whose routes resolve to zero falls back to the RU
+  default list ONLY when its sources legitimately resolved to nothing. When every configured fetch
+  FAILED (RIPEstat outage / network partition), the fallback is suppressed — the peer keeps an
+  empty set (fail closed) instead of receiving the entire RU table it never asked for.
+  Implemented via a per-build failure flag in `RouteAssembler` (`#488`).
+- **Decision (seed takeover):** a peer's announcement of a seeded prefix takes over the shared-table
+  entry (D12), and that session's teardown then removes the entry WITHOUT restoring the seed value.
+  Accepted: in the production composition the outbound path reads sources, never the shared table
+  (D13), so only `GET /api/routes` / LPM lose the prefix until restart; the degraded composition is
+  a named error mode of its own. Restoring seeds would require retaining seed data in `RouteTable`
+  — revisit only if the degraded composition ever becomes supported.
+- **Context:** both behaviors were silent policy gaps found by the 2026-09-04 audit (#488); neither
+  corrupted state — one substituted a huge unintended set on failure, the other lost an API-view row.
+- **Consequence:** during a total source outage, subscribed peers keep an empty advertisement (they
+  were withdrawn at refresh start anyway); an unknown subscription name now logs a Warning per build
+  instead of being silently ignored.
+- **Tracker:** #488.

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -354,10 +354,12 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
 
 ### D26. Outbound policy under failure — total-source failure fails CLOSED; seed-takeover loss is accepted
 - **Decision (RU fallback):** a CONFIGURED peer whose routes resolve to zero falls back to the RU
-  default list ONLY when its sources legitimately resolved to nothing. When every configured fetch
-  FAILED (RIPEstat outage / network partition), the fallback is suppressed — the peer keeps an
-  empty set (fail closed) instead of receiving the entire RU table it never asked for.
-  Implemented via a per-build failure flag in `RouteAssembler` (`#488`).
+  default list unless EVERY attempted fetch failed (a total failure — RIPEstat outage / network
+  partition). On total failure the fallback is suppressed: the peer keeps an empty set (fail
+  closed) instead of receiving the entire RU table it never asked for. A MIXED build — some sources
+  failed, others resolved (even to empty lists) — is not total and keeps the documented fallback.
+  Implemented via per-build fetch attempt/failure counters in `RouteAssembler` (`#488`, refined by
+  the #503 review).
 - **Decision (seed takeover):** a peer's announcement of a seeded prefix takes over the shared-table
   entry (D12), and that session's teardown then removes the entry WITHOUT restoring the seed value.
   Accepted: in the production composition the outbound path reads sources, never the shared table

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -335,3 +335,19 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
   conditional on the peer's offer (its receiving half has existed since #14).
 - **Tracker:** #466 (echo removed 2026-09-03, receive implemented same day after the
   `compose-integration` finding).
+
+### D25. A zero-length AS_PATH is rejected at the eBGP policy layer (Malformed AS_PATH)
+- **Decision:** an inbound UPDATE whose AS_PATH attribute has a zero-length value is rejected as
+  Malformed AS_PATH (subcode 11, treat-as-withdraw) in `UpdateCodec.ParseRouteAttributes`. The
+  codec (`AttributeHelper.ReadAsPath`/`WriteAsPath`) stays encoding-neutral — a zero-length
+  attribute is the on-wire form of an empty path, and the writer's empty-path roundtrip stands
+  (#248 review). AS4_PATH stays lenient: RFC 6793 leaves an empty one to the merge, which ignores it.
+- **Context:** RFC 4271 §5.1.2 defines a path segment as carrying "one or more AS numbers" and
+  permits an empty path only toward INTERNAL peers (iBGP); BGPLite serves eBGP exclusively, where
+  the sender's own ASN must be present — an empty path is malformed in practice (major
+  implementations reject it), though the RFC does not state it verbatim. #238 settled the
+  empty-SEGMENT case; #486 settled the empty-ATTRIBUTE case.
+- **Consequence:** an UPDATE a maximally lenient implementation might accept is
+  treated-as-withdraw; routes never install with an empty path (which the AS-loop exclusion,
+  RFC 4271 §9.1.2, could never match anyway — D23).
+- **Tracker:** #486.


### PR DESCRIPTION
Integration of the 2026-09-04 audit batch (tracking #489). One PR per issue, all CI-green and CodeQL-clean on their dev merge-refs.

Closes #476
Closes #477
Closes #478
Closes #479
Closes #480
Closes #481
Closes #482
Closes #483
Closes #484
Closes #485
Closes #486
Closes #487
Closes #488

## Per-issue summary
- **#476** (PR #490, HIGH): `MergeDuplicatePrefixes` now carries `IsIpv4` — a duplicated IPv6 prefix no longer crashes the initial send (flap loop) or leaks a bogus `0.0.0.0/N` classic NLRI. One-line fix + red/green test.
- **#477** (PR #491): the documented-valid `PrefixSources:` YAML-null no longer NREs at startup — `?? []` at all seven consumers.
- **#478** (PR #492): UserSourceCache gate bookkeeping (register / last-leaver removal / sweeps) is one atomic section under `_gateSync` — the #468 duplicate-fetch TOCTOU window closed by construction.
- **#479** (PR #493): source URLs with query-string tokens stay out of the logs (#149 policy); the validator's reason moved to the 400 response.
- **#480** (PR #494): `/api/asn-lists` degrades to the partial JSON on ExternalFetchBudget expiry instead of aborting the connection.
- **#481** (PR #495): `MaxPrefixesPerPeer` ships bounded at 1,000,000 (RFC 4486 defense on out of the box; 0 = explicit opt-out). **Behavior change.**
- **#482** (PR #496): four teardown dispose-race guards (CancelAsync ODE, initial-send lock, `_cts.Token` reads, send-mirror wire-truth).
- **#483** (PR #497): pre-OPEN phase per the FSM — a peer NOTIFICATION is never replied to, other non-OPEN first messages get exactly one 5/0; both sends CAS-latched. **Wire-visible behavior change** for peers that talk before our OPEN.
- **#484** (PR #498): treat-as-withdraw applies the MP_UNREACH_NLRI of the same UPDATE (RFC 7606 §2 whole-message semantics).
- **#485** (PR #499): caller-vs-foreign OCE contract at RipeStatPrefixCache / PrefixService RU path; WarmUp unwinds on shutdown instead of a WARN per ASN.
- **#486** (PR #500): zero-length AS_PATH rejected at the eBGP policy layer (3/11, codec stays encoding-neutral); recorded as D25. **Behavior change.**
- **#487** (PR #501): minor batch — statusTimer dispose, BgpConstants.BgpPort, FileSystemWatcher.Error, PATCH-vs-DELETE 404, file-size cap parity, AddSource field/count limits, O(n²) eviction, stale comment, volatile fields.
- **#488** (PR #502): total-source-failure fails CLOSED (no RU dump substitution), unknown subscription names warned, both recorded as D26. **Behavior change.**

## Verification
- Per-PR: `dotnet format` / `dotnet build BGPLite.sln` 0w/0e / full `dotnet test` green; dev CI (build-test, format-check, analyze) green; CodeQL 0 alerts on every merge-ref.
- Cumulative suite: 1074 → **1092** tests (15 red/green-proven regressions).
- Design decisions recorded: D25, D26; DESIGN_DECISIONS updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable per-peer prefix protection, enabled by default with a 1 million-prefix limit.
  - Added limits for custom source names, URLs, and the number of sources per peer.
  - Added warnings when configuration changes cannot be monitored or subscriptions reference unknown sources.

- **Bug Fixes**
  - Improved handling of source outages, cancellations, oversized files, empty configurations, and concurrent peer changes.
  - Prevented sensitive source URL tokens from appearing in logs.
  - Improved BGP protocol error handling, route withdrawals, IPv6 announcements, and session shutdown reliability.

- **Documentation**
  - Documented the prefix limit and updated design decisions for routing and protocol behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->