### PR TITLE
fix(server): rethrow BgpNotificationException from AwaitLoopTaskAsync — the MaxPrefixes reset keeps its Cease subcode (#505)

### DIFF
--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -756,6 +756,11 @@ public sealed class BgpSession : IDisposable
         try { await task; }
         catch (OperationCanceledException) { }
         catch (BgpParseException) { throw; }
+        // #505: a BgpNotificationException faulting a loop (the #304 cap reset thrown from
+        // HandleUpdateAsync on the read loop) must reach RunAsync's handler, which sends the
+        // carried code/subcode — Cease/MaxPrefixes per RFC 4486 §2. The generic catch below
+        // swallowed it, so HoldTime>0 sessions got a bare Cease 6/0 from the finally instead.
+        catch (BgpNotificationException) { throw; }
         catch (Exception ex) { _logger.LogWarning(ex, "{Label} loop faulted for {Peer}", label, _peer); }
     }
 

--- a/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
+++ b/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
@@ -743,6 +743,52 @@ public class BgpSessionRouteOwnershipTests
         Assert.Equal(0, routeTable.Count);                  // owned routes flushed by the finally
     }
 
+    /// <summary>
+    /// #505: the SAME cap-reset as <see cref="ExceedingMaxPrefixes_SendsCeaseMaxPrefixes_AndFlushesOwned"/>
+    /// but on a HoldTime &gt; 0 session — the read loop runs behind <c>Task.WhenAny</c>, and
+    /// <c>AwaitLoopTaskAsync</c>'s generic catch swallowed the cap's BgpNotificationException
+    /// (it only rethrew BgpParseException), so RunAsync's finally sent a bare Cease 6/0 and the
+    /// RFC 4486 §2 subcode never reached the peer. The rethrow restores the carried subcode here.
+    /// </summary>
+    [Fact]
+    public async Task ExceedingMaxPrefixes_WithHoldTimer_StillCarriesSubcode1()
+    {
+        var routeTable = new RouteTable();
+        var conn = new ScriptedConnection();
+        var config = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 30, KeepAlive = 10, MaxPrefixesPerPeer = 2 };
+        var session = new BgpSession(
+            conn, new PeerConfig { Address = "127.0.0.1" }, config, routeTable,
+            AllowAllFilter.Instance, new BgpMetrics(), NullLogger<BgpSession>.Instance);
+        var run = session.RunAsync();
+        conn.EnqueueMessage(new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = 30,
+            RouterId = 0x0A000002,
+            Capabilities = [BgpCapabilityInfo.FourOctetAsn(65002)],
+        });
+        conn.EnqueueMessage(BgpKeepaliveMessage.Instance);
+        for (var i = 0; i < 200 && !session.IsEstablished; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        Assert.True(session.IsEstablished, "session must reach Established");
+
+        conn.EnqueueFrame(AnnounceFrame(8, 0x0A));                  // 1/2
+        conn.EnqueueFrame(AnnounceFrame(24, 0xC0, 0x00, 0x02));     // 2/2
+        conn.EnqueueFrame(AnnounceFrame(16, 0xC0, 0x01));           // 3rd distinct prefix — over
+        await run.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.False(session.IsEstablished);
+
+        var ceases = conn.Sent
+            .Select(b => BgpMessageReader.ReadMessage(b.AsSpan()))
+            .OfType<BgpNotificationMessage>()
+            .Where(n => n.ErrorCode == BgpConstants.Error.Cease)
+            .ToList();
+        var maxPrefixes = Assert.Single(ceases);                    // exactly one Cease on the wire
+        Assert.Equal(BgpConstants.SubError.CeaseMaxPrefixes, maxPrefixes.SubErrorCode);   // RED pre-fix: 0 (Unspecific)
+        Assert.Equal(0, routeTable.Count);                          // flush still happens
+    }
+
     /// <summary>#391: waits for the route table to reach the expected size. Generous timeout:
     /// a cold-JIT first run can take longer than SettleAsync's 2 s window to get from
     /// Established through the establish dump to a started read loop.</summary>


### PR DESCRIPTION
Closes #505   # linkage only — the integration PR aggregates the closing keywords

## Problem
The #304 per-peer cap reset throws `BgpNotificationException(Cease, CeaseMaxPrefixes)` from `HandleUpdateAsync` on the read loop. On **HoldTime > 0** sessions the read loop runs behind `Task.WhenAny`, and `AwaitLoopTaskAsync`'s generic catch — which rethrows only `BgpParseException` (the #223 contract) — swallowed the notification exception. `RunAsync` then returned normally, the finally saw `teardownReason == None` and sent a **bare Cease 6/0**: the RFC 4486 §2 "Maximum Number of Prefixes Reached" subcode never reached the peer. Wire-verified on the local integration stand (sniffed 6/0; `host.log` showed "read loop faulted … exceeded the per-peer prefix limit" followed by "NotificationSent … 6/0").

## Root Cause
The loop-refactor (#253-era `WhenAny` + `AwaitLoopTaskAsync`) added a swallow-all catch that predates the cap exception's design intent (its comment says it "unwinds to RunAsync's BgpNotificationException handler"). The HoldTime == 0 path awaits `ReadLoopAsync` directly and was unaffected.

## Fix
One rethrow in `AwaitLoopTaskAsync`: `catch (BgpNotificationException) { throw; }` beside the `BgpParseException` rethrow. `RunAsync`'s existing handler sends the carried code/subcode and CAS-latches `LocalCease`, so the finally cannot double-send (the exactly-one-NOTIFICATION invariant holds).

## Correctness
- Only exception class affected: `BgpNotificationException` — on these loops it is thrown solely by the cap reset (per-source fetch failures are caught in the assembler; treat-as-withdraw errors are caught in the read loop).
- The keepalive loop never throws it (its IOException path returns cleanly).
- HoldTime == 0 path unchanged.

## Regression Test
`BgpSessionRouteOwnershipTests.ExceedingMaxPrefixes_WithHoldTimer_StillCarriesSubcode1` — hold 30/keepalive 10 session at cap 2, three distinct announces: exactly ONE Cease on the wire, subcode == MaxPrefixes, owned routes flushed. **Red/green proven** (pre-fix: subcode 0).

## Verification
- `dotnet format` clean; `dotnet build BGPLite.sln` 0w/0e; `dotnet test BGPLite.sln` 1094/1094 (+1)
- Post-merge the integration stand's analyzer check F1 (sniffed 6/1) is expected to flip green.

## RFC
- RFC 4486 §2/§3 (Cease/Maximum Number of Prefixes Reached), RFC 4271 §8.1 (exactly one NOTIFICATION).

## Behavior Change
HoldTime > 0 peers exceeding the cap now receive 6/1 instead of 6/0.

## Deviation from Issue Proposal
None.