### PR TITLE
test: determinize the two CI-flaky timing tests (#507)

### DIFF
--- a/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
+++ b/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
@@ -72,6 +72,23 @@ public class PrefixAutoRefreshServiceTests
     }
 
     /// <summary>
+    /// #507: wait for an OBSERVABLE condition instead of a fixed real-time sleep. The old
+    /// <c>Task.Delay(50)</c> after each clock advance raced the refresh loop's continuation —
+    /// on a loaded runner 50 ms is not always enough for the loop to observe the tick, so the
+    /// assertion counted 0 polls. Condition-polling with a generous deadline is deterministic.
+    /// </summary>
+    private static async Task WaitForAsync(Func<bool> condition, string what, int timeoutMilliseconds = 30_000)
+    {
+        var deadline = Environment.TickCount64 + timeoutMilliseconds;
+        while (!condition())
+        {
+            if (Environment.TickCount64 > deadline)
+                Assert.Fail($"timed out after {timeoutMilliseconds} ms waiting for: {what}");
+            await Task.Delay(5);
+        }
+    }
+
+    /// <summary>
     /// #214: a source supporting conditional requests is polled at IntervalSeconds; a source without
     /// ETag support (asn) is polled at the longer NoEtagIntervalSeconds. On a timer tick that falls
     /// between the two intervals, only the conditional source is re-polled.
@@ -96,13 +113,13 @@ public class PrefixAutoRefreshServiceTests
 
         // Tick 1 (t=60s): both sources due (first check) → 1 call each.
         time.Advance(TimeSpan.FromSeconds(60));
-        await Task.Delay(50); // let the loop observe the tick
+        await WaitForAsync(() => svc.RefreshCalls.GetValueOrDefault("asn-src") >= 1, "tick 1: both sources polled");
         Assert.Equal(1, svc.RefreshCalls.GetValueOrDefault("http-src"));
         Assert.Equal(1, svc.RefreshCalls.GetValueOrDefault("asn-src"));
 
         // Tick 2 (t=120s): http-src due again (interval=60s), asn-src NOT due (next at 60+600=660s).
         time.Advance(TimeSpan.FromSeconds(60));
-        await Task.Delay(50);
+        await WaitForAsync(() => svc.RefreshCalls.GetValueOrDefault("http-src") >= 2, "tick 2: http-src re-polled");
         Assert.Equal(2, svc.RefreshCalls.GetValueOrDefault("http-src"));
         Assert.Equal(1, svc.RefreshCalls.GetValueOrDefault("asn-src"));
 
@@ -134,14 +151,29 @@ public class PrefixAutoRefreshServiceTests
         // Tick 1 (t=60s): first source checked immediately (no jitter on the very first check), then
         // the second is delayed by jitter (0..5000ms). Advance the clock to release the jittered delay.
         time.Advance(TimeSpan.FromSeconds(60));
-        await Task.Delay(50); // let the loop start the tick
-        // Only 'a' (first source, no jitter) has been polled so far; 'b' is waiting on the jitter delay.
+        // Wait until 'a' (first source, no jitter) has been polled — the loop is then mid-tick,
+        // deterministically before 'b' whose jitter delay is FakeTimeProvider-driven and can only
+        // be released by the Advance below.
+        await WaitForAsync(() => svc.RefreshCalls.GetValueOrDefault("a") >= 1, "tick: first source polled");
         Assert.Equal(1, svc.RefreshCalls.GetValueOrDefault("a"));
         Assert.Equal(0, svc.RefreshCalls.GetValueOrDefault("b"));
 
-        // Advance past the jitter window (Random(0).Next(0, 5001) is deterministic = some value ≤5000ms).
-        time.Advance(TimeSpan.FromMilliseconds(5000));
-        await Task.Delay(50);
+        // Advance past the jitter window. #507: the delay for 'b' may not be SCHEDULED on the fake
+        // clock yet when 'a' is observed — the loop thread can be preempted between polling 'a'
+        // and registering the delay, and a batch of advances landing before the schedule point
+        // would leave the delay in the future with nobody to release it (the CI flake shape).
+        // Therefore interleave: each 1 s step yields REAL time (20 ms) so a preempted loop can
+        // register the delay, and the NEXT step releases it. Jitter ∈ [0, 5000] ms (Random(0) →
+        // 3631), so once registered ≤5 steps suffice; the 55-step cap (~1.1 s of real yield)
+        // tolerates heavy scheduling pressure while never crossing tick 2 at 120 s — counts stay
+        // exactly 1/1.
+        for (var i = 0; i < 55 && svc.RefreshCalls.GetValueOrDefault("b") == 0; i++)
+        {
+            time.Advance(TimeSpan.FromMilliseconds(1000));
+            if (svc.RefreshCalls.GetValueOrDefault("b") > 0) break;
+            await Task.Delay(20);
+        }
+        await WaitForAsync(() => svc.RefreshCalls.GetValueOrDefault("b") >= 1, "jitter released: second source polled");
         // Now 'b' has been polled too.
         Assert.Equal(1, svc.RefreshCalls.GetValueOrDefault("b"));
 
@@ -161,9 +193,9 @@ public class PrefixAutoRefreshServiceTests
 
         await service.StartAsync(CancellationToken.None);
 
-        // Advancing the clock must NOT trigger any refresh (service disabled).
+        // Advancing the clock must NOT trigger any refresh (service disabled — StartAsync
+        // created no loop, so there is nothing to synchronize with; assert immediately).
         time.Advance(TimeSpan.FromHours(1));
