### PR TITLE
chore: integrate dev — Cease subcode fixes #505–#506, timing-test determinization #507

### DIFF
--- a/BGPLite.Protocol/BgpConstants.cs
+++ b/BGPLite.Protocol/BgpConstants.cs
@@ -71,7 +71,9 @@ public static class BgpConstants
         public const byte CeaseMaxPrefixes = 1;
         public const byte CeaseAdministrativeShutdown = 2;
         public const byte CeasePeerDeconfigured = 3;
-        public const byte CeaseAdministrativeReset = 6;
+        // #506: RFC 4486 §3 assigns 4 to "Administrative Reset" (6 is "Other Configuration
+        // Change") — the constant was 6, mislabeling every graceful reset on the wire.
+        public const byte CeaseAdministrativeReset = 4;
         public const byte CeaseConnectionRejected = 7;
     }
 

--- a/BGPLite.Server/BgpSession.cs
+++ b/BGPLite.Server/BgpSession.cs
@@ -756,6 +756,11 @@ public sealed class BgpSession : IDisposable
         try { await task; }
         catch (OperationCanceledException) { }
         catch (BgpParseException) { throw; }
+        // #505: a BgpNotificationException faulting a loop (the #304 cap reset thrown from
+        // HandleUpdateAsync on the read loop) must reach RunAsync's handler, which sends the
+        // carried code/subcode — Cease/MaxPrefixes per RFC 4486 §2. The generic catch below
+        // swallowed it, so HoldTime>0 sessions got a bare Cease 6/0 from the finally instead.
+        catch (BgpNotificationException) { throw; }
         catch (Exception ex) { _logger.LogWarning(ex, "{Label} loop faulted for {Peer}", label, _peer); }
     }
 

--- a/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
+++ b/BGPLite.Tests/BgpSessionRouteOwnershipTests.cs
@@ -743,6 +743,52 @@ public class BgpSessionRouteOwnershipTests
         Assert.Equal(0, routeTable.Count);                  // owned routes flushed by the finally
     }
 
+    /// <summary>
+    /// #505: the SAME cap-reset as <see cref="ExceedingMaxPrefixes_SendsCeaseMaxPrefixes_AndFlushesOwned"/>
+    /// but on a HoldTime &gt; 0 session — the read loop runs behind <c>Task.WhenAny</c>, and
+    /// <c>AwaitLoopTaskAsync</c>'s generic catch swallowed the cap's BgpNotificationException
+    /// (it only rethrew BgpParseException), so RunAsync's finally sent a bare Cease 6/0 and the
+    /// RFC 4486 §2 subcode never reached the peer. The rethrow restores the carried subcode here.
+    /// </summary>
+    [Fact]
+    public async Task ExceedingMaxPrefixes_WithHoldTimer_StillCarriesSubcode1()
+    {
+        var routeTable = new RouteTable();
+        var conn = new ScriptedConnection();
+        var config = new BgpConfig { Asn = 65001, RouterId = "127.0.0.1", HoldTime = 30, KeepAlive = 10, MaxPrefixesPerPeer = 2 };
+        var session = new BgpSession(
+            conn, new PeerConfig { Address = "127.0.0.1" }, config, routeTable,
+            AllowAllFilter.Instance, new BgpMetrics(), NullLogger<BgpSession>.Instance);
+        var run = session.RunAsync();
+        conn.EnqueueMessage(new BgpOpenMessage
+        {
+            Version = BgpConstants.BgpVersion,
+            Asn = 65002,
+            HoldTime = 30,
+            RouterId = 0x0A000002,
+            Capabilities = [BgpCapabilityInfo.FourOctetAsn(65002)],
+        });
+        conn.EnqueueMessage(BgpKeepaliveMessage.Instance);
+        for (var i = 0; i < 200 && !session.IsEstablished; i++)
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        Assert.True(session.IsEstablished, "session must reach Established");
+
+        conn.EnqueueFrame(AnnounceFrame(8, 0x0A));                  // 1/2
+        conn.EnqueueFrame(AnnounceFrame(24, 0xC0, 0x00, 0x02));     // 2/2
+        conn.EnqueueFrame(AnnounceFrame(16, 0xC0, 0x01));           // 3rd distinct prefix — over
+        await run.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.False(session.IsEstablished);
+
+        var ceases = conn.Sent
+            .Select(b => BgpMessageReader.ReadMessage(b.AsSpan()))
+            .OfType<BgpNotificationMessage>()
+            .Where(n => n.ErrorCode == BgpConstants.Error.Cease)
+            .ToList();
+        var maxPrefixes = Assert.Single(ceases);                    // exactly one Cease on the wire
+        Assert.Equal(BgpConstants.SubError.CeaseMaxPrefixes, maxPrefixes.SubErrorCode);   // RED pre-fix: 0 (Unspecific)
+        Assert.Equal(0, routeTable.Count);                          // flush still happens
+    }
+
     /// <summary>#391: waits for the route table to reach the expected size. Generous timeout:
     /// a cold-JIT first run can take longer than SettleAsync's 2 s window to get from
     /// Established through the establish dump to a started read loop.</summary>

