### PR TITLE
fix(protocol): CeaseAdministrativeReset is subcode 4 per RFC 4486 §3 (#506)

### DIFF
--- a/BGPLite.Protocol/BgpConstants.cs
+++ b/BGPLite.Protocol/BgpConstants.cs
@@ -71,7 +71,9 @@ public static class BgpConstants
         public const byte CeaseMaxPrefixes = 1;
         public const byte CeaseAdministrativeShutdown = 2;
         public const byte CeasePeerDeconfigured = 3;
-        public const byte CeaseAdministrativeReset = 6;
+        // #506: RFC 4486 §3 assigns 4 to "Administrative Reset" (6 is "Other Configuration
+        // Change") — the constant was 6, mislabeling every graceful reset on the wire.
+        public const byte CeaseAdministrativeReset = 4;
         public const byte CeaseConnectionRejected = 7;
     }
 

--- a/BGPLite.Tests/BgpSessionShutdownTests.cs
+++ b/BGPLite.Tests/BgpSessionShutdownTests.cs
@@ -73,6 +73,29 @@ public class BgpSessionShutdownTests
         Assert.Equal(BgpConstants.SubError.CeaseAdministrativeReset, notif.SubErrorCode);
     }
 
+    [Fact]
+    public async Task NotifyCease_SubcodeIs4_AdministrativeReset_PerRfc4486()
+    {
+        // #506: the subcode value itself, asserted as a LITERAL so a wrong constant cannot pass.
+        // RFC 4486 §3 table: 4 = "Administrative Reset"; 6 = "Other Configuration Change".
+        // CeaseAdministrativeReset was 6, mislabeling every graceful reset/shutdown/delete.
+        var (server, client) = ConnectedPair();
+        using var clientSock = client;
+        using var session = NewSession(server);
+
+        await session.NotifyCeaseAsync();
+
+        var buf = new byte[64];
+        ReadExact(client, buf, 0, BgpConstants.MessageHeaderSize);
+        var len = BgpMessageReader.GetMessageLength(buf);
+        ReadExact(client, buf, BgpConstants.MessageHeaderSize, len - BgpConstants.MessageHeaderSize);
+
+        var msg = BgpMessageReader.ReadMessage(buf.AsSpan(0, len));
+        var notif = Assert.IsType<BgpNotificationMessage>(msg);
+        Assert.Equal(BgpConstants.Error.Cease, notif.ErrorCode);
+        Assert.Equal(4, notif.SubErrorCode);   // RED pre-fix: 6
+    }
+
     /// <summary>
     /// Regression #325: UpdateSessionStatus in the RunAsync finally is a best-effort DB write on a
     /// fire-and-forget task (RunSessionAsync has no catch) — a transient store failure must not


### PR DESCRIPTION
Closes #506   # linkage only — the integration PR aggregates the closing keywords

## Problem
`BgpConstants.SubError.CeaseAdministrativeReset = 6`, but RFC 4486 §3 assigns **4** to "Administrative Reset" (6 is "Other Configuration Change"). Every `NotifyCeaseAsync` — server shutdown without GR, API peer deletion — labeled its Cease with the wrong reason on the wire (sniff-verified: delete-peer → 6/6).

## Root Cause
A wrong value in the RFC 4486 subcode table since the constant was introduced; the neighboring entries (1/2/3) match the same table.

## Fix
One constant: `6` → `4`, with the RFC citation in a comment.

## Regression Test
`BgpSessionShutdownTests.NotifyCease_SubcodeIs4_AdministrativeReset_PerRfc4486` — asserts the LITERAL wire value 4 (not via the constant, which would pass with any value). **Red/green proven** (pre-fix: 6).

## Verification
- `dotnet format` clean; `dotnet build BGPLite.sln` 0w/0e; `dotnet test BGPLite.sln` 1095/1095 (+1)
- The two existing tests asserting via the constant follow automatically; post-merge the stand's analyzer check F2 (sniffed 6/4) flips green.

## RFC
- RFC 4486 §3 (Cease subcode table — verified verbatim against the RFC text).

## Behavior Change
Administrative resets now carry subcode 4 on the wire.

## Deviation from Issue Proposal
None.