### PR TITLE
fix: address four CodeRabbit findings from the #503 integration review

### DIFF
--- a/BGPLite.Api/ManagementApi.cs
+++ b/BGPLite.Api/ManagementApi.cs
@@ -1264,10 +1264,11 @@ public sealed class ManagementApi : IHostedService, IDisposable
         // (unlike ASP.NET Core's RequestAborted), so the timeout is purely time-bounded.
         using var validationCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         bool isValid;
-        string? validationError;
         try
         {
-            (isValid, validationError) = await PrefixSourceUrlValidator.ValidateUrlAsync(data.Url, ct: validationCts.Token);
+            // #503 review: the validator's reason string embeds the URL and DNS internals —
+            // discarded; the log names the source and the response carries a fixed classification.
+            (isValid, _) = await PrefixSourceUrlValidator.ValidateUrlAsync(data.Url, ct: validationCts.Token);
         }
         catch (OperationCanceledException) when (validationCts.IsCancellationRequested)
         {
@@ -1279,11 +1280,13 @@ public sealed class ManagementApi : IHostedService, IDisposable
         if (!isValid)
         {
             // #479 (#149): neither the URL nor the validator's message (which embeds it) belongs in
-            // the log. The reason goes to the RESPONSE instead — the operator just submitted this
-            // URL, so echoing it there leaks nothing.
+            // the log. #503 review (CWE-209): the validator's message ALSO embeds resolved
+            // addresses and raw DNS exception text — classify for the response instead of echoing
+            // server-side resolution internals back to the caller.
             _logger.LogWarning("Save-time URL validation rejected source '{Name}' for peer {PeerId}",
                 SanitizeForLog(data.Name), SanitizeForLog(peerId));
-            return ApiResponse.Error($"Invalid URL: {validationError ?? "the host could not be reached or is not allowed"}", 400);
+            return ApiResponse.Error(
+                "Invalid URL: the scheme must be http/https on port 80/443 and the host must resolve to a reachable public address", 400);
         }
 
         var source = await _store.AddCustomSourceAsync(peerId, data.Name, data.Url, data.Community);

--- a/BGPLite.Providers/FilePrefixProvider.cs
+++ b/BGPLite.Providers/FilePrefixProvider.cs
@@ -41,14 +41,29 @@ public sealed class FilePrefixProvider(ILogger<FilePrefixProvider> logger) : IPr
         // #321 item 5: async read with the caller's token — the sync ReadAllText held a threadpool
         // thread under the per-source gate for the whole file. The metadata probes above stay
         // sync: they are single stat calls, not reads.
-        // #487: cap parity with the HTTP paths (HttpPrefixProvider.MaxResponseBytes) — the file is
-        // operator-controlled, but a multi-GB "prefix list" is never legitimate and the uncapped
-        // read was an asymmetric memory-amplification footgun.
-        var length = new FileInfo(fullPath).Length;
-        if (length > HttpPrefixProvider.MaxResponseBytes)
-            throw new InvalidOperationException(
-                $"Prefix file for source '{source.Name}' is {length} bytes — over the {HttpPrefixProvider.MaxResponseBytes}-byte cap.");
-        var text = await File.ReadAllTextAsync(fullPath, ct);
+        // #487 + #503 review: cap parity with the HTTP paths (HttpPrefixProvider.MaxResponseBytes),
+        // enforced WHILE reading — a length probe alone races a concurrent writer extending the
+        // file between the stat and the read.
+        string text;
+        await using (var fs = File.OpenRead(fullPath))
+        {
+            if (fs.Length > HttpPrefixProvider.MaxResponseBytes)
+                throw new InvalidOperationException(
+                    $"Prefix file for source '{source.Name}' is {fs.Length} bytes — over the {HttpPrefixProvider.MaxResponseBytes}-byte cap.");
+            using var ms = new MemoryStream(capacity: (int)Math.Min(fs.Length, HttpPrefixProvider.MaxResponseBytes));
+            var buffer = new byte[81920];
+            int read;
+            long total = 0;
+            while ((read = await fs.ReadAsync(buffer, ct)) > 0)
+            {
+                total += read;
+                if (total > HttpPrefixProvider.MaxResponseBytes)
+                    throw new InvalidOperationException(
+                        $"Prefix file for source '{source.Name}' grew past the {HttpPrefixProvider.MaxResponseBytes}-byte cap while reading.");
+                ms.Write(buffer, 0, read);
+            }
+            text = System.Text.Encoding.UTF8.GetString(ms.ToArray());
+        }
         var prefixes = PrefixListParser.Parse(text);
         logger.LogInformation("Source '{Name}' (file): loaded {Count} prefixes from {Path}", source.Name, prefixes.Count, fullPath);
         return SourceLoadResult.Ok(prefixes, lastModified: fileMtime);

--- a/BGPLite.Providers/PrefixService.cs
+++ b/BGPLite.Providers/PrefixService.cs
@@ -327,7 +327,11 @@ public sealed class PrefixService : IPrefixService
                 await GetPrefixesAsync(asn, ct);
                 _logger?.LogInformation("WarmUp: AS{Asn} cached", asn);
             }