--- a/BGPLite.Tests/BgpSessionShutdownTests.cs
+++ b/BGPLite.Tests/BgpSessionShutdownTests.cs
@@ -73,6 +73,29 @@ public class BgpSessionShutdownTests
         Assert.Equal(BgpConstants.SubError.CeaseAdministrativeReset, notif.SubErrorCode);
     }
 
+    [Fact]
+    public async Task NotifyCease_SubcodeIs4_AdministrativeReset_PerRfc4486()
+    {
+        // #506: the subcode value itself, asserted as a LITERAL so a wrong constant cannot pass.
+        // RFC 4486 §3 table: 4 = "Administrative Reset"; 6 = "Other Configuration Change".
+        // CeaseAdministrativeReset was 6, mislabeling every graceful reset/shutdown/delete.
+        var (server, client) = ConnectedPair();
+        using var clientSock = client;
+        using var session = NewSession(server);
+
+        await session.NotifyCeaseAsync();
+
+        var buf = new byte[64];
+        ReadExact(client, buf, 0, BgpConstants.MessageHeaderSize);
+        var len = BgpMessageReader.GetMessageLength(buf);
+        ReadExact(client, buf, BgpConstants.MessageHeaderSize, len - BgpConstants.MessageHeaderSize);
+
+        var msg = BgpMessageReader.ReadMessage(buf.AsSpan(0, len));
+        var notif = Assert.IsType<BgpNotificationMessage>(msg);
+        Assert.Equal(BgpConstants.Error.Cease, notif.ErrorCode);
+        Assert.Equal(4, notif.SubErrorCode);   // RED pre-fix: 6
+    }
+
     /// <summary>
     /// Regression #325: UpdateSessionStatus in the RunAsync finally is a best-effort DB write on a
     /// fire-and-forget task (RunSessionAsync has no catch) — a transient store failure must not