-        await Task.Delay(50);
         Assert.Empty(svc.RefreshCalls);
         Assert.Equal(0, sessions.RefreshAllCalls);
 
@@ -186,7 +218,7 @@ public class PrefixAutoRefreshServiceTests
         await service.StartAsync(CancellationToken.None);
 
         time.Advance(TimeSpan.FromSeconds(60));
-        await Task.Delay(50);
+        await WaitForAsync(() => sessions.RefreshAllCalls >= 1, "changed source: peer refresh pushed");
 
         Assert.Equal(1, sessions.RefreshAllCalls);
 
@@ -217,7 +249,7 @@ public class PrefixAutoRefreshServiceTests
         await service.StartAsync(CancellationToken.None);
 
         time.Advance(TimeSpan.FromSeconds(60));
-        await Task.Delay(50);
+        await WaitForAsync(() => sessions.RefreshAllCalls >= 1, "changed sources: aggregated peer refresh pushed");
 
         // All 3 sources changed, but exactly ONE aggregated peer refresh (not 3+1).
         Assert.Equal(1, sessions.RefreshAllCalls);

--- a/BGPLite.Tests/RefreshDebounceTests.cs
+++ b/BGPLite.Tests/RefreshDebounceTests.cs
@@ -147,7 +147,21 @@ public class RefreshDebounceTests
         using var serverSock = server;
         using var sessionH = session;
 
-        var baseline = store.LoadCalls; // initial dump already ran during establishment
+        // #507: EstablishAsync waits for the Established STATE, not for the initial dump to
+        // finish — and the dump (RouteAssembler → LoadPeerRoutingViewAsync) can still be in
+        // flight here. Under runner load its Load then lands INSIDE the armed gate below,
+        // masquerading as the refresh cycle's load: the "4 callers returned" condition was
+        // satisfied with the winner parked on _advertisedPrefixesLock (held by the dump), and
+        // the final total came out 3 (dump + cycle + lap). Drain the dump deterministically:
+        // a probe refresh can only acquire the dump's lock after the dump released it, so a
+        // completed probe proves the dump is done and `baseline` is stable.
+        var probe = session.RefreshRoutesAsync();
+        await WaitForAsync(
+            () => Volatile.Read(ref store.LoadCalls) >= 1,
+            () => $"probe load={Volatile.Read(ref store.LoadCalls)} (want 1)");
+        await probe.WaitAsync(TimeSpan.FromSeconds(10));
+
+        var baseline = store.LoadCalls; // initial dump AND probe drained — nothing else calls Load
         store.Armed = true;
 
         try


### PR DESCRIPTION
Closes #507   # linkage only — the integration PR aggregates the closing keywords

## Problem
Two timing tests failed on loaded CI runners and passed on rerun with zero changes (evidence table in #507): `PrefixAutoRefreshServiceTests.PollsConditionalSourceMoreOftenThanNoEtagSource` (#503 run) and `RefreshDebounceTests.ConcurrentRefreshes_CoalesceIntoOneCyclePlusOneLap` (the #302 signature recurring on #500). Root causes found while fixing — two DIFFERENT races:

1. **Auto-refresh tests:** every fixed `Task.Delay(50)` after a `FakeTimeProvider.Advance` raced the loop's continuation — if the loop had not observed the tick within 50 real ms, the count assertion read 0.
2. **Debounce test:** `baseline` was read right after the FSM reached Established, but the **initial route dump** (`RouteAssembler` → `LoadPeerRoutingViewAsync`) could still be in flight; under load its Load landed inside the armed gate and masqueraded as the refresh cycle's load → dump + cycle + lap = 3 against the asserted 1–2 (exactly the CI "Actual: 3").

## Fix
1. All seven fixed sleeps replaced by condition-waits on the observable state (`WaitForAsync`, 30 s deadline, 5 ms poll). The jitter test's release additionally **interleaves** 1 s clock advances with 20 ms real thread yields: the second source's jitter delay may not be scheduled on the fake clock yet when the first source is observed, and advances landing before the schedule point would strand the delay in the future. 55 steps (≈1.1 s real tolerance, ~20× the original 50 ms) never cross tick 2 at 120 s, so counts stay pinned 1/1.
2. The initial dump is drained deterministically by a **probe refresh** before `baseline` is read: the probe can only acquire `_advertisedPrefixesLock` after the dump released it, so a completed probe proves the dump is done and the baseline is stable. The rest of the coalescing choreography (armed gate, CAS, 4 completed callers, InRange 1–2) is unchanged and now measures only refresh loads.

## Correctness
- No product code touched — tests only. Assertions never weakened: the counts/limits asserted are identical to before (1/1 polls; 1–2 loads); the change is HOW the tests wait, not WHAT they require.

## Regression Test
The fixed tests are the coverage. Locally: the auto-refresh class previously failed 3/6 combined runs and the debounce pair 3/5 — after the fix **8/8 combined runs green** (both classes in parallel = the load scenario), plus the full suite green.

## Verification
- `dotnet format` clean; `dotnet build BGPLite.sln` 0w/0e; `dotnet test BGPLite.sln` 1095/1095; the two classes 8/8 stable.

## RFC
- none.

## Behavior Change
None (tests only).

## Deviation from Issue Proposal
The issue proposed FakeTimeProvider/barrier shapes generically; implementation found a THIRD race (initial-dump masquerade in the debounce test) that neither proposal covered — fixed with the probe-drain. The optional `[Trait]` marking was skipped to keep the diff minimal.