-            catch (OperationCanceledException) { throw; }   // #485: host shutdown unwinds the loop, not a WARN per remaining ASN
+            // #485: host shutdown unwinds the loop, not a WARN per remaining ASN.
+            // #503 review: filter CALLER cancellation — a foreign-token OCE (body deadline on a
+            // cold ASN, escaping RipeStatPrefixCache's no-stale rethrow) is a per-ASN fetch
+            // failure like any other; unfiltered, one cold timeout aborted the whole warm-up.
+            catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
             catch (Exception ex)
             {
                 _logger?.LogWarning(ex, "WarmUp: AS{Asn} failed", asn);

--- a/BGPLite.Server/RouteAssembler.cs
+++ b/BGPLite.Server/RouteAssembler.cs
@@ -95,9 +95,12 @@ public sealed class RouteAssembler : IRouteAssembler
 
             _logger.LogInformation("Peer {Peer} subscriptions: [{Subs}]", peerLabel, string.Join(", ", subscriptionIds));
 
-            // #488 (D26): tracks whether any configured fetch FAILED (vs legitimately resolved to
-            // nothing). The RU fallback below must not fire on total failure — see the gate there.
-            var anyFetchFailed = false;
+            // #488 (D26): fetch outcome counters — the RU fallback below is suppressed only on a
+            // TOTAL failure (every attempted fetch failed). A mixed build (one source failed,
+            // another resolved — even to an empty list) is not total: the fallback keeps the
+            // documented "configured peer resolved 0 prefixes" behavior.
+            var fetchAttempts = 0;
+            var fetchFailures = 0;
 
             var subscribedLists = _appConfig.RipeStat?.AsnLists
                 .Where(l => subscriptionIds.Contains(l.Name))
@@ -114,6 +117,7 @@ public sealed class RouteAssembler : IRouteAssembler
                 var before = routes.Count;
                 foreach (var list in asnLists)
                 {
+                    fetchAttempts++;
                     try
                     {
                         var comms = _communityResolver.Resolve(
@@ -128,7 +132,7 @@ public sealed class RouteAssembler : IRouteAssembler
                     catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#330
                     catch (Exception ex)
                     {
-                        anyFetchFailed = true;   // #488
+                        fetchFailures++;   // #488
                         _logger.LogError(ex, "Failed to fetch prefixes for {Peer} (list '{List}')", peerLabel, list.Name);
                     }
                 }
@@ -140,6 +144,7 @@ public sealed class RouteAssembler : IRouteAssembler
             var countryLists = subscribedLists.Where(l => l.Asns.Count == 0 && l.Country is not null).ToList();
             if (countryLists.Count > 0)
             {
+                fetchAttempts++;
                 try
                 {
                     var comms = _communityResolver.Resolve(
@@ -152,7 +157,7 @@ public sealed class RouteAssembler : IRouteAssembler
                 catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#330
                 catch (Exception ex)
                 {
-                    anyFetchFailed = true;   // #488
+                    fetchFailures++;   // #488
                     _logger.LogError(ex, "Failed to fetch RU prefixes for {Peer}", peerLabel);
                 }
             }
@@ -175,6 +180,7 @@ public sealed class RouteAssembler : IRouteAssembler
 
             foreach (var name in sourceNames)
             {
+                fetchAttempts++;
                 try
                 {
                     var comms = _communityResolver.Resolve(new CommunitySource(CommunitySourceKind.PrefixSource, name));
@@ -187,7 +193,7 @@ public sealed class RouteAssembler : IRouteAssembler
                 catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#330
                 catch (Exception ex)
                 {
-                    anyFetchFailed = true;   // #488
+                    fetchFailures++;   // #488
                     _logger.LogError(ex, "Failed to fetch source '{Source}' for {Peer}", name, peerLabel);
                 }
             }
@@ -216,6 +222,7 @@ public sealed class RouteAssembler : IRouteAssembler
             // Add custom AS prefixes. Custom-AS routes carry the static "custom AS" community.
             if (customAsns.Count > 0)
             {
+                fetchAttempts++;
                 try
                 {
                     var customAsnComms = _communityResolver.Resolve(new CommunitySource(CommunitySourceKind.CustomAsn));
@@ -228,7 +235,7 @@ public sealed class RouteAssembler : IRouteAssembler
                 catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }  // #114/#330
                 catch (Exception ex)
                 {
-                    anyFetchFailed = true;   // #488
+                    fetchFailures++;   // #488
                     _logger.LogError(ex, "Failed to fetch custom AS prefixes for {Peer}", peerLabel);
                 }
             }
@@ -236,8 +243,10 @@ public sealed class RouteAssembler : IRouteAssembler
             // Per-peer user URL sources (#143/#147): each Active source fetched + community-stamped.
             foreach (var source in peer.UserSources)
             {
-                anyFetchFailed |= !await AddUserSourceRoutesAsync(
-                    routes, source, nextHop, _prefixService, _communityResolver, _logger, peerLabel, ct);
+                fetchAttempts++;
+                if (!await AddUserSourceRoutesAsync(
+                        routes, source, nextHop, _prefixService, _communityResolver, _logger, peerLabel, ct))
+                    fetchFailures++;
             }
 
             // #220 "suppress more-specifics": a custom prefix is an explicit operator override, so
@@ -255,13 +264,13 @@ public sealed class RouteAssembler : IRouteAssembler
 
             _logger.LogInformation("Sending {Count} total routes to {Peer}", routes.Count, peerLabel);
 
-            // Configured peer resolved 0 prefixes — fall back to RU. #488 (D26): ONLY when the
-            // peer's configured sources legitimately resolved to nothing. When every fetch FAILED
-            // (RIPEstat outage / network partition), substituting the full RU dump would advertise
-            // hundreds of thousands of prefixes the peer never asked for — total-source failure
-            // fails CLOSED: the peer keeps an empty set and the per-source errors above carry the
-            // cause.
-            if (routes.Count == 0 && anyFetchFailed)
+            // Configured peer resolved 0 prefixes — fall back to RU. #488 (D26): suppressed only
+            // on a TOTAL failure — every attempted fetch failed (RIPEstat outage / network
+            // partition). Substituting the full RU dump then would advertise hundreds of thousands
+            // of prefixes the peer never asked for — fail CLOSED: the peer keeps an empty set and
+            // the per-source errors above carry the cause. A MIXED build (some failed, some
+            // resolved to empty) is not total and keeps the documented fallback.
+            if (routes.Count == 0 && fetchAttempts > 0 && fetchFailures == fetchAttempts)
             {
                 _logger.LogWarning(
                     "Peer {Peer} resolved 0 prefixes WITH fetch failures — NOT falling back to RU defaults (total-source failure fails closed)",

--- a/BGPLite.Tests/RouteAssemblerPolicyTests.cs
+++ b/BGPLite.Tests/RouteAssemblerPolicyTests.cs
@@ -34,7 +34,11 @@ public sealed class RouteAssemblerPolicyTests
         Bgp = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1" },
         RipeStat = new RipeStatConfig
         {
-            AsnLists = [new AsnList { Name = "tier1", Asns = [65010], Community = "65001:200" }]
+            AsnLists =
+            [
+                new AsnList { Name = "tier1", Asns = [65010], Community = "65001:200" },
+                new AsnList { Name = "tier2", Asns = [65020], Community = "65001:201" }
+            ]
         }
     };
 
@@ -59,8 +63,7 @@ public sealed class RouteAssemblerPolicyTests
     /// <summary>An existing peer subscribed to "tier1" — the configured-peer branch.</summary>
     private sealed class ConfiguredPeerStore : IPeerStore
     {
-        public List<string> Subscriptions { get; set; } = ["tier1"];
-        public Task<string> CreatePeerAsync(string ip, uint asn, string? description, CancellationToken ct = default) => Task.FromResult("id");
+        public List<string> Subscriptions { get; set; } = ["tier1"]; public Task<string> CreatePeerAsync(string ip, uint asn, string? description, CancellationToken ct = default) => Task.FromResult("id");
         public Task UpsertPeerAsync(string ip, uint asn, CancellationToken ct = default) => Task.CompletedTask;
         public Task UpdateSessionStatusAsync(string ip, uint asn, bool active, CancellationToken ct = default) => Task.CompletedTask;
         public Task<int?> GetPeerMaxPrefixAsync(string ip, uint asn, CancellationToken ct = default) => Task.FromResult<int?>(null);
@@ -99,6 +102,32 @@ public sealed class RouteAssemblerPolicyTests
 
         var route = Assert.Single(routes);
         Assert.Equal((RuPrefix, (byte)8), (route.Prefix, route.PrefixLength));
+    }
+
+    [Fact]
+    public async Task MixedFailureAndEmptyResolution_StillFallsBackToRu()
+    {
+        // #503 review (D26 refinement): fail-closed is for TOTAL failure only. tier1 fails
+        // (outage), tier2 RESOLVES to an empty list — a source answered, so the build is not a
+        // total failure and the documented "configured peer resolved 0 prefixes" fallback applies.
+        var store = new ConfiguredPeerStore { Subscriptions = ["tier1", "tier2"] };
+        var config = Config();
+        var service = new StubPrefixService
+        {
+            OnGetPrefixesForAsns = (asns, _) => asns.Contains(65010u)
+                ? throw new InvalidOperationException("simulated outage")
+                : Task.FromResult(new List<(UInt128 Prefix, byte Length, bool IsIpv4, uint Asn)>())
+        };
+        var assembler = new RouteAssembler(
+            service, store,
+            new ConfigCommunityResolver(config, config.Bgp),
+            AllowAllFilter.Instance, config, config.Bgp, NullLogger<RouteAssembler>.Instance);
+
+        var routes = await assembler.BuildOutboundRoutesAsync(
+            "203.0.113.7", 65002, new PeerConfig { Address = "203.0.113.7" }, "203.0.113.7", CancellationToken.None);
+
+        var route = Assert.Single(routes);
+        Assert.Equal((RuPrefix, (byte)8), (route.Prefix, route.PrefixLength));   // the RU fallback fired
     }
 
     [Fact]

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -354,10 +354,12 @@ For section-by-section RFC conformance status, see `RFC_COMPLIANCE.md` (2026-07-
 
 ### D26. Outbound policy under failure — total-source failure fails CLOSED; seed-takeover loss is accepted
 - **Decision (RU fallback):** a CONFIGURED peer whose routes resolve to zero falls back to the RU
-  default list ONLY when its sources legitimately resolved to nothing. When every configured fetch
-  FAILED (RIPEstat outage / network partition), the fallback is suppressed — the peer keeps an
-  empty set (fail closed) instead of receiving the entire RU table it never asked for.
-  Implemented via a per-build failure flag in `RouteAssembler` (`#488`).
+  default list unless EVERY attempted fetch failed (a total failure — RIPEstat outage / network
+  partition). On total failure the fallback is suppressed: the peer keeps an empty set (fail
+  closed) instead of receiving the entire RU table it never asked for. A MIXED build — some sources
+  failed, others resolved (even to empty lists) — is not total and keeps the documented fallback.
+  Implemented via per-build fetch attempt/failure counters in `RouteAssembler` (`#488`, refined by
+  the #503 review).
 - **Decision (seed takeover):** a peer's announcement of a seeded prefix takes over the shared-table
   entry (D12), and that session's teardown then removes the entry WITHOUT restoring the seed value.
   Accepted: in the production composition the outbound path reads sources, never the shared table


### PR DESCRIPTION
Follow-up to the #503 integration review — four independently verified findings fixed; the remaining three are answered with rationale on the integration PR.

## Fixes
1. **WarmUp foreign-OCE filter** (`PrefixService`): the #485 loop rethrow lacked `when (ct.IsCancellationRequested)` — a foreign-token OCE (body deadline on a cold ASN escaping `RipeStatPrefixCache`'s no-stale rethrow) aborted the whole warm-up; now a per-ASN failure like every #114/#324 site.
2. **Total-failure semantics for the #488 gate** (`RouteAssembler`): the code suppressed the RU fallback on ANY failure while D26 documents TOTAL failure — mixed builds (one source failed, another resolved, even to empty) keep the documented fallback. Attempt/failure counters; D26 wording aligned; `MixedFailureAndEmptyResolution_StillFallsBackToRu` regression test.
3. **Bounded file read** (`FilePrefixProvider`): the cap is enforced DURING the read (bounded stream + overrun reject) — the pre-read length probe raced a concurrent writer extending the file.
4. **CWE-209 classification** (`ManagementApi`): the #479 400-response no longer echoes the validator's message (resolved addresses + raw DNS exception text); fixed classification instead.

## Verification
- `dotnet format` / `dotnet build BGPLite.sln` 0w/0e / `dotnet test BGPLite.sln` 1093/1093 (+1 test)

## RFC
- none