--- a/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
+++ b/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
@@ -25,13 +25,14 @@ public class PrefixAutoRefreshServiceTests
     {
 
         public event Action<string>? ContentCommitted;
-        public Dictionary<string, int> RefreshCalls { get; } = new();
+        // #511 review: the service loop writes while the test thread reads — concurrent access.
+        public System.Collections.Concurrent.ConcurrentDictionary<string, int> RefreshCalls { get; } = new();
         public Dictionary<string, bool> Conditional { get; } = new();
         public bool ReportChanged { get; set; }
 
         public Task<bool> RefreshAsync(string sourceName, CancellationToken ct = default)
         {
-            RefreshCalls[sourceName] = RefreshCalls.TryGetValue(sourceName, out var c) ? c + 1 : 1;
+            RefreshCalls.AddOrUpdate(sourceName, 1, (_, c) => c + 1);
             return Task.FromResult(ReportChanged);
         }
 
@@ -49,11 +50,13 @@ public class PrefixAutoRefreshServiceTests
     /// <summary>A no-op ISessionManager that records RefreshAllEstablishedAsync invocations.</summary>
     private sealed class RecordingSessionManager : ISessionManager
     {
-        public int RefreshAllCalls;
+        // #511 review: incremented on the service loop, read on the test thread — atomic access.
+        private int _refreshAllCalls;
+        public int RefreshAllCalls => Volatile.Read(ref _refreshAllCalls);
         public Task RefreshPeerAsync(string peerIp, uint asn) => Task.CompletedTask;
         public List<string> GetActivePeerIps() => [];
         public int GetAdvertisedPrefixCount(string peerIp, uint asn) => 0;
-        public Task RefreshAllEstablishedAsync() { RefreshAllCalls++; return Task.CompletedTask; }
+        public Task RefreshAllEstablishedAsync() { Interlocked.Increment(ref _refreshAllCalls); return Task.CompletedTask; }
         public Task TerminatePeerAsync(string peerIp, uint asn, CancellationToken ct = default) => Task.CompletedTask;
         public Task TerminatePeerByIpAsync(string peerIp, CancellationToken ct = default) => Task.CompletedTask;
         public void SetPeerMd5Key(string peerIp, string? password) { }
@@ -140,17 +143,20 @@ public class PrefixAutoRefreshServiceTests
             Conditional = { ["a"] = true, ["b"] = true }
         };
         var sessions = new RecordingSessionManager();
+        // #511 review: the tick period is 600 s (not 60) so the advance-until-fired loop below has
+        // no tick-2 ceiling — it may step as long as scheduling pressure requires without a second
+        // tick ever changing the counts.
         var config = ConfigWith(
-            new AutoRefreshConfig { Enabled = true, IntervalSeconds = 60, NoEtagIntervalSeconds = 60, MaxJitterMs = 5000 },
+            new AutoRefreshConfig { Enabled = true, IntervalSeconds = 600, NoEtagIntervalSeconds = 600, MaxJitterMs = 5000 },
             ("a", "http"), ("b", "http"));
         using var service = new PrefixAutoRefreshService(svc, sessions, config,
             NullLogger<PrefixAutoRefreshService>.Instance, time, new Random(0));
 
         await service.StartAsync(CancellationToken.None);
 
-        // Tick 1 (t=60s): first source checked immediately (no jitter on the very first check), then
+        // Tick 1 (t=600s): first source checked immediately (no jitter on the very first check), then
         // the second is delayed by jitter (0..5000ms). Advance the clock to release the jittered delay.
-        time.Advance(TimeSpan.FromSeconds(60));
+        time.Advance(TimeSpan.FromSeconds(600));
         // Wait until 'a' (first source, no jitter) has been polled — the loop is then mid-tick,
         // deterministically before 'b' whose jitter delay is FakeTimeProvider-driven and can only
         // be released by the Advance below.
@@ -162,12 +168,12 @@ public class PrefixAutoRefreshServiceTests
         // clock yet when 'a' is observed — the loop thread can be preempted between polling 'a'
         // and registering the delay, and a batch of advances landing before the schedule point
         // would leave the delay in the future with nobody to release it (the CI flake shape).
-        // Therefore interleave: each 1 s step yields REAL time (20 ms) so a preempted loop can
-        // register the delay, and the NEXT step releases it. Jitter ∈ [0, 5000] ms (Random(0) →
-        // 3631), so once registered ≤5 steps suffice; the 55-step cap (~1.1 s of real yield)
-        // tolerates heavy scheduling pressure while never crossing tick 2 at 120 s — counts stay
-        // exactly 1/1.
-        for (var i = 0; i < 55 && svc.RefreshCalls.GetValueOrDefault("b") == 0; i++)
+        // Therefore KEEP ADVANCING until 'b' fires: every 1 s step yields real time (20 ms) so a
+        // preempted loop can register the delay, and the NEXT step releases it. With the 600 s
+        // period, 500 steps (fake +500 s) can never reach tick 2 — the loop is bounded only by
+        // its own goal, so any scheduling latency is tolerated. Jitter ∈ [0, 5000] ms (Random(0)
+        // → 3631), so in practice ≤5 steps fire.
+        while (svc.RefreshCalls.GetValueOrDefault("b") == 0)
         {
             time.Advance(TimeSpan.FromMilliseconds(1000));
             if (svc.RefreshCalls.GetValueOrDefault("b") > 0) break;

--- a/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
+++ b/BGPLite.Tests/PrefixAutoRefreshServiceTests.cs
@@ -72,6 +72,23 @@ public class PrefixAutoRefreshServiceTests
     }
 
     /// <summary>
+    /// #507: wait for an OBSERVABLE condition instead of a fixed real-time sleep. The old
+    /// <c>Task.Delay(50)</c> after each clock advance raced the refresh loop's continuation —
+    /// on a loaded runner 50 ms is not always enough for the loop to observe the tick, so the
+    /// assertion counted 0 polls. Condition-polling with a generous deadline is deterministic.
+    /// </summary>
+    private static async Task WaitForAsync(Func<bool> condition, string what, int timeoutMilliseconds = 30_000)
+    {
+        var deadline = Environment.TickCount64 + timeoutMilliseconds;
+        while (!condition())
+        {
+            if (Environment.TickCount64 > deadline)
+                Assert.Fail($"timed out after {timeoutMilliseconds} ms waiting for: {what}");
+            await Task.Delay(5);
+        }
+    }
+
+    /// <summary>
     /// #214: a source supporting conditional requests is polled at IntervalSeconds; a source without
     /// ETag support (asn) is polled at the longer NoEtagIntervalSeconds. On a timer tick that falls
     /// between the two intervals, only the conditional source is re-polled.
@@ -96,13 +113,13 @@ public class PrefixAutoRefreshServiceTests
 
         // Tick 1 (t=60s): both sources due (first check) → 1 call each.
         time.Advance(TimeSpan.FromSeconds(60));
-        await Task.Delay(50); // let the loop observe the tick
+        await WaitForAsync(() => svc.RefreshCalls.GetValueOrDefault("asn-src") >= 1, "tick 1: both sources polled");
         Assert.Equal(1, svc.RefreshCalls.GetValueOrDefault("http-src"));
         Assert.Equal(1, svc.RefreshCalls.GetValueOrDefault("asn-src"));
 
         // Tick 2 (t=120s): http-src due again (interval=60s), asn-src NOT due (next at 60+600=660s).
         time.Advance(TimeSpan.FromSeconds(60));
-        await Task.Delay(50);
+        await WaitForAsync(() => svc.RefreshCalls.GetValueOrDefault("http-src") >= 2, "tick 2: http-src re-polled");
         Assert.Equal(2, svc.RefreshCalls.GetValueOrDefault("http-src"));
         Assert.Equal(1, svc.RefreshCalls.GetValueOrDefault("asn-src"));
 
@@ -134,14 +151,29 @@ public class PrefixAutoRefreshServiceTests
         // Tick 1 (t=60s): first source checked immediately (no jitter on the very first check), then
         // the second is delayed by jitter (0..5000ms). Advance the clock to release the jittered delay.
         time.Advance(TimeSpan.FromSeconds(60));
-        await Task.Delay(50); // let the loop start the tick
-        // Only 'a' (first source, no jitter) has been polled so far; 'b' is waiting on the jitter delay.
+        // Wait until 'a' (first source, no jitter) has been polled — the loop is then mid-tick,
+        // deterministically before 'b' whose jitter delay is FakeTimeProvider-driven and can only
+        // be released by the Advance below.
+        await WaitForAsync(() => svc.RefreshCalls.GetValueOrDefault("a") >= 1, "tick: first source polled");
         Assert.Equal(1, svc.RefreshCalls.GetValueOrDefault("a"));
         Assert.Equal(0, svc.RefreshCalls.GetValueOrDefault("b"));
 
-        // Advance past the jitter window (Random(0).Next(0, 5001) is deterministic = some value ≤5000ms).
-        time.Advance(TimeSpan.FromMilliseconds(5000));
-        await Task.Delay(50);
+        // Advance past the jitter window. #507: the delay for 'b' may not be SCHEDULED on the fake
+        // clock yet when 'a' is observed — the loop thread can be preempted between polling 'a'
+        // and registering the delay, and a batch of advances landing before the schedule point
+        // would leave the delay in the future with nobody to release it (the CI flake shape).
+        // Therefore interleave: each 1 s step yields REAL time (20 ms) so a preempted loop can
+        // register the delay, and the NEXT step releases it. Jitter ∈ [0, 5000] ms (Random(0) →
+        // 3631), so once registered ≤5 steps suffice; the 55-step cap (~1.1 s of real yield)
+        // tolerates heavy scheduling pressure while never crossing tick 2 at 120 s — counts stay
+        // exactly 1/1.
+        for (var i = 0; i < 55 && svc.RefreshCalls.GetValueOrDefault("b") == 0; i++)
+        {
+            time.Advance(TimeSpan.FromMilliseconds(1000));
+            if (svc.RefreshCalls.GetValueOrDefault("b") > 0) break;
+            await Task.Delay(20);
+        }
+        await WaitForAsync(() => svc.RefreshCalls.GetValueOrDefault("b") >= 1, "jitter released: second source polled");
         // Now 'b' has been polled too.
         Assert.Equal(1, svc.RefreshCalls.GetValueOrDefault("b"));
 
@@ -161,9 +193,9 @@ public class PrefixAutoRefreshServiceTests
 
         await service.StartAsync(CancellationToken.None);
 
-        // Advancing the clock must NOT trigger any refresh (service disabled).
+        // Advancing the clock must NOT trigger any refresh (service disabled — StartAsync
+        // created no loop, so there is nothing to synchronize with; assert immediately).
         time.Advance(TimeSpan.FromHours(1));
-        await Task.Delay(50);
         Assert.Empty(svc.RefreshCalls);
         Assert.Equal(0, sessions.RefreshAllCalls);
 
@@ -186,7 +218,7 @@ public class PrefixAutoRefreshServiceTests
         await service.StartAsync(CancellationToken.None);
 
         time.Advance(TimeSpan.FromSeconds(60));
-        await Task.Delay(50);
+        await WaitForAsync(() => sessions.RefreshAllCalls >= 1, "changed source: peer refresh pushed");
 
         Assert.Equal(1, sessions.RefreshAllCalls);
 
@@ -217,7 +249,7 @@ public class PrefixAutoRefreshServiceTests
         await service.StartAsync(CancellationToken.None);
 
         time.Advance(TimeSpan.FromSeconds(60));
-        await Task.Delay(50);
+        await WaitForAsync(() => sessions.RefreshAllCalls >= 1, "changed sources: aggregated peer refresh pushed");
 
         // All 3 sources changed, but exactly ONE aggregated peer refresh (not 3+1).
         Assert.Equal(1, sessions.RefreshAllCalls);

--- a/BGPLite.Tests/RefreshDebounceTests.cs
+++ b/BGPLite.Tests/RefreshDebounceTests.cs
@@ -147,7 +147,21 @@ public class RefreshDebounceTests
         using var serverSock = server;
         using var sessionH = session;
 
-        var baseline = store.LoadCalls; // initial dump already ran during establishment
+        // #507: EstablishAsync waits for the Established STATE, not for the initial dump to
+        // finish — and the dump (RouteAssembler → LoadPeerRoutingViewAsync) can still be in
+        // flight here. Under runner load its Load then lands INSIDE the armed gate below,
+        // masquerading as the refresh cycle's load: the "4 callers returned" condition was
+        // satisfied with the winner parked on _advertisedPrefixesLock (held by the dump), and
+        // the final total came out 3 (dump + cycle + lap). Drain the dump deterministically:
+        // a probe refresh can only acquire the dump's lock after the dump released it, so a
+        // completed probe proves the dump is done and `baseline` is stable.
+        var probe = session.RefreshRoutesAsync();
+        await WaitForAsync(
+            () => Volatile.Read(ref store.LoadCalls) >= 1,
+            () => $"probe load={Volatile.Read(ref store.LoadCalls)} (want 1)");
+        await probe.WaitAsync(TimeSpan.FromSeconds(10));
+
+        var baseline = store.LoadCalls; // initial dump AND probe drained — nothing else calls Load
         store.Armed = true;
 
         try


### PR DESCRIPTION
Three fixes found by the post-#503 local integration stand (sniffed traffic + RFC fact-checks) and the CI-flake pattern observed during the #476–#488 batch.

Closes #505
Closes #506
Closes #507

## Per-issue summary
- **#505** (PR #508, HIGH): `AwaitLoopTaskAsync` swallowed the cap-reset `BgpNotificationException`, so HoldTime>0 sessions sent a bare Cease **6/0** instead of **6/1** (RFC 4486 §2 "Maximum Number of Prefixes Reached") — wire-verified on the sniffing stand. Fix: one rethrow; red/green test (hold 30 session at cap → exactly one Cease with subcode 1).
- **#506** (PR #509, MEDIUM): `CeaseAdministrativeReset` was **6** ("Other Configuration Change") — RFC 4486 §3 assigns **4** ("Administrative Reset"); every graceful reset/shutdown/peer deletion was mislabeled on the wire. Fix: one constant; regression test asserts the LITERAL wire value 4.
- **#507** (PR #510): the two CI-flaky timing tests determinized — condition-waits replace the fixed 50 ms sleeps (the #503 CI failure shape), the jitter test interleaves clock advances with thread yields (scheduling-order immune), and the debounce test drains the initial route dump via a probe refresh before reading its baseline (the #500 "Actual: 3" shape — the dump's Load masqueraded as the refresh cycle's). 8/8 combined stability runs; assertions not weakened.

## Verification
- Per-PR: format/build 0w/0e, full suite green, dev CI green, CodeQL 0 alerts.
- Cumulative: 1095 tests; the stand's analyzer checks F1/F2 (sniffed 6/1 and 6/4) are the post-merge verification target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected BGP Administrative Reset notifications to use the RFC-defined subcode.
  * Preserved max-prefix notification details when sessions exceed configured prefix limits, ensuring routes are properly withdrawn.

* **Tests**
  * Added coverage for administrative reset and max-prefix session shutdown behavior.
  * Improved refresh-related test reliability and determinism